### PR TITLE
feat(tool): add create_work_item MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MCP server providing AI assistants (Claude, Cursor, Copilot) with read access to Polarion ALM via the Model Context Protocol. Built on FastMCP 3.0 with a strict async-only, fully-typed Python codebase.
+
+## Commands
+
+```bash
+uv sync --dev          # install dependencies
+uv run pytest          # run all tests
+uv run pytest tests/tools/test_read.py::TestGetWorkItem -v       # single class
+uv run pytest tests/tools/test_read.py::TestGetWorkItem::test_returns_work_item_detail  # single test
+uv run ruff check .    # lint
+uv run ruff format .   # format
+uv run mypy src/       # type check
+uv run mcp-server-polarion  # run server (stdio transport)
+```
+
+CI runs: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
+
+## Architecture
+
+Three-layer design:
+
+**`core/`** — Infrastructure
+- `client.py`: Async `httpx` wrapper. Constructor takes `(config, *, write_delay=1.5)`. Implements exponential backoff for retryable statuses (429/5xx) and a `write_delay` after each mutation. Maps responses to `PolarionError` subclasses (401/403 → auth, 404 → not-found).
+- `config.py`: Pydantic `PolarionConfig` loading `POLARION_URL` + `POLARION_TOKEN` from env / `.env`.
+- `exceptions.py`: `PolarionError`, `PolarionAuthError`, `PolarionNotFoundError`.
+
+**`tools/`** — MCP tools registered via `@mcp.tool()`
+- `read.py`: 7 read-only tools (`list_projects`, `list_documents`, `get_document`, `get_document_parts`, `list_work_items`, `get_work_item`, `get_linked_work_items`).
+- `_helpers.py`: Shared utilities — `WI_LIST_FIELDS` / `WI_DETAIL_FIELDS` (sparse fieldsets including relationship names), pagination (`compute_has_more`, `has_links_next`, `extract_total_count`), JSON:API helpers (`extract_relationship_id`, `extract_relationship_ids`, `split_module_id`, `extract_short_id`, `build_included_workitem_map`), and `build_work_item_summary_kwargs` (returns a `WorkItemSummaryKwargs` TypedDict shared between list / detail tools so `WorkItemDetail` stays a strict superset of `WorkItemSummary`).
+
+**`utils/html.py`** — HTML ↔ Markdown conversion (markdownify + BeautifulSoup4 sanitization).
+
+**`models.py`** — Pydantic v2 input/output models. `PaginatedResult[T]` wraps all list responses. `WorkItemDetail` extends `WorkItemSummary`; `Hyperlink` is a structured shape for work-item external links.
+
+**`server.py`** — FastMCP instance with lifespan that initializes/closes `PolarionClient`.
+
+## Non-Negotiable Rules
+
+- **NEVER `print()`** — stdout is reserved for MCP JSON-RPC; log to stderr only.
+- **NEVER `typing.Any`** — use concrete types or `object`.
+- **All functions** must have full type annotations + `from __future__ import annotations`.
+- **All tool functions** must be `async def`.
+- **Return Pydantic models**, never raw `dict`.
+- **HTML on read**: convert to Markdown via `html_to_markdown()`.
+- **HTML on write**: convert from Markdown + sanitize (allowed tags: p, br, b, i, u, strong, em, ul, ol, li, h1-h4, table, tr/td/th/thead/tbody, a, span, div, pre, code; allowed schemes: http, https, mailto).
+- **Every list tool** must support `page_size` (max 100) and `page_number`; return `PaginatedResult[T]` with `has_more`.
+- **Tool docstrings** are the LLM's manual — Google-style with Args/Returns/Raises sections. Keep return-field bullets in sync with the Pydantic model.
+
+## Error Handling Pattern
+
+Map domain exceptions to user-facing ones at the tool layer:
+- `PolarionNotFoundError` → `ValueError` with actionable message
+- `PolarionAuthError` → `PermissionError`
+- `PolarionError` → `RuntimeError`
+
+## Polarion API & Gotchas
+
+JSON:API v1 format. Key endpoints:
+- `GET /projects` — list projects
+- `GET /projects/{projectId}/workitems?query=...` — Lucene search
+- `GET /projects/{projectId}/workitems/{wiId}` — single work item
+- `GET /projects/{projectId}/workitems/{wiId}/linkedworkitems` — outgoing links
+- `GET /projects/{projectId}/spaces/{spaceId}/documents/{documentName}` — document metadata
+- `GET /projects/{projectId}/spaces/{spaceId}/documents/{documentName}/parts` — doc structure
+
+**Lucene query restrictions:** trailing wildcards (`title:SRS*`) are supported; **leading wildcards** (`*SRS*`) cause HTTP 400. The `module` field is **not indexed** and cannot be queried.
+
+**HTML payloads** are stored as `{ "type": "text/html", "value": "..." }`.
+
+**Linked work-item IDs** have 5 segments: `{projectId}/{sourceWiId}/{role}/{targetProjectId}/{targetWiId}`. Always derive the target via `relationships.workItem.data.id`, never by parsing the raw ID.
+
+**Module IDs** have 3 segments: `{projectId}/{spaceId}/{documentName}`. Document names may contain `/` — use `split_module_id` (splits on first two slashes only).
+
+### Sparse fieldset filters BOTH attributes AND relationships
+
+`fields[workitems]=title,type,status` removes **all** `relationships` from the response, not just other attributes. To receive a relationship, list its name explicitly:
+
+```python
+WI_LIST_FIELDS = "title,type,status,priority,updated,module,assignee"
+```
+
+Forgetting this causes `relationships.module` / `relationships.assignee` / `relationships.author` to silently disappear from responses, leaving derived fields like `space_id` / `document_name` / `assignee_ids` / `author_id` empty.
+
+### To-many relationships need `include=`
+
+Polarion does not inline `data` for to-many relationships (e.g. `assignee`) — only `links` come back. To populate `relationships.assignee.data` (so `extract_relationship_ids` can read it), pass `"include": "assignee"` in the request params. To-one relationships (`module`, `author`, `project`) are inlined without `include`.
+
+### `/backlinkedworkitems` is NOT supported on this server
+
+The newer Polarion endpoint that exposes back-links with their original role is unavailable on the deployed server version. `get_linked_work_items` therefore falls back to a `query=linkedWorkItems:{wi}` search, which returns the source WI list **without role information**. Back-direction items are returned with `role=None` (intentional — do not reintroduce the legacy `"backlink"` placeholder; the `None` is an explicit "unknown" signal that future code can fill once the endpoint becomes available).
+
+## Server-Side Constraints (informational)
+
+The company's Polarion server enforces:
+- **≤ 3 API calls/second**
+- **No concurrent requests**
+
+`PolarionClient` does **not** currently implement client-side rate limiting or request serialization — callers must respect these limits or rely on Polarion's HTTP 429 responses (the client retries with exponential backoff). When adding bulk-operation tools, factor pacing into the design.
+
+## Testing
+
+`pytest-asyncio` runs in `mode=auto`. Two test patterns coexist:
+
+1. **Tool tests (`tests/tools/`)** call tool functions directly with a `mock_client` (an `AsyncMock(spec=PolarionClient)`) injected via a `mock_ctx`. FastMCP 3.0's `@mcp.tool()` returns the original function unchanged, so direct invocation works. Tests set `mock_client.get.return_value = {...}` (or `side_effect = [...]` for multi-call flows) with hand-built JSON:API payloads.
+2. **Client tests (`tests/core/test_client.py`)** use `respx` to mock the underlying `httpx` transport for retry/backoff/error-mapping behavior.
+
+Shared fixtures live in `tests/conftest.py` (`polarion_config`, `polarion_client`). Tool tests define their own `mock_client` / `mock_ctx` at the file level. Pass `write_delay=0` when constructing a real `PolarionClient` in tests to skip the post-write sleep.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-server-polarion
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **Polarion ALM**. Lets AI assistants read documents, work items, and traceability links directly from your Polarion instance.
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **Polarion ALM**. Lets AI assistants read documents, work items, and traceability links — and create new work items — directly from your Polarion instance.
 
 [![PyPI](https://img.shields.io/pypi/v/mcp-server-polarion)](https://pypi.org/project/mcp-server-polarion/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
@@ -122,6 +122,8 @@ claude mcp add mcp-server-polarion \
 
 ## Tools
 
+### Read
+
 | Tool | Description |
 |---|---|
 | `list_projects` | List all accessible Polarion projects (supports Lucene query filtering) |
@@ -134,6 +136,12 @@ claude mcp add mcp-server-polarion \
 
 All list tools support pagination via `page_size` (1–100) and `page_number` parameters.
 
+### Write
+
+| Tool | Description |
+|---|---|
+| `create_work_item` | Create a new work item (`project_id`, `title`, `type` required; `description` accepted as Markdown and converted to sanitized HTML; supports optional `status`, `priority`, `severity`, `assignee_ids`, `due_date`, `initial_estimate`, `hyperlinks`; `dry_run=True` previews the JSON:API payload without calling Polarion) |
+
 ## Example Prompts
 
 > "List all projects in Polarion"
@@ -145,6 +153,8 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 > "Find all approved requirements in project MCPT"
 
 > "What work items are linked to MCPT-001?"
+
+> "Create a task in project MCPT titled 'Refactor authentication module'"
 
 ## License
 

--- a/src/mcp_server_polarion/tools/__init__.py
+++ b/src/mcp_server_polarion/tools/__init__.py
@@ -1,7 +1,8 @@
-"""MCP tool definitions — read tools for Polarion ALM."""
+"""MCP tool definitions — read and write tools for Polarion ALM."""
 
 from __future__ import annotations
 
-import mcp_server_polarion.tools.read  # noqa: F401
+import mcp_server_polarion.tools.read
+import mcp_server_polarion.tools.write  # noqa: F401
 
 __all__: list[str] = []

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -1,0 +1,311 @@
+"""Write MCP tools for Polarion ALM.
+
+Currently provides ``create_work_item``.  All write tools follow the
+strict patterns documented in ``CLAUDE.md``: they convert Markdown
+input to sanitized HTML, build minimal JSON:API payloads (skipping
+unset fields rather than sending empty values), and map domain
+exceptions to user-facing ones at the tool layer.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from fastmcp import Context
+from pydantic import Field
+
+from mcp_server_polarion.core.exceptions import (
+    PolarionAuthError,
+    PolarionError,
+    PolarionNotFoundError,
+)
+from mcp_server_polarion.models import (
+    Hyperlink,
+    JsonValue,
+    WorkItemCreateResult,
+)
+from mcp_server_polarion.server import mcp
+from mcp_server_polarion.tools._helpers import (
+    encode_path_segment,
+    extract_short_id,
+    get_client,
+    safe_str,
+)
+from mcp_server_polarion.utils import markdown_to_html, sanitize_html
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_work_item_payload(  # noqa: PLR0913
+    *,
+    title: str,
+    type: str,
+    description_html: str,
+    status: str | None,
+    priority: str | None,
+    severity: str | None,
+    assignee_ids: list[str] | None,
+    due_date: str | None,
+    initial_estimate: str | None,
+    hyperlinks: list[Hyperlink] | None,
+) -> dict[str, JsonValue]:
+    """Build the JSON:API request body for ``POST /projects/{p}/workitems``.
+
+    Only attaches keys for values that are explicitly set — ``None``,
+    empty strings, and empty lists are skipped so we never overwrite
+    Polarion defaults with empty values on creation.
+    """
+    attributes: dict[str, JsonValue] = {
+        "title": title,
+        "type": type,
+    }
+    if description_html:
+        attributes["description"] = {
+            "type": "text/html",
+            "value": description_html,
+        }
+    if status:
+        attributes["status"] = status
+    if priority:
+        attributes["priority"] = priority
+    if severity:
+        attributes["severity"] = severity
+    if due_date:
+        attributes["dueDate"] = due_date
+    if initial_estimate:
+        attributes["initialEstimate"] = initial_estimate
+    if hyperlinks:
+        attributes["hyperlinks"] = [
+            {"role": h.role, "title": h.title, "uri": h.uri} for h in hyperlinks
+        ]
+
+    relationships: dict[str, JsonValue] = {}
+    if assignee_ids:
+        relationships["assignee"] = {
+            "data": [{"type": "users", "id": uid} for uid in assignee_ids]
+        }
+
+    item: dict[str, JsonValue] = {
+        "type": "workitems",
+        "attributes": attributes,
+    }
+    if relationships:
+        item["relationships"] = relationships
+
+    return {"data": [item]}
+
+
+def _extract_created_id(response: dict[str, object]) -> str | None:
+    """Extract the short work-item ID from a 201 create response.
+
+    Polarion returns ``{"data": [{"type": "workitems",
+    "id": "projectId/MCPT-042", ...}]}``.  Returns the short ID
+    (``"MCPT-042"``) or ``None`` if the response shape is unexpected.
+    """
+    data = response.get("data")
+    if not isinstance(data, list) or not data:
+        return None
+    first = data[0]
+    if not isinstance(first, dict):
+        return None
+    full_id = safe_str(first.get("id", ""))
+    if not full_id:
+        return None
+    return extract_short_id(full_id)
+
+
+# ---------------------------------------------------------------------------
+# Write tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(tags={"write"}, timeout=60.0)
+async def create_work_item(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(
+        description=(
+            "Polarion project ID (e.g. 'myproject'). "
+            "Use ``list_projects`` to discover valid IDs."
+        ),
+    ),
+    title: str = Field(
+        min_length=1,
+        description="Work item title (required, non-empty).",
+    ),
+    type: str = Field(
+        min_length=1,
+        description=(
+            "Work item type, e.g. 'requirement', 'task', 'testCase', "
+            "'defect'. Project-specific; refer to existing work items "
+            "via ``get_work_item`` if unsure of allowed values."
+        ),
+    ),
+    description: str | None = Field(
+        default=None,
+        description=(
+            "Markdown body. Converted to Polarion-safe HTML on write. "
+            "Pass None (or omit) to leave the description unset."
+        ),
+    ),
+    status: str | None = Field(
+        default=None,
+        description=(
+            "Initial workflow status (e.g. 'draft', 'open'). "
+            "Server default applies when omitted. Project-specific."
+        ),
+    ),
+    priority: str | None = Field(
+        default=None,
+        description=(
+            "Priority value as a string (e.g. '50.0'). "
+            "Free-form; Polarion validates server-side."
+        ),
+    ),
+    severity: str | None = Field(
+        default=None,
+        description=(
+            "Severity classification, primarily for defects "
+            "(e.g. 'major', 'critical'). Free-form."
+        ),
+    ),
+    assignee_ids: list[str] | None = Field(  # noqa: B008
+        default=None,
+        description=(
+            "Short user IDs (e.g. ['alice', 'bob']). "
+            "Each is wrapped as {type:'users', id:'<id>'} in the "
+            "assignee to-many relationship."
+        ),
+    ),
+    due_date: str | None = Field(
+        default=None,
+        description="Due date in ISO-8601 format 'YYYY-MM-DD'.",
+    ),
+    initial_estimate: str | None = Field(
+        default=None,
+        description=("Polarion duration string, e.g. '5 1/2d', '1w 2d', '4h'."),
+    ),
+    hyperlinks: list[Hyperlink] | None = Field(  # noqa: B008
+        default=None,
+        description=(
+            "External hyperlinks attached to the work item. "
+            "Each must specify ``role`` and ``uri``; ``title`` is optional."
+        ),
+    ),
+    dry_run: bool = Field(
+        default=False,
+        description=(
+            "When True, build and return the JSON:API payload preview "
+            "without calling Polarion. Useful for verifying the request "
+            "shape before committing."
+        ),
+    ),
+) -> WorkItemCreateResult:
+    """Create a new Polarion work item in a project.
+
+    Builds a JSON:API ``POST /projects/{projectId}/workitems`` request
+    from the supplied fields, optionally previewing the payload with
+    ``dry_run=True``.  The created work item is *not* attached to any
+    document — for document-bound work items, use a future
+    ``create_document_part`` tool that uses the ``/parts`` endpoint and
+    supports outline positioning.
+
+    Description handling: ``description`` is treated as Markdown,
+    converted via ``markdown_to_html`` (CommonMark + GFM tables), and
+    sanitized via ``sanitize_html`` before being stored as
+    ``{"type": "text/html", "value": "..."}``. Dangerous link schemes
+    such as ``javascript:`` are stripped automatically.
+
+    Free-form fields (``status``, ``priority``, ``severity``) are
+    validated by Polarion server-side. If you're unsure of the allowed
+    values for the project, inspect an existing work item with
+    ``get_work_item`` and reuse its values.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        title: Work item title (required, non-empty).
+        type: Work item type (e.g. 'requirement', 'task').
+        description: Optional Markdown body.
+        status: Optional initial workflow status.
+        priority: Optional priority string.
+        severity: Optional severity classification.
+        assignee_ids: Optional list of short user IDs to assign.
+        due_date: Optional ISO-8601 date 'YYYY-MM-DD'.
+        initial_estimate: Optional Polarion duration string.
+        hyperlinks: Optional list of ``Hyperlink`` objects.
+        dry_run: When True, return payload preview without calling
+            Polarion. Defaults to False.
+
+    Returns:
+        WorkItemCreateResult with:
+        - ``created``: True on a successful real create, False when
+          ``dry_run=True``.
+        - ``dry_run``: Echo of the dry_run flag.
+        - ``work_item_id``: Short ID of the created work item
+          (e.g. 'MCPT-042'). None on dry-run.
+        - ``payload_preview``: The JSON:API request body. Populated on
+          dry-run; None after a successful real create.
+
+    Raises:
+        ValueError: If the project ID is not found.
+        PermissionError: If the token lacks permissions to create work
+            items in the project.
+        RuntimeError: On other Polarion API errors, or if Polarion
+            accepts the request but returns no work-item ID.
+    """
+    description_html = (
+        sanitize_html(markdown_to_html(description)) if description else ""
+    )
+
+    payload = _build_work_item_payload(
+        title=title,
+        type=type,
+        description_html=description_html,
+        status=status,
+        priority=priority,
+        severity=severity,
+        assignee_ids=assignee_ids,
+        due_date=due_date,
+        initial_estimate=initial_estimate,
+        hyperlinks=hyperlinks,
+    )
+
+    if dry_run:
+        return WorkItemCreateResult(
+            created=False,
+            dry_run=True,
+            work_item_id=None,
+            payload_preview=payload,
+        )
+
+    client = get_client(ctx)
+    path = f"/projects/{encode_path_segment(project_id)}/workitems"
+    try:
+        response = await client.post(path, json=cast(dict[str, object], payload))
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot create work item -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Project '{project_id}' not found. "
+            "Use `list_projects` to discover valid project IDs."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(f"Failed to create work item: {exc.message}") from exc
+
+    new_id = _extract_created_id(response)
+    if new_id is None:
+        raise RuntimeError(
+            "Polarion accepted the create request but returned no work-item ID. "
+            "The work item may or may not exist; verify with list_work_items."
+        )
+
+    return WorkItemCreateResult(
+        created=True,
+        dry_run=False,
+        work_item_id=new_id,
+        payload_preview=None,
+    )

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -160,7 +160,10 @@ async def create_work_item(  # noqa: PLR0913
         default=None,
         description=(
             "Priority value as a string (e.g. '50.0'). "
-            "Free-form; Polarion validates server-side."
+            "WARNING: this Polarion server version silently coerces "
+            "unrecognised values to the project default. Inspect an "
+            "existing work item with ``get_work_item`` to discover the "
+            "project's actual priority values before relying on this."
         ),
     ),
     severity: str | None = Field(
@@ -217,10 +220,13 @@ async def create_work_item(  # noqa: PLR0913
     ``{"type": "text/html", "value": "..."}``. Dangerous link schemes
     such as ``javascript:`` are stripped automatically.
 
-    Free-form fields (``status``, ``priority``, ``severity``) are
-    validated by Polarion server-side. If you're unsure of the allowed
-    values for the project, inspect an existing work item with
-    ``get_work_item`` and reuse its values.
+    Free-form fields (``type``, ``status``, ``priority``, ``severity``)
+    are NOT strictly validated by this Polarion server version.
+    Unrecognised ``priority`` values are silently coerced to the project
+    default; arbitrary ``type`` strings are stored verbatim (which can
+    create "ghost" work-item types that won't appear in any project
+    schema). Always inspect an existing work item with ``get_work_item``
+    and reuse its values to avoid corrupting the project's enum space.
 
     Args:
         ctx: MCP tool context (injected automatically).

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -7,10 +7,12 @@ injected via a mock ``Context``.
 
 from __future__ import annotations
 
-from typing import cast
+import inspect
+from typing import Annotated, cast, get_type_hints
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import TypeAdapter, ValidationError
 
 from mcp_server_polarion.core.client import PolarionClient
 from mcp_server_polarion.core.exceptions import (
@@ -579,3 +581,41 @@ class TestCreateWorkItemResponseParsing:
                 hyperlinks=None,
                 dry_run=False,
             )
+
+
+# ---------------------------------------------------------------------------
+# create_work_item — Pydantic Field constraints
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkItemFieldValidation:
+    """Verify ``min_length=1`` constraints attached to required parameters.
+
+    FastMCP enforces these via JSON Schema at the MCP protocol layer
+    before the tool function is invoked; calling the function directly
+    in unit tests bypasses that gate. To prove the constraint is wired
+    correctly, we rebuild a ``TypeAdapter`` from each parameter's
+    annotation + ``FieldInfo`` and assert the constraint actually
+    rejects bad input at the schema layer.
+    """
+
+    @staticmethod
+    def _adapter_for(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(create_work_item)
+        sig = inspect.signature(create_work_item)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_title_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("title").validate_python("")
+
+    def test_title_accepts_non_empty(self) -> None:
+        assert self._adapter_for("title").validate_python("hello") == "hello"
+
+    def test_type_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("type").validate_python("")
+
+    def test_type_accepts_non_empty(self) -> None:
+        assert self._adapter_for("type").validate_python("task") == "task"

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -1,0 +1,581 @@
+"""Tests for the write MCP tools (currently ``create_work_item``).
+
+Mirrors the test patterns in ``test_read.py``: each tool is exercised by
+calling the async function directly with a mock ``PolarionClient``
+injected via a mock ``Context``.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mcp_server_polarion.core.client import PolarionClient
+from mcp_server_polarion.core.exceptions import (
+    PolarionAuthError,
+    PolarionError,
+    PolarionNotFoundError,
+)
+from mcp_server_polarion.models import Hyperlink, WorkItemCreateResult
+from mcp_server_polarion.tools import write as _write_mod
+
+# In FastMCP 3.0, @mcp.tool returns the original function unchanged
+# (not a FunctionTool wrapper), so we reference them directly.
+create_work_item = _write_mod.create_work_item
+_build_work_item_payload = _write_mod._build_work_item_payload
+_extract_created_id = _write_mod._extract_created_id
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client() -> AsyncMock:
+    """Return a mock PolarionClient with async methods."""
+    client = AsyncMock(spec=PolarionClient)
+    client.post = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def mock_ctx(mock_client: AsyncMock) -> MagicMock:
+    """Return a mock FastMCP Context with the mock client."""
+    ctx = MagicMock()
+    ctx.lifespan_context = {
+        "polarion_client": mock_client,
+    }
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# _build_work_item_payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWorkItemPayload:
+    """Tests for the private ``_build_work_item_payload`` helper."""
+
+    def test_minimal_payload_has_only_required_attrs(self) -> None:
+        payload = _build_work_item_payload(
+            title="My WI",
+            type="task",
+            description_html="",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+        )
+
+        assert payload == {
+            "data": [
+                {
+                    "type": "workitems",
+                    "attributes": {"title": "My WI", "type": "task"},
+                }
+            ]
+        }
+        # No relationships key, no description, no other attributes.
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        assert "relationships" not in item
+        attrs = cast(dict[str, object], item["attributes"])
+        assert set(attrs.keys()) == {"title", "type"}
+
+    def test_skips_none_and_empty_string_fields(self) -> None:
+        payload = _build_work_item_payload(
+            title="x",
+            type="task",
+            description_html="",
+            status="",
+            priority=None,
+            severity="",
+            assignee_ids=[],
+            due_date="",
+            initial_estimate=None,
+            hyperlinks=[],
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attrs = cast(dict[str, object], item["attributes"])
+        # Only title + type — nothing else slipped through.
+        assert set(attrs.keys()) == {"title", "type"}
+        assert "relationships" not in item
+
+    def test_includes_description_block(self) -> None:
+        payload = _build_work_item_payload(
+            title="x",
+            type="task",
+            description_html="<p>hello</p>",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attrs = cast(dict[str, object], item["attributes"])
+        assert attrs["description"] == {
+            "type": "text/html",
+            "value": "<p>hello</p>",
+        }
+
+    def test_assignee_ids_become_to_many_users_relationship(self) -> None:
+        payload = _build_work_item_payload(
+            title="x",
+            type="task",
+            description_html="",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=["alice", "bob"],
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        rels = cast(dict[str, object], item["relationships"])
+        assert rels["assignee"] == {
+            "data": [
+                {"type": "users", "id": "alice"},
+                {"type": "users", "id": "bob"},
+            ]
+        }
+
+    def test_hyperlinks_serialise_role_title_uri(self) -> None:
+        payload = _build_work_item_payload(
+            title="x",
+            type="task",
+            description_html="",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=[
+                Hyperlink(role="ref_ext", title="Spec", uri="https://example.com"),
+                Hyperlink(role="implementation", uri="https://example.com/code"),
+            ],
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attrs = cast(dict[str, object], item["attributes"])
+        assert attrs["hyperlinks"] == [
+            {
+                "role": "ref_ext",
+                "title": "Spec",
+                "uri": "https://example.com",
+            },
+            {
+                "role": "implementation",
+                "title": "",
+                "uri": "https://example.com/code",
+            },
+        ]
+
+    def test_all_optional_attrs_included_when_set(self) -> None:
+        payload = _build_work_item_payload(
+            title="x",
+            type="task",
+            description_html="",
+            status="open",
+            priority="50.0",
+            severity="major",
+            assignee_ids=None,
+            due_date="2026-05-31",
+            initial_estimate="5 1/2d",
+            hyperlinks=None,
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attrs = cast(dict[str, object], item["attributes"])
+        assert attrs["status"] == "open"
+        assert attrs["priority"] == "50.0"
+        assert attrs["severity"] == "major"
+        assert attrs["dueDate"] == "2026-05-31"
+        assert attrs["initialEstimate"] == "5 1/2d"
+
+
+# ---------------------------------------------------------------------------
+# _extract_created_id
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCreatedId:
+    """Tests for the private ``_extract_created_id`` helper."""
+
+    def test_extracts_short_id_from_data_array(self) -> None:
+        response: dict[str, object] = {
+            "data": [
+                {
+                    "type": "workitems",
+                    "id": "MyProj/MCPT-042",
+                    "links": {"self": "..."},
+                }
+            ]
+        }
+        assert _extract_created_id(response) == "MCPT-042"
+
+    def test_returns_none_when_data_missing(self) -> None:
+        assert _extract_created_id({}) is None
+
+    def test_returns_none_when_data_empty_list(self) -> None:
+        assert _extract_created_id({"data": []}) is None
+
+    def test_returns_none_when_data_not_a_list(self) -> None:
+        assert _extract_created_id({"data": {"id": "MyProj/MCPT-1"}}) is None
+
+    def test_returns_none_when_first_entry_missing_id(self) -> None:
+        assert _extract_created_id({"data": [{"type": "workitems"}]}) is None
+
+    def test_returns_none_when_first_entry_not_dict(self) -> None:
+        assert _extract_created_id({"data": ["not a dict"]}) is None
+
+
+# ---------------------------------------------------------------------------
+# create_work_item — dry run
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkItemDryRun:
+    """Tests for ``create_work_item`` with ``dry_run=True``."""
+
+    async def test_dry_run_returns_payload_without_calling_post(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_work_item(
+            mock_ctx,
+            project_id="MyProj",
+            title="Dry test",
+            type="task",
+            description=None,
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            dry_run=True,
+        )
+
+        mock_client.post.assert_not_called()
+        assert isinstance(result, WorkItemCreateResult)
+        assert result.dry_run is True
+        assert result.created is False
+        assert result.work_item_id is None
+        assert result.payload_preview is not None
+        # payload_preview is a plain dict (no Pydantic objects leaked).
+        assert isinstance(result.payload_preview, dict)
+        item = cast(list[dict[str, object]], result.payload_preview["data"])[0]
+        attrs = cast(dict[str, object], item["attributes"])
+        assert attrs == {"title": "Dry test", "type": "task"}
+
+
+# ---------------------------------------------------------------------------
+# create_work_item — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkItemHappyPath:
+    """Tests for a successful ``create_work_item`` call."""
+
+    async def test_returns_short_id_on_201(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [
+                {
+                    "type": "workitems",
+                    "id": "MyProj/MCPT-042",
+                    "links": {"self": "..."},
+                }
+            ]
+        }
+
+        result = await create_work_item(
+            mock_ctx,
+            project_id="MyProj",
+            title="Real",
+            type="task",
+            description=None,
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            dry_run=False,
+        )
+
+        assert isinstance(result, WorkItemCreateResult)
+        assert result.created is True
+        assert result.dry_run is False
+        assert result.work_item_id == "MCPT-042"
+        assert result.payload_preview is None
+
+    async def test_post_called_with_correct_path_and_body(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "workitems", "id": "MyProj/MCPT-1"}]
+        }
+
+        await create_work_item(
+            mock_ctx,
+            project_id="MyProj",
+            title="t",
+            type="task",
+            description=None,
+            status="open",
+            priority=None,
+            severity=None,
+            assignee_ids=["alice"],
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            dry_run=False,
+        )
+
+        args, kwargs = mock_client.post.call_args
+        assert args == ("/projects/MyProj/workitems",)
+        body = kwargs["json"]
+        item = body["data"][0]
+        assert item["attributes"]["title"] == "t"
+        assert item["attributes"]["type"] == "task"
+        assert item["attributes"]["status"] == "open"
+        assert item["relationships"]["assignee"]["data"] == [
+            {"type": "users", "id": "alice"}
+        ]
+
+    async def test_description_is_converted_and_sanitized(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "workitems", "id": "MyProj/MCPT-1"}]
+        }
+
+        await create_work_item(
+            mock_ctx,
+            project_id="MyProj",
+            title="t",
+            type="task",
+            description="**bold** [link](https://example.com)",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            dry_run=False,
+        )
+
+        _, kwargs = mock_client.post.call_args
+        desc = kwargs["json"]["data"][0]["attributes"]["description"]
+        assert desc["type"] == "text/html"
+        # Markdown was rendered to HTML by markdown_to_html.
+        assert "<strong>bold</strong>" in desc["value"]
+        # Safe https link survives both markdown-it and sanitize_html.
+        assert 'href="https://example.com"' in desc["value"]
+
+    async def test_description_strips_dangerous_link_schemes(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Verify no anchor with a javascript: href is ever sent.
+
+        markdown-it-py already rejects javascript: in link URLs (it
+        leaves the literal source text unrendered), and sanitize_html
+        strips javascript: hrefs as a defense-in-depth second layer.
+        Either way, the sent payload must not contain a usable XSS
+        anchor.
+        """
+        mock_client.post.return_value = {
+            "data": [{"type": "workitems", "id": "MyProj/MCPT-1"}]
+        }
+
+        await create_work_item(
+            mock_ctx,
+            project_id="MyProj",
+            title="t",
+            type="task",
+            description="[click](javascript:alert(1))",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            dry_run=False,
+        )
+
+        _, kwargs = mock_client.post.call_args
+        desc_html = kwargs["json"]["data"][0]["attributes"]["description"]["value"]
+        # No dangerous href attribute — neither markdown-it nor
+        # sanitize_html should let one through.
+        assert 'href="javascript:' not in desc_html
+        assert "href='javascript:" not in desc_html
+
+
+# ---------------------------------------------------------------------------
+# create_work_item — error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkItemErrorMapping:
+    """Tests that domain exceptions are mapped at the tool layer."""
+
+    async def test_401_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await create_work_item(
+                mock_ctx,
+                project_id="MyProj",
+                title="t",
+                type="task",
+                description=None,
+                status=None,
+                priority=None,
+                severity=None,
+                assignee_ids=None,
+                due_date=None,
+                initial_estimate=None,
+                hyperlinks=None,
+                dry_run=False,
+            )
+
+    async def test_404_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionNotFoundError(
+            "not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="list_projects"):
+            await create_work_item(
+                mock_ctx,
+                project_id="ghost",
+                title="t",
+                type="task",
+                description=None,
+                status=None,
+                priority=None,
+                severity=None,
+                assignee_ids=None,
+                due_date=None,
+                initial_estimate=None,
+                hyperlinks=None,
+                dry_run=False,
+            )
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionError("boom", status_code=500)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await create_work_item(
+                mock_ctx,
+                project_id="MyProj",
+                title="t",
+                type="task",
+                description=None,
+                status=None,
+                priority=None,
+                severity=None,
+                assignee_ids=None,
+                due_date=None,
+                initial_estimate=None,
+                hyperlinks=None,
+                dry_run=False,
+            )
+
+
+# ---------------------------------------------------------------------------
+# create_work_item — response parsing failures
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkItemResponseParsing:
+    """Tests for unexpected 2xx response shapes from Polarion."""
+
+    async def test_empty_data_array_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {"data": []}
+
+        with pytest.raises(RuntimeError, match="no work-item ID"):
+            await create_work_item(
+                mock_ctx,
+                project_id="MyProj",
+                title="t",
+                type="task",
+                description=None,
+                status=None,
+                priority=None,
+                severity=None,
+                assignee_ids=None,
+                due_date=None,
+                initial_estimate=None,
+                hyperlinks=None,
+                dry_run=False,
+            )
+
+    async def test_data_not_a_list_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {"data": {"id": "MyProj/MCPT-1"}}
+
+        with pytest.raises(RuntimeError, match="no work-item ID"):
+            await create_work_item(
+                mock_ctx,
+                project_id="MyProj",
+                title="t",
+                type="task",
+                description=None,
+                status=None,
+                priority=None,
+                severity=None,
+                assignee_ids=None,
+                due_date=None,
+                initial_estimate=None,
+                hyperlinks=None,
+                dry_run=False,
+            )
+
+    async def test_missing_id_field_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {"data": [{"type": "workitems"}]}
+
+        with pytest.raises(RuntimeError, match="no work-item ID"):
+            await create_work_item(
+                mock_ctx,
+                project_id="MyProj",
+                title="t",
+                type="task",
+                description=None,
+                status=None,
+                priority=None,
+                severity=None,
+                assignee_ids=None,
+                due_date=None,
+                initial_estimate=None,
+                hyperlinks=None,
+                dry_run=False,
+            )


### PR DESCRIPTION
## Summary

Adds the first **write** MCP tool to the Polarion server: `create_work_item`. LLM clients can now create Polarion work items via `POST /projects/{projectId}/workitems`, with Markdown→sanitized HTML description handling, dry-run preview, and full domain-exception mapping.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- New tool `create_work_item` with 11 LLM-facing parameters: `project_id`/`title`/`type` required; `description`/`status`/`priority`/`severity`/`assignee_ids`/`due_date`/`initial_estimate`/`hyperlinks`/`dry_run` optional. `module_id` deferred to a future `create_document_part` tool that will use the `/parts` endpoint for outline positioning.
- Private helpers `_build_work_item_payload` (skips `None`/empty values to never overwrite Polarion defaults on create) and `_extract_created_id` (defensive parsing of the 201 response).
- 23 new pytest cases covering the payload builder, ID extraction, dry-run path, happy path, error mapping (401/404/other), and unexpected response shapes.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [x] `dry_run=True` path verified for all write tools
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src --strict` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run pytest tests/tools/test_write.py -v   # 23 passed
uv run pytest                                # 261 passed
```

---

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [x] All new tool functions are `async def`
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] HTML sanitized via `sanitize_html()` in write paths
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

(Pagination / `html_to_text` items N/A — this is a write tool, not a list tool.)

---

## Notes for Reviewers

- **Description handling has two security layers**: `markdown_to_html` (markdown-it-py with `html_block`/`html_inline` disabled) plus `sanitize_html`. Defense-in-depth — markdown-it already strips `javascript:` URL schemes during rendering, but the second sanitizer pass guards against future changes (new extensions, raw HTML re-enabled). Both layers are tested.
- **`module_id` intentionally omitted from v1**. The `POST /workitems` endpoint can attach a WI to a document but cannot specify outline position. A separate `create_document_part` tool using `/parts` with `previousPart`/`nextPart` will handle positioned inserts.
- **Two `# noqa` directives**: `PLR0913` on the tool function and the payload builder (parameter-rich by API necessity), and `B008` on the two `list[...] | None = Field(...)` parameters (false positive — `Field()` returns a `FieldInfo` singleton, not a mutable list).