### PR TITLE
feat(tool): add space_id/document_name to create_work_item

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 
 | Tool | Description |
 |---|---|
-| `create_work_item` | Create a new work item |
+| `create_work_item` | Create a new work item, optionally appending it to a document at creation time |
 | `move_work_item_to_document` | Move an existing work item into a Polarion document at a specific outline position |
 
 ## Example Prompts
@@ -156,6 +156,8 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 > "What work items are linked to MCPT-001?"
 
 > "Create a task in project MCPT titled 'Refactor authentication module'"
+
+> "Create a requirement titled 'OAuth login' inside the SRS document of project MCPT"
 
 > "Move work item MCPT-042 to the appropriate section of the SRS document."
 

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -51,12 +51,20 @@ def _build_work_item_payload(  # noqa: PLR0913
     due_date: str | None,
     initial_estimate: str | None,
     hyperlinks: list[Hyperlink] | None,
+    project_id: str,
+    space_id: str | None,
+    document_name: str | None,
 ) -> dict[str, JsonValue]:
     """Build the JSON:API request body for ``POST /projects/{p}/workitems``.
 
     Only attaches keys for values that are explicitly set — ``None``,
     empty strings, and empty lists are skipped so we never overwrite
     Polarion defaults with empty values on creation.
+
+    When both ``space_id`` and ``document_name`` are provided, attaches
+    a ``module`` to-one relationship pointing at the target document so
+    Polarion appends the new work item to that document. Pairing of
+    space_id/document_name is enforced by the tool layer.
     """
     attributes: dict[str, JsonValue] = {
         "title": title,
@@ -86,6 +94,13 @@ def _build_work_item_payload(  # noqa: PLR0913
     if assignee_ids:
         relationships["assignee"] = {
             "data": [{"type": "users", "id": uid} for uid in assignee_ids]
+        }
+    if space_id is not None and document_name is not None:
+        relationships["module"] = {
+            "data": {
+                "type": "documents",
+                "id": f"{project_id}/{space_id}/{document_name}",
+            }
         }
 
     item: dict[str, JsonValue] = {
@@ -230,6 +245,27 @@ async def create_work_item(  # noqa: PLR0913
             "Each must specify ``role`` and ``uri``; ``title`` is optional."
         ),
     ),
+    space_id: str | None = Field(
+        default=None,
+        description=(
+            "Space ID of the document to insert this work item into "
+            "(e.g. '_default', 'Requirements'). When provided together "
+            "with ``document_name``, the work item is created INSIDE the "
+            "document and appended at the end. Discover with "
+            "``list_documents``. Mutually paired with ``document_name``: "
+            "either both are set or both are None."
+        ),
+    ),
+    document_name: str | None = Field(
+        default=None,
+        description=(
+            "Document name within ``space_id`` (e.g. 'Software Requirement "
+            "Specification'). When provided together with ``space_id``, "
+            "the new work item is appended to that document. Discover with "
+            "``list_documents``. For precise positioning within the "
+            "document, follow up with ``move_work_item_to_document``."
+        ),
+    ),
     dry_run: bool = Field(
         default=False,
         description=(
@@ -243,9 +279,11 @@ async def create_work_item(  # noqa: PLR0913
 
     Builds a JSON:API ``POST /projects/{projectId}/workitems`` request
     from the supplied fields, optionally previewing the payload with
-    ``dry_run=True``.  The created work item is *not* attached to any
-    document — to place it inside a document at a specific outline
-    position, follow up with ``move_work_item_to_document``.
+    ``dry_run=True``. By default the work item is *not* attached to any
+    document; pass ``space_id`` + ``document_name`` to append it
+    directly to a document at creation time, or follow up with
+    ``move_work_item_to_document`` to place it at a specific outline
+    position.
 
     Description handling: ``description`` is treated as Markdown,
     converted via ``markdown_to_html`` (CommonMark + GFM tables), and
@@ -274,6 +312,13 @@ async def create_work_item(  # noqa: PLR0913
         due_date: Optional ISO-8601 date 'YYYY-MM-DD'.
         initial_estimate: Optional Polarion duration string.
         hyperlinks: Optional list of ``Hyperlink`` objects.
+        space_id: Optional space ID of the document to attach this
+            work item to. Must be provided together with
+            ``document_name``.
+        document_name: Optional document name within ``space_id``.
+            Must be provided together with ``space_id``. The new work
+            item is appended to the end of the document; for precise
+            positioning use ``move_work_item_to_document`` afterward.
         dry_run: When True, return payload preview without calling
             Polarion. Defaults to False.
 
@@ -288,12 +333,22 @@ async def create_work_item(  # noqa: PLR0913
           dry-run; None after a successful real create.
 
     Raises:
-        ValueError: If the project ID is not found.
+        ValueError: If only one of ``space_id`` / ``document_name`` is
+            provided (they must be paired), or if the project /
+            document is not found.
         PermissionError: If the token lacks permissions to create work
             items in the project.
         RuntimeError: On other Polarion API errors, or if Polarion
             accepts the request but returns no work-item ID.
     """
+    if (space_id is None) != (document_name is None):
+        raise ValueError(
+            "space_id and document_name must be provided together. "
+            "Set both to attach the new work item to a document, or "
+            "leave both unset to create a free-floating work item. "
+            "Use `list_documents` to discover valid space/document IDs."
+        )
+
     description_html = (
         sanitize_html(markdown_to_html(description)) if description else ""
     )
@@ -309,6 +364,9 @@ async def create_work_item(  # noqa: PLR0913
         due_date=due_date,
         initial_estimate=initial_estimate,
         hyperlinks=hyperlinks,
+        project_id=project_id,
+        space_id=space_id,
+        document_name=document_name,
     )
 
     if dry_run:
@@ -328,9 +386,12 @@ async def create_work_item(  # noqa: PLR0913
             "Cannot create work item -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionNotFoundError as exc:
+        doc_hint = (
+            f" or document '{space_id}/{document_name}'" if space_id is not None else ""
+        )
         raise ValueError(
-            f"Project '{project_id}' not found. "
-            "Use `list_projects` to discover valid project IDs."
+            f"Project '{project_id}'{doc_hint} not found. "
+            "Use `list_projects` and `list_documents` to discover valid IDs."
         ) from exc
     except PolarionError as exc:
         raise RuntimeError(f"Failed to create work item: {exc.message}") from exc

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -79,6 +79,9 @@ class TestBuildWorkItemPayload:
             due_date=None,
             initial_estimate=None,
             hyperlinks=None,
+            project_id="MyProj",
+            space_id=None,
+            document_name=None,
         )
 
         assert payload == {
@@ -107,6 +110,9 @@ class TestBuildWorkItemPayload:
             due_date="",
             initial_estimate=None,
             hyperlinks=[],
+            project_id="MyProj",
+            space_id=None,
+            document_name=None,
         )
 
         item = cast(list[dict[str, object]], payload["data"])[0]
@@ -127,6 +133,9 @@ class TestBuildWorkItemPayload:
             due_date=None,
             initial_estimate=None,
             hyperlinks=None,
+            project_id="MyProj",
+            space_id=None,
+            document_name=None,
         )
 
         item = cast(list[dict[str, object]], payload["data"])[0]
@@ -148,6 +157,9 @@ class TestBuildWorkItemPayload:
             due_date=None,
             initial_estimate=None,
             hyperlinks=None,
+            project_id="MyProj",
+            space_id=None,
+            document_name=None,
         )
 
         item = cast(list[dict[str, object]], payload["data"])[0]
@@ -174,6 +186,9 @@ class TestBuildWorkItemPayload:
                 Hyperlink(role="ref_ext", title="Spec", uri="https://example.com"),
                 Hyperlink(role="implementation", uri="https://example.com/code"),
             ],
+            project_id="MyProj",
+            space_id=None,
+            document_name=None,
         )
 
         item = cast(list[dict[str, object]], payload["data"])[0]
@@ -203,6 +218,9 @@ class TestBuildWorkItemPayload:
             due_date="2026-05-31",
             initial_estimate="5 1/2d",
             hyperlinks=None,
+            project_id="MyProj",
+            space_id=None,
+            document_name=None,
         )
 
         item = cast(list[dict[str, object]], payload["data"])[0]
@@ -212,6 +230,96 @@ class TestBuildWorkItemPayload:
         assert attrs["severity"] == "major"
         assert attrs["dueDate"] == "2026-05-31"
         assert attrs["initialEstimate"] == "5 1/2d"
+
+    def test_module_relationship_attached_when_space_and_doc_set(self) -> None:
+        payload = _build_work_item_payload(
+            title="x",
+            type="task",
+            description_html="",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            project_id="MyProj",
+            space_id="Requirements",
+            document_name="SRS",
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        rels = cast(dict[str, object], item["relationships"])
+        assert rels["module"] == {
+            "data": {"type": "documents", "id": "MyProj/Requirements/SRS"}
+        }
+
+    def test_module_skipped_when_both_space_and_doc_are_none(self) -> None:
+        payload = _build_work_item_payload(
+            title="x",
+            type="task",
+            description_html="",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            project_id="MyProj",
+            space_id=None,
+            document_name=None,
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        assert "relationships" not in item
+
+    def test_module_id_preserves_slashes_in_document_name(self) -> None:
+        # JSON body IDs must NOT be URL-encoded — only URL paths are.
+        payload = _build_work_item_payload(
+            title="x",
+            type="task",
+            description_html="",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            project_id="MyProj",
+            space_id="Design",
+            document_name="Folder/Sub Doc",
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        rels = cast(dict[str, object], item["relationships"])
+        module_data = cast(
+            dict[str, object], cast(dict[str, object], rels["module"])["data"]
+        )
+        assert module_data["id"] == "MyProj/Design/Folder/Sub Doc"
+
+    def test_module_and_assignee_can_coexist(self) -> None:
+        payload = _build_work_item_payload(
+            title="x",
+            type="task",
+            description_html="",
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=["alice"],
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            project_id="MyProj",
+            space_id="S",
+            document_name="D",
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        rels = cast(dict[str, object], item["relationships"])
+        assert "assignee" in rels
+        assert "module" in rels
 
 
 # ---------------------------------------------------------------------------
@@ -274,6 +382,8 @@ class TestCreateWorkItemDryRun:
             due_date=None,
             initial_estimate=None,
             hyperlinks=None,
+            space_id=None,
+            document_name=None,
             dry_run=True,
         )
 
@@ -324,6 +434,8 @@ class TestCreateWorkItemHappyPath:
             due_date=None,
             initial_estimate=None,
             hyperlinks=None,
+            space_id=None,
+            document_name=None,
             dry_run=False,
         )
 
@@ -353,6 +465,8 @@ class TestCreateWorkItemHappyPath:
             due_date=None,
             initial_estimate=None,
             hyperlinks=None,
+            space_id=None,
+            document_name=None,
             dry_run=False,
         )
 
@@ -387,6 +501,8 @@ class TestCreateWorkItemHappyPath:
             due_date=None,
             initial_estimate=None,
             hyperlinks=None,
+            space_id=None,
+            document_name=None,
             dry_run=False,
         )
 
@@ -426,6 +542,8 @@ class TestCreateWorkItemHappyPath:
             due_date=None,
             initial_estimate=None,
             hyperlinks=None,
+            space_id=None,
+            document_name=None,
             dry_run=False,
         )
 
@@ -435,6 +553,138 @@ class TestCreateWorkItemHappyPath:
         # sanitize_html should let one through.
         assert 'href="javascript:' not in desc_html
         assert "href='javascript:" not in desc_html
+
+    async def test_module_relationship_in_posted_body(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "workitems", "id": "MyProj/MCPT-99"}]
+        }
+
+        await create_work_item(
+            mock_ctx,
+            project_id="MyProj",
+            title="t",
+            type="requirement",
+            description=None,
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            space_id="Requirements",
+            document_name="SRS",
+            dry_run=False,
+        )
+
+        body = mock_client.post.call_args.kwargs["json"]
+        rels = body["data"][0]["relationships"]
+        assert rels["module"] == {
+            "data": {"type": "documents", "id": "MyProj/Requirements/SRS"}
+        }
+
+
+# ---------------------------------------------------------------------------
+# create_work_item — module pairing
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkItemModulePairing:
+    """``space_id`` and ``document_name`` must be provided together."""
+
+    async def test_only_space_id_raises(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        with pytest.raises(ValueError, match="must be provided together"):
+            await create_work_item(
+                mock_ctx,
+                project_id="MyProj",
+                title="t",
+                type="task",
+                description=None,
+                status=None,
+                priority=None,
+                severity=None,
+                assignee_ids=None,
+                due_date=None,
+                initial_estimate=None,
+                hyperlinks=None,
+                space_id="Requirements",
+                document_name=None,
+                dry_run=True,
+            )
+        mock_client.post.assert_not_called()
+
+    async def test_only_document_name_raises(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        with pytest.raises(ValueError, match="must be provided together"):
+            await create_work_item(
+                mock_ctx,
+                project_id="MyProj",
+                title="t",
+                type="task",
+                description=None,
+                status=None,
+                priority=None,
+                severity=None,
+                assignee_ids=None,
+                due_date=None,
+                initial_estimate=None,
+                hyperlinks=None,
+                space_id=None,
+                document_name="SRS",
+                dry_run=True,
+            )
+        mock_client.post.assert_not_called()
+
+    async def test_both_set_passes_validation(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_work_item(
+            mock_ctx,
+            project_id="MyProj",
+            title="t",
+            type="task",
+            description=None,
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            space_id="Requirements",
+            document_name="SRS",
+            dry_run=True,
+        )
+        assert result.dry_run is True
+        mock_client.post.assert_not_called()
+
+    async def test_both_unset_passes_validation(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_work_item(
+            mock_ctx,
+            project_id="MyProj",
+            title="t",
+            type="task",
+            description=None,
+            status=None,
+            priority=None,
+            severity=None,
+            assignee_ids=None,
+            due_date=None,
+            initial_estimate=None,
+            hyperlinks=None,
+            space_id=None,
+            document_name=None,
+            dry_run=True,
+        )
+        assert result.dry_run is True
+        mock_client.post.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -464,6 +714,8 @@ class TestCreateWorkItemErrorMapping:
                 due_date=None,
                 initial_estimate=None,
                 hyperlinks=None,
+                space_id=None,
+                document_name=None,
                 dry_run=False,
             )
 
@@ -488,6 +740,36 @@ class TestCreateWorkItemErrorMapping:
                 due_date=None,
                 initial_estimate=None,
                 hyperlinks=None,
+                space_id=None,
+                document_name=None,
+                dry_run=False,
+            )
+
+    async def test_404_with_module_includes_document_in_message(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # When space_id/document_name are set, the error message must
+        # also mention the document so callers know which lookup failed.
+        mock_client.post.side_effect = PolarionNotFoundError(
+            "not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="Requirements/SRS"):
+            await create_work_item(
+                mock_ctx,
+                project_id="MyProj",
+                title="t",
+                type="task",
+                description=None,
+                status=None,
+                priority=None,
+                severity=None,
+                assignee_ids=None,
+                due_date=None,
+                initial_estimate=None,
+                hyperlinks=None,
+                space_id="Requirements",
+                document_name="SRS",
                 dry_run=False,
             )
 
@@ -510,6 +792,8 @@ class TestCreateWorkItemErrorMapping:
                 due_date=None,
                 initial_estimate=None,
                 hyperlinks=None,
+                space_id=None,
+                document_name=None,
                 dry_run=False,
             )
 
@@ -541,6 +825,8 @@ class TestCreateWorkItemResponseParsing:
                 due_date=None,
                 initial_estimate=None,
                 hyperlinks=None,
+                space_id=None,
+                document_name=None,
                 dry_run=False,
             )
 
@@ -563,6 +849,8 @@ class TestCreateWorkItemResponseParsing:
                 due_date=None,
                 initial_estimate=None,
                 hyperlinks=None,
+                space_id=None,
+                document_name=None,
                 dry_run=False,
             )
 
@@ -585,6 +873,8 @@ class TestCreateWorkItemResponseParsing:
                 due_date=None,
                 initial_estimate=None,
                 hyperlinks=None,
+                space_id=None,
+                document_name=None,
                 dry_run=False,
             )
 
@@ -625,6 +915,12 @@ class TestCreateWorkItemFieldValidation:
 
     def test_type_accepts_non_empty(self) -> None:
         assert self._adapter_for("type").validate_python("task") == "task"
+
+    def test_space_id_accepts_none(self) -> None:
+        assert self._adapter_for("space_id").validate_python(None) is None
+
+    def test_document_name_accepts_none(self) -> None:
+        assert self._adapter_for("document_name").validate_python(None) is None
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Adds optional `space_id` + `document_name` parameters to `create_work_item` so a new work item can be appended to a Polarion document at creation time, instead of always being created as a free-floating backlog item.

This collapses the common "create then move" sequence into a single API call (saving one of two write requests against the company's ≤3 req/s server) and opens a path for creating heading WIs inside a document — `move_work_item_to_document` cannot relocate headings (server returns "Cannot move headings"), so they must be placed at creation time.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- Added `space_id` / `document_name` Optional Field params to `create_work_item`. Both must be provided together (or both omitted) — a mismatched pair raises `ValueError` before any HTTP call.
- Extended `_build_work_item_payload` to attach a `module` to-one relationship (`{"type": "documents", "id": "{project_id}/{space_id}/{document_name}"}`) when both are set; the ID is intentionally not URL-encoded since it lives in the JSON body.
- Broadened the 404 error message: when `space_id`/`document_name` are present, the message now mentions both the project and the document so callers know which lookup failed.
- Updated docstring (intro paragraph, Args, Raises) to document the new parameters and the pairing rule.
- README: tool description + one example prompt.
- Tests (12 new): 4 helper cases for the `module` payload (attached, both-None skip, slash preservation, coexistence with `assignee`), 4 tool-level pairing cases (only-space, only-doc, both-set, both-unset), 1 happy-path case asserting the module relationship in the POST body, 1 error-mapping case asserting 404 messages include the document ID, and 2 Field-validation cases for the Optional schema.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [x] `dry_run=True` path verified for all write tools
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src --strict` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run pytest tests/ -v       # 297 passed
uv run mypy src/              # Success: no issues found in 15 source files
uv run ruff check .           # All checks passed
uv run ruff format --check .  # all formatted
```

E2E against `MCP_Test_Project` will be exercised after CI in PR comments (dry-run preview, real create with module, list_parts verification, pairing-error cases, heading creation attempt).

---

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [x] All new tool functions are `async def`
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] HTML converted via `html_to_text()` in read paths
- [x] HTML sanitized via `text_to_polarion_html()` or `sanitize_html()` in write paths
- [x] Any new list tool supports `page_size` and `page_number` pagination (N/A — no new list tools)
- [x] No secrets hardcoded — env vars via `pydantic-settings` only