### PR TITLE
feat(server): add FastMCP server instance, lifespan management, and entry point

### DIFF
--- a/src/mcp_server_polarion/__main__.py
+++ b/src/mcp_server_polarion/__main__.py
@@ -1,0 +1,14 @@
+"""Entry point for the MCP server — ``python -m mcp_server_polarion``."""
+
+from __future__ import annotations
+
+from mcp_server_polarion.server import mcp
+
+
+def main() -> None:
+    """Run the Polarion MCP server over stdio transport."""
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -154,6 +154,11 @@ class PolarionClient:
     ) -> None:
         await self.close()
 
+    @property
+    def is_closed(self) -> bool:
+        """Whether the underlying HTTP transport has been closed."""
+        return self._client.is_closed
+
     async def close(self) -> None:
         """Close the underlying ``httpx.AsyncClient``."""
         await self._client.aclose()

--- a/src/mcp_server_polarion/server.py
+++ b/src/mcp_server_polarion/server.py
@@ -1,0 +1,57 @@
+"""FastMCP server instance and lifespan management."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastmcp import FastMCP
+
+from mcp_server_polarion.core.client import PolarionClient
+from mcp_server_polarion.core.config import PolarionConfig
+from mcp_server_polarion.core.logging import setup_logging
+
+logger = logging.getLogger("mcp_server_polarion.server")
+
+type LifespanContext = dict[str, PolarionClient]
+
+
+@asynccontextmanager
+async def _lifespan(
+    _server: FastMCP[LifespanContext],
+) -> AsyncIterator[LifespanContext]:
+    """Initialize and clean up shared resources for the MCP server.
+
+    Creates a ``PolarionClient`` from environment configuration and
+    makes it available to all tools via the lifespan context.
+
+    Args:
+        _server: The FastMCP server instance (provided automatically).
+
+    Yields:
+        A dict containing the ``polarion_client`` key mapped to an
+        active ``PolarionClient`` instance.
+    """
+    setup_logging()
+    config = PolarionConfig()  # type: ignore[call-arg]
+    logger.info("Connecting to Polarion at %s", config.polarion_url)
+
+    async with PolarionClient(config) as client:
+        logger.info("Polarion client ready")
+        yield {"polarion_client": client}
+
+    logger.info("Polarion client closed")
+
+
+mcp = FastMCP(
+    name="mcp-server-polarion",
+    instructions=(
+        "MCP server for Polarion ALM. "
+        "Read and write documents and work items in Polarion."
+    ),
+    lifespan=_lifespan,
+)
+
+# Register tool modules — must be at bottom to avoid circular imports.
+import mcp_server_polarion.tools  # noqa: E402, F401

--- a/src/mcp_server_polarion/server.py
+++ b/src/mcp_server_polarion/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import TypedDict
 
 from fastmcp import FastMCP
 
@@ -14,7 +15,11 @@ from mcp_server_polarion.core.logging import setup_logging
 
 logger = logging.getLogger("mcp_server_polarion.server")
 
-type LifespanContext = dict[str, PolarionClient]
+
+class LifespanContext(TypedDict):
+    """Typed context yielded by the server lifespan."""
+
+    polarion_client: PolarionClient
 
 
 @asynccontextmanager

--- a/src/mcp_server_polarion/tools/__init__.py
+++ b/src/mcp_server_polarion/tools/__init__.py
@@ -1,0 +1,5 @@
+"""MCP tool definitions — read and write tools for Polarion ALM."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/tests/core/test_client.py
+++ b/tests/core/test_client.py
@@ -653,13 +653,13 @@ class TestContextManager:
             assert client.base_url.endswith("/polarion/rest/v1")
 
         # After closing, the underlying httpx client is closed.
-        assert client._client.is_closed
+        assert client.is_closed
 
     async def test_manual_close(self) -> None:
         """Calling ``close()`` directly also shuts down the client."""
         client = PolarionClient(_config(), write_delay=0)
         await client.close()
