### PR TITLE
feat(tool): implement 7 read-only MCP tools for Polarion ALM

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ These rules apply to **every file** in the codebase. Violating any of them will 
 | 11 | **Every write tool must support `dry_run`** — preview payload without mutating. |
 | 12 | **Secrets in `.env` only** — never hardcode credentials. Load via `pydantic-settings`. |
 | 13 | **Use `uv` exclusively** — no pip, poetry, or pipenv. |
-| 14 | **Keep tool count minimal** — 13 tools total (8 read + 5 write). |
+| 14 | **Keep tool count minimal** — 12 tools total (7 read + 5 write). |
 
 ---
 
@@ -89,7 +89,7 @@ mcp-server-polarion/
 │       │   └── html.py           # HTML ↔ Markdown conversion + HTML sanitization
 │       └── tools/                # MCP tool definitions
 │           ├── __init__.py       # Imports read & write to register tools on mcp
-│           ├── read.py           # 8 read tools
+│       │   ├── read.py           # 7 read tools
 │           └── write.py          # 5 write tools
 └── tests/
     ├── conftest.py               # Shared fixtures (mock client, MCP test client)
@@ -103,7 +103,7 @@ mcp-server-polarion/
     │   └── test_html.py          # HTML ↔ Markdown conversion edge cases
     └── tools/
         ├── __init__.py
-        ├── test_read.py          # 8 read tools
+│       ├── test_read.py          # 7 read tools
         └── test_write.py         # 5 write tools + dry_run verification
 ```
 
@@ -252,20 +252,19 @@ All list endpoints support `page[size]` and `page[number]` (1-based) query param
 
 ### Tool → Endpoint Mapping
 
-#### Read Tools (8)
+#### Read Tools (7)
 
 | Tool | Method | Path |
 |---|---|---|
 | `list_projects` | GET | `/projects` |
-| `list_spaces` | GET | `/projects/{projectId}/workitems?fields[workitems]=module` (indirect — parse `module` field to extract unique Space IDs) |
+| `list_documents` | GET | `/projects/{projectId}/workitems?fields[workitems]=module&query=type:heading&sort=module` (indirect — parse `module` field to extract unique Space ID + Document Name pairs) |
 | `get_document` | GET | `/projects/{projectId}/spaces/{spaceId}/documents/{documentName}` |
 | `get_document_parts` | GET | `/projects/{projectId}/spaces/{spaceId}/documents/{documentName}/parts` |
-| `list_work_items` | GET | `/projects/{projectId}/workitems` |
+| `list_work_items` | GET | `/projects/{projectId}/workitems` (optional `query` param for Lucene filtering) |
 | `get_work_item` | GET | `/projects/{projectId}/workitems/{workItemId}` |
-| `search_work_items` | GET | `/projects/{projectId}/workitems?query={luceneQuery}` |
 | `get_linked_work_items` | GET | `/projects/{projectId}/workitems/{workItemId}/linkedworkitems` |
 
-> **Unsupported**: `list_documents` (`GET /projects/{projectId}/documents`) — not available on the target Polarion version.
+> **Unsupported**: `GET /projects/{projectId}/documents` — not available on the target Polarion version. `list_documents` uses an indirect approach via heading work items.
 
 #### Write Tools (5)
 
@@ -284,8 +283,8 @@ All list endpoints support `page[size]` and `page[number]` (1-based) query param
 - **The description field is always HTML**: `{ "type": "text/html", "value": "<p>...</p>" }`.
 - **Content-Type is `application/json`** — NOT `application/vnd.api+json`.
 - **`POST /workitems` returns 201 with array response**: `{"data": [...]}` — parse accordingly.
-- **`GET /projects/{projectId}/spaces` does NOT exist** — `list_spaces` must use an indirect approach: query Work Items with `fields[workitems]=module`, parse the `module` field (`{spaceId}/{documentName}` format), and extract unique Space IDs.
-- **Space ID is required to access documents** — guide the user to call `list_spaces` first in tool docstrings.
+- **`GET /projects/{projectId}/spaces` does NOT exist** — `list_documents` must use an indirect approach: query heading Work Items with `fields[workitems]=module` and `query=type:heading`, parse the `module` field (`{projectId}/{spaceId}/{documentName}` format), and extract unique (Space ID, Document Name) pairs.
+- **Space ID and document name are required to access documents** — guide the user to call `list_documents` first in tool docstrings.
 - **`update_work_item` must GET current state first**, then PATCH only the changed fields.
 - **Document Recycle Bin**: Creating a Work Item with a `module` relationship places it in the Document's Recycle Bin — it is NOT visible. After `create_work_item`, call `create_document_part` separately to insert the Work Item into the document body as a visible Part.
 - **`get_linked_work_items`** must fetch both forward links (`linkedworkitems`) and back links (`backlinkedworkitems`) and merge into a single result for complete traceability.
@@ -305,11 +304,11 @@ All tool inputs and outputs are defined as Pydantic `BaseModel` subclasses. Add 
 |---|---|
 | `PaginatedResult[T]` | Common response wrapper for all list tools (`items`, `total_count`, `page`, `page_size`) |
 | `ProjectSummary` | Item returned by `list_projects` (`id`, `name`) |
-| `SpaceSummary` | Item returned by `list_spaces` (`id`, `name`) |
+| `DocumentSummary` | Item returned by `list_documents` (`space_id`, `document_name`) |
 | `DocumentPartCreateResult` | Response from `create_document_part` (`created`, `dry_run`, `part_id`, `payload_preview`) |
-| `DocumentDetail` | Response from `get_document` (`id`, `title`, `description`, `space_id`, `project_id`) |
+| `DocumentDetail` | Response from `get_document` (`id`, `title`, `content`, `space_id`, `project_id`) |
 | `DocumentPart` | Item returned by `get_document_parts` (`id`, `title`, `content`, `type`, `level`) |
-| `WorkItemSummary` | Item returned by `list_work_items` and `search_work_items` (`id`, `title`, `type`, `status`) |
+| `WorkItemSummary` | Item returned by `list_work_items` (`id`, `title`, `type`, `status`) |
 | `WorkItemDetail` | Response from `get_work_item` — extends `WorkItemSummary` (`description`, `project_id`) |
 | `WorkItemCreateResult` | Response from `create_work_item` (`created`, `dry_run`, `work_item_id`, `payload_preview`) |
 | `WorkItemUpdateResult` | Response from `update_work_item` (`updated`, `dry_run`, `current`, `changes`) |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -334,7 +334,7 @@ Every tool must have a Google-style docstring with these mandatory sections:
 3. **Args**: Every parameter with type context and example values.
 4. **Returns**: Field descriptions of the returned model.
 5. **Raises**: Every exception the tool may throw.
-6. **Cross-reference other tools**: e.g., "Use `list_spaces` first to discover space IDs."
+6. **Cross-reference other tools**: e.g., "Use `list_documents` first to discover space IDs and document names."
 
 ### Read Tool Rules
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,9 +88,8 @@ mcp-server-polarion/
 │       │   ├── __init__.py       # Re-exports: html_to_markdown, markdown_to_html, sanitize_html
 │       │   └── html.py           # HTML ↔ Markdown conversion + HTML sanitization
 │       └── tools/                # MCP tool definitions
-│           ├── __init__.py       # Imports read & write to register tools on mcp
-│       │   ├── read.py           # 7 read tools
-│           └── write.py          # 5 write tools
+│           ├── __init__.py       # Imports read to register tools on mcp
+│           └── read.py           # 7 read tools
 └── tests/
     ├── conftest.py               # Shared fixtures (mock client, MCP test client)
     ├── test_models.py            # Pydantic model validation
@@ -103,15 +102,14 @@ mcp-server-polarion/
     │   └── test_html.py          # HTML ↔ Markdown conversion edge cases
     └── tools/
         ├── __init__.py
-│       ├── test_read.py          # 7 read tools
-        └── test_write.py         # 5 write tools + dry_run verification
+        └── test_read.py          # 7 read tools
 ```
 
 ### Import Structure
 
 - `server.py` creates the `mcp = FastMCP(...)` instance.
-- `tools/read.py` and `tools/write.py` import it via `from mcp_server_polarion.server import mcp` to use the `@mcp.tool()` decorator.
-- `tools/__init__.py` runs `import mcp_server_polarion.tools.read` and `import mcp_server_polarion.tools.write` to register all tools.
+- `tools/read.py` imports it via `from mcp_server_polarion.server import mcp` to use the `@mcp.tool()` decorator.
+- `tools/__init__.py` runs `import mcp_server_polarion.tools.read` to register all tools.
 - `server.py` calls `import mcp_server_polarion.tools` at the very bottom of the module (to avoid circular imports).
 - `core/__init__.py` re-exports `PolarionClient`, `PolarionConfig`, and exception classes.
 - `utils/__init__.py` re-exports `html_to_markdown`, `markdown_to_html`, and `sanitize_html`.

--- a/src/mcp_server_polarion/core/config.py
+++ b/src/mcp_server_polarion/core/config.py
@@ -26,7 +26,8 @@ class PolarionConfig(BaseSettings):
 
     polarion_url: str = Field(
         description=(
-            "Base URL of the Polarion instance. "
+            "Base URL of the Polarion instance including the application "
+            "context path (e.g. 'https://example.com/polarion'). "
             "Trailing slashes are accepted and will be stripped automatically."
         ),
     )
@@ -37,4 +38,4 @@ class PolarionConfig(BaseSettings):
     @property
     def base_api_url(self) -> str:
         """Return the full REST API v1 base URL."""
-        return f"{self.polarion_url.rstrip('/')}/polarion/rest/v1"
+        return f"{self.polarion_url.rstrip('/')}/rest/v1"

--- a/src/mcp_server_polarion/core/config.py
+++ b/src/mcp_server_polarion/core/config.py
@@ -14,8 +14,9 @@ class PolarionConfig(BaseSettings):
     """Environment-based configuration for the Polarion MCP server.
 
     Attributes:
-        polarion_url: Base URL of the Polarion instance.  Trailing slashes
-            are accepted and will be stripped automatically.
+        polarion_url: Base URL of the Polarion instance root (without the
+            '/polarion' context path).  Trailing slashes are accepted and
+            will be stripped automatically.
         polarion_token: Personal access token for Bearer authentication.
     """
 
@@ -26,9 +27,9 @@ class PolarionConfig(BaseSettings):
 
     polarion_url: str = Field(
         description=(
-            "Base URL of the Polarion instance including the application "
-            "context path (e.g. 'https://example.com/polarion'). "
-            "Trailing slashes are accepted and will be stripped automatically."
+            "Base URL of the Polarion instance root (e.g. 'https://example.com'), "
+            "without the '/polarion' application context path. Trailing slashes "
+            "are accepted and will be stripped automatically."
         ),
     )
     polarion_token: str = Field(

--- a/src/mcp_server_polarion/core/config.py
+++ b/src/mcp_server_polarion/core/config.py
@@ -38,4 +38,4 @@ class PolarionConfig(BaseSettings):
     @property
     def base_api_url(self) -> str:
         """Return the full REST API v1 base URL."""
-        return f"{self.polarion_url.rstrip('/')}/rest/v1"
+        return f"{self.polarion_url.rstrip('/')}/polarion/rest/v1"

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -67,16 +67,19 @@ class ProjectSummary(BaseModel):
     )
 
 
-class SpaceSummary(BaseModel):
-    """Summary of a Polarion space returned by ``list_spaces``."""
+class DocumentSummary(BaseModel):
+    """Summary of a Polarion document returned by ``list_documents``."""
 
