### PR TITLE
feat(tool): add move_work_item_to_document MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | Tool | Description |
 |---|---|
 | `create_work_item` | Create a new work item (`project_id`, `title`, `type` required; `description` accepted as Markdown and converted to sanitized HTML; supports optional `status`, `priority`, `severity`, `assignee_ids`, `due_date`, `initial_estimate`, `hyperlinks`; `dry_run=True` previews the JSON:API payload without calling Polarion) |
+| `move_work_item_to_document` | Move an existing work item into a Polarion document at a specific outline position (`project_id`, `work_item_id`, `target_space_id`, `target_document_name` required; position via exactly one of `previous_part_id`/`next_part_id`; works for all work-item types including headings; `dry_run` supported) |
 
 ## Example Prompts
 
@@ -155,6 +156,8 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 > "What work items are linked to MCPT-001?"
 
 > "Create a task in project MCPT titled 'Refactor authentication module'"
+
+> "Move work item MCPT-042 into the SRS document right after MCPT-001"
 
 ## License
 

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -560,6 +560,27 @@ class DocumentPartCreateResult(BaseModel):
     )
 
 
+class WorkItemMoveResult(BaseModel):
+    """Result of a ``move_work_item_to_document`` operation."""
+
+    moved: bool = Field(
+        description=(
+            "True if the work item was actually moved into the target "
+            "document. False when dry_run is True."
+        ),
+    )
+    dry_run: bool = Field(
+        description="Whether this was a dry-run (preview only, no mutation).",
+    )
+    payload_preview: dict[str, JsonValue] | None = Field(
+        description=(
+            "Request payload that was (or would be) sent. "
+            "Usually populated for dry-run previews and may be None "
+            "after a successful real operation."
+        ),
+    )
+
+
 __all__: list[str] = [
     "CommentResult",
     "DocumentDetail",
@@ -575,6 +596,7 @@ __all__: list[str] = [
     "ProjectSummary",
     "WorkItemCreateResult",
     "WorkItemDetail",
+    "WorkItemMoveResult",
     "WorkItemSummary",
     "WorkItemUpdateResult",
 ]

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -129,8 +129,18 @@ def _build_move_to_document_payload(
 
     Note: this endpoint is NOT JSON:API — the body is a flat object
     with ``targetDocument``, plus exactly one of ``previousPart`` or
-    ``nextPart``. Caller is responsible for the position invariant.
+    ``nextPart``. The tool layer validates the exactly-one invariant
+    before calling this helper, but we re-check here so a future
+    direct caller cannot accidentally produce a ``".../None"``
+    literal-string payload.
     """
+    if (previous_part_id is None) == (next_part_id is None):
+        msg = (
+            "_build_move_to_document_payload requires exactly one of "
+            "previous_part_id or next_part_id to be set."
+        )
+        raise ValueError(msg)
+
     target_doc = f"{project_id}/{target_space_id}/{target_document_name}"
     payload: dict[str, JsonValue] = {"targetDocument": target_doc}
     if previous_part_id is not None:

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -1,10 +1,10 @@
 """Write MCP tools for Polarion ALM.
 
-Currently provides ``create_work_item``.  All write tools follow the
-strict patterns documented in ``CLAUDE.md``: they convert Markdown
-input to sanitized HTML, build minimal JSON:API payloads (skipping
-unset fields rather than sending empty values), and map domain
-exceptions to user-facing ones at the tool layer.
+Currently provides ``create_work_item`` and ``move_work_item_to_document``.
+All write tools follow the strict patterns documented in ``CLAUDE.md``:
+they convert Markdown input to sanitized HTML, build minimal request
+payloads (skipping unset fields rather than sending empty values), and
+map domain exceptions to user-facing ones at the tool layer.
 """
 
 from __future__ import annotations
@@ -23,6 +23,7 @@ from mcp_server_polarion.models import (
     Hyperlink,
     JsonValue,
     WorkItemCreateResult,
+    WorkItemMoveResult,
 )
 from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools._helpers import (
@@ -114,6 +115,29 @@ def _extract_created_id(response: dict[str, object]) -> str | None:
     if not full_id:
         return None
     return extract_short_id(full_id)
+
+
+def _build_move_to_document_payload(
+    *,
+    project_id: str,
+    target_space_id: str,
+    target_document_name: str,
+    previous_part_id: str | None,
+    next_part_id: str | None,
+) -> dict[str, JsonValue]:
+    """Build the request body for the ``moveToDocument`` action endpoint.
+
+    Note: this endpoint is NOT JSON:API — the body is a flat object
+    with ``targetDocument``, plus exactly one of ``previousPart`` or
+    ``nextPart``. Caller is responsible for the position invariant.
+    """
+    target_doc = f"{project_id}/{target_space_id}/{target_document_name}"
+    payload: dict[str, JsonValue] = {"targetDocument": target_doc}
+    if previous_part_id is not None:
+        payload["previousPart"] = f"{target_doc}/{previous_part_id}"
+    else:
+        payload["nextPart"] = f"{target_doc}/{next_part_id}"
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -313,5 +337,171 @@ async def create_work_item(  # noqa: PLR0913
         created=True,
         dry_run=False,
         work_item_id=new_id,
+        payload_preview=None,
+    )
+
+
+@mcp.tool(tags={"write"}, timeout=60.0)
+async def move_work_item_to_document(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(
+        description=(
+            "Polarion project ID containing the work item being moved. "
+            "Use ``list_projects`` to discover valid IDs."
+        ),
+    ),
+    work_item_id: str = Field(
+        min_length=1,
+        description=(
+            "Short ID of an EXISTING work item to move into the target "
+            "document (e.g. 'MCPT-042'). Use ``create_work_item`` first "
+            "if the work item does not yet exist."
+        ),
+    ),
+    target_space_id: str = Field(
+        min_length=1,
+        description=(
+            "Space ID of the target document. Use '_default' for the "
+            "default space. Discover with ``list_documents``."
+        ),
+    ),
+    target_document_name: str = Field(
+        min_length=1,
+        description=("Name of the target document within ``target_space_id``."),
+    ),
+    previous_part_id: str | None = Field(
+        default=None,
+        description=(
+            "Short part ID (e.g. 'workitem_MCPT-001', 'heading_MCPT-005') "
+            "to insert the work item AFTER. Discover existing part IDs "
+            "with ``get_document_parts``. Mutually exclusive with "
+            "``next_part_id``; exactly one must be provided."
+        ),
+    ),
+    next_part_id: str | None = Field(
+        default=None,
+        description=(
+            "Short part ID to insert the work item BEFORE. Discover "
+            "existing part IDs with ``get_document_parts``. Mutually "
+            "exclusive with ``previous_part_id``; exactly one must be "
+            "provided."
+        ),
+    ),
+    dry_run: bool = Field(
+        default=False,
+        description=(
+            "When True, build and return the request payload preview "
+            "without calling Polarion."
+        ),
+    ),
+) -> WorkItemMoveResult:
+    """Move a work item into a Polarion document at a specific outline position.
+
+    Calls Polarion's ``moveToDocument`` action endpoint
+    (``POST /projects/{p}/workitems/{wi}/actions/moveToDocument``) which:
+
+    - Updates the work item's ``module`` relationship to point at the
+      target document. After the move, the work item is a NATIVE member
+      of the document (its ``space_id`` / ``document_name`` will reflect
+      the target), not an external reference.
+    - Inserts a corresponding document part at the position specified
+      by ``previous_part_id`` or ``next_part_id``.
+    - Works for ALL work-item types including 'heading' (the older
+      ``/parts`` create endpoint refuses to create heading parts).
+
+    Prerequisite: the work item must already exist. Use
+    ``create_work_item`` first to create a free-floating work item.
+    Note that if the work item is already attached to a different
+    document, this tool detaches it from the source — the operation is
+    a true move, not a copy.
+
+    Position is specified by exactly ONE of ``previous_part_id``
+    (insert AFTER that part) or ``next_part_id`` (insert BEFORE that
+    part). Discover existing part IDs by calling ``get_document_parts``
+    on the target document; pass the short ID
+    (e.g. 'workitem_MCPT-001', 'heading_MCPT-005', 'polarion_1')
+    unchanged.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Project containing the work item to move.
+        work_item_id: Short ID of an existing work item.
+        target_space_id: Space ID of the target document.
+        target_document_name: Name of the target document.
+        previous_part_id: Insert AFTER this part. Mutually exclusive
+            with ``next_part_id``.
+        next_part_id: Insert BEFORE this part. Mutually exclusive with
+            ``previous_part_id``.
+        dry_run: When True, return payload preview without calling
+            Polarion. Defaults to False.
+
+    Returns:
+        WorkItemMoveResult with:
+        - ``moved``: True on a successful real move, False when
+          ``dry_run=True``.
+        - ``dry_run``: Echo of the dry_run flag.
+        - ``payload_preview``: The request body. Populated on dry-run;
+          None after a successful real move. The Polarion server
+          returns 204 No Content on success, so no part ID is
+          included; call ``get_document_parts`` on the target document
+          if you need the new part's ID.
+
+    Raises:
+        ValueError: If neither or both of ``previous_part_id`` and
+            ``next_part_id`` are provided, or if the work item, target
+            document, or referenced part is not found.
+        PermissionError: If the token lacks permissions to modify the
+            work item or the target document.
+        RuntimeError: On other Polarion API errors.
+    """
+    if (previous_part_id is None) == (next_part_id is None):
+        raise ValueError(
+            "Exactly one of previous_part_id or next_part_id must be "
+            "provided. Use previous_part_id to insert AFTER an existing "
+            "part, or next_part_id to insert BEFORE an existing part. "
+            "Discover existing part IDs with `get_document_parts`."
+        )
+
+    payload = _build_move_to_document_payload(
+        project_id=project_id,
+        target_space_id=target_space_id,
+        target_document_name=target_document_name,
+        previous_part_id=previous_part_id,
+        next_part_id=next_part_id,
+    )
+
+    if dry_run:
+        return WorkItemMoveResult(
+            moved=False,
+            dry_run=True,
+            payload_preview=payload,
+        )
+
+    client = get_client(ctx)
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/workitems/{encode_path_segment(work_item_id)}"
+        "/actions/moveToDocument"
+    )
+    try:
+        await client.post(path, json=cast(dict[str, object], payload))
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot move work item -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Work item '{work_item_id}' (project '{project_id}') or "
+            f"target document '{target_document_name}' (space "
+            f"'{target_space_id}') or referenced part not found. "
+            "Verify with `get_work_item`, `list_documents`, and "
+            "`get_document_parts`."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(f"Failed to move work item: {exc.message}") from exc
+
+    return WorkItemMoveResult(
+        moved=True,
+        dry_run=False,
         payload_preview=None,
     )

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -405,9 +405,17 @@ async def move_work_item_to_document(  # noqa: PLR0913
       of the document (its ``space_id`` / ``document_name`` will reflect
       the target), not an external reference.
     - Inserts a corresponding document part at the position specified
-      by ``previous_part_id`` or ``next_part_id``.
-    - Works for ALL work-item types including 'heading' (the older
-      ``/parts`` create endpoint refuses to create heading parts).
+      by ``previous_part_id`` or ``next_part_id`` and assigns the work
+      item a proper ``outline_number``.
+    - Works for all NON-heading work-item types.
+
+    LIMITATION: this Polarion server version rejects heading-type work
+    items with HTTP 400 ("Cannot move headings"). Headings appear to be
+    locked into the document that originally created them and cannot be
+    relocated via the API. If you need a heading inside a particular
+    document, the heading must be created inside that document at
+    work-item creation time (a future ``module_id`` parameter on
+    ``create_work_item`` is the planned path).
 
     Prerequisite: the work item must already exist. Use
     ``create_work_item`` first to create a free-floating work item.

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -20,12 +20,18 @@ from mcp_server_polarion.core.exceptions import (
     PolarionError,
     PolarionNotFoundError,
 )
-from mcp_server_polarion.models import Hyperlink, WorkItemCreateResult
+from mcp_server_polarion.models import (
+    Hyperlink,
+    WorkItemCreateResult,
+    WorkItemMoveResult,
+)
 from mcp_server_polarion.tools import write as _write_mod
 
 # In FastMCP 3.0, @mcp.tool returns the original function unchanged
 # (not a FunctionTool wrapper), so we reference them directly.
 create_work_item = _write_mod.create_work_item
+move_work_item_to_document = _write_mod.move_work_item_to_document
+_build_move_to_document_payload = _write_mod._build_move_to_document_payload
 _build_work_item_payload = _write_mod._build_work_item_payload
 _extract_created_id = _write_mod._extract_created_id
 
@@ -619,3 +625,334 @@ class TestCreateWorkItemFieldValidation:
 
     def test_type_accepts_non_empty(self) -> None:
         assert self._adapter_for("type").validate_python("task") == "task"
+
+
+# ===========================================================================
+# move_work_item_to_document
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# _build_move_to_document_payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMoveToDocumentPayload:
+    """Tests for the private ``_build_move_to_document_payload`` helper."""
+
+    def test_minimal_payload_with_previous_part(self) -> None:
+        payload = _build_move_to_document_payload(
+            project_id="MyProj",
+            target_space_id="Requirements",
+            target_document_name="SRS",
+            previous_part_id="workitem_MCPT-001",
+            next_part_id=None,
+        )
+
+        # NOT JSON:API — flat object with two top-level keys.
+        assert payload == {
+            "targetDocument": "MyProj/Requirements/SRS",
+            "previousPart": "MyProj/Requirements/SRS/workitem_MCPT-001",
+        }
+
+    def test_minimal_payload_with_next_part(self) -> None:
+        payload = _build_move_to_document_payload(
+            project_id="MyProj",
+            target_space_id="_default",
+            target_document_name="My Doc",
+            previous_part_id=None,
+            next_part_id="heading_MCPT-9",
+        )
+
+        assert payload == {
+            "targetDocument": "MyProj/_default/My Doc",
+            "nextPart": "MyProj/_default/My Doc/heading_MCPT-9",
+        }
+        # previousPart and nextPart are mutually exclusive in the body.
+        assert "previousPart" not in payload
+
+    def test_document_name_with_slashes_preserved_verbatim(self) -> None:
+        # JSON body IDs must NOT be URL-encoded — only URL paths are.
+        payload = _build_move_to_document_payload(
+            project_id="MyProj",
+            target_space_id="Design",
+            target_document_name="Folder/Sub Doc",
+            previous_part_id="workitem_MCPT-2",
+            next_part_id=None,
+        )
+
+        assert payload["targetDocument"] == "MyProj/Design/Folder/Sub Doc"
+        assert payload["previousPart"] == "MyProj/Design/Folder/Sub Doc/workitem_MCPT-2"
+
+
+# ---------------------------------------------------------------------------
+# move_work_item_to_document — position validation
+# ---------------------------------------------------------------------------
+
+
+class TestMoveWorkItemToDocumentPositionValidation:
+    """Tests for the exactly-one-of-position rule."""
+
+    async def test_neither_position_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        with pytest.raises(ValueError, match="Exactly one"):
+            await move_work_item_to_document(
+                mock_ctx,
+                project_id="MyProj",
+                work_item_id="MCPT-1",
+                target_space_id="S",
+                target_document_name="D",
+                previous_part_id=None,
+                next_part_id=None,
+                dry_run=False,
+            )
+        mock_client.post.assert_not_called()
+
+    async def test_both_positions_raise_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        with pytest.raises(ValueError, match="Exactly one"):
+            await move_work_item_to_document(
+                mock_ctx,
+                project_id="MyProj",
+                work_item_id="MCPT-1",
+                target_space_id="S",
+                target_document_name="D",
+                previous_part_id="workitem_MCPT-2",
+                next_part_id="workitem_MCPT-3",
+                dry_run=False,
+            )
+        mock_client.post.assert_not_called()
+
+    async def test_previous_only_passes_validation(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await move_work_item_to_document(
+            mock_ctx,
+            project_id="MyProj",
+            work_item_id="MCPT-1",
+            target_space_id="S",
+            target_document_name="D",
+            previous_part_id="workitem_MCPT-2",
+            next_part_id=None,
+            dry_run=True,
+        )
+        assert result.dry_run is True
+
+    async def test_next_only_passes_validation(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await move_work_item_to_document(
+            mock_ctx,
+            project_id="MyProj",
+            work_item_id="MCPT-1",
+            target_space_id="S",
+            target_document_name="D",
+            previous_part_id=None,
+            next_part_id="workitem_MCPT-2",
+            dry_run=True,
+        )
+        assert result.dry_run is True
+
+
+# ---------------------------------------------------------------------------
+# move_work_item_to_document — dry run
+# ---------------------------------------------------------------------------
+
+
+class TestMoveWorkItemToDocumentDryRun:
+    """Tests for ``move_work_item_to_document`` with ``dry_run=True``."""
+
+    async def test_dry_run_returns_payload_without_calling_post(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await move_work_item_to_document(
+            mock_ctx,
+            project_id="MyProj",
+            work_item_id="MCPT-42",
+            target_space_id="Requirements",
+            target_document_name="SRS",
+            previous_part_id="workitem_MCPT-1",
+            next_part_id=None,
+            dry_run=True,
+        )
+
+        mock_client.post.assert_not_called()
+        assert isinstance(result, WorkItemMoveResult)
+        assert result.moved is False
+        assert result.dry_run is True
+        assert result.payload_preview is not None
+        assert isinstance(result.payload_preview, dict)
+        assert result.payload_preview["targetDocument"] == "MyProj/Requirements/SRS"
+
+
+# ---------------------------------------------------------------------------
+# move_work_item_to_document — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestMoveWorkItemToDocumentHappyPath:
+    """Tests for a successful ``move_work_item_to_document`` call."""
+
+    async def test_returns_moved_true_on_204(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # client.post returns {} on 204 No Content.
+        mock_client.post.return_value = {}
+
+        result = await move_work_item_to_document(
+            mock_ctx,
+            project_id="MyProj",
+            work_item_id="MCPT-42",
+            target_space_id="Requirements",
+            target_document_name="SRS",
+            previous_part_id="workitem_MCPT-1",
+            next_part_id=None,
+            dry_run=False,
+        )
+
+        assert isinstance(result, WorkItemMoveResult)
+        assert result.moved is True
+        assert result.dry_run is False
+        assert result.payload_preview is None
+
+    async def test_post_called_with_correct_path_and_body(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {}
+
+        await move_work_item_to_document(
+            mock_ctx,
+            project_id="MyProj",
+            work_item_id="MCPT-42",
+            target_space_id="Requirements",
+            target_document_name="My Doc",
+            previous_part_id="workitem_MCPT-1",
+            next_part_id=None,
+            dry_run=False,
+        )
+
+        args, kwargs = mock_client.post.call_args
+        # Path uses the WI ID, with URL-encoded segments.
+        expected_path = "/projects/MyProj/workitems/MCPT-42/actions/moveToDocument"
+        assert args == (expected_path,)
+        body = kwargs["json"]
+        assert body == {
+            "targetDocument": "MyProj/Requirements/My Doc",
+            "previousPart": "MyProj/Requirements/My Doc/workitem_MCPT-1",
+        }
+
+    async def test_path_url_encodes_special_chars_in_project_id(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Defensive: ensure encode_path_segment is applied to project_id
+        # path segment.
+        mock_client.post.return_value = {}
+
+        await move_work_item_to_document(
+            mock_ctx,
+            project_id="My Proj",
+            work_item_id="MCPT-1",
+            target_space_id="S",
+            target_document_name="D",
+            previous_part_id="workitem_MCPT-2",
+            next_part_id=None,
+            dry_run=False,
+        )
+
+        args, _ = mock_client.post.call_args
+        assert args == ("/projects/My%20Proj/workitems/MCPT-1/actions/moveToDocument",)
+
+
+# ---------------------------------------------------------------------------
+# move_work_item_to_document — error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestMoveWorkItemToDocumentErrorMapping:
+    """Tests that domain exceptions are mapped at the tool layer."""
+
+    async def test_401_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await move_work_item_to_document(
+                mock_ctx,
+                project_id="MyProj",
+                work_item_id="MCPT-1",
+                target_space_id="S",
+                target_document_name="D",
+                previous_part_id="workitem_MCPT-2",
+                next_part_id=None,
+                dry_run=False,
+            )
+
+    async def test_404_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionNotFoundError(
+            "not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await move_work_item_to_document(
+                mock_ctx,
+                project_id="MyProj",
+                work_item_id="MCPT-ghost",
+                target_space_id="S",
+                target_document_name="D",
+                previous_part_id="workitem_MCPT-2",
+                next_part_id=None,
+                dry_run=False,
+            )
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionError("boom", status_code=500)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await move_work_item_to_document(
+                mock_ctx,
+                project_id="MyProj",
+                work_item_id="MCPT-1",
+                target_space_id="S",
+                target_document_name="D",
+                previous_part_id="workitem_MCPT-2",
+                next_part_id=None,
+                dry_run=False,
+            )
+
+
+# ---------------------------------------------------------------------------
+# move_work_item_to_document — Pydantic Field constraints
+# ---------------------------------------------------------------------------
+
+
+class TestMoveWorkItemToDocumentFieldValidation:
+    """Verify ``min_length=1`` constraints attached to required parameters."""
+
+    @staticmethod
+    def _adapter_for(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(move_work_item_to_document)
+        sig = inspect.signature(move_work_item_to_document)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_work_item_id_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("work_item_id").validate_python("")
+
+    def test_target_space_id_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("target_space_id").validate_python("")
+
+    def test_target_document_name_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("target_document_name").validate_python("")
+
+    def test_work_item_id_accepts_non_empty(self) -> None:
+        assert self._adapter_for("work_item_id").validate_python("MCPT-1") == "MCPT-1"

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -684,6 +684,28 @@ class TestBuildMoveToDocumentPayload:
         assert payload["targetDocument"] == "MyProj/Design/Folder/Sub Doc"
         assert payload["previousPart"] == "MyProj/Design/Folder/Sub Doc/workitem_MCPT-2"
 
+    def test_helper_rejects_neither_position(self) -> None:
+        # Defensive guard: the tool layer validates first, but a future
+        # direct caller must not be able to produce a ".../None" literal.
+        with pytest.raises(ValueError, match="exactly one"):
+            _build_move_to_document_payload(
+                project_id="MyProj",
+                target_space_id="S",
+                target_document_name="D",
+                previous_part_id=None,
+                next_part_id=None,
+            )
+
+    def test_helper_rejects_both_positions(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            _build_move_to_document_payload(
+                project_id="MyProj",
+                target_space_id="S",
+                target_document_name="D",
+                previous_part_id="workitem_MCPT-2",
+                next_part_id="workitem_MCPT-3",
+            )
+
 
 # ---------------------------------------------------------------------------
 # move_work_item_to_document — position validation


### PR DESCRIPTION
## Summary

Adds the second **write** tool: `move_work_item_to_document`. Relocates an existing Polarion work item INTO a document at a specific outline position, completing the `create_work_item` → place-in-document workflow.

> **History note:** an earlier revision of this PR proposed `create_document_part` (POST `/parts`). E2E testing on the live server (see [the prior PR comment](https://github.com/devemberx/mcp-server-polarion/pull/11#issuecomment-4359005595)) revealed two fundamental limitations of that endpoint: heading parts cannot be created, and attached work items become "external" references rather than native document members. The user spotted Polarion's `moveToDocument` action endpoint, which avoids the ownership issue (though, as the post-pivot e2e revealed, Polarion still rejects heading moves with HTTP 400 — that limitation is server-side and applies to both endpoints). The PR was force-pushed to replace the implementation entirely.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- New tool `move_work_item_to_document` calling `POST /projects/{p}/workitems/{wi}/actions/moveToDocument`. Required: `project_id`, `work_item_id`, `target_space_id`, `target_document_name`. Position via **exactly one** of `previous_part_id` / `next_part_id` (mutually-exclusive, validated at the tool layer with a clear `ValueError`). Standard `dry_run` preview.
- The endpoint is NOT JSON:API — body is a flat object with `targetDocument`, plus exactly one of `previousPart` or `nextPart` (full IDs `{project}/{space}/{doc}` and `{project}/{space}/{doc}/{part_short}`, NOT URL-encoded inside the body).
- New `WorkItemMoveResult` Pydantic model with `moved`, `dry_run`, `payload_preview`. Server returns 204 No Content (no body), so no `part_id` field — the docstring directs callers to `get_document_parts` if they need the new part's ID.
- Private helper `_build_move_to_document_payload` encapsulates the body construction (with a defensive `ValueError` for the both-None case to prevent latent `".../None"` literal-string footguns).
- 18 new pytest cases: payload-builder shape (3), position-validation rule (4), dry-run (1), happy path including URL-encoded path (3), error mapping (3), Pydantic Field constraints — `min_length=1` on string IDs (4), plus reuse of mock_client/mock_ctx fixtures.
- README updated: replace the old write tool row with the new tool, update the example prompt.
- Docstring tightened in a follow-up commit (`c5e58de`) after e2e revealed the heading rejection: the LIMITATION block now explicitly notes that Polarion server-side rejects heading moves and points to the planned `create_work_item(module_id=...)` parameter as the path forward.

---

## Why this is better than the original `create_document_part` design

| | `/parts` POST (rejected) | `moveToDocument` (this PR) |
|---|---|---|
| WI's `module` relationship | Unchanged | Properly updated |
| Resulting part's `external` flag | `true` (foreign reference) | `false` (native member) |
| WI's `outline_number` | Not assigned | Assigned (e.g. `1.2-1`) |
| Heading work items | ❌ Server 400 ("Creation of heading Parts is not supported") | ❌ Server 400 ("Cannot move headings") — same Polarion-side lockdown, [confirmed via e2e](https://github.com/devemberx/mcp-server-polarion/pull/11#issuecomment-4361755527). Acknowledged in the docstring LIMITATION block. |
| Tool surface | 3 required + 4 optional + `type` enum + `level` | 4 required + 2 position params + `dry_run` |
| Response | 201 + part_id | 204 (caller queries `get_document_parts` if needed) |

Net win for non-heading WIs (the dominant LLM use case) — concretely visible in the test project's document chain where MCPT-535 (moved) sits as a native member alongside MCPT-530 (created via the old path) which is still `external: true`. Headings remain unsolved by either endpoint and are deferred to a future `create_work_item(module_id=...)` follow-up.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [x] `dry_run=True` path verified
- [x] `uv run pytest` passes locally (283 total — was 296 with the old `create_document_part` tests; the move tool needs fewer specialized cases since there's no JSON:API response to parse)
- [x] `uv run mypy src --strict` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings
- [x] Live e2e against `MCP_Test_Project` ([results](https://github.com/devemberx/mcp-server-polarion/pull/11#issuecomment-4361755527))

```bash
uv run pytest tests/tools/test_write.py -v   # 45 passed (27 create_work_item + 18 move)
uv run pytest                                # 283 passed
```

---

## Golden Rule Compliance

- [x] No `print()` calls
- [x] `from __future__ import annotations` present
- [x] All tool inputs/outputs are Pydantic models
- [x] All new tool functions are `async def`
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] HTML-handling N/A
- [x] No secrets hardcoded

---

## Notes for Reviewers

- **Position validation** uses `(previous_part_id is None) == (next_part_id is None)` — single condition rejects both "neither set" and "both set". Test class `TestMoveWorkItemToDocumentPositionValidation` covers all four quadrants.
- **204 No Content handling** — `PolarionClient` already returns `{}` on 204, so the tool just checks success and constructs `WorkItemMoveResult(moved=True, payload_preview=None)`. No response-parsing helper needed (cleaner than the previous `_extract_created_part_id`).
- **`module_id` parameter for `create_work_item` was deferred to a separate tool** — this PR fulfills part of that deferral via `move_work_item_to_document`. The remaining gap (heading creation, `module_id` for one-shot create-in-document) is planned as the next PR.
- **Heading limitation is server-side** — both this tool and the original `/parts` design hit it. The docstring documents the constraint and the planned workaround.