-        assert client._client.is_closed
+        assert client.is_closed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,21 @@
+"""Tests for the __main__ entry point module."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mcp_server_polarion.__main__ import main
+
+
+class TestMain:
+    """Verify the CLI entry point."""
+
+    def test_main_calls_mcp_run_with_stdio(self) -> None:
+        with patch("mcp_server_polarion.__main__.mcp") as mock_mcp:
+            main()
+            mock_mcp.run.assert_called_once_with(transport="stdio")
+
+    def test_main_returns_none(self) -> None:
+        with patch("mcp_server_polarion.__main__.mcp"):
+            result = main()
+            assert result is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -72,9 +72,7 @@ class TestLifespan:
                     pass
 
             connect_calls = [
-                c
-                for c in mock_logger.info.call_args_list
-                if "Connecting" in str(c)
+                c for c in mock_logger.info.call_args_list if "Connecting" in str(c)
             ]
             assert len(connect_calls) >= 1
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,87 @@
+"""Tests for the FastMCP server instance and lifespan management."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mcp_server_polarion.core.client import PolarionClient
+from mcp_server_polarion.server import LifespanContext, _lifespan, mcp
+
+_FAKE_ENV = {
+    "POLARION_URL": "https://polarion.example.com",
+    "POLARION_TOKEN": "test-token-secret",
+}
+
+
+class TestMcpInstance:
+    """Verify the FastMCP instance is configured correctly."""
+
+    def test_server_name(self) -> None:
+        assert mcp.name == "mcp-server-polarion"
+
+    def test_server_has_instructions(self) -> None:
+        assert mcp.instructions is not None
+
+    def test_instructions_mention_polarion(self) -> None:
+        assert mcp.instructions is not None
+        assert "Polarion" in mcp.instructions
+
+
+class TestLifespan:
+    """Verify the lifespan context manager."""
+
+    async def test_lifespan_yields_polarion_client(self) -> None:
+        with patch.dict("os.environ", _FAKE_ENV, clear=False):
+            async with _lifespan(mcp) as ctx:
+                assert "polarion_client" in ctx
+                assert isinstance(ctx["polarion_client"], PolarionClient)
+
+    async def test_lifespan_client_is_open_during_context(self) -> None:
+        with patch.dict("os.environ", _FAKE_ENV, clear=False):
+            async with _lifespan(mcp) as ctx:
+                client = ctx["polarion_client"]
+                assert not client._client.is_closed
+
+    async def test_lifespan_client_is_closed_after_context(self) -> None:
+        with patch.dict("os.environ", _FAKE_ENV, clear=False):
+            async with _lifespan(mcp) as ctx:
+                client = ctx["polarion_client"]
+
+            assert client._client.is_closed
+
+    async def test_lifespan_context_type(self) -> None:
+        with patch.dict("os.environ", _FAKE_ENV, clear=False):
+            async with _lifespan(mcp) as ctx:
+                result: LifespanContext = ctx
+                assert isinstance(result, dict)
+
+    async def test_lifespan_calls_setup_logging(self) -> None:
+        with (
+            patch.dict("os.environ", _FAKE_ENV, clear=False),
+            patch(
+                "mcp_server_polarion.server.setup_logging",
+            ) as mock_setup,
+        ):
+            async with _lifespan(mcp) as _ctx:
+                mock_setup.assert_called_once()
+
+    async def test_lifespan_logs_connecting_message(self) -> None:
+        with patch.dict("os.environ", _FAKE_ENV, clear=False):
+            with patch("mcp_server_polarion.server.logger") as mock_logger:
+                async with _lifespan(mcp) as _ctx:
+                    pass
+
+            connect_calls = [
+                c
+                for c in mock_logger.info.call_args_list
+                if "Connecting" in str(c)
+            ]
+            assert len(connect_calls) >= 1
+
+    async def test_lifespan_client_has_correct_base_url(self) -> None:
+        with patch.dict("os.environ", _FAKE_ENV, clear=False):
+            async with _lifespan(mcp) as ctx:
+                client = ctx["polarion_client"]
+                base_url = str(client._client.base_url)
+                assert "polarion.example.com" in base_url
+                assert "polarion/rest/v1" in base_url

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -40,14 +40,14 @@ class TestLifespan:
         with patch.dict("os.environ", _FAKE_ENV, clear=False):
             async with _lifespan(mcp) as ctx:
                 client = ctx["polarion_client"]
-                assert not client._client.is_closed
+                assert not client.is_closed
 
     async def test_lifespan_client_is_closed_after_context(self) -> None:
         with patch.dict("os.environ", _FAKE_ENV, clear=False):
             async with _lifespan(mcp) as ctx:
                 client = ctx["polarion_client"]
 
-            assert client._client.is_closed
+            assert client.is_closed
 
     async def test_lifespan_context_type(self) -> None:
         with patch.dict("os.environ", _FAKE_ENV, clear=False):
@@ -71,15 +71,15 @@ class TestLifespan:
                 async with _lifespan(mcp) as _ctx:
                     pass
 
-            connect_calls = [
-                c for c in mock_logger.info.call_args_list if "Connecting" in str(c)
-            ]
-            assert len(connect_calls) >= 1
+            mock_logger.info.assert_any_call(
+                "Connecting to Polarion at %s",
+                _FAKE_ENV["POLARION_URL"],
+            )
 
     async def test_lifespan_client_has_correct_base_url(self) -> None:
         with patch.dict("os.environ", _FAKE_ENV, clear=False):
             async with _lifespan(mcp) as ctx:
                 client = ctx["polarion_client"]
-                base_url = str(client._client.base_url)
+                base_url = str(client.base_url)
                 assert "polarion.example.com" in base_url
                 assert "polarion/rest/v1" in base_url


### PR DESCRIPTION
## Summary

Add the FastMCP server instance, lifespan management, and the CLI entry point that ties the core infrastructure layer together into a runnable MCP server.

This is the last foundational step before tool implementation — it establishes the shared `PolarionClient` lifecycle, wires the `mcp` instance used by all `@mcp.tool()` decorators, and exposes the `mcp-server-polarion` console script.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- **`src/mcp_server_polarion/server.py`** — Creates the `FastMCP` instance (`mcp`) with the `_lifespan` async context manager. On startup it calls `setup_logging()`, loads `PolarionConfig` from environment variables, and starts a `PolarionClient`; on shutdown it closes the client. The client is exposed to all tools via `lifespan_context["polarion_client"]`. Defines `LifespanContext` (PEP 695 type alias) for mypy strict compliance. Tools are registered at the bottom of the module via `import mcp_server_polarion.tools` to avoid circular imports.
- **`src/mcp_server_polarion/__main__.py`** — Thin entry point that calls `mcp.run(transport="stdio")`. Matches the `[project.scripts]` entry in `pyproject.toml` so `uvx mcp-server-polarion` works.
- **`src/mcp_server_polarion/tools/__init__.py`** — Empty package stub that satisfies the `import mcp_server_polarion.tools` registration call in `server.py`. Will import `read` and `write` submodules once they are implemented.
- **`tests/test_server.py`** — 10 tests covering: `mcp.name`, `mcp.instructions`, lifespan yields a `PolarionClient`, client is open during context and closed after, context type is `LifespanContext`, `setup_logging()` is called once, "Connecting" log message is emitted, and base URL is constructed correctly from config.
- **`tests/test_main.py`** — 2 tests verifying that `main()` calls `mcp.run(transport="stdio")` exactly once and returns `None`.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [ ] `dry_run=True` path verified for all write tools *(no write tools in this PR)*
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src --strict` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run pytest tests/ -v
# 175 passed in 15.29s

uv run mypy --strict src/mcp_server_polarion/
# Success: no issues found in 12 source files

uv run ruff check .
# All checks passed!
```

---

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [x] All new tool functions are `async def`
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [ ] HTML converted via `html_to_markdown()` in read paths *(no tool reads in this PR)*
- [ ] HTML sanitized via `markdown_to_html()` or `sanitize_html()` in write paths *(no tool writes in this PR)*
- [ ] Any new list tool supports `page_size` and `page_number` pagination *(no list tools in this PR)*
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

---

## Screenshots / Logs

<details>
<summary>Expand</summary>

```
$ uv run pytest tests/ -v
...
tests/test_main.py::TestMain::test_main_calls_mcp_run_with_stdio PASSED
tests/test_main.py::TestMain::test_main_returns_none PASSED
tests/test_server.py::TestMcpInstance::test_server_name PASSED
tests/test_server.py::TestMcpInstance::test_server_has_instructions PASSED
tests/test_server.py::TestMcpInstance::test_instructions_mention_polarion PASSED
tests/test_server.py::TestLifespan::test_lifespan_yields_polarion_client PASSED
tests/test_server.py::TestLifespan::test_lifespan_client_is_open_during_context PASSED
tests/test_server.py::TestLifespan::test_lifespan_client_is_closed_after_context PASSED
tests/test_server.py::TestLifespan::test_lifespan_context_type PASSED
tests/test_server.py::TestLifespan::test_lifespan_calls_setup_logging PASSED
tests/test_server.py::TestLifespan::test_lifespan_logs_connecting_message PASSED
tests/test_server.py::TestLifespan::test_lifespan_client_has_correct_base_url PASSED
============================= 175 passed in 15.29s =============================
```

</details>

---

## Notes for Reviewers

- `PolarionConfig()` is called with `# type: ignore[call-arg]` because `pydantic-settings` populates the required fields (`polarion_url`, `polarion_token`) from environment variables at runtime, which mypy cannot verify statically.
- The `import mcp_server_polarion.tools` at the bottom of `server.py` intentionally violates PEP 8's top-of-file import rule. This is a deliberate architectural choice to break the circular import between `server.py` (which defines `mcp`) and `tools/*.py` (which imports `mcp` to use `@mcp.tool()`). The `# noqa: E402, F401` suppression is justified and documented inline.
- `tools/__init__.py` is currently a stub. It will be populated with `import mcp_server_polarion.tools.read` and `import mcp_server_polarion.tools.write` in the next PR.