-    id: str = Field(
-        description="Space identifier (e.g. '_default', 'Design').",
-    )
-    name: str = Field(
+    space_id: str = Field(
         description=(
-            "Human-readable space name. "
-            "Defaults to the space ID when no display name is available."
+            "Space identifier that contains the document"
+            " (e.g. '_default', 'Design')."
+        ),
+    )
+    document_name: str = Field(
+        description=(
+            "Document name within the space"
+            " (e.g. 'Software Requirement Specification')."
         ),
     )
 
@@ -90,10 +93,10 @@ class DocumentDetail(BaseModel):
     title: str = Field(
         description="Document title.",
     )
-    description: str = Field(
+    content: str = Field(
         description=(
-            "Document description converted to Markdown. "
-            "Empty string when the document has no description."
+            "Full document content (homePageContent) converted to Markdown. "
+            "Empty string when the document has no content."
         ),
     )
     space_id: str = Field(
@@ -338,13 +341,13 @@ __all__: list[str] = [
     "DocumentDetail",
     "DocumentPart",
     "DocumentPartCreateResult",
+    "DocumentSummary",
     "JsonValue",
     "LinkResult",
     "LinkedWorkItemSummary",
     "LinkedWorkItemsList",
     "PaginatedResult",
     "ProjectSummary",
-    "SpaceSummary",
     "WorkItemCreateResult",
     "WorkItemDetail",
     "WorkItemSummary",

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -72,8 +72,7 @@ class DocumentSummary(BaseModel):
 
     space_id: str = Field(
         description=(
-            "Space identifier that contains the document"
-            " (e.g. '_default', 'Design')."
+            "Space identifier that contains the document (e.g. '_default', 'Design')."
         ),
     )
     document_name: str = Field(

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -123,8 +123,11 @@ class DocumentPart(BaseModel):
             "Empty string when the part has no body content."
         ),
     )
-    type: Literal["heading", "workitem"] = Field(
-        description="Part type: 'heading' or 'workitem'.",
+    type: Literal["heading", "workitem", "normal", "toc", "wikiblock"] = Field(
+        description=(
+            "Part type: 'heading', 'workitem', 'normal' (rich text), "
+            "'toc' (table of contents), or 'wikiblock' (wiki macro block)."
+        ),
     )
     level: int = Field(
         description=(

--- a/src/mcp_server_polarion/tools/__init__.py
+++ b/src/mcp_server_polarion/tools/__init__.py
@@ -2,4 +2,6 @@
 
 from __future__ import annotations
 
+import mcp_server_polarion.tools.read  # noqa: F401
+
 __all__: list[str] = []

--- a/src/mcp_server_polarion/tools/__init__.py
+++ b/src/mcp_server_polarion/tools/__init__.py
@@ -1,4 +1,4 @@
-"""MCP tool definitions — read and write tools for Polarion ALM."""
+"""MCP tool definitions — read tools for Polarion ALM."""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -265,6 +265,14 @@ async def _discover_documents(
 @mcp.tool()
 async def list_projects(
     ctx: Context,
+    query: str | None = Field(
+        default=None,
+        description=(
+            "Optional Lucene query string for filtering projects. "
+            "Examples: 'name:myproject', 'name:*infotainment*'. "
+            "Omit to list all accessible projects."
+        ),
+    ),
     page_size: int = Field(
         default=_DEFAULT_PAGE_SIZE,
         ge=1,
@@ -283,8 +291,12 @@ async def list_projects(
     can access.  Use this as the starting point to discover valid project
     IDs for other tools.
 
+    Pass a Lucene ``query`` to search for specific projects by name,
+    or omit it to list all accessible projects.
+
     Args:
         ctx: MCP tool context (injected automatically).
+        query: Optional Lucene query string for filtering projects.
         page_size: Number of projects per page (1-100, default 100).
         page_number: Page number to retrieve (1-based, default 1).
 
@@ -301,14 +313,17 @@ async def list_projects(
         RuntimeError: On unexpected Polarion API errors.
     """
     client = _get_client(ctx)
+    params: dict[str, str | int] = {
+        "fields[projects]": "id,name",
+        "page[size]": page_size,
+        "page[number]": page_number,
+    }
+    if query is not None:
+        params["query"] = query
     try:
         response = await client.get(
             "/projects",
-            params={
-                "fields[projects]": "id,name",
-                "page[size]": page_size,
-                "page[number]": page_number,
-            },
+            params=params,
         )
     except PolarionAuthError as exc:
         raise PermissionError(

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -156,13 +156,10 @@ async def list_projects(
         )
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot list projects -- "
-            "check your POLARION_TOKEN permissions."
+            "Cannot list projects -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionError as exc:
-        raise RuntimeError(
-            f"Failed to list projects: {exc.message}"
-        ) from exc
+        raise RuntimeError(f"Failed to list projects: {exc.message}") from exc
 
     data = response.get("data", [])
     items: list[ProjectSummary] = []
@@ -250,13 +247,11 @@ async def list_spaces(
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot list spaces -- "
-            "check your POLARION_TOKEN permissions."
+            "Cannot list spaces -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionError as exc:
         raise RuntimeError(
-            f"Failed to list spaces for project "
-            f"'{project_id}': {exc.message}"
+            f"Failed to list spaces for project '{project_id}': {exc.message}"
         ) from exc
 
     # Parse module from relationships to extract unique space IDs.
@@ -277,9 +272,7 @@ async def list_spaces(
         if isinstance(mod_id, str) and mod_id:
             parts = mod_id.split("/")
             # Format: "projectId/spaceId/docName" → parts[1] is spaceId
-            if len(parts) >= 3:
-                space_ids.add(parts[1])
-            elif len(parts) == 2:
+            if len(parts) >= 2:  # noqa: PLR2004
                 space_ids.add(parts[1])
 
     sorted_spaces = sorted(space_ids)
@@ -366,13 +359,11 @@ async def get_document(
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot access document -- "
-            "check your POLARION_TOKEN permissions."
+            "Cannot access document -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionError as exc:
         raise RuntimeError(
-            f"Failed to get document '{document_name}': "
-            f"{exc.message}"
+            f"Failed to get document '{document_name}': {exc.message}"
         ) from exc
 
     data = response.get("data", {})
@@ -476,13 +467,11 @@ async def get_document_parts(  # noqa: PLR0913
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot access document parts -- "
-            "check your POLARION_TOKEN permissions."
+            "Cannot access document parts -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionError as exc:
         raise RuntimeError(
-            f"Failed to get parts for "
-            f"'{document_name}': {exc.message}"
+            f"Failed to get parts for '{document_name}': {exc.message}"
         ) from exc
 
     data = response.get("data", [])
@@ -509,7 +498,8 @@ async def get_document_parts(  # noqa: PLR0913
 
             # Content/description is HTML.
             content_obj = attrs.get(
-                "content", attrs.get("description", {}),
+                "content",
+                attrs.get("description", {}),
             )
             content_html = ""
             if isinstance(content_obj, dict):
@@ -542,8 +532,7 @@ async def list_work_items(
     ctx: Context,
     project_id: str = Field(
         description=(
-            "Polarion project ID. "
-            "Use ``list_projects`` to discover valid IDs."
+            "Polarion project ID. Use ``list_projects`` to discover valid IDs."
         ),
     ),
     page_size: int = Field(
@@ -600,13 +589,10 @@ async def list_work_items(
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot list work items -- "
-            "check your POLARION_TOKEN permissions."
+            "Cannot list work items -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionError as exc:
-        raise RuntimeError(
-            f"Failed to list work items: {exc.message}"
-        ) from exc
+        raise RuntimeError(f"Failed to list work items: {exc.message}") from exc
 
     data = response.get("data", [])
     items = _parse_work_item_summaries(data)
@@ -673,13 +659,11 @@ async def get_work_item(
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot access work item -- "
-            "check your POLARION_TOKEN permissions."
+            "Cannot access work item -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionError as exc:
         raise RuntimeError(
-            f"Failed to get work item "
-            f"'{work_item_id}': {exc.message}"
+            f"Failed to get work item '{work_item_id}': {exc.message}"
         ) from exc
 
     data = response.get("data", {})
@@ -698,9 +682,7 @@ async def get_work_item(
     # Extract work item ID from JSON:API id
     # (format: "projectId/WI-001").
     raw_id = _safe_str(data.get("id", ""))
-    wi_id = (
-        raw_id.split("/", maxsplit=1)[-1] if "/" in raw_id else raw_id
-    )
+    wi_id = raw_id.split("/", maxsplit=1)[-1] if "/" in raw_id else raw_id
 
     return WorkItemDetail(
         id=wi_id or work_item_id,
@@ -785,13 +767,10 @@ async def search_work_items(
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot search work items -- "
-            "check your POLARION_TOKEN permissions."
+            "Cannot search work items -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionError as exc:
-        raise RuntimeError(
-            f"Failed to search work items: {exc.message}"
-        ) from exc
+        raise RuntimeError(f"Failed to search work items: {exc.message}") from exc
 
     data = response.get("data", [])
     items = _parse_work_item_summaries(data)
@@ -847,9 +826,7 @@ async def get_linked_work_items(
         RuntimeError: On unexpected Polarion API errors.
     """
     client = _get_client(ctx)
-    base_path = (
-        f"/projects/{project_id}/workitems/{work_item_id}"
-    )
+    base_path = f"/projects/{project_id}/workitems/{work_item_id}"
 
     try:
         forward_response = await client.get(
@@ -866,20 +843,20 @@ async def get_linked_work_items(
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot access linked work items -- "
-            "check your POLARION_TOKEN permissions."
+            "Cannot access linked work items -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionError as exc:
         raise RuntimeError(
-            f"Failed to get links for "
-            f"'{work_item_id}': {exc.message}"
+            f"Failed to get links for '{work_item_id}': {exc.message}"
         ) from exc
 
     forward_items = _parse_linked_items(
-        forward_response, direction="forward",
+        forward_response,
+        direction="forward",
     )
     back_items = _parse_linked_items(
-        back_response, direction="back",
+        back_response,
+        direction="back",
     )
 
     all_items = forward_items + back_items
@@ -921,11 +898,7 @@ def _parse_work_item_summaries(
         # Extract ID from JSON:API id
         # (format: "projectId/WI-001").
         raw_id = _safe_str(item.get("id", ""))
-        wi_id = (
-            raw_id.split("/", maxsplit=1)[-1]
-            if "/" in raw_id
-            else raw_id
-        )
+        wi_id = raw_id.split("/", maxsplit=1)[-1] if "/" in raw_id else raw_id
 
         items.append(
             WorkItemSummary(
@@ -967,11 +940,7 @@ def _parse_linked_items(
 
         # Extract the linked work item ID.
         raw_id = _safe_str(item.get("id", ""))
-        wi_id = (
-            raw_id.split("/", maxsplit=1)[-1]
-            if "/" in raw_id
-            else raw_id
-        )
+        wi_id = raw_id.split("/", maxsplit=1)[-1] if "/" in raw_id else raw_id
 
         # Parse role from attributes.
         role = _safe_str(attrs.get("role", ""))

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -305,14 +305,10 @@ async def list_documents(  # noqa: PLR0913
     # Apply filters.
     filtered: list[tuple[str, str]] = sorted(documents)
     if space_filter is not None:
-        filtered = [
-            (s, d) for s, d in filtered if s == space_filter
-        ]
+        filtered = [(s, d) for s, d in filtered if s == space_filter]
     if name_filter is not None:
         name_lower = name_filter.lower()
-        filtered = [
-            (s, d) for s, d in filtered if name_lower in d.lower()
-        ]
+        filtered = [(s, d) for s, d in filtered if name_lower in d.lower()]
 
     total = len(filtered)
 
@@ -321,10 +317,7 @@ async def list_documents(  # noqa: PLR0913
     end = start + page_size
     page_slice = filtered[start:end]
 
-    items = [
-        DocumentSummary(space_id=s, document_name=d)
-        for s, d in page_slice
-    ]
+    items = [DocumentSummary(space_id=s, document_name=d) for s, d in page_slice]
 
     return PaginatedResult[DocumentSummary](
         items=items,

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -370,7 +370,7 @@ async def list_documents(  # noqa: PLR0913
         description=(
             "Optional substring filter for document names "
             "(case-insensitive, client-side). "
-            "E.g. 'SRS' matches 'Software Requirement Specification'."
+            "E.g. 'Requirement' matches 'Software Requirement Specification'."
         ),
     ),
     space_filter: str | None = Field(

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -1,0 +1,991 @@
+"""Read-only MCP tools for querying Polarion ALM.
+
+Eight tools that retrieve projects, spaces, documents, work items, and
+their relationships.  Every tool returns Pydantic models -- never raw
+``dict`` -- and converts HTML descriptions to Markdown via
+``html_to_markdown()``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Final
+from urllib.parse import quote
+
+from fastmcp import Context
+from pydantic import Field
+
+from mcp_server_polarion.core.client import PolarionClient
+from mcp_server_polarion.core.exceptions import (
+    PolarionAuthError,
+    PolarionError,
+    PolarionNotFoundError,
+)
+from mcp_server_polarion.models import (
+    DocumentDetail,
+    DocumentPart,
+    LinkedWorkItemsList,
+    LinkedWorkItemSummary,
+    PaginatedResult,
+    ProjectSummary,
+    SpaceSummary,
+    WorkItemDetail,
+    WorkItemSummary,
+)
+from mcp_server_polarion.server import mcp
+from mcp_server_polarion.utils import html_to_markdown
+
+logger: Final = logging.getLogger("mcp_server_polarion.tools.read")
+
+# Default page size -- Polarion caps at 100.
+_DEFAULT_PAGE_SIZE: Final[int] = 100
+
+# Sparse fieldset for list/search endpoints.
+_WI_LIST_FIELDS: Final[str] = "title,type,status"
+_WI_DETAIL_FIELDS: Final[str] = "title,description,type,status"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_client(ctx: Context) -> PolarionClient:
+    """Extract ``PolarionClient`` from the lifespan context.
+
+    Args:
+        ctx: FastMCP tool context.
+
+    Returns:
+        The active ``PolarionClient`` instance.
+    """
+    lifespan_ctx: dict[str, object] = ctx.request_context.lifespan_context  # type: ignore[union-attr]
+    client = lifespan_ctx["polarion_client"]
+    if not isinstance(client, PolarionClient):  # pragma: no cover
+        msg = "polarion_client is not a PolarionClient instance"
+        raise TypeError(msg)
+    return client
+
+
+def _safe_str(value: object) -> str:
+    """Convert a value to ``str``, returning ``""`` for ``None``."""
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _extract_total_count(response: dict[str, object]) -> int:
+    """Extract ``meta.totalCount`` from a JSON:API response.
+
+    Args:
+        response: Decoded JSON:API response.
+
+    Returns:
+        The total count, or 0 if the field is missing.
+    """
+    meta = response.get("meta")
+    if isinstance(meta, dict):
+        total = meta.get("totalCount", 0)
+        if isinstance(total, int):
+            return total
+    return 0
+
+
+def _encode_path_segment(segment: str) -> str:
+    """URL-encode a single path segment (e.g. document name with spaces).
+
+    Args:
+        segment: Raw path segment string.
+
+    Returns:
+        URL-encoded segment safe for use in URL paths.
+    """
+    return quote(segment, safe="")
+
+
+# ---------------------------------------------------------------------------
+# Read tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def list_projects(
+    ctx: Context,
+    page_size: int = Field(
+        default=_DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=100,
+        description="Number of projects per page (1-100, default 100).",
+    ),
+    page_number: int = Field(
+        default=1,
+        ge=1,
+        description="Page number to retrieve (1-based, default 1).",
+    ),
+) -> PaginatedResult[ProjectSummary]:
+    """List all accessible Polarion projects.
+
+    Returns a paginated list of Polarion projects the authenticated user
+    can access.  Use this as the starting point to discover valid project
+    IDs for other tools.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        page_size: Number of projects per page (1-100, default 100).
+        page_number: Page number to retrieve (1-based, default 1).
+
+    Returns:
+        PaginatedResult containing ``ProjectSummary`` items with:
+        - ``id``: Project identifier.
+        - ``name``: Human-readable project name.
+        - ``total_count``: Total number of projects.
+        - ``page`` / ``page_size``: Current pagination state.
+
+    Raises:
+        PermissionError: If the authentication token is invalid or
+            lacks permissions.
+        RuntimeError: On unexpected Polarion API errors.
+    """
+    client = _get_client(ctx)
+    try:
+        response = await client.get(
+            "/projects",
+            params={
+                "page[size]": page_size,
+                "page[number]": page_number,
+            },
+        )
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot list projects -- "
+            "check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to list projects: {exc.message}"
+        ) from exc
+
+    data = response.get("data", [])
+    items: list[ProjectSummary] = []
+    if isinstance(data, list):
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            attrs = item.get("attributes", {})
+            if not isinstance(attrs, dict):
+                attrs = {}
+            items.append(
+                ProjectSummary(
+                    id=_safe_str(item.get("id", "")),
+                    name=_safe_str(attrs.get("name", "")),
+                )
+            )
+
+    return PaginatedResult[ProjectSummary](
+        items=items,
+        total_count=_extract_total_count(response),
+        page=page_number,
+        page_size=page_size,
+    )
+
+
+@mcp.tool()
+async def list_spaces(
+    ctx: Context,
+    project_id: str = Field(
+        description=(
+            "Polarion project ID (e.g. 'myproject'). "
+            "Use ``list_projects`` to discover valid IDs."
+        ),
+    ),
+    page_size: int = Field(
+        default=_DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=100,
+        description="Number of spaces per page (1-100, default 100).",
+    ),
+    page_number: int = Field(
+        default=1,
+        ge=1,
+        description="Page number to retrieve (1-based, default 1).",
+    ),
+) -> PaginatedResult[SpaceSummary]:
+    """List all spaces (folders) in a Polarion project.
+
+    Spaces are containers for documents.  Use this tool to discover Space
+    IDs before calling ``get_document`` or ``get_document_parts``.
+
+    Since ``GET /projects/{projectId}/spaces`` does not exist in the
+    target Polarion version, this tool queries work items with
+    ``fields[workitems]=module``, parses the ``relationships.module.data.id``
+    field (format: ``projectId/spaceId/documentName``) to extract unique
+    Space IDs, and returns them as ``SpaceSummary`` items.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        page_size: Number of spaces per page (1-100, default 100).
+        page_number: Page number to retrieve (1-based, default 1).
+
+    Returns:
+        PaginatedResult containing ``SpaceSummary`` items with:
+        - ``id``: Space identifier (e.g. '_default', 'Design').
+        - ``name``: Defaults to the space ID.
+        - ``total_count``: Total number of unique spaces found.
+
+    Raises:
+        ValueError: If the project ID is invalid or not found.
+        PermissionError: If the token lacks permissions.
+        RuntimeError: On unexpected Polarion API errors.
+    """
+    client = _get_client(ctx)
+    try:
+        all_items = await client.get_all_pages(
+            f"/projects/{project_id}/workitems",
+            params={"fields[workitems]": "module"},
+        )
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Project '{project_id}' not found. "
+            "Use `list_projects` to discover valid project IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot list spaces -- "
+            "check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to list spaces for project "
+            f"'{project_id}': {exc.message}"
+        ) from exc
+
+    # Parse module from relationships to extract unique space IDs.
+    # The API returns module in relationships.module.data.id with format:
+    # "{projectId}/{spaceId}/{documentName}".
+    space_ids: set[str] = set()
+    for item in all_items:
+        rels = item.get("relationships", {})
+        if not isinstance(rels, dict):
+            continue
+        module_rel = rels.get("module", {})
+        if not isinstance(module_rel, dict):
+            continue
+        mod_data = module_rel.get("data")
+        if not isinstance(mod_data, dict):
+            continue
+        mod_id = mod_data.get("id", "")
+        if isinstance(mod_id, str) and mod_id:
+            parts = mod_id.split("/")
+            # Format: "projectId/spaceId/docName" → parts[1] is spaceId
+            if len(parts) >= 3:
+                space_ids.add(parts[1])
+            elif len(parts) == 2:
+                space_ids.add(parts[1])
+
+    sorted_spaces = sorted(space_ids)
+    total = len(sorted_spaces)
+
+    # Manual pagination over the extracted set.
+    start = (page_number - 1) * page_size
+    end = start + page_size
+    page_slice = sorted_spaces[start:end]
+
+    items = [SpaceSummary(id=sid, name=sid) for sid in page_slice]
+
+    return PaginatedResult[SpaceSummary](
+        items=items,
+        total_count=total,
+        page=page_number,
+        page_size=page_size,
+    )
+
+
+@mcp.tool()
+async def get_document(
+    ctx: Context,
+    project_id: str = Field(
+        description="Polarion project ID.",
+    ),
+    space_id: str = Field(
+        description=(
+            "Space ID that contains the document (e.g. '_default'). "
+            "Use ``list_spaces`` to discover valid IDs."
+        ),
+    ),
+    document_name: str = Field(
+        description=(
+            "Document name within the space "
+            "(e.g. 'Software Requirement Specification'). "
+            "Spaces in the name are handled automatically."
+        ),
+    ),
+) -> DocumentDetail:
+    """Get full details of a Polarion document.
+
+    Retrieves the title, description, and metadata for a specific
+    document in a space.  Use ``list_spaces`` first to discover valid
+    space IDs, then call this tool with the space ID and document name.
+
+    The document description is automatically converted from HTML to
+    Markdown for easier consumption.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        space_id: Space ID containing the document.
+        document_name: Document name within the space.
+
+    Returns:
+        DocumentDetail with:
+        - ``id``: Document identifier.
+        - ``title``: Document title.
+        - ``description``: Description in Markdown.
+        - ``space_id``: Containing space.
+        - ``project_id``: Containing project.
+
+    Raises:
+        ValueError: If the document, space, or project is not found.
+        PermissionError: If the token lacks permissions.
+        RuntimeError: On unexpected Polarion API errors.
+    """
+    client = _get_client(ctx)
+    encoded_name = _encode_path_segment(document_name)
+    path = (
+        f"/projects/{project_id}"
+        f"/spaces/{_encode_path_segment(space_id)}"
+        f"/documents/{encoded_name}"
+    )
+
+    try:
+        response = await client.get(path)
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Document '{document_name}' not found in space "
+            f"'{space_id}' of project '{project_id}'. "
+            "Use `list_spaces` to verify the space ID."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot access document -- "
+            "check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to get document '{document_name}': "
+            f"{exc.message}"
+        ) from exc
+
+    data = response.get("data", {})
+    if not isinstance(data, dict):
+        data = {}
+    attrs = data.get("attributes", {})
+    if not isinstance(attrs, dict):
+        attrs = {}
+
+    # Description is always HTML:
+    # { "type": "text/html", "value": "<p>...</p>" }
+    desc_obj = attrs.get("description", {})
+    desc_html = ""
+    if isinstance(desc_obj, dict):
+        desc_html = _safe_str(desc_obj.get("value", ""))
+
+    return DocumentDetail(
+        id=_safe_str(attrs.get("id", data.get("id", ""))),
+        title=_safe_str(attrs.get("title", "")),
+        description=html_to_markdown(desc_html),
+        space_id=space_id,
+        project_id=project_id,
+    )
+
+
+@mcp.tool()
+async def get_document_parts(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(
+        description="Polarion project ID.",
+    ),
+    space_id: str = Field(
+        description="Space ID that contains the document.",
+    ),
+    document_name: str = Field(
+        description="Document name within the space.",
+    ),
+    page_size: int = Field(
+        default=_DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=100,
+        description="Number of parts per page (1-100, default 100).",
+    ),
+    page_number: int = Field(
+        default=1,
+        ge=1,
+        description="Page number to retrieve (1-based, default 1).",
+    ),
+) -> PaginatedResult[DocumentPart]:
+    """List the parts (headings and work items) of a Polarion document.
+
+    Returns the ordered list of parts that make up a document's body.
+    Each part is either a heading or a work item reference.  Use
+    ``get_document`` first to verify the document exists.
+
+    Part content (descriptions) is automatically converted from HTML to
+    Markdown.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        space_id: Space ID containing the document.
+        document_name: Document name within the space.
+        page_size: Number of parts per page (1-100, default 100).
+        page_number: Page number to retrieve (1-based, default 1).
+
+    Returns:
+        PaginatedResult containing ``DocumentPart`` items with:
+        - ``id``: Part identifier (e.g. 'heading_MCPT-001').
+        - ``title``: Part title or heading text.
+        - ``content``: Body content in Markdown.
+        - ``type``: 'heading' or 'workitem'.
+        - ``level``: Heading level (1-4) or 0 for work items.
+
+    Raises:
+        ValueError: If the document, space, or project is not found.
+        PermissionError: If the token lacks permissions.
+        RuntimeError: On unexpected Polarion API errors.
+    """
+    client = _get_client(ctx)
+    encoded_name = _encode_path_segment(document_name)
+    path = (
+        f"/projects/{project_id}"
+        f"/spaces/{_encode_path_segment(space_id)}"
+        f"/documents/{encoded_name}/parts"
+    )
+
+    try:
+        response = await client.get(
+            path,
+            params={
+                "page[size]": page_size,
+                "page[number]": page_number,
+            },
+        )
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Document '{document_name}' not found in space "
+            f"'{space_id}' of project '{project_id}'. "
+            "Use `list_spaces` to discover valid space IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot access document parts -- "
+            "check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to get parts for "
+            f"'{document_name}': {exc.message}"
+        ) from exc
+
+    data = response.get("data", [])
+    items: list[DocumentPart] = []
+    if isinstance(data, list):
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            attrs = item.get("attributes", {})
+            if not isinstance(attrs, dict):
+                attrs = {}
+            part_id = _safe_str(item.get("id", ""))
+
+            # Determine type from ID prefix.
+            part_type: str = "workitem"
+            if part_id.startswith("heading_"):
+                part_type = "heading"
+
+            # Extract heading level.
+            level = 0
+            raw_level = attrs.get("level")
+            if isinstance(raw_level, int):
+                level = raw_level
+
+            # Content/description is HTML.
+            content_obj = attrs.get(
+                "content", attrs.get("description", {}),
+            )
+            content_html = ""
+            if isinstance(content_obj, dict):
+                content_html = _safe_str(
+                    content_obj.get("value", ""),
+                )
+            elif isinstance(content_obj, str):
+                content_html = content_obj
+
+            items.append(
+                DocumentPart(
+                    id=part_id,
+                    title=_safe_str(attrs.get("title", "")),
+                    content=html_to_markdown(content_html),
+                    type=part_type,  # type: ignore[arg-type]
+                    level=level,
+                )
+            )
+
+    return PaginatedResult[DocumentPart](
+        items=items,
+        total_count=_extract_total_count(response),
+        page=page_number,
+        page_size=page_size,
+    )
+
+
+@mcp.tool()
+async def list_work_items(
+    ctx: Context,
+    project_id: str = Field(
+        description=(
+            "Polarion project ID. "
+            "Use ``list_projects`` to discover valid IDs."
+        ),
+    ),
+    page_size: int = Field(
+        default=_DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=100,
+        description="Number of work items per page (1-100, default 100).",
+    ),
+    page_number: int = Field(
+        default=1,
+        ge=1,
+        description="Page number to retrieve (1-based, default 1).",
+    ),
+) -> PaginatedResult[WorkItemSummary]:
+    """List work items in a Polarion project.
+
+    Returns a paginated list of work items with basic metadata (title,
+    type, status).  Use ``search_work_items`` to apply Lucene query
+    filters, or ``get_work_item`` for full details including the
+    description.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        page_size: Number of work items per page (1-100, default 100).
+        page_number: Page number to retrieve (1-based, default 1).
+
+    Returns:
+        PaginatedResult containing ``WorkItemSummary`` items with:
+        - ``id``: Work Item ID (e.g. 'MCPT-001').
+        - ``title``: Work Item title.
+        - ``type``: Work Item type (e.g. 'requirement').
+        - ``status``: Workflow status (e.g. 'draft').
+
+    Raises:
+        ValueError: If the project is not found.
+        PermissionError: If the token lacks permissions.
+        RuntimeError: On unexpected Polarion API errors.
+    """
+    client = _get_client(ctx)
+    try:
+        response = await client.get(
+            f"/projects/{project_id}/workitems",
+            params={
+                "fields[workitems]": _WI_LIST_FIELDS,
+                "page[size]": page_size,
+                "page[number]": page_number,
+            },
+        )
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Project '{project_id}' not found. "
+            "Use `list_projects` to discover valid project IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot list work items -- "
+            "check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to list work items: {exc.message}"
+        ) from exc
+
+    data = response.get("data", [])
+    items = _parse_work_item_summaries(data)
+
+    return PaginatedResult[WorkItemSummary](
+        items=items,
+        total_count=_extract_total_count(response),
+        page=page_number,
+        page_size=page_size,
+    )
+
+
+@mcp.tool()
+async def get_work_item(
+    ctx: Context,
+    project_id: str = Field(
+        description="Polarion project ID.",
+    ),
+    work_item_id: str = Field(
+        description=(
+            "Work Item ID (e.g. 'MCPT-001'). "
+            "Use ``list_work_items`` or ``search_work_items`` to "
+            "discover valid IDs."
+        ),
+    ),
+) -> WorkItemDetail:
+    """Get full details of a single Polarion work item.
+
+    Retrieves the complete work item including its description (converted
+    to Markdown).  Use ``list_work_items`` or ``search_work_items`` first
+    to discover valid work item IDs.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        work_item_id: Work Item ID (e.g. 'MCPT-001').
+
+    Returns:
+        WorkItemDetail with:
+        - ``id``: Work Item ID.
+        - ``title``: Work Item title.
+        - ``type``: Work Item type.
+        - ``status``: Workflow status.
+        - ``description``: Full description in Markdown.
+        - ``project_id``: Containing project.
+
+    Raises:
+        ValueError: If the work item or project is not found.
+        PermissionError: If the token lacks permissions.
+        RuntimeError: On unexpected Polarion API errors.
+    """
+    client = _get_client(ctx)
+    path = f"/projects/{project_id}/workitems/{work_item_id}"
+    try:
+        response = await client.get(
+            path,
+            params={"fields[workitems]": _WI_DETAIL_FIELDS},
+        )
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Work item '{work_item_id}' not found in project "
+            f"'{project_id}'. "
+            "Use `list_work_items` to discover valid IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot access work item -- "
+            "check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to get work item "
+            f"'{work_item_id}': {exc.message}"
+        ) from exc
+
+    data = response.get("data", {})
+    if not isinstance(data, dict):
+        data = {}
+    attrs = data.get("attributes", {})
+    if not isinstance(attrs, dict):
+        attrs = {}
+
+    # Extract description HTML.
+    desc_obj = attrs.get("description", {})
+    desc_html = ""
+    if isinstance(desc_obj, dict):
+        desc_html = _safe_str(desc_obj.get("value", ""))
+
+    # Extract work item ID from JSON:API id
+    # (format: "projectId/WI-001").
+    raw_id = _safe_str(data.get("id", ""))
+    wi_id = (
+        raw_id.split("/", maxsplit=1)[-1] if "/" in raw_id else raw_id
+    )
+
+    return WorkItemDetail(
+        id=wi_id or work_item_id,
+        title=_safe_str(attrs.get("title", "")),
+        type=_safe_str(attrs.get("type", "")),
+        status=_safe_str(attrs.get("status", "")),
+        description=html_to_markdown(desc_html),
+        project_id=project_id,
+    )
+
+
+@mcp.tool()
+async def search_work_items(
+    ctx: Context,
+    project_id: str = Field(
+        description="Polarion project ID.",
+    ),
+    query: str = Field(
+        description=(
+            "Lucene query string for filtering work items "
+            "(e.g. 'type:requirement AND status:approved'). "
+            "See Polarion documentation for query syntax."
+        ),
+    ),
+    page_size: int = Field(
+        default=_DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=100,
+        description="Number of work items per page (1-100, default 100).",
+    ),
+    page_number: int = Field(
+        default=1,
+        ge=1,
+        description="Page number to retrieve (1-based, default 1).",
+    ),
+) -> PaginatedResult[WorkItemSummary]:
+    """Search work items using a Lucene query.
+
+    Filters work items in a Polarion project using the Polarion Lucene
+    query syntax.  Common query examples:
+
+    - ``type:requirement`` -- all requirements
+    - ``status:approved AND type:requirement`` -- approved requirements
+    - ``title:Login`` -- work items with "Login" in the title
+    - ``type:testCase AND status:draft`` -- draft test cases
+
+    Use ``list_work_items`` without a query to retrieve all work items,
+    or ``get_work_item`` for full details of a specific work item.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        query: Lucene query string.
+        page_size: Number of work items per page (1-100, default 100).
+        page_number: Page number to retrieve (1-based, default 1).
+
+    Returns:
+        PaginatedResult containing ``WorkItemSummary`` items matching
+        the query, with the same fields as ``list_work_items``.
+
+    Raises:
+        ValueError: If the project is not found.
+        PermissionError: If the token lacks permissions.
+        RuntimeError: On unexpected Polarion API errors (including
+            invalid Lucene query syntax).
+    """
+    client = _get_client(ctx)
+    try:
+        response = await client.get(
+            f"/projects/{project_id}/workitems",
+            params={
+                "fields[workitems]": _WI_LIST_FIELDS,
+                "query": query,
+                "page[size]": page_size,
+                "page[number]": page_number,
+            },
+        )
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Project '{project_id}' not found. "
+            "Use `list_projects` to discover valid project IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot search work items -- "
+            "check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to search work items: {exc.message}"
+        ) from exc
+
+    data = response.get("data", [])
+    items = _parse_work_item_summaries(data)
+
+    return PaginatedResult[WorkItemSummary](
+        items=items,
+        total_count=_extract_total_count(response),
+        page=page_number,
+        page_size=page_size,
+    )
+
+
+@mcp.tool()
+async def get_linked_work_items(
+    ctx: Context,
+    project_id: str = Field(
+        description="Polarion project ID.",
+    ),
+    work_item_id: str = Field(
+        description=(
+            "Work Item ID (e.g. 'MCPT-001'). "
+            "Use ``list_work_items`` to discover valid IDs."
+        ),
+    ),
+) -> LinkedWorkItemsList:
+    """Get all linked work items (forward and back links).
+
+    Retrieves both forward (outgoing) and back (incoming) links for a
+    work item and merges them into a single result.  This provides
+    complete traceability information.
+
+    Link roles include relationships like ``parent``, ``relates_to``,
+    ``verifies``, ``depends_on``, etc.  The ``suspect`` flag indicates
+    whether the linked item has changed since the link was last reviewed.
+
+    Use ``list_work_items`` or ``search_work_items`` first to discover
+    valid work item IDs.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        work_item_id: Work Item ID (e.g. 'MCPT-001').
+
+    Returns:
+        LinkedWorkItemsList with:
+        - ``items``: All linked work items (both directions).
+        - ``forward_count``: Number of forward links.
+        - ``back_count``: Number of back links.
+
+    Raises:
+        ValueError: If the work item or project is not found.
+        PermissionError: If the token lacks permissions.
+        RuntimeError: On unexpected Polarion API errors.
+    """
+    client = _get_client(ctx)
+    base_path = (
+        f"/projects/{project_id}/workitems/{work_item_id}"
+    )
+
+    try:
+        forward_response = await client.get(
+            f"{base_path}/linkedworkitems",
+        )
+        back_response = await client.get(
+            f"{base_path}/backlinkedworkitems",
+        )
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Work item '{work_item_id}' not found in project "
+            f"'{project_id}'. "
+            "Use `list_work_items` to discover valid IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot access linked work items -- "
+            "check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to get links for "
+            f"'{work_item_id}': {exc.message}"
+        ) from exc
+
+    forward_items = _parse_linked_items(
+        forward_response, direction="forward",
+    )
+    back_items = _parse_linked_items(
+        back_response, direction="back",
+    )
+
+    all_items = forward_items + back_items
+
+    return LinkedWorkItemsList(
+        items=all_items,
+        forward_count=len(forward_items),
+        back_count=len(back_items),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_work_item_summaries(
+    data: object,
+) -> list[WorkItemSummary]:
+    """Parse a JSON:API ``data`` array into ``WorkItemSummary`` models.
+
+    Args:
+        data: The ``data`` field from a JSON:API response.
+
+    Returns:
+        List of parsed ``WorkItemSummary`` instances.
+    """
+    items: list[WorkItemSummary] = []
+    if not isinstance(data, list):
+        return items
+
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        attrs = item.get("attributes", {})
+        if not isinstance(attrs, dict):
+            attrs = {}
+
+        # Extract ID from JSON:API id
+        # (format: "projectId/WI-001").
+        raw_id = _safe_str(item.get("id", ""))
+        wi_id = (
+            raw_id.split("/", maxsplit=1)[-1]
+            if "/" in raw_id
+            else raw_id
+        )
+
+        items.append(
+            WorkItemSummary(
+                id=wi_id,
+                title=_safe_str(attrs.get("title", "")),
+                type=_safe_str(attrs.get("type", "")),
+                status=_safe_str(attrs.get("status", "")),
+            )
+        )
+    return items
+
+
+def _parse_linked_items(
+    response: dict[str, object],
+    *,
+    direction: str,
+) -> list[LinkedWorkItemSummary]:
+    """Parse linked work items from a JSON:API response.
+
+    Args:
+        response: Decoded JSON:API response from the linked items
+            endpoint.
+        direction: Link direction ('forward' or 'back').
+
+    Returns:
+        List of parsed ``LinkedWorkItemSummary`` instances.
+    """
+    items: list[LinkedWorkItemSummary] = []
+    data = response.get("data", [])
+    if not isinstance(data, list):
+        return items
+
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        attrs = item.get("attributes", {})
+        if not isinstance(attrs, dict):
+            attrs = {}
+
+        # Extract the linked work item ID.
+        raw_id = _safe_str(item.get("id", ""))
+        wi_id = (
+            raw_id.split("/", maxsplit=1)[-1]
+            if "/" in raw_id
+            else raw_id
+        )
+
+        # Parse role from attributes.
+        role = _safe_str(attrs.get("role", ""))
+
+        # Parse suspect flag.
+        suspect = bool(attrs.get("suspect", False))
+
+        items.append(
+            LinkedWorkItemSummary(
+                id=wi_id,
+                title=_safe_str(attrs.get("title", "")),
+                role=role,
+                direction=direction,  # type: ignore[arg-type]
+                suspect=suspect,
+            )
+        )
+    return items

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -9,7 +9,7 @@ relationships.  Every tool returns Pydantic models -- never raw
 from __future__ import annotations
 
 import re
-from typing import Final, Literal
+from typing import Final, Literal, cast
 from urllib.parse import quote
 
 from fastmcp import Context
@@ -41,6 +41,12 @@ _DEFAULT_PAGE_SIZE: Final[int] = 100
 # Sparse fieldset for list/search endpoints.
 _WI_LIST_FIELDS: Final[str] = "title,type,status"
 _WI_DETAIL_FIELDS: Final[str] = "title,description,type,status"
+
+# Valid document part types returned by Polarion.
+type _PartType = Literal["heading", "workitem", "normal", "toc", "wikiblock"]
+_VALID_PART_TYPES: Final[frozenset[str]] = frozenset(
+    {"heading", "workitem", "normal", "toc", "wikiblock"},
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -98,6 +104,159 @@ def _encode_path_segment(segment: str) -> str:
         URL-encoded segment safe for use in URL paths.
     """
     return quote(segment, safe="")
+
+
+def _extract_document_pair(
+    item: object,
+    documents: set[tuple[str, str]],
+) -> None:
+    """Parse ``module`` relationship from a heading work item and add the
+    (space_id, document_name) pair to *documents*.
+
+    The module relationship ``data.id`` has the format
+    ``{projectId}/{spaceId}/{documentName}``.
+
+    Args:
+        item: A single JSON:API resource object from the ``data`` array.
+        documents: Mutable set to collect unique (space, doc) pairs into.
+    """
+    mod_id = _get_module_id(item)
+    if mod_id:
+        parts = mod_id.split("/")
+        # Format: "projectId/spaceId/docName" → parts[1], parts[2:]
+        if len(parts) >= 3:  # noqa: PLR2004
+            space_id = parts[1]
+            doc_name = "/".join(parts[2:])
+            documents.add((space_id, doc_name))
+
+
+def _get_module_id(item: object) -> str:
+    """Extract the ``module`` relationship ID from a heading work item.
+
+    Args:
+        item: A single JSON:API resource object.
+
+    Returns:
+        The module ID string (e.g. ``projectId/spaceId/docName``),
+        or ``""`` if not available.
+    """
+    if not isinstance(item, dict):
+        return ""
+    rels = item.get("relationships", {})
+    if not isinstance(rels, dict):
+        return ""
+    module_rel = rels.get("module", {})
+    if not isinstance(module_rel, dict):
+        return ""
+    mod_data = module_rel.get("data")
+    if not isinstance(mod_data, dict):
+        return ""
+    mod_id = mod_data.get("id", "")
+    return str(mod_id) if isinstance(mod_id, str) else ""
+
+
+async def _discover_documents(
+    client: PolarionClient,
+    project_id: str,
+) -> set[tuple[str, str]]:
+    """Discover all unique (space_id, document_name) pairs via binary search.
+
+    Because heading work items are sorted by ``module``, all headings for the
+    same document are contiguous.  This lets us **binary search** for document
+    transition boundaries rather than scanning every page linearly.
+
+    Complexity: O(D * log(N / D)) page fetches, where D is the number of
+    unique documents and N is the total number of pages.
+
+    Args:
+        client: Active ``PolarionClient`` instance.
+        project_id: Polarion project ID.
+
+    Returns:
+        Set of (space_id, document_name) tuples.
+    """
+    base_params: dict[str, str | int] = {
+        "fields[workitems]": "module",
+        "query": "type:heading",
+        "sort": "module",
+        "page[size]": _DEFAULT_PAGE_SIZE,
+    }
+
+    async def _fetch_page(page: int) -> list[object]:
+        """Fetch a single page and return the ``data`` array."""
+        resp = await client.get(
+            f"/projects/{project_id}/workitems",
+            params={**base_params, "page[number]": page},
+        )
+        data = resp.get("data", [])
+        return data if isinstance(data, list) else []
+
+    # -- Step 1: fetch page 1 to get the total count. --------------------
+    first_resp = await client.get(
+        f"/projects/{project_id}/workitems",
+        params={**base_params, "page[number]": 1},
+    )
+    first_data = first_resp.get("data", [])
+    if not isinstance(first_data, list) or not first_data:
+        return set()
+
+    total_count = _extract_total_count(first_resp)
+    max_page = max(1, -(-total_count // _DEFAULT_PAGE_SIZE))  # ceil div
+
+    documents: set[tuple[str, str]] = set()
+    for item in first_data:
+        _extract_document_pair(item, documents)
+
+    if max_page <= 1:
+        return documents
+
+    # -- Step 2: binary search for successive document boundaries. -------
+    # ``last_module`` is the module ID of the *last* item on the most
+    # recently processed boundary page.  Because results are sorted,
+    # all items between the current position and the next transition have
+    # the same (or earlier) module.
+    last_module = _get_module_id(first_data[-1])
+    current_page = 1
+
+    while current_page < max_page:
+        # Binary-search for the first page after ``current_page`` where
+        # at least one item has a module different from ``last_module``.
+        lo, hi = current_page + 1, max_page
+        transition_page = 0
+        transition_data: list[object] = []
+
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            mid_data = await _fetch_page(mid)
+            if not mid_data:
+                hi = mid - 1
+                continue
+
+            # Collect documents from every probed page (free wins).
+            for item in mid_data:
+                _extract_document_pair(item, documents)
+
+            # Check monotonic property: does this page have any item
+            # whose module differs from ``last_module``?
+            has_new = any(
+                _get_module_id(it) != last_module for it in mid_data
+            )
+
+            if has_new:
+                transition_page = mid
+                transition_data = mid_data
+                hi = mid - 1
+            else:
+                lo = mid + 1
+
+        if transition_page == 0:
+            break  # No more transitions — all documents discovered.
+
+        # Advance to the transition page for the next iteration.
+        current_page = transition_page
+        last_module = _get_module_id(transition_data[-1])
+
+    return documents
 
 
 # ---------------------------------------------------------------------------
@@ -257,15 +416,11 @@ async def list_documents(  # noqa: PLR0913
         RuntimeError: On unexpected Polarion API errors.
     """
     client = _get_client(ctx)
+
+    # Binary-search discovery: O(D * log(N/D)) page fetches instead of
+    # O(N) linear scanning, where D = unique documents, N = total pages.
     try:
-        all_items = await client.get_all_pages(
-            f"/projects/{project_id}/workitems",
-            params={
-                "fields[workitems]": "module",
-                "query": "type:heading",
-                "sort": "module",
-            },
-        )
+        documents = await _discover_documents(client, project_id)
     except PolarionNotFoundError as exc:
         raise ValueError(
             f"Project '{project_id}' not found. "
@@ -279,29 +434,6 @@ async def list_documents(  # noqa: PLR0913
         raise RuntimeError(
             f"Failed to list documents for project '{project_id}': {exc.message}"
         ) from exc
-
-    # Parse module from relationships to extract unique (space, doc) pairs.
-    # The API returns module in relationships.module.data.id with format:
-    # "{projectId}/{spaceId}/{documentName}".
-    documents: set[tuple[str, str]] = set()
-    for item in all_items:
-        rels = item.get("relationships", {})
-        if not isinstance(rels, dict):
-            continue
-        module_rel = rels.get("module", {})
-        if not isinstance(module_rel, dict):
-            continue
-        mod_data = module_rel.get("data")
-        if not isinstance(mod_data, dict):
-            continue
-        mod_id = mod_data.get("id", "")
-        if isinstance(mod_id, str) and mod_id:
-            parts = mod_id.split("/")
-            # Format: "projectId/spaceId/docName" → parts[1], parts[2:]
-            if len(parts) >= 3:  # noqa: PLR2004
-                space_id = parts[1]
-                doc_name = "/".join(parts[2:])
-                documents.add((space_id, doc_name))
 
     # Apply filters.
     filtered: list[tuple[str, str]] = sorted(documents)
@@ -538,11 +670,11 @@ async def get_document_parts(  # noqa: PLR0913
             part_id = _safe_str(item.get("id", ""))
 
             # Use API's type attribute directly.
-            _VALID_PART_TYPES = frozenset(
-                {"heading", "workitem", "normal", "toc", "wikiblock"},
-            )
             raw_type = _safe_str(attrs.get("type", ""))
-            part_type = raw_type if raw_type in _VALID_PART_TYPES else "normal"
+            part_type: _PartType = cast(
+                _PartType,
+                raw_type if raw_type in _VALID_PART_TYPES else "normal",
+            )
 
             # Content is returned as a plain HTML string (not a dict).
             content_html = ""

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -1,7 +1,7 @@
 """Read-only MCP tools for querying Polarion ALM.
 
-Eight tools that retrieve projects, spaces, documents, work items, and
-their relationships.  Every tool returns Pydantic models -- never raw
+Seven tools that retrieve projects, documents, work items, and their
+relationships.  Every tool returns Pydantic models -- never raw
 ``dict`` -- and converts HTML descriptions to Markdown via
 ``html_to_markdown()``.
 """
@@ -23,11 +23,11 @@ from mcp_server_polarion.core.exceptions import (
 from mcp_server_polarion.models import (
     DocumentDetail,
     DocumentPart,
+    DocumentSummary,
     LinkedWorkItemsList,
     LinkedWorkItemSummary,
     PaginatedResult,
     ProjectSummary,
-    SpaceSummary,
     WorkItemDetail,
     WorkItemSummary,
 )
@@ -147,6 +147,7 @@ async def list_projects(
         response = await client.get(
             "/projects",
             params={
+                "fields[projects]": "id,name",
                 "page[size]": page_size,
                 "page[number]": page_number,
             },
@@ -183,7 +184,7 @@ async def list_projects(
 
 
 @mcp.tool()
-async def list_spaces(
+async def list_documents(  # noqa: PLR0913
     ctx: Context,
     project_id: str = Field(
         description=(
@@ -191,40 +192,63 @@ async def list_spaces(
             "Use ``list_projects`` to discover valid IDs."
         ),
     ),
+    name_filter: str | None = Field(
+        default=None,
+        description=(
+            "Optional substring filter for document names "
+            "(case-insensitive, client-side). "
+            "E.g. 'SRS' matches 'Software Requirement Specification'."
+        ),
+    ),
+    space_filter: str | None = Field(
+        default=None,
+        description=(
+            "Optional exact-match filter for Space ID "
+            "(e.g. '_default', 'Design'). Only returns documents "
+            "in the specified space."
+        ),
+    ),
     page_size: int = Field(
         default=_DEFAULT_PAGE_SIZE,
         ge=1,
         le=100,
-        description="Number of spaces per page (1-100, default 100).",
+        description="Number of documents per page (1-100, default 100).",
     ),
     page_number: int = Field(
         default=1,
         ge=1,
         description="Page number to retrieve (1-based, default 1).",
     ),
-) -> PaginatedResult[SpaceSummary]:
-    """List all spaces (folders) in a Polarion project.
+) -> PaginatedResult[DocumentSummary]:
+    """List all documents in a Polarion project.
 
-    Spaces are containers for documents.  Use this tool to discover Space
-    IDs before calling ``get_document`` or ``get_document_parts``.
+    Returns space IDs and document names so the LLM can call
+    ``get_document`` or ``get_document_parts`` with the correct
+    parameters.
 
-    Since ``GET /projects/{projectId}/spaces`` does not exist in the
-    target Polarion version, this tool queries work items with
-    ``fields[workitems]=module``, parses the ``relationships.module.data.id``
-    field (format: ``projectId/spaceId/documentName``) to extract unique
-    Space IDs, and returns them as ``SpaceSummary`` items.
+    Since ``GET /projects/{projectId}/documents`` is not available on
+    the target Polarion version, this tool queries heading-type work
+    items with ``fields[workitems]=module`` and ``query=type:heading``
+    to extract unique (space_id, document_name) pairs from the
+    ``relationships.module.data.id`` field (format:
+    ``projectId/spaceId/documentName``).
+
+    Use ``name_filter`` for client-side substring matching on document
+    names, or ``space_filter`` to restrict results to a specific space.
 
     Args:
         ctx: MCP tool context (injected automatically).
         project_id: Polarion project ID.
-        page_size: Number of spaces per page (1-100, default 100).
+        name_filter: Optional substring filter for document names.
+        space_filter: Optional exact Space ID filter.
+        page_size: Number of documents per page (1-100, default 100).
         page_number: Page number to retrieve (1-based, default 1).
 
     Returns:
-        PaginatedResult containing ``SpaceSummary`` items with:
-        - ``id``: Space identifier (e.g. '_default', 'Design').
-        - ``name``: Defaults to the space ID.
-        - ``total_count``: Total number of unique spaces found.
+        PaginatedResult containing ``DocumentSummary`` items with:
+        - ``space_id``: Space that contains the document.
+        - ``document_name``: Document name within the space.
+        - ``total_count``: Total number of documents found.
 
     Raises:
         ValueError: If the project ID is invalid or not found.
@@ -235,7 +259,11 @@ async def list_spaces(
     try:
         all_items = await client.get_all_pages(
             f"/projects/{project_id}/workitems",
-            params={"fields[workitems]": "module"},
+            params={
+                "fields[workitems]": "module",
+                "query": "type:heading",
+                "sort": "module",
+            },
         )
     except PolarionNotFoundError as exc:
         raise ValueError(
@@ -244,17 +272,17 @@ async def list_spaces(
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot list spaces -- check your POLARION_TOKEN permissions."
+            "Cannot list documents -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionError as exc:
         raise RuntimeError(
-            f"Failed to list spaces for project '{project_id}': {exc.message}"
+            f"Failed to list documents for project '{project_id}': {exc.message}"
         ) from exc
 
-    # Parse module from relationships to extract unique space IDs.
+    # Parse module from relationships to extract unique (space, doc) pairs.
     # The API returns module in relationships.module.data.id with format:
     # "{projectId}/{spaceId}/{documentName}".
-    space_ids: set[str] = set()
+    documents: set[tuple[str, str]] = set()
     for item in all_items:
         rels = item.get("relationships", {})
         if not isinstance(rels, dict):
@@ -268,21 +296,37 @@ async def list_spaces(
         mod_id = mod_data.get("id", "")
         if isinstance(mod_id, str) and mod_id:
             parts = mod_id.split("/")
-            # Format: "projectId/spaceId/docName" → parts[1] is spaceId
-            if len(parts) >= 2:  # noqa: PLR2004
-                space_ids.add(parts[1])
+            # Format: "projectId/spaceId/docName" → parts[1], parts[2:]
+            if len(parts) >= 3:  # noqa: PLR2004
+                space_id = parts[1]
+                doc_name = "/".join(parts[2:])
+                documents.add((space_id, doc_name))
 
-    sorted_spaces = sorted(space_ids)
-    total = len(sorted_spaces)
+    # Apply filters.
+    filtered: list[tuple[str, str]] = sorted(documents)
+    if space_filter is not None:
+        filtered = [
+            (s, d) for s, d in filtered if s == space_filter
+        ]
+    if name_filter is not None:
+        name_lower = name_filter.lower()
+        filtered = [
+            (s, d) for s, d in filtered if name_lower in d.lower()
+        ]
+
+    total = len(filtered)
 
     # Manual pagination over the extracted set.
     start = (page_number - 1) * page_size
     end = start + page_size
-    page_slice = sorted_spaces[start:end]
+    page_slice = filtered[start:end]
 
-    items = [SpaceSummary(id=sid, name=sid) for sid in page_slice]
+    items = [
+        DocumentSummary(space_id=s, document_name=d)
+        for s, d in page_slice
+    ]
 
-    return PaginatedResult[SpaceSummary](
+    return PaginatedResult[DocumentSummary](
         items=items,
         total_count=total,
         page=page_number,
@@ -299,7 +343,7 @@ async def get_document(
     space_id: str = Field(
         description=(
             "Space ID that contains the document (e.g. '_default'). "
-            "Use ``list_spaces`` to discover valid IDs."
+            "Use ``list_documents`` to discover valid IDs."
         ),
     ),
     document_name: str = Field(
@@ -312,11 +356,11 @@ async def get_document(
 ) -> DocumentDetail:
     """Get full details of a Polarion document.
 
-    Retrieves the title, description, and metadata for a specific
-    document in a space.  Use ``list_spaces`` first to discover valid
-    space IDs, then call this tool with the space ID and document name.
+    Retrieves the title, full content (homePageContent), and metadata
+    for a specific document in a space.  Use ``list_documents`` first
+    to discover valid space IDs and document names.
 
-    The document description is automatically converted from HTML to
+    The document content is automatically converted from HTML to
     Markdown for easier consumption.
 
     Args:
@@ -329,7 +373,7 @@ async def get_document(
         DocumentDetail with:
         - ``id``: Document identifier.
         - ``title``: Document title.
-        - ``description``: Description in Markdown.
+        - ``content``: Full document content in Markdown.
         - ``space_id``: Containing space.
         - ``project_id``: Containing project.
 
@@ -347,12 +391,15 @@ async def get_document(
     )
 
     try:
-        response = await client.get(path)
+        response = await client.get(
+            path,
+            params={"fields[documents]": "title,homePageContent"},
+        )
     except PolarionNotFoundError as exc:
         raise ValueError(
             f"Document '{document_name}' not found in space "
             f"'{space_id}' of project '{project_id}'. "
-            "Use `list_spaces` to verify the space ID."
+            "Use `list_documents` to verify the space ID and document name."
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
@@ -370,17 +417,17 @@ async def get_document(
     if not isinstance(attrs, dict):
         attrs = {}
 
-    # Description is always HTML:
+    # homePageContent is always HTML:
     # { "type": "text/html", "value": "<p>...</p>" }
-    desc_obj = attrs.get("description", {})
-    desc_html = ""
-    if isinstance(desc_obj, dict):
-        desc_html = _safe_str(desc_obj.get("value", ""))
+    content_obj = attrs.get("homePageContent", {})
+    content_html = ""
+    if isinstance(content_obj, dict):
+        content_html = _safe_str(content_obj.get("value", ""))
 
     return DocumentDetail(
         id=_safe_str(attrs.get("id", data.get("id", ""))),
         title=_safe_str(attrs.get("title", "")),
-        description=html_to_markdown(desc_html),
+        content=html_to_markdown(content_html),
         space_id=space_id,
         project_id=project_id,
     )
@@ -393,7 +440,10 @@ async def get_document_parts(  # noqa: PLR0913
         description="Polarion project ID.",
     ),
     space_id: str = Field(
-        description="Space ID that contains the document.",
+        description=(
+            "Space ID that contains the document. "
+            "Use ``list_documents`` to discover valid IDs."
+        ),
     ),
     document_name: str = Field(
         description="Document name within the space.",
@@ -460,7 +510,7 @@ async def get_document_parts(  # noqa: PLR0913
         raise ValueError(
             f"Document '{document_name}' not found in space "
             f"'{space_id}' of project '{project_id}'. "
-            "Use `list_spaces` to discover valid space IDs."
+            "Use `list_documents` to discover valid space IDs and document names."
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(
@@ -532,6 +582,18 @@ async def list_work_items(
             "Polarion project ID. Use ``list_projects`` to discover valid IDs."
         ),
     ),
+    query: str | None = Field(
+        default=None,
+        description=(
+            "Optional Lucene query string for filtering work items. "
+            "Examples: 'type:requirement', "
+            "'status:approved AND type:requirement', "
+            "'title:SRS*' (trailing wildcard only — leading wildcards "
+            "like '*SRS*' cause 400 errors). "
+            "The ``module`` field is NOT indexed and cannot be queried. "
+            "Omit to list all work items without filtering."
+        ),
+    ),
     page_size: int = Field(
         default=_DEFAULT_PAGE_SIZE,
         ge=1,
@@ -544,16 +606,26 @@ async def list_work_items(
         description="Page number to retrieve (1-based, default 1).",
     ),
 ) -> PaginatedResult[WorkItemSummary]:
-    """List work items in a Polarion project.
+    """List and search work items in a Polarion project.
 
     Returns a paginated list of work items with basic metadata (title,
-    type, status).  Use ``search_work_items`` to apply Lucene query
-    filters, or ``get_work_item`` for full details including the
-    description.
+    type, status).  Pass a Lucene ``query`` to filter results, or omit
+    it to list all work items.
+
+    Common Lucene query examples:
+
+    - ``type:requirement`` — all requirements
+    - ``status:approved AND type:requirement`` — approved requirements
+    - ``title:Login`` — work items with "Login" in the title
+    - ``title:SRS*`` — trailing wildcard (leading wildcards not supported)
+    - ``type:testCase AND status:draft`` — draft test cases
+
+    Use ``get_work_item`` for full details including the description.
 
     Args:
         ctx: MCP tool context (injected automatically).
         project_id: Polarion project ID.
+        query: Optional Lucene query string for filtering.
         page_size: Number of work items per page (1-100, default 100).
         page_number: Page number to retrieve (1-based, default 1).
 
@@ -567,17 +639,21 @@ async def list_work_items(
     Raises:
         ValueError: If the project is not found.
         PermissionError: If the token lacks permissions.
-        RuntimeError: On unexpected Polarion API errors.
+        RuntimeError: On unexpected Polarion API errors (including
+            invalid Lucene query syntax).
     """
     client = _get_client(ctx)
+    params: dict[str, str | int] = {
+        "fields[workitems]": _WI_LIST_FIELDS,
+        "page[size]": page_size,
+        "page[number]": page_number,
+    }
+    if query is not None:
+        params["query"] = query
     try:
         response = await client.get(
             f"/projects/{project_id}/workitems",
-            params={
-                "fields[workitems]": _WI_LIST_FIELDS,
-                "page[size]": page_size,
-                "page[number]": page_number,
-            },
+            params=params,
         )
     except PolarionNotFoundError as exc:
         raise ValueError(
@@ -611,16 +687,15 @@ async def get_work_item(
     work_item_id: str = Field(
         description=(
             "Work Item ID (e.g. 'MCPT-001'). "
-            "Use ``list_work_items`` or ``search_work_items`` to "
-            "discover valid IDs."
+            "Use ``list_work_items`` to discover valid IDs."
         ),
     ),
 ) -> WorkItemDetail:
     """Get full details of a single Polarion work item.
 
     Retrieves the complete work item including its description (converted
-    to Markdown).  Use ``list_work_items`` or ``search_work_items`` first
-    to discover valid work item IDs.
+    to Markdown).  Use ``list_work_items`` first to discover valid work
+    item IDs.
 
     Args:
         ctx: MCP tool context (injected automatically).
@@ -692,95 +767,6 @@ async def get_work_item(
 
 
 @mcp.tool()
-async def search_work_items(
-    ctx: Context,
-    project_id: str = Field(
-        description="Polarion project ID.",
-    ),
-    query: str = Field(
-        description=(
-            "Lucene query string for filtering work items "
-            "(e.g. 'type:requirement AND status:approved'). "
-            "See Polarion documentation for query syntax."
-        ),
-    ),
-    page_size: int = Field(
-        default=_DEFAULT_PAGE_SIZE,
-        ge=1,
-        le=100,
-        description="Number of work items per page (1-100, default 100).",
-    ),
-    page_number: int = Field(
-        default=1,
-        ge=1,
-        description="Page number to retrieve (1-based, default 1).",
-    ),
-) -> PaginatedResult[WorkItemSummary]:
-    """Search work items using a Lucene query.
-
-    Filters work items in a Polarion project using the Polarion Lucene
-    query syntax.  Common query examples:
-
-    - ``type:requirement`` -- all requirements
-    - ``status:approved AND type:requirement`` -- approved requirements
-    - ``title:Login`` -- work items with "Login" in the title
-    - ``type:testCase AND status:draft`` -- draft test cases
-
-    Use ``list_work_items`` without a query to retrieve all work items,
-    or ``get_work_item`` for full details of a specific work item.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        query: Lucene query string.
-        page_size: Number of work items per page (1-100, default 100).
-        page_number: Page number to retrieve (1-based, default 1).
-
-    Returns:
-        PaginatedResult containing ``WorkItemSummary`` items matching
-        the query, with the same fields as ``list_work_items``.
-
-    Raises:
-        ValueError: If the project is not found.
-        PermissionError: If the token lacks permissions.
-        RuntimeError: On unexpected Polarion API errors (including
-            invalid Lucene query syntax).
-    """
-    client = _get_client(ctx)
-    try:
-        response = await client.get(
-            f"/projects/{project_id}/workitems",
-            params={
-                "fields[workitems]": _WI_LIST_FIELDS,
-                "query": query,
-                "page[size]": page_size,
-                "page[number]": page_number,
-            },
-        )
-    except PolarionNotFoundError as exc:
-        raise ValueError(
-            f"Project '{project_id}' not found. "
-            "Use `list_projects` to discover valid project IDs."
-        ) from exc
-    except PolarionAuthError as exc:
-        raise PermissionError(
-            "Cannot search work items -- check your POLARION_TOKEN permissions."
-        ) from exc
-    except PolarionError as exc:
-        raise RuntimeError(f"Failed to search work items: {exc.message}") from exc
-
-    data = response.get("data", [])
-    items = _parse_work_item_summaries(data)
-
-    return PaginatedResult[WorkItemSummary](
-        items=items,
-        total_count=_extract_total_count(response),
-        page=page_number,
-        page_size=page_size,
-    )
-
-
-@mcp.tool()
 async def get_linked_work_items(
     ctx: Context,
     project_id: str = Field(
@@ -803,8 +789,7 @@ async def get_linked_work_items(
     ``verifies``, ``depends_on``, etc.  The ``suspect`` flag indicates
     whether the linked item has changed since the link was last reviewed.
 
-    Use ``list_work_items`` or ``search_work_items`` first to discover
-    valid work item IDs.
+    Use ``list_work_items`` first to discover valid work item IDs.
 
     Args:
         ctx: MCP tool context (injected automatically).

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -238,9 +238,7 @@ async def _discover_documents(
 
             # Check monotonic property: does this page have any item
             # whose module differs from ``last_module``?
-            has_new = any(
-                _get_module_id(it) != last_module for it in mid_data
-            )
+            has_new = any(_get_module_id(it) != last_module for it in mid_data)
 
             if has_new:
                 transition_page = mid
@@ -392,6 +390,12 @@ async def list_documents(  # noqa: PLR0913
     to extract unique (space_id, document_name) pairs from the
     ``relationships.module.data.id`` field (format:
     ``projectId/spaceId/documentName``).
+
+    **Performance note:** This tool discovers documents by scanning
+    heading work items across multiple API pages and applying
+    client-side filtering.  For projects with many work items this
+    may be expensive; ``page_number`` controls the result window but
+    does not reduce the number of API calls.
 
     Use ``name_filter`` for client-side substring matching on document
     names, or ``space_filter`` to restrict results to a specific space.

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -8,6 +8,7 @@ relationships.  Every tool returns Pydantic models -- never raw
 
 from __future__ import annotations
 
+import re
 from typing import Final, Literal
 from urllib.parse import quote
 
@@ -349,12 +350,19 @@ async def get_document(
 ) -> DocumentDetail:
     """Get full details of a Polarion document.
 
-    Retrieves the title, full content (homePageContent), and metadata
-    for a specific document in a space.  Use ``list_documents`` first
-    to discover valid space IDs and document names.
+    Retrieves the title, **complete body content**, and metadata for a
+    specific document in a space.  The returned ``content`` field
+    contains the entire document text (all sections, headings, and
+    descriptions) — it is NOT a summary or excerpt.
 
-    The document content is automatically converted from HTML to
-    Markdown for easier consumption.
+    **This tool alone is sufficient for reading, summarising, or
+    analysing a document.**  There is no need to call
+    ``get_document_parts`` afterward unless you specifically need the
+    structural part IDs (e.g. for ``create_document_part`` positioning).
+
+    Use ``list_documents`` first to discover valid space IDs and
+    document names.  The content is automatically converted from HTML
+    to Markdown for easier consumption.
 
     Args:
         ctx: MCP tool context (injected automatically).
@@ -366,7 +374,7 @@ async def get_document(
         DocumentDetail with:
         - ``id``: Document identifier.
         - ``title``: Document title.
-        - ``content``: Full document content in Markdown.
+        - ``content``: Complete document body in Markdown (not a summary).
         - ``space_id``: Containing space.
         - ``project_id``: Containing project.
 
@@ -453,14 +461,17 @@ async def get_document_parts(  # noqa: PLR0913
         description="Page number to retrieve (1-based, default 1).",
     ),
 ) -> PaginatedResult[DocumentPart]:
-    """List the parts (headings and work items) of a Polarion document.
+    """List the structural parts (headings and work items) of a document.
 
-    Returns the ordered list of parts that make up a document's body.
-    Each part is either a heading or a work item reference.  Use
-    ``get_document`` first to verify the document exists.
+    Returns the ordered list of part IDs, titles, and types that make
+    up a document's body.  Use this tool **only** when you need:
 
-    Part content (descriptions) is automatically converted from HTML to
-    Markdown.
+    - Part IDs for positioning with ``create_document_part``
+      (``next_part_id`` / ``previous_part_id``).
+    - The hierarchical structure (heading levels) of the document.
+
+    **Do NOT call this tool just to read or summarise a document.**
+    ``get_document`` already returns the complete document body.
 
     Args:
         ctx: MCP tool context (injected automatically).
@@ -495,6 +506,7 @@ async def get_document_parts(  # noqa: PLR0913
         response = await client.get(
             path,
             params={
+                "fields[document_parts]": "content,type",
                 "page[size]": page_size,
                 "page[number]": page_number,
             },
@@ -525,29 +537,31 @@ async def get_document_parts(  # noqa: PLR0913
                 attrs = {}
             part_id = _safe_str(item.get("id", ""))
 
-            # Determine type from ID prefix.
-            part_type: Literal["heading", "workitem"] = "workitem"
-            if part_id.startswith("heading_"):
-                part_type = "heading"
-
-            # Extract heading level.
-            level = 0
-            raw_level = attrs.get("level")
-            if isinstance(raw_level, int):
-                level = raw_level
-
-            # Content/description is HTML.
-            content_obj = attrs.get(
-                "content",
-                attrs.get("description", {}),
+            # Use API's type attribute directly.
+            _VALID_PART_TYPES = frozenset(
+                {"heading", "workitem", "normal", "toc", "wikiblock"},
             )
+            raw_type = _safe_str(attrs.get("type", ""))
+            part_type = raw_type if raw_type in _VALID_PART_TYPES else "normal"
+
+            # Content is returned as a plain HTML string (not a dict).
             content_html = ""
+            content_obj = attrs.get("content")
             if isinstance(content_obj, dict):
-                content_html = _safe_str(
-                    content_obj.get("value", ""),
-                )
+                content_html = _safe_str(content_obj.get("value", ""))
             elif isinstance(content_obj, str):
                 content_html = content_obj
+
+            # Extract heading level from HTML tag (e.g. <h2 …> → 2).
+            level = 0
+            if part_type == "heading":
+                heading_match = re.match(
+                    r"<h(\d)",
+                    content_html,
+                    re.IGNORECASE,
+                )
+                if heading_match:
+                    level = int(heading_match.group(1))
 
             items.append(
                 DocumentPart(

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -8,8 +8,7 @@ their relationships.  Every tool returns Pydantic models -- never raw
 
 from __future__ import annotations
 
-import logging
-from typing import Final
+from typing import Final, Literal
 from urllib.parse import quote
 
 from fastmcp import Context
@@ -34,8 +33,6 @@ from mcp_server_polarion.models import (
 )
 from mcp_server_polarion.server import mcp
 from mcp_server_polarion.utils import html_to_markdown
-
-logger: Final = logging.getLogger("mcp_server_polarion.tools.read")
 
 # Default page size -- Polarion caps at 100.
 _DEFAULT_PAGE_SIZE: Final[int] = 100
@@ -486,7 +483,7 @@ async def get_document_parts(  # noqa: PLR0913
             part_id = _safe_str(item.get("id", ""))
 
             # Determine type from ID prefix.
-            part_type: str = "workitem"
+            part_type: Literal["heading", "workitem"] = "workitem"
             if part_id.startswith("heading_"):
                 part_type = "heading"
 
@@ -514,7 +511,7 @@ async def get_document_parts(  # noqa: PLR0913
                     id=part_id,
                     title=_safe_str(attrs.get("title", "")),
                     content=html_to_markdown(content_html),
-                    type=part_type,  # type: ignore[arg-type]
+                    type=part_type,
                     level=level,
                 )
             )
@@ -914,7 +911,7 @@ def _parse_work_item_summaries(
 def _parse_linked_items(
     response: dict[str, object],
     *,
-    direction: str,
+    direction: Literal["forward", "back"],
 ) -> list[LinkedWorkItemSummary]:
     """Parse linked work items from a JSON:API response.
 
@@ -953,7 +950,7 @@ def _parse_linked_items(
                 id=wi_id,
                 title=_safe_str(attrs.get("title", "")),
                 role=role,
-                direction=direction,  # type: ignore[arg-type]
+                direction=direction,
                 suspect=suspect,
             )
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,12 +10,12 @@ from mcp_server_polarion.models import (
     DocumentDetail,
     DocumentPart,
     DocumentPartCreateResult,
+    DocumentSummary,
     LinkedWorkItemsList,
     LinkedWorkItemSummary,
     LinkResult,
     PaginatedResult,
     ProjectSummary,
-    SpaceSummary,
     WorkItemCreateResult,
     WorkItemDetail,
     WorkItemSummary,
@@ -111,18 +111,22 @@ class TestProjectSummary:
 
 
 # ---------------------------------------------------------------------------
-# SpaceSummary
+# DocumentSummary
 # ---------------------------------------------------------------------------
 
 
-class TestSpaceSummary:
+class TestDocumentSummary:
     def test_valid(self):
-        s = SpaceSummary(id="_default", name="_default")
-        assert s.id == "_default"
+        d = DocumentSummary(space_id="_default", document_name="SRS")
+        assert d.space_id == "_default"
+        assert d.document_name == "SRS"
 
-    def test_custom_name(self):
-        s = SpaceSummary(id="Design", name="Design Space")
-        assert s.name == "Design Space"
+    def test_custom_document_name(self):
+        d = DocumentSummary(
+            space_id="Design",
+            document_name="Software Requirement Specification",
+        )
+        assert d.document_name == "Software Requirement Specification"
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +139,7 @@ class TestDocumentDetail:
         d = DocumentDetail(
             id="SRS",
             title="Software Requirement Specification",
-            description="## Overview\n\nSystem requirements.",
+            content="## Overview\n\nSystem requirements.",
             space_id="_default",
             project_id="myproject",
         )
@@ -143,15 +147,15 @@ class TestDocumentDetail:
         assert d.title == "Software Requirement Specification"
         assert d.space_id == "_default"
 
-    def test_empty_description(self):
+    def test_empty_content(self):
         d = DocumentDetail(
             id="doc1",
             title="Empty Doc",
-            description="",
+            content="",
             space_id="space1",
             project_id="proj1",
         )
-        assert d.description == ""
+        assert d.content == ""
 
     def test_missing_required_field(self):
         with pytest.raises(ValidationError):
@@ -603,7 +607,7 @@ class TestCrossModelIntegration:
         """Every field in every model must have a description for LLM docs."""
         models = [
             ProjectSummary,
-            SpaceSummary,
+            DocumentSummary,
             DocumentDetail,
             DocumentPart,
             WorkItemSummary,

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -1,0 +1,1018 @@
+"""Tests for the 8 read-only MCP tools.
+
+Each tool is tested by calling the async function directly with a mock
+``PolarionClient`` injected via a mock ``Context``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mcp_server_polarion.core.client import PolarionClient
+from mcp_server_polarion.core.exceptions import (
+    PolarionAuthError,
+    PolarionError,
+    PolarionNotFoundError,
+)
+from mcp_server_polarion.models import (
+    DocumentDetail,
+    DocumentPart,
+    LinkedWorkItemsList,
+    PaginatedResult,
+    ProjectSummary,
+    WorkItemDetail,
+)
+from mcp_server_polarion.tools import read as _read_mod
+
+# Extract the underlying async functions from FunctionTool wrappers
+# so they can be called directly in tests.
+get_document = _read_mod.get_document.fn
+get_document_parts = _read_mod.get_document_parts.fn
+get_linked_work_items = _read_mod.get_linked_work_items.fn
+get_work_item = _read_mod.get_work_item.fn
+list_projects = _read_mod.list_projects.fn
+list_spaces = _read_mod.list_spaces.fn
+list_work_items = _read_mod.list_work_items.fn
+search_work_items = _read_mod.search_work_items.fn
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client() -> AsyncMock:
+    """Return a mock PolarionClient with async methods."""
+    client = AsyncMock(spec=PolarionClient)
+    client.get = AsyncMock()
+    client.get_all_pages = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def mock_ctx(mock_client: AsyncMock) -> MagicMock:
+    """Return a mock FastMCP Context with the mock client."""
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {
+        "polarion_client": mock_client,
+    }
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# list_projects
+# ---------------------------------------------------------------------------
+
+
+class TestListProjects:
+    """Tests for the ``list_projects`` tool."""
+
+    async def test_returns_projects(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "projects",
+                    "id": "proj1",
+                    "attributes": {"name": "Project One"},
+                },
+                {
+                    "type": "projects",
+                    "id": "proj2",
+                    "attributes": {"name": "Project Two"},
+                },
+            ],
+            "meta": {"totalCount": 2},
+        }
+
+        result = await list_projects(
+            mock_ctx, page_size=100, page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert len(result.items) == 2
+        assert result.total_count == 2
+        assert result.page == 1
+        assert result.page_size == 100
+        p1 = ProjectSummary(id="proj1", name="Project One")
+        assert result.items[0] == p1
+        p2 = ProjectSummary(id="proj2", name="Project Two")
+        assert result.items[1] == p2
+
+    async def test_empty_projects(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        result = await list_projects(
+            mock_ctx, page_size=100, page_number=1,
+        )
+
+        assert result.items == []
+        assert result.total_count == 0
+
+    async def test_pagination_params(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await list_projects(
+            mock_ctx, page_size=10, page_number=3,
+        )
+
+        mock_client.get.assert_called_once_with(
+            "/projects",
+            params={"page[size]": 10, "page[number]": 3},
+        )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError(
+            "Unauthorized", status_code=401,
+        )
+
+        with pytest.raises(PermissionError, match="POLARION_TOKEN"):
+            await list_projects(
+                mock_ctx, page_size=100, page_number=1,
+            )
+
+    async def test_generic_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError(
+            "Server error", status_code=500,
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to list"):
+            await list_projects(
+                mock_ctx, page_size=100, page_number=1,
+            )
+
+    async def test_missing_meta_returns_zero_total(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": []}
+
+        result = await list_projects(
+            mock_ctx, page_size=100, page_number=1,
+        )
+
+        assert result.total_count == 0
+
+
+# ---------------------------------------------------------------------------
+# list_spaces
+# ---------------------------------------------------------------------------
+
+
+class TestListSpaces:
+    """Tests for the ``list_spaces`` tool."""
+
+    async def test_extracts_spaces_from_modules(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_all_pages.return_value = [
+            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/_default/Doc1"}}}},
+            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/_default/Doc2"}}}},
+            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Design/SRS"}}}},
+            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Design/SDD"}}}},
+            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Testing/TestPlan"}}}},
+        ]
+
+        result = await list_spaces(
+            mock_ctx, project_id="proj1",
+            page_size=100, page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert result.total_count == 3
+        ids = [s.id for s in result.items]
+        assert sorted(ids) == ["Design", "Testing", "_default"]
+
+    async def test_deduplicates_spaces(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_all_pages.return_value = [
+            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Space1/DocA"}}}},
+            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Space1/DocB"}}}},
+            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Space1/DocC"}}}},
+        ]
+
+        result = await list_spaces(
+            mock_ctx, project_id="proj1",
+            page_size=100, page_number=1,
+        )
+
+        assert result.total_count == 1
+        assert result.items[0].id == "Space1"
+
+    async def test_pagination_slicing(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_all_pages.return_value = [
+            {"relationships": {"module": {"data": {"type": "documents", "id": f"proj1/Space{i}/Doc"}}}}
+            for i in range(5)
+        ]
+
+        result = await list_spaces(
+            mock_ctx, project_id="proj1",
+            page_size=2, page_number=2,
+        )
+
+        assert result.total_count == 5
+        assert len(result.items) == 2
+        assert result.page == 2
+
+    async def test_empty_modules(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_all_pages.return_value = [
+            {"relationships": {"module": {"data": None}}},
+            {"relationships": {}},
+            {"relationships": {"module": {}}},
+        ]
+
+        result = await list_spaces(
+            mock_ctx, project_id="proj1",
+            page_size=100, page_number=1,
+        )
+
+        assert result.total_count == 0
+        assert result.items == []
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_all_pages.side_effect = (
+            PolarionNotFoundError("Not found", status_code=404)
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await list_spaces(
+                mock_ctx, project_id="missing",
+                page_size=100, page_number=1,
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_all_pages.side_effect = (
+            PolarionAuthError("Forbidden", status_code=403)
+        )
+
+        with pytest.raises(PermissionError, match="POLARION_TOKEN"):
+            await list_spaces(
+                mock_ctx, project_id="proj1",
+                page_size=100, page_number=1,
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_document
+# ---------------------------------------------------------------------------
+
+
+class TestGetDocument:
+    """Tests for the ``get_document`` tool."""
+
+    async def test_returns_document_detail(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "type": "documents",
+                "id": "proj1/_default/SRS",
+                "attributes": {
+                    "id": "SRS",
+                    "title": "Software Requirement Spec",
+                    "description": {
+                        "type": "text/html",
+                        "value": (
+                            "<p>This is the "
+                            "<strong>SRS</strong> document.</p>"
+                        ),
+                    },
+                },
+            },
+        }
+
+        result = await get_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="SRS",
+        )
+
+        assert isinstance(result, DocumentDetail)
+        assert result.id == "SRS"
+        assert result.title == "Software Requirement Spec"
+        assert "SRS" in result.description
+        assert "<p>" not in result.description
+        assert result.space_id == "_default"
+        assert result.project_id == "proj1"
+
+    async def test_encodes_document_name_with_spaces(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "attributes": {"title": "Test", "id": "Test Doc"},
+            },
+        }
+
+        await get_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="Software Requirement Specification",
+        )
+
+        call_path = mock_client.get.call_args[0][0]
+        assert "Software%20Requirement%20Specification" in call_path
+
+    async def test_empty_description(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "attributes": {
+                    "id": "EmptyDoc",
+                    "title": "Empty",
+                    "description": {
+                        "type": "text/html",
+                        "value": "",
+                    },
+                },
+            },
+        }
+
+        result = await get_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="EmptyDoc",
+        )
+
+        assert result.description == ""
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await get_document(
+                mock_ctx,
+                project_id="proj1",
+                space_id="_default",
+                document_name="Missing",
+            )
+
+    async def test_no_description_field(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "attributes": {
+                    "id": "NoDesc",
+                    "title": "No Description",
+                },
+            },
+        }
+
+        result = await get_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="NoDesc",
+        )
+
+        assert result.description == ""
+
+
+# ---------------------------------------------------------------------------
+# get_document_parts
+# ---------------------------------------------------------------------------
+
+
+class TestGetDocumentParts:
+    """Tests for the ``get_document_parts`` tool."""
+
+    async def test_returns_document_parts(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "document_parts",
+                    "id": "heading_MCPT-001",
+                    "attributes": {
+                        "title": "Introduction",
+                        "level": 1,
+                        "content": {
+                            "type": "text/html",
+                            "value": "<p>This is the intro.</p>",
+                        },
+                    },
+                },
+                {
+                    "type": "document_parts",
+                    "id": "workitem_MCPT-002",
+                    "attributes": {
+                        "title": "Login Feature",
+                        "level": 0,
+                        "content": {
+                            "type": "text/html",
+                            "value": "<p>Login requirement.</p>",
+                        },
+                    },
+                },
+            ],
+            "meta": {"totalCount": 2},
+        }
+
+        result = await get_document_parts(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="SRS",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert len(result.items) == 2
+        assert result.total_count == 2
+
+        heading = result.items[0]
+        assert isinstance(heading, DocumentPart)
+        assert heading.id == "heading_MCPT-001"
+        assert heading.title == "Introduction"
+        assert heading.type == "heading"
+        assert heading.level == 1
+        assert "<p>" not in heading.content
+
+        wi_part = result.items[1]
+        assert wi_part.id == "workitem_MCPT-002"
+        assert wi_part.type == "workitem"
+        assert wi_part.level == 0
+
+    async def test_pagination_params_forwarded(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await get_document_parts(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="Doc",
+            page_size=10,
+            page_number=2,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["page[size]"] == 10
+        assert kwargs["params"]["page[number]"] == 2
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await get_document_parts(
+                mock_ctx,
+                project_id="proj1",
+                space_id="_default",
+                document_name="Missing",
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_string_content_field(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Plain string content (not dict) is handled."""
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "id": "heading_MCPT-003",
+                    "attributes": {
+                        "title": "Heading",
+                        "level": 2,
+                        "content": "<p>Plain string content.</p>",
+                    },
+                },
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await get_document_parts(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="Doc",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert len(result.items) == 1
+        assert "Plain string content" in result.items[0].content
+
+
+# ---------------------------------------------------------------------------
+# list_work_items
+# ---------------------------------------------------------------------------
+
+
+class TestListWorkItems:
+    """Tests for the ``list_work_items`` tool."""
+
+    async def test_returns_work_items(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "workitems",
+                    "id": "proj1/MCPT-001",
+                    "attributes": {
+                        "title": "Login Feature",
+                        "type": "requirement",
+                        "status": "draft",
+                    },
+                },
+                {
+                    "type": "workitems",
+                    "id": "proj1/MCPT-002",
+                    "attributes": {
+                        "title": "Logout Feature",
+                        "type": "requirement",
+                        "status": "approved",
+                    },
+                },
+            ],
+            "meta": {"totalCount": 2},
+        }
+
+        result = await list_work_items(
+            mock_ctx, project_id="proj1",
+            page_size=100, page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert len(result.items) == 2
+        assert result.total_count == 2
+        assert result.items[0].id == "MCPT-001"
+        assert result.items[0].title == "Login Feature"
+        assert result.items[1].id == "MCPT-002"
+
+    async def test_sparse_fieldset_requested(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await list_work_items(
+            mock_ctx, project_id="proj1",
+            page_size=100, page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert "fields[workitems]" in kwargs["params"]
+
+    async def test_project_not_found(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await list_work_items(
+                mock_ctx, project_id="missing",
+                page_size=100, page_number=1,
+            )
+
+    async def test_strips_project_prefix_from_id(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "id": "myproject/WI-100",
+                    "attributes": {
+                        "title": "Test",
+                        "type": "task",
+                        "status": "open",
+                    },
+                },
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_work_items(
+            mock_ctx, project_id="myproject",
+            page_size=100, page_number=1,
+        )
+
+        assert result.items[0].id == "WI-100"
+
+
+# ---------------------------------------------------------------------------
+# get_work_item
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkItem:
+    """Tests for the ``get_work_item`` tool."""
+
+    async def test_returns_work_item_detail(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "type": "workitems",
+                "id": "proj1/MCPT-001",
+                "attributes": {
+                    "title": "Login Feature",
+                    "type": "requirement",
+                    "status": "draft",
+                    "description": {
+                        "type": "text/html",
+                        "value": (
+                            "<p>User must be able to "
+                            "<strong>log in</strong>.</p>"
+                        ),
+                    },
+                },
+            },
+        }
+
+        result = await get_work_item(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-001",
+        )
+
+        assert isinstance(result, WorkItemDetail)
+        assert result.id == "MCPT-001"
+        assert result.title == "Login Feature"
+        assert result.type == "requirement"
+        assert result.status == "draft"
+        assert "log in" in result.description
+        assert "<p>" not in result.description
+        assert result.project_id == "proj1"
+
+    async def test_no_description(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "id": "proj1/MCPT-002",
+                "attributes": {
+                    "title": "Minimal",
+                    "type": "task",
+                    "status": "open",
+                },
+            },
+        }
+
+        result = await get_work_item(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-002",
+        )
+
+        assert result.description == ""
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await get_work_item(
+                mock_ctx,
+                project_id="proj1",
+                work_item_id="MCPT-999",
+            )
+
+    async def test_api_path_includes_work_item_id(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "id": "proj1/MCPT-010",
+                "attributes": {
+                    "title": "Test",
+                    "type": "task",
+                    "status": "open",
+                },
+            },
+        }
+
+        await get_work_item(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-010",
+        )
+
+        call_path = mock_client.get.call_args[0][0]
+        expected = "/projects/proj1/workitems/MCPT-010"
+        assert call_path == expected
+
+
+# ---------------------------------------------------------------------------
+# search_work_items
+# ---------------------------------------------------------------------------
+
+
+class TestSearchWorkItems:
+    """Tests for the ``search_work_items`` tool."""
+
+    async def test_returns_matching_items(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "id": "proj1/MCPT-001",
+                    "attributes": {
+                        "title": "Login Feature",
+                        "type": "requirement",
+                        "status": "approved",
+                    },
+                },
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await search_work_items(
+            mock_ctx,
+            project_id="proj1",
+            query="type:requirement AND status:approved",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert len(result.items) == 1
+        assert result.items[0].id == "MCPT-001"
+
+    async def test_query_param_forwarded(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await search_work_items(
+            mock_ctx,
+            project_id="proj1",
+            query="type:testCase",
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["query"] == "type:testCase"
+
+    async def test_empty_results(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        result = await search_work_items(
+            mock_ctx,
+            project_id="proj1",
+            query="type:nonexistent",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.items == []
+        assert result.total_count == 0
+
+    async def test_project_not_found(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await search_work_items(
+                mock_ctx,
+                project_id="missing",
+                query="type:requirement",
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_generic_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError(
+            "Bad query syntax", status_code=400,
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to search"):
+            await search_work_items(
+                mock_ctx,
+                project_id="proj1",
+                query="invalid:::query",
+                page_size=100,
+                page_number=1,
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_linked_work_items
+# ---------------------------------------------------------------------------
+
+
+class TestGetLinkedWorkItems:
+    """Tests for the ``get_linked_work_items`` tool."""
+
+    async def test_merges_forward_and_back_links(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # First call = forward, second = back.
+        mock_client.get.side_effect = [
+            {
+                "data": [
+                    {
+                        "id": "proj1/MCPT-010",
+                        "attributes": {
+                            "title": "Parent Item",
+                            "role": "parent",
+                            "suspect": False,
+                        },
+                    },
+                ],
+            },
+            {
+                "data": [
+                    {
+                        "id": "proj1/MCPT-020",
+                        "attributes": {
+                            "title": "Child Item",
+                            "role": "relates_to",
+                            "suspect": True,
+                        },
+                    },
+                    {
+                        "id": "proj1/MCPT-030",
+                        "attributes": {
+                            "title": "Verifier",
+                            "role": "verifies",
+                            "suspect": False,
+                        },
+                    },
+                ],
+            },
+        ]
+
+        result = await get_linked_work_items(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-001",
+        )
+
+        assert isinstance(result, LinkedWorkItemsList)
+        assert result.forward_count == 1
+        assert result.back_count == 2
+        assert len(result.items) == 3
+
+        fwd = [i for i in result.items if i.direction == "forward"]
+        back = [i for i in result.items if i.direction == "back"]
+        assert len(fwd) == 1
+        assert len(back) == 2
+
+        assert fwd[0].id == "MCPT-010"
+        assert fwd[0].role == "parent"
+        assert fwd[0].suspect is False
+
+        suspects = [i for i in result.items if i.suspect]
+        assert len(suspects) == 1
+        assert suspects[0].id == "MCPT-020"
+
+    async def test_no_links(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = [
+            {"data": []},
+            {"data": []},
+        ]
+
+        result = await get_linked_work_items(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-001",
+        )
+
+        assert result.forward_count == 0
+        assert result.back_count == 0
+        assert result.items == []
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await get_linked_work_items(
+                mock_ctx,
+                project_id="proj1",
+                work_item_id="MCPT-999",
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError(
+            "Forbidden", status_code=403,
+        )
+
+        with pytest.raises(PermissionError, match="POLARION_TOKEN"):
+            await get_linked_work_items(
+                mock_ctx,
+                project_id="proj1",
+                work_item_id="MCPT-001",
+            )
+
+    async def test_api_calls_both_endpoints(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = [
+            {"data": []},
+            {"data": []},
+        ]
+
+        await get_linked_work_items(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-001",
+        )
+
+        calls = mock_client.get.call_args_list
+        assert len(calls) == 2
+        base = "/projects/proj1/workitems/MCPT-001"
+        assert calls[0][0][0] == f"{base}/linkedworkitems"
+        assert calls[1][0][0] == f"{base}/backlinkedworkitems"
+
+    async def test_strips_project_prefix_from_linked_ids(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = [
+            {
+                "data": [
+                    {
+                        "id": "proj1/MCPT-010",
+                        "attributes": {
+                            "title": "Linked",
+                            "role": "parent",
+                            "suspect": False,
+                        },
+                    },
+                ],
+            },
+            {"data": []},
+        ]
+
+        result = await get_linked_work_items(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-001",
+        )
+
+        assert result.items[0].id == "MCPT-010"

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -795,7 +795,7 @@ class TestGetDocumentParts:
                     "attributes": {
                         "content": (
                             '<h1 id="polarion_wiki macro'
-                            ' name=module-workitem;'
+                            " name=module-workitem;"
                             'params=id=MCPT-001"></h1>'
                         ),
                         "type": "heading",
@@ -807,7 +807,7 @@ class TestGetDocumentParts:
                     "attributes": {
                         "content": (
                             '<div id="polarion_wiki macro'
-                            ' name=module-workitem;'
+                            " name=module-workitem;"
                             'params=id=MCPT-002"></div>'
                         ),
                         "type": "workitem",

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -89,7 +89,9 @@ class TestListProjects:
         }
 
         result = await list_projects(
-            mock_ctx, page_size=100, page_number=1,
+            mock_ctx,
+            page_size=100,
+            page_number=1,
         )
 
         assert isinstance(result, PaginatedResult)
@@ -111,7 +113,9 @@ class TestListProjects:
         }
 
         result = await list_projects(
-            mock_ctx, page_size=100, page_number=1,
+            mock_ctx,
+            page_size=100,
+            page_number=1,
         )
 
         assert result.items == []
@@ -126,7 +130,9 @@ class TestListProjects:
         }
 
         await list_projects(
-            mock_ctx, page_size=10, page_number=3,
+            mock_ctx,
+            page_size=10,
+            page_number=3,
         )
 
         mock_client.get.assert_called_once_with(
@@ -138,24 +144,30 @@ class TestListProjects:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionAuthError(
-            "Unauthorized", status_code=401,
+            "Unauthorized",
+            status_code=401,
         )
 
         with pytest.raises(PermissionError, match="POLARION_TOKEN"):
             await list_projects(
-                mock_ctx, page_size=100, page_number=1,
+                mock_ctx,
+                page_size=100,
+                page_number=1,
             )
 
     async def test_generic_error_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionError(
-            "Server error", status_code=500,
+            "Server error",
+            status_code=500,
         )
 
         with pytest.raises(RuntimeError, match="Failed to list"):
             await list_projects(
-                mock_ctx, page_size=100, page_number=1,
+                mock_ctx,
+                page_size=100,
+                page_number=1,
             )
 
     async def test_missing_meta_returns_zero_total(
@@ -164,7 +176,9 @@ class TestListProjects:
         mock_client.get.return_value = {"data": []}
 
         result = await list_projects(
-            mock_ctx, page_size=100, page_number=1,
+            mock_ctx,
+            page_size=100,
+            page_number=1,
         )
 
         assert result.total_count == 0
@@ -182,16 +196,44 @@ class TestListSpaces:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get_all_pages.return_value = [
-            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/_default/Doc1"}}}},
-            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/_default/Doc2"}}}},
-            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Design/SRS"}}}},
-            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Design/SDD"}}}},
-            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Testing/TestPlan"}}}},
+            {
+                "relationships": {
+                    "module": {
+                        "data": {"type": "documents", "id": "proj1/_default/Doc1"}
+                    }
+                }
+            },
+            {
+                "relationships": {
+                    "module": {
+                        "data": {"type": "documents", "id": "proj1/_default/Doc2"}
+                    }
+                }
+            },
+            {
+                "relationships": {
+                    "module": {"data": {"type": "documents", "id": "proj1/Design/SRS"}}
+                }
+            },
+            {
+                "relationships": {
+                    "module": {"data": {"type": "documents", "id": "proj1/Design/SDD"}}
+                }
+            },
+            {
+                "relationships": {
+                    "module": {
+                        "data": {"type": "documents", "id": "proj1/Testing/TestPlan"}
+                    }
+                }
+            },
         ]
 
         result = await list_spaces(
-            mock_ctx, project_id="proj1",
-            page_size=100, page_number=1,
+            mock_ctx,
+            project_id="proj1",
+            page_size=100,
+            page_number=1,
         )
 
         assert isinstance(result, PaginatedResult)
@@ -203,14 +245,28 @@ class TestListSpaces:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get_all_pages.return_value = [
-            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Space1/DocA"}}}},
-            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Space1/DocB"}}}},
-            {"relationships": {"module": {"data": {"type": "documents", "id": "proj1/Space1/DocC"}}}},
+            {
+                "relationships": {
+                    "module": {"data": {"type": "documents", "id": "proj1/Space1/DocA"}}
+                }
+            },
+            {
+                "relationships": {
+                    "module": {"data": {"type": "documents", "id": "proj1/Space1/DocB"}}
+                }
+            },
+            {
+                "relationships": {
+                    "module": {"data": {"type": "documents", "id": "proj1/Space1/DocC"}}
+                }
+            },
         ]
 
         result = await list_spaces(
-            mock_ctx, project_id="proj1",
-            page_size=100, page_number=1,
+            mock_ctx,
+            project_id="proj1",
+            page_size=100,
+            page_number=1,
         )
 
         assert result.total_count == 1
@@ -220,13 +276,21 @@ class TestListSpaces:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get_all_pages.return_value = [
-            {"relationships": {"module": {"data": {"type": "documents", "id": f"proj1/Space{i}/Doc"}}}}
+            {
+                "relationships": {
+                    "module": {
+                        "data": {"type": "documents", "id": f"proj1/Space{i}/Doc"}
+                    }
+                }
+            }
             for i in range(5)
         ]
 
         result = await list_spaces(
-            mock_ctx, project_id="proj1",
-            page_size=2, page_number=2,
+            mock_ctx,
+            project_id="proj1",
+            page_size=2,
+            page_number=2,
         )
 
         assert result.total_count == 5
@@ -243,8 +307,10 @@ class TestListSpaces:
         ]
 
         result = await list_spaces(
-            mock_ctx, project_id="proj1",
-            page_size=100, page_number=1,
+            mock_ctx,
+            project_id="proj1",
+            page_size=100,
+            page_number=1,
         )
 
         assert result.total_count == 0
@@ -253,27 +319,31 @@ class TestListSpaces:
     async def test_not_found_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.side_effect = (
-            PolarionNotFoundError("Not found", status_code=404)
+        mock_client.get_all_pages.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
         )
 
         with pytest.raises(ValueError, match="not found"):
             await list_spaces(
-                mock_ctx, project_id="missing",
-                page_size=100, page_number=1,
+                mock_ctx,
+                project_id="missing",
+                page_size=100,
+                page_number=1,
             )
 
     async def test_auth_error_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.side_effect = (
-            PolarionAuthError("Forbidden", status_code=403)
+        mock_client.get_all_pages.side_effect = PolarionAuthError(
+            "Forbidden", status_code=403
         )
 
         with pytest.raises(PermissionError, match="POLARION_TOKEN"):
             await list_spaces(
-                mock_ctx, project_id="proj1",
-                page_size=100, page_number=1,
+                mock_ctx,
+                project_id="proj1",
+                page_size=100,
+                page_number=1,
             )
 
 
@@ -297,10 +367,7 @@ class TestGetDocument:
                     "title": "Software Requirement Spec",
                     "description": {
                         "type": "text/html",
-                        "value": (
-                            "<p>This is the "
-                            "<strong>SRS</strong> document.</p>"
-                        ),
+                        "value": ("<p>This is the <strong>SRS</strong> document.</p>"),
                     },
                 },
             },
@@ -369,7 +436,8 @@ class TestGetDocument:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionNotFoundError(
-            "Not found", status_code=404,
+            "Not found",
+            status_code=404,
         )
 
         with pytest.raises(ValueError, match="not found"):
@@ -494,7 +562,8 @@ class TestGetDocumentParts:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionNotFoundError(
-            "Not found", status_code=404,
+            "Not found",
+            status_code=404,
         )
 
         with pytest.raises(ValueError, match="not found"):
@@ -574,8 +643,10 @@ class TestListWorkItems:
         }
 
         result = await list_work_items(
-            mock_ctx, project_id="proj1",
-            page_size=100, page_number=1,
+            mock_ctx,
+            project_id="proj1",
+            page_size=100,
+            page_number=1,
         )
 
         assert isinstance(result, PaginatedResult)
@@ -594,8 +665,10 @@ class TestListWorkItems:
         }
 
         await list_work_items(
-            mock_ctx, project_id="proj1",
-            page_size=100, page_number=1,
+            mock_ctx,
+            project_id="proj1",
+            page_size=100,
+            page_number=1,
         )
 
         _, kwargs = mock_client.get.call_args
@@ -605,13 +678,16 @@ class TestListWorkItems:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionNotFoundError(
-            "Not found", status_code=404,
+            "Not found",
+            status_code=404,
         )
 
         with pytest.raises(ValueError, match="not found"):
             await list_work_items(
-                mock_ctx, project_id="missing",
-                page_size=100, page_number=1,
+                mock_ctx,
+                project_id="missing",
+                page_size=100,
+                page_number=1,
             )
 
     async def test_strips_project_prefix_from_id(
@@ -632,8 +708,10 @@ class TestListWorkItems:
         }
 
         result = await list_work_items(
-            mock_ctx, project_id="myproject",
-            page_size=100, page_number=1,
+            mock_ctx,
+            project_id="myproject",
+            page_size=100,
+            page_number=1,
         )
 
         assert result.items[0].id == "WI-100"
@@ -661,8 +739,7 @@ class TestGetWorkItem:
                     "description": {
                         "type": "text/html",
                         "value": (
-                            "<p>User must be able to "
-                            "<strong>log in</strong>.</p>"
+                            "<p>User must be able to <strong>log in</strong>.</p>"
                         ),
                     },
                 },
@@ -710,7 +787,8 @@ class TestGetWorkItem:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionNotFoundError(
-            "Not found", status_code=404,
+            "Not found",
+            status_code=404,
         )
 
         with pytest.raises(ValueError, match="not found"):
@@ -824,7 +902,8 @@ class TestSearchWorkItems:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionNotFoundError(
-            "Not found", status_code=404,
+            "Not found",
+            status_code=404,
         )
 
         with pytest.raises(ValueError, match="not found"):
@@ -840,7 +919,8 @@ class TestSearchWorkItems:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionError(
-            "Bad query syntax", status_code=400,
+            "Bad query syntax",
+            status_code=400,
         )
 
         with pytest.raises(RuntimeError, match="Failed to search"):
@@ -924,9 +1004,7 @@ class TestGetLinkedWorkItems:
         assert len(suspects) == 1
         assert suspects[0].id == "MCPT-020"
 
-    async def test_no_links(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
+    async def test_no_links(self, mock_ctx: MagicMock, mock_client: AsyncMock) -> None:
         mock_client.get.side_effect = [
             {"data": []},
             {"data": []},
@@ -946,7 +1024,8 @@ class TestGetLinkedWorkItems:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionNotFoundError(
-            "Not found", status_code=404,
+            "Not found",
+            status_code=404,
         )
 
         with pytest.raises(ValueError, match="not found"):
@@ -960,7 +1039,8 @@ class TestGetLinkedWorkItems:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionAuthError(
-            "Forbidden", status_code=403,
+            "Forbidden",
+            status_code=403,
         )
 
         with pytest.raises(PermissionError, match="POLARION_TOKEN"):

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -1,4 +1,4 @@
-"""Tests for the 8 read-only MCP tools.
+"""Tests for the 7 read-only MCP tools.
 
 Each tool is tested by calling the async function directly with a mock
 ``PolarionClient`` injected via a mock ``Context``.
@@ -32,10 +32,9 @@ get_document = _read_mod.get_document.fn
 get_document_parts = _read_mod.get_document_parts.fn
 get_linked_work_items = _read_mod.get_linked_work_items.fn
 get_work_item = _read_mod.get_work_item.fn
+list_documents = _read_mod.list_documents.fn
 list_projects = _read_mod.list_projects.fn
-list_spaces = _read_mod.list_spaces.fn
 list_work_items = _read_mod.list_work_items.fn
-search_work_items = _read_mod.search_work_items.fn
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -137,7 +136,7 @@ class TestListProjects:
 
         mock_client.get.assert_called_once_with(
             "/projects",
-            params={"page[size]": 10, "page[number]": 3},
+            params={"fields[projects]": "id,name", "page[size]": 10, "page[number]": 3},
         )
 
     async def test_auth_error_raises_permission_error(
@@ -185,14 +184,14 @@ class TestListProjects:
 
 
 # ---------------------------------------------------------------------------
-# list_spaces
+# list_documents
 # ---------------------------------------------------------------------------
 
 
-class TestListSpaces:
-    """Tests for the ``list_spaces`` tool."""
+class TestListDocuments:
+    """Tests for the ``list_documents`` tool."""
 
-    async def test_extracts_spaces_from_modules(
+    async def test_extracts_documents_from_modules(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get_all_pages.return_value = [
@@ -229,19 +228,25 @@ class TestListSpaces:
             },
         ]
 
-        result = await list_spaces(
+        result = await list_documents(
             mock_ctx,
             project_id="proj1",
+            name_filter=None,
+            space_filter=None,
             page_size=100,
             page_number=1,
         )
 
         assert isinstance(result, PaginatedResult)
-        assert result.total_count == 3
-        ids = [s.id for s in result.items]
-        assert sorted(ids) == ["Design", "Testing", "_default"]
+        assert result.total_count == 5
+        space_doc_pairs = [(d.space_id, d.document_name) for d in result.items]
+        assert ("_default", "Doc1") in space_doc_pairs
+        assert ("_default", "Doc2") in space_doc_pairs
+        assert ("Design", "SDD") in space_doc_pairs
+        assert ("Design", "SRS") in space_doc_pairs
+        assert ("Testing", "TestPlan") in space_doc_pairs
 
-    async def test_deduplicates_spaces(
+    async def test_deduplicates_documents(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get_all_pages.return_value = [
@@ -252,25 +257,28 @@ class TestListSpaces:
             },
             {
                 "relationships": {
-                    "module": {"data": {"type": "documents", "id": "proj1/Space1/DocB"}}
+                    "module": {"data": {"type": "documents", "id": "proj1/Space1/DocA"}}
                 }
             },
             {
                 "relationships": {
-                    "module": {"data": {"type": "documents", "id": "proj1/Space1/DocC"}}
+                    "module": {"data": {"type": "documents", "id": "proj1/Space1/DocA"}}
                 }
             },
         ]
 
-        result = await list_spaces(
+        result = await list_documents(
             mock_ctx,
             project_id="proj1",
+            name_filter=None,
+            space_filter=None,
             page_size=100,
             page_number=1,
         )
 
         assert result.total_count == 1
-        assert result.items[0].id == "Space1"
+        assert result.items[0].space_id == "Space1"
+        assert result.items[0].document_name == "DocA"
 
     async def test_pagination_slicing(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -286,9 +294,11 @@ class TestListSpaces:
             for i in range(5)
         ]
 
-        result = await list_spaces(
+        result = await list_documents(
             mock_ctx,
             project_id="proj1",
+            name_filter=None,
+            space_filter=None,
             page_size=2,
             page_number=2,
         )
@@ -306,15 +316,120 @@ class TestListSpaces:
             {"relationships": {"module": {}}},
         ]
 
-        result = await list_spaces(
+        result = await list_documents(
             mock_ctx,
             project_id="proj1",
+            name_filter=None,
+            space_filter=None,
             page_size=100,
             page_number=1,
         )
 
         assert result.total_count == 0
         assert result.items == []
+
+    async def test_name_filter(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_all_pages.return_value = [
+            {
+                "relationships": {
+                    "module": {
+                        "data": {
+                            "type": "documents",
+                            "id": "proj1/_default/Software Requirement Specification",
+                        }
+                    }
+                }
+            },
+            {
+                "relationships": {
+                    "module": {
+                        "data": {
+                            "type": "documents",
+                            "id": "proj1/_default/SDD",
+                        }
+                    }
+                }
+            },
+        ]
+
+        result = await list_documents(
+            mock_ctx,
+            project_id="proj1",
+            name_filter="SRS",
+            space_filter=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        # "SRS" should not match either document
+        assert result.total_count == 0
+
+        result2 = await list_documents(
+            mock_ctx,
+            project_id="proj1",
+            name_filter="Requirement",
+            space_filter=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result2.total_count == 1
+        assert result2.items[0].document_name == "Software Requirement Specification"
+
+    async def test_space_filter(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_all_pages.return_value = [
+            {
+                "relationships": {
+                    "module": {
+                        "data": {"type": "documents", "id": "proj1/_default/Doc1"}
+                    }
+                }
+            },
+            {
+                "relationships": {
+                    "module": {"data": {"type": "documents", "id": "proj1/Design/SRS"}}
+                }
+            },
+        ]
+
+        result = await list_documents(
+            mock_ctx,
+            project_id="proj1",
+            name_filter=None,
+            space_filter="Design",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.total_count == 1
+        assert result.items[0].space_id == "Design"
+        assert result.items[0].document_name == "SRS"
+
+    async def test_api_params_include_query_and_sort(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get_all_pages.return_value = []
+
+        await list_documents(
+            mock_ctx,
+            project_id="proj1",
+            name_filter=None,
+            space_filter=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        call_args = mock_client.get_all_pages.call_args
+        params = call_args[1].get(
+            "params",
+            call_args[0][1] if len(call_args[0]) > 1 else {},
+        )
+        assert params["query"] == "type:heading"
+        assert params["sort"] == "module"
 
     async def test_not_found_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -324,9 +439,11 @@ class TestListSpaces:
         )
 
         with pytest.raises(ValueError, match="not found"):
-            await list_spaces(
+            await list_documents(
                 mock_ctx,
                 project_id="missing",
+                name_filter=None,
+                space_filter=None,
                 page_size=100,
                 page_number=1,
             )
@@ -339,9 +456,11 @@ class TestListSpaces:
         )
 
         with pytest.raises(PermissionError, match="POLARION_TOKEN"):
-            await list_spaces(
+            await list_documents(
                 mock_ctx,
                 project_id="proj1",
+                name_filter=None,
+                space_filter=None,
                 page_size=100,
                 page_number=1,
             )
@@ -365,7 +484,7 @@ class TestGetDocument:
                 "attributes": {
                     "id": "SRS",
                     "title": "Software Requirement Spec",
-                    "description": {
+                    "homePageContent": {
                         "type": "text/html",
                         "value": ("<p>This is the <strong>SRS</strong> document.</p>"),
                     },
@@ -383,8 +502,8 @@ class TestGetDocument:
         assert isinstance(result, DocumentDetail)
         assert result.id == "SRS"
         assert result.title == "Software Requirement Spec"
-        assert "SRS" in result.description
-        assert "<p>" not in result.description
+        assert "SRS" in result.content
+        assert "<p>" not in result.content
         assert result.space_id == "_default"
         assert result.project_id == "proj1"
 
@@ -407,7 +526,7 @@ class TestGetDocument:
         call_path = mock_client.get.call_args[0][0]
         assert "Software%20Requirement%20Specification" in call_path
 
-    async def test_empty_description(
+    async def test_empty_content(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.return_value = {
@@ -415,7 +534,7 @@ class TestGetDocument:
                 "attributes": {
                     "id": "EmptyDoc",
                     "title": "Empty",
-                    "description": {
+                    "homePageContent": {
                         "type": "text/html",
                         "value": "",
                     },
@@ -430,7 +549,7 @@ class TestGetDocument:
             document_name="EmptyDoc",
         )
 
-        assert result.description == ""
+        assert result.content == ""
 
     async def test_not_found_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -448,14 +567,14 @@ class TestGetDocument:
                 document_name="Missing",
             )
 
-    async def test_no_description_field(
+    async def test_no_content_field(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.get.return_value = {
             "data": {
                 "attributes": {
-                    "id": "NoDesc",
-                    "title": "No Description",
+                    "id": "NoContent",
+                    "title": "No Content",
                 },
             },
         }
@@ -464,10 +583,10 @@ class TestGetDocument:
             mock_ctx,
             project_id="proj1",
             space_id="_default",
-            document_name="NoDesc",
+            document_name="NoContent",
         )
 
-        assert result.description == ""
+        assert result.content == ""
 
 
 # ---------------------------------------------------------------------------
@@ -645,6 +764,7 @@ class TestListWorkItems:
         result = await list_work_items(
             mock_ctx,
             project_id="proj1",
+            query=None,
             page_size=100,
             page_number=1,
         )
@@ -667,6 +787,7 @@ class TestListWorkItems:
         await list_work_items(
             mock_ctx,
             project_id="proj1",
+            query=None,
             page_size=100,
             page_number=1,
         )
@@ -686,6 +807,7 @@ class TestListWorkItems:
             await list_work_items(
                 mock_ctx,
                 project_id="missing",
+                query=None,
                 page_size=100,
                 page_number=1,
             )
@@ -710,11 +832,79 @@ class TestListWorkItems:
         result = await list_work_items(
             mock_ctx,
             project_id="myproject",
+            query=None,
             page_size=100,
             page_number=1,
         )
 
         assert result.items[0].id == "WI-100"
+
+    async def test_query_param_forwarded(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await list_work_items(
+            mock_ctx,
+            project_id="proj1",
+            query="type:testCase",
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["query"] == "type:testCase"
+
+    async def test_query_none_omits_param(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await list_work_items(
+            mock_ctx,
+            project_id="proj1",
+            query=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert "query" not in kwargs["params"]
+
+    async def test_query_returns_matching_items(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "id": "proj1/MCPT-001",
+                    "attributes": {
+                        "title": "Login Feature",
+                        "type": "requirement",
+                        "status": "approved",
+                    },
+                },
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_work_items(
+            mock_ctx,
+            project_id="proj1",
+            query="type:requirement AND status:approved",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert len(result.items) == 1
+        assert result.items[0].id == "MCPT-001"
 
 
 # ---------------------------------------------------------------------------
@@ -821,116 +1011,6 @@ class TestGetWorkItem:
         call_path = mock_client.get.call_args[0][0]
         expected = "/projects/proj1/workitems/MCPT-010"
         assert call_path == expected
-
-
-# ---------------------------------------------------------------------------
-# search_work_items
-# ---------------------------------------------------------------------------
-
-
-class TestSearchWorkItems:
-    """Tests for the ``search_work_items`` tool."""
-
-    async def test_returns_matching_items(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        mock_client.get.return_value = {
-            "data": [
-                {
-                    "id": "proj1/MCPT-001",
-                    "attributes": {
-                        "title": "Login Feature",
-                        "type": "requirement",
-                        "status": "approved",
-                    },
-                },
-            ],
-            "meta": {"totalCount": 1},
-        }
-
-        result = await search_work_items(
-            mock_ctx,
-            project_id="proj1",
-            query="type:requirement AND status:approved",
-            page_size=100,
-            page_number=1,
-        )
-
-        assert isinstance(result, PaginatedResult)
-        assert len(result.items) == 1
-        assert result.items[0].id == "MCPT-001"
-
-    async def test_query_param_forwarded(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        mock_client.get.return_value = {
-            "data": [],
-            "meta": {"totalCount": 0},
-        }
-
-        await search_work_items(
-            mock_ctx,
-            project_id="proj1",
-            query="type:testCase",
-            page_size=100,
-            page_number=1,
-        )
-
-        _, kwargs = mock_client.get.call_args
-        assert kwargs["params"]["query"] == "type:testCase"
-
-    async def test_empty_results(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        mock_client.get.return_value = {
-            "data": [],
-            "meta": {"totalCount": 0},
-        }
-
-        result = await search_work_items(
-            mock_ctx,
-            project_id="proj1",
-            query="type:nonexistent",
-            page_size=100,
-            page_number=1,
-        )
-
-        assert result.items == []
-        assert result.total_count == 0
-
-    async def test_project_not_found(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        mock_client.get.side_effect = PolarionNotFoundError(
-            "Not found",
-            status_code=404,
-        )
-
-        with pytest.raises(ValueError, match="not found"):
-            await search_work_items(
-                mock_ctx,
-                project_id="missing",
-                query="type:requirement",
-                page_size=100,
-                page_number=1,
-            )
-
-    async def test_generic_error_raises_runtime_error(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        mock_client.get.side_effect = PolarionError(
-            "Bad query syntax",
-            status_code=400,
-        )
-
-        with pytest.raises(RuntimeError, match="Failed to search"):
-            await search_work_items(
-                mock_ctx,
-                project_id="proj1",
-                query="invalid:::query",
-                page_size=100,
-                page_number=1,
-            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -604,30 +604,30 @@ class TestGetDocumentParts:
             "data": [
                 {
                     "type": "document_parts",
-                    "id": "heading_MCPT-001",
+                    "id": "proj1/_default/SRS/heading_MCPT-001",
                     "attributes": {
-                        "title": "Introduction",
-                        "level": 1,
-                        "content": {
-                            "type": "text/html",
-                            "value": "<p>This is the intro.</p>",
-                        },
+                        "content": '<h1 id="polarion_wiki macro name=module-workitem;params=id=MCPT-001"></h1>',
+                        "type": "heading",
                     },
                 },
                 {
                     "type": "document_parts",
-                    "id": "workitem_MCPT-002",
+                    "id": "proj1/_default/SRS/workitem_MCPT-002",
                     "attributes": {
-                        "title": "Login Feature",
-                        "level": 0,
-                        "content": {
-                            "type": "text/html",
-                            "value": "<p>Login requirement.</p>",
-                        },
+                        "content": '<div id="polarion_wiki macro name=module-workitem;params=id=MCPT-002"></div>',
+                        "type": "workitem",
+                    },
+                },
+                {
+                    "type": "document_parts",
+                    "id": "proj1/_default/SRS/polarion_1",
+                    "attributes": {
+                        "content": "<p>Normal text content.</p>",
+                        "type": "normal",
                     },
                 },
             ],
-            "meta": {"totalCount": 2},
+            "meta": {"totalCount": 3},
         }
 
         result = await get_document_parts(
@@ -640,21 +640,23 @@ class TestGetDocumentParts:
         )
 
         assert isinstance(result, PaginatedResult)
-        assert len(result.items) == 2
-        assert result.total_count == 2
+        assert len(result.items) == 3
+        assert result.total_count == 3
 
         heading = result.items[0]
         assert isinstance(heading, DocumentPart)
-        assert heading.id == "heading_MCPT-001"
-        assert heading.title == "Introduction"
+        assert heading.id == "proj1/_default/SRS/heading_MCPT-001"
         assert heading.type == "heading"
         assert heading.level == 1
-        assert "<p>" not in heading.content
 
         wi_part = result.items[1]
-        assert wi_part.id == "workitem_MCPT-002"
+        assert wi_part.id == "proj1/_default/SRS/workitem_MCPT-002"
         assert wi_part.type == "workitem"
         assert wi_part.level == 0
+
+        normal_part = result.items[2]
+        assert normal_part.type == "normal"
+        assert normal_part.level == 0
 
     async def test_pagination_params_forwarded(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -674,6 +676,7 @@ class TestGetDocumentParts:
         )
 
         _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["fields[document_parts]"] == "content,type"
         assert kwargs["params"]["page[size]"] == 10
         assert kwargs["params"]["page[number]"] == 2
 
@@ -702,11 +705,10 @@ class TestGetDocumentParts:
         mock_client.get.return_value = {
             "data": [
                 {
-                    "id": "heading_MCPT-003",
+                    "id": "proj1/_default/Doc/heading_MCPT-003",
                     "attributes": {
-                        "title": "Heading",
-                        "level": 2,
-                        "content": "<p>Plain string content.</p>",
+                        "content": "<h2>Plain string content.</h2>",
+                        "type": "heading",
                     },
                 },
             ],
@@ -723,6 +725,8 @@ class TestGetDocumentParts:
         )
 
         assert len(result.items) == 1
+        assert result.items[0].type == "heading"
+        assert result.items[0].level == 2
         assert "Plain string content" in result.items[0].content
 
 

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -194,7 +194,7 @@ class TestListDocuments:
     async def test_extracts_documents_from_modules(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.return_value = [
+        items = [
             {
                 "relationships": {
                     "module": {
@@ -227,6 +227,11 @@ class TestListDocuments:
                 }
             },
         ]
+        # Single page — totalCount ≤ page_size, so no binary search.
+        mock_client.get.return_value = {
+            "data": items,
+            "meta": {"totalCount": 5},
+        }
 
         result = await list_documents(
             mock_ctx,
@@ -249,7 +254,7 @@ class TestListDocuments:
     async def test_deduplicates_documents(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.return_value = [
+        items = [
             {
                 "relationships": {
                     "module": {"data": {"type": "documents", "id": "proj1/Space1/DocA"}}
@@ -266,6 +271,10 @@ class TestListDocuments:
                 }
             },
         ]
+        mock_client.get.return_value = {
+            "data": items,
+            "meta": {"totalCount": 3},
+        }
 
         result = await list_documents(
             mock_ctx,
@@ -283,7 +292,7 @@ class TestListDocuments:
     async def test_pagination_slicing(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.return_value = [
+        items = [
             {
                 "relationships": {
                     "module": {
@@ -293,6 +302,10 @@ class TestListDocuments:
             }
             for i in range(5)
         ]
+        mock_client.get.return_value = {
+            "data": items,
+            "meta": {"totalCount": 5},
+        }
 
         result = await list_documents(
             mock_ctx,
@@ -310,11 +323,15 @@ class TestListDocuments:
     async def test_empty_modules(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.return_value = [
+        items = [
             {"relationships": {"module": {"data": None}}},
             {"relationships": {}},
             {"relationships": {"module": {}}},
         ]
+        mock_client.get.return_value = {
+            "data": items,
+            "meta": {"totalCount": 3},
+        }
 
         result = await list_documents(
             mock_ctx,
@@ -328,10 +345,110 @@ class TestListDocuments:
         assert result.total_count == 0
         assert result.items == []
 
+    async def test_binary_search_skips_pages(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Binary search discovers document boundaries without scanning every page.
+
+        Layout (5 pages total, sorted by module):
+          Page 1: DocA × 100   (page 1 always fetched)
+          Page 2: DocA × 100
+          Page 3: DocA × 50 + DocB × 50  (transition)
+          Page 4: DocB × 100
+          Page 5: DocB × 30   (partial → end)
+
+        Binary search from page 1 (last_module=DocA):
+          lo=2, hi=5 → mid=3 → DocA+DocB (has_new) → transition_page=3, hi=2
+          lo=2, hi=2 → mid=2 → DocA only → lo=3
+          lo>hi → done, transition_page=3
+        Then from page 3 (last_module=DocB):
+          lo=4, hi=5 → mid=4 → DocB only → lo=5
+          lo=5, hi=5 → mid=5 → DocB only → lo=6
+          lo>hi → done, no transition
+        Total fetches: page 1 + page 3 + page 2 + page 4 + page 5 = 5
+        (but in a larger dataset, most pages would be skipped)
+        """
+
+        def _make_item(doc: str) -> dict:
+            return {
+                "relationships": {
+                    "module": {"data": {"type": "documents", "id": f"p/S/{doc}"}}
+                }
+            }
+
+        page_data = {
+            1: [_make_item("DocA")] * 100,
+            2: [_make_item("DocA")] * 100,
+            3: [_make_item("DocA")] * 50 + [_make_item("DocB")] * 50,
+            4: [_make_item("DocB")] * 100,
+            5: [_make_item("DocB")] * 30,
+        }
+
+        async def _mock_get(path, *, params=None):
+            page_num = params["page[number]"]
+            return {
+                "data": page_data.get(page_num, []),
+                "meta": {"totalCount": 430},  # 5 pages
+            }
+
+        mock_client.get.side_effect = _mock_get
+
+        result = await list_documents(
+            mock_ctx,
+            project_id="p",
+            name_filter=None,
+            space_filter=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.total_count == 2
+        pairs = {(d.space_id, d.document_name) for d in result.items}
+        assert pairs == {("S", "DocA"), ("S", "DocB")}
+
+    async def test_binary_search_many_documents_on_few_pages(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """When multiple small documents fit on one page, all are discovered."""
+
+        def _make_item(doc: str) -> dict:
+            return {
+                "relationships": {
+                    "module": {"data": {"type": "documents", "id": f"p/S/{doc}"}}
+                }
+            }
+
+        # Single page with 4 different documents (sorted).
+        items = (
+            [_make_item("Alpha")] * 25
+            + [_make_item("Bravo")] * 25
+            + [_make_item("Charlie")] * 25
+            + [_make_item("Delta")] * 25
+        )
+        mock_client.get.return_value = {
+            "data": items,
+            "meta": {"totalCount": 100},
+        }
+
+        result = await list_documents(
+            mock_ctx,
+            project_id="p",
+            name_filter=None,
+            space_filter=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.total_count == 4
+        names = {d.document_name for d in result.items}
+        assert names == {"Alpha", "Bravo", "Charlie", "Delta"}
+        # Only 1 API call needed (single page).
+        assert mock_client.get.call_count == 1
+
     async def test_name_filter(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.return_value = [
+        items = [
             {
                 "relationships": {
                     "module": {
@@ -353,6 +470,10 @@ class TestListDocuments:
                 }
             },
         ]
+        mock_client.get.return_value = {
+            "data": items,
+            "meta": {"totalCount": 2},
+        }
 
         result = await list_documents(
             mock_ctx,
@@ -366,6 +487,10 @@ class TestListDocuments:
         # "SRS" should not match either document
         assert result.total_count == 0
 
+        mock_client.get.return_value = {
+            "data": items,
+            "meta": {"totalCount": 2},
+        }
         result2 = await list_documents(
             mock_ctx,
             project_id="proj1",
@@ -381,7 +506,7 @@ class TestListDocuments:
     async def test_space_filter(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.return_value = [
+        items = [
             {
                 "relationships": {
                     "module": {
@@ -395,6 +520,10 @@ class TestListDocuments:
                 }
             },
         ]
+        mock_client.get.return_value = {
+            "data": items,
+            "meta": {"totalCount": 2},
+        }
 
         result = await list_documents(
             mock_ctx,
@@ -412,7 +541,10 @@ class TestListDocuments:
     async def test_api_params_include_query_and_sort(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.return_value = []
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
 
         await list_documents(
             mock_ctx,
@@ -423,7 +555,7 @@ class TestListDocuments:
             page_number=1,
         )
 
-        call_args = mock_client.get_all_pages.call_args
+        call_args = mock_client.get.call_args
         params = call_args[1].get(
             "params",
             call_args[0][1] if len(call_args[0]) > 1 else {},
@@ -434,7 +566,7 @@ class TestListDocuments:
     async def test_not_found_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.side_effect = PolarionNotFoundError(
+        mock_client.get.side_effect = PolarionNotFoundError(
             "Not found", status_code=404
         )
 
@@ -451,7 +583,7 @@ class TestListDocuments:
     async def test_auth_error_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get_all_pages.side_effect = PolarionAuthError(
+        mock_client.get.side_effect = PolarionAuthError(
             "Forbidden", status_code=403
         )
 

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -89,6 +89,7 @@ class TestListProjects:
 
         result = await list_projects(
             mock_ctx,
+            query=None,
             page_size=100,
             page_number=1,
         )
@@ -113,6 +114,7 @@ class TestListProjects:
 
         result = await list_projects(
             mock_ctx,
+            query=None,
             page_size=100,
             page_number=1,
         )
@@ -130,6 +132,7 @@ class TestListProjects:
 
         await list_projects(
             mock_ctx,
+            query=None,
             page_size=10,
             page_number=3,
         )
@@ -150,6 +153,7 @@ class TestListProjects:
         with pytest.raises(PermissionError, match="POLARION_TOKEN"):
             await list_projects(
                 mock_ctx,
+                query=None,
                 page_size=100,
                 page_number=1,
             )
@@ -165,6 +169,7 @@ class TestListProjects:
         with pytest.raises(RuntimeError, match="Failed to list"):
             await list_projects(
                 mock_ctx,
+                query=None,
                 page_size=100,
                 page_number=1,
             )
@@ -176,11 +181,63 @@ class TestListProjects:
 
         result = await list_projects(
             mock_ctx,
+            query=None,
             page_size=100,
             page_number=1,
         )
 
         assert result.total_count == 0
+
+    async def test_query_param_passed_to_api(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "projects",
+                    "id": "proj1",
+                    "attributes": {"name": "Project One"},
+                },
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_projects(
+            mock_ctx,
+            query="name:proj1",
+            page_size=100,
+            page_number=1,
+        )
+
+        mock_client.get.assert_called_once_with(
+            "/projects",
+            params={
+                "fields[projects]": "id,name",
+                "page[size]": 100,
+                "page[number]": 1,
+                "query": "name:proj1",
+            },
+        )
+        assert len(result.items) == 1
+        assert result.items[0].id == "proj1"
+
+    async def test_query_none_omits_query_param(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await list_projects(
+            mock_ctx,
+            query=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        call_params = mock_client.get.call_args[1]["params"]
+        assert "query" not in call_params
 
 
 # ---------------------------------------------------------------------------
@@ -583,9 +640,7 @@ class TestListDocuments:
     async def test_auth_error_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get.side_effect = PolarionAuthError(
-            "Forbidden", status_code=403
-        )
+        mock_client.get.side_effect = PolarionAuthError("Forbidden", status_code=403)
 
         with pytest.raises(PermissionError, match="POLARION_TOKEN"):
             await list_documents(

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -408,11 +408,11 @@ class TestListDocuments:
         """Binary search discovers document boundaries without scanning every page.
 
         Layout (5 pages total, sorted by module):
-          Page 1: DocA × 100   (page 1 always fetched)
-          Page 2: DocA × 100
-          Page 3: DocA × 50 + DocB × 50  (transition)
-          Page 4: DocB × 100
-          Page 5: DocB × 30   (partial → end)
+          Page 1: DocA x 100   (page 1 always fetched)
+          Page 2: DocA x 100
+          Page 3: DocA x 50 + DocB x 50  (transition)
+          Page 4: DocB x 100
+          Page 5: DocB x 30   (partial -> end)
 
         Binary search from page 1 (last_module=DocA):
           lo=2, hi=5 → mid=3 → DocA+DocB (has_new) → transition_page=3, hi=2
@@ -793,7 +793,11 @@ class TestGetDocumentParts:
                     "type": "document_parts",
                     "id": "proj1/_default/SRS/heading_MCPT-001",
                     "attributes": {
-                        "content": '<h1 id="polarion_wiki macro name=module-workitem;params=id=MCPT-001"></h1>',
+                        "content": (
+                            '<h1 id="polarion_wiki macro'
+                            ' name=module-workitem;'
+                            'params=id=MCPT-001"></h1>'
+                        ),
                         "type": "heading",
                     },
                 },
@@ -801,7 +805,11 @@ class TestGetDocumentParts:
                     "type": "document_parts",
                     "id": "proj1/_default/SRS/workitem_MCPT-002",
                     "attributes": {
-                        "content": '<div id="polarion_wiki macro name=module-workitem;params=id=MCPT-002"></div>',
+                        "content": (
+                            '<div id="polarion_wiki macro'
+                            ' name=module-workitem;'
+                            'params=id=MCPT-002"></div>'
+                        ),
                         "type": "workitem",
                     },
                 },


### PR DESCRIPTION
## Summary

Implements all 7 read-only MCP tools for querying Polarion ALM, along with a comprehensive test suite of 45 tests.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- **`src/mcp_server_polarion/tools/read.py`** — 7 read-only MCP tools using FastMCP 2.0 flat-parameter pattern with `Field()` defaults:
  - `list_projects` — paginated list of all accessible Polarion projects (with optional Lucene `query` filter)
  - `list_documents` — extract unique (Space ID, Document Name) pairs by querying heading work items with `fields[workitems]=module` (workaround for missing `/documents` endpoint)
  - `get_document` — full document detail including Markdown-converted description
  - `get_document_parts` — paginated list of document parts (headings + work item references)
  - `list_work_items` — paginated work item list with sparse fieldset and optional Lucene query
  - `get_work_item` — full work item detail including Markdown-converted description
  - `get_linked_work_items` — merged forward + back links for complete traceability
- **`src/mcp_server_polarion/tools/__init__.py`** — registers `tools.read` module to activate `@mcp.tool()` decorators at import time
- **`tests/tools/__init__.py`** — package init for test discovery
- **`tests/tools/test_read.py`** — 45 tests across 7 test classes; uses `spec=PolarionClient` mock and `.fn` accessor to call the underlying async functions directly

---

## Technical Notes

- **FastMCP 2.0 compatibility**: `@mcp.tool()` wraps functions into `FunctionTool` objects. Combined with `from __future__ import annotations`, custom input model types cause a `NameError` at decorator registration time (FastMCP's internal wrapper's `__globals__` doesn't include the module's definitions when annotations are strings). All tools therefore use flat parameters with `Field()` — the standard FastMCP pattern.
- **`list_documents` workaround**: `GET /projects/{projectId}/documents` does not exist in the target Polarion version. The tool queries heading work items requesting only the `module` field, then uses binary search to discover unique (space_id, document_name) pairs efficiently.
- **`get_linked_work_items`**: Makes two sequential API calls (`/linkedworkitems` and `/backlinkedworkitems`) and merges results with a `direction` field for complete traceability.
- **Error mapping**: `PolarionAuthError` → `PermissionError`, `PolarionNotFoundError` → `ValueError`, `PolarionError` → `RuntimeError`, each with actionable messages suggesting the next step.
- **HTML handling**: All HTML descriptions are converted to Markdown via `html_to_markdown()` before returning to the LLM.
- **URL encoding**: Document names with spaces are percent-encoded using `quote(segment, safe="")`.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [ ] `dry_run=True` path verified for all write tools
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src --strict` passes with no errors
- [x] `uv run ruff check .` passes with no warnings

```bash
uv run pytest tests/tools/test_read.py -v
# 45 passed

uv run mypy src --strict
# Success: no issues found in 13 source files

uv run ruff check .
# All checks passed!
```

---

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [x] All new tool functions are `async def`
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] HTML converted via `html_to_markdown()` in read paths
- [x] Any new list tool supports `page_size` and `page_number` pagination
- [x] No secrets hardcoded — env vars via `pydantic-settings` only