### PR TITLE
feat(tool): add update_work_item MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,14 +101,24 @@ The newer Polarion endpoint that exposes back-links with their original role is 
 
 Polarion does NOT strictly validate `type`, `status`, `priority`, or `severity` strings on create. Unrecognised values are silently coerced (`priority="not_a_number"` → project default) or stored verbatim (`type="not_a_real_type"` → ghost type). Use a `Literal[...]` annotation on the Pydantic Field for closed sets where the docstring claim of validation matters; otherwise add a WARNING to the field description. Discovered during PR #10 e2e against `MCP_Test_Project`.
 
-### Heading work items are server-locked
+### Heading work items are server-locked for create/move (but PATCH works)
 
 Polarion rejects all API attempts to create or relocate heading parts:
 - `POST .../documents/{d}/parts` with `type="heading"` → 400 "Creation of heading Parts is not supported"
 - `POST .../documents/{d}/parts` attaching a heading WI as `type="workitem"` → 400 "Cannot add external Work Item of type Heading"
 - `POST .../actions/moveToDocument` for a heading WI → 400 "Cannot move headings"
 
-Headings appear immovable once Polarion creates them. The planned workaround is to create the heading WI inside the target document at creation time via the `module` relationship on `create_work_item` (a future `module_id` parameter — see PR #11 discussion).
+However, **`PATCH /workitems/{wi}` IS allowed on heading WIs** — `update_work_item` can edit a heading's attributes (title, priority, etc.) just like any other work item (verified in PR #13 e2e against `MCPT-1`). The lock is specific to creation/relocation; in-place updates of an existing heading are unrestricted.
+
+Headings appear immovable once Polarion creates them. The planned workaround for placement is to create the heading WI inside the target document at creation time via the `module` relationship on `create_work_item` (a future `module_id` parameter — see PR #11 discussion).
+
+### `PATCH /workitems/{wi}` requires a non-empty body
+
+Polarion rejects PATCH bodies that have neither `attributes` nor `relationships` ("At least one of the members is required: 'attributes, relationships'"), even when only the `workflowAction` / `changeTypeTo` query parameter is set. Action-only transitions therefore must be paired with at least one body field. `update_work_item` validates this at the tool layer (raises `ValueError`) so the caller gets an actionable message instead of a Polarion 400. Discovered during PR #13 e2e against `MCP_Test_Project`.
+
+### `changeTypeTo` resets the workflow status
+
+Setting `changeTypeTo` on `update_work_item` resets the work item's `status` to the new type's initial workflow state — observed in PR #13 e2e: `task` (status=`approved`) → `defect` produces a defect with status=`open`. The docstring warns about this; callers that need to preserve the prior status must re-apply it in a follow-up `update_work_item` call.
 
 ## Server-Side Constraints (informational)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-server-polarion
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **Polarion ALM**. Lets AI assistants read documents, work items, and traceability links — and create new work items — directly from your Polarion instance.
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **Polarion ALM**. Lets AI assistants read documents, work items, and traceability links — and create, update, and reorganize work items — directly from your Polarion instance.
 
 [![PyPI](https://img.shields.io/pypi/v/mcp-server-polarion)](https://pypi.org/project/mcp-server-polarion/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
@@ -141,6 +141,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | Tool | Description |
 |---|---|
 | `create_work_item` | Create a new work item |
+| `update_work_item` | Update an existing work item |
 | `move_work_item_to_document` | Move an existing work item into a Polarion document at a specific outline position |
 
 ## Example Prompts
@@ -156,6 +157,8 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 > "What work items are linked to MCPT-001?"
 
 > "Create a task in project MCPT titled 'Refactor authentication module'"
+
+> "Update MCPT-042's status to approved and bump priority to 90."
 
 > "Move work item MCPT-042 to the appropriate section of the SRS document."
 

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -480,12 +480,20 @@ class WorkItemUpdateResult(BaseModel):
     )
     current: WorkItemDetail | None = Field(
         description=(
-            "Current state of the work item before the update. "
-            "Included so the LLM can verify what changed."
+            "Post-update state of the work item, fetched after the PATCH "
+            "succeeds. Included so the LLM can verify the change applied. "
+            "None on dry-run."
         ),
     )
     changes: dict[str, JsonValue] = Field(
         description="Map of field names to their new values in the PATCH payload.",
+    )
+    payload_preview: dict[str, JsonValue] | None = Field(
+        description=(
+            "JSON:API request payload that was (or would be) sent. "
+            "Usually populated for dry-run previews and may be None "
+            "after a successful real operation."
+        ),
     )
 
 

--- a/src/mcp_server_polarion/tools/_helpers.py
+++ b/src/mcp_server_polarion/tools/_helpers.py
@@ -13,7 +13,8 @@ from urllib.parse import quote
 from fastmcp import Context
 
 from mcp_server_polarion.core.client import PolarionClient
-from mcp_server_polarion.models import WorkItemSummary
+from mcp_server_polarion.models import Hyperlink, WorkItemDetail, WorkItemSummary
+from mcp_server_polarion.utils import html_to_markdown
 
 
 class WorkItemSummaryKwargs(TypedDict):
@@ -297,6 +298,84 @@ def build_work_item_summary_kwargs(
     }
 
 
+def parse_hyperlinks(value: object) -> list[Hyperlink]:
+    """Parse the ``attributes.hyperlinks`` field into ``Hyperlink`` models.
+
+    Polarion returns hyperlinks as a list of dicts with ``role``,
+    ``title``, and ``uri`` keys. Entries without a usable ``uri`` are
+    skipped to keep the response signal clean for the LLM.
+    """
+    if not isinstance(value, list):
+        return []
+    links: list[Hyperlink] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        uri = safe_str(entry.get("uri", ""))
+        if not uri:
+            continue
+        links.append(
+            Hyperlink(
+                role=safe_str(entry.get("role", "")),
+                title=safe_str(entry.get("title", "")),
+                uri=uri,
+            )
+        )
+    return links
+
+
+def parse_work_item_detail(
+    item: dict[str, object],
+    *,
+    project_id: str,
+    fallback_id: str = "",
+) -> WorkItemDetail:
+    """Parse a single JSON:API work-item resource into a ``WorkItemDetail``.
+
+    Shared by ``get_work_item`` and ``update_work_item`` (which issues a
+    follow-up GET after the PATCH succeeds). Expects the resource to
+    have been fetched with ``fields[workitems]=WI_DETAIL_FIELDS`` and
+    ``include=assignee`` so that ``relationships.assignee.data`` is
+    populated.
+
+    Args:
+        item: A single JSON:API resource object (the ``data`` element).
+        project_id: Project that contains this work item.
+        fallback_id: Used as ``WorkItemDetail.id`` when ``item.id`` is
+            missing. Pass the caller-supplied work-item ID.
+
+    Returns:
+        A fully-populated ``WorkItemDetail`` model.
+    """
+    attrs = item.get("attributes", {})
+    if not isinstance(attrs, dict):
+        attrs = {}
+    rels = item.get("relationships", {})
+    if not isinstance(rels, dict):
+        rels = {}
+
+    desc_obj = attrs.get("description", {})
+    desc_html = ""
+    if isinstance(desc_obj, dict):
+        desc_html = safe_str(desc_obj.get("value", ""))
+
+    summary_kwargs = build_work_item_summary_kwargs(item)
+    if not summary_kwargs["id"]:
+        summary_kwargs["id"] = fallback_id
+
+    return WorkItemDetail(
+        **summary_kwargs,
+        description=html_to_markdown(desc_html),
+        project_id=project_id,
+        author_id=extract_short_id(extract_relationship_id(rels, "author")),
+        created=safe_str(attrs.get("created", "")),
+        resolution=safe_str(attrs.get("resolution", "")),
+        severity=safe_str(attrs.get("severity", "")),
+        outline_number=safe_str(attrs.get("outlineNumber", "")),
+        hyperlinks=parse_hyperlinks(attrs.get("hyperlinks")),
+    )
+
+
 def parse_work_item_summaries(
     data: object,
 ) -> list[WorkItemSummary]:
@@ -333,6 +412,8 @@ __all__: list[str] = [
     "extract_total_count",
     "get_client",
     "has_links_next",
+    "parse_hyperlinks",
+    "parse_work_item_detail",
     "parse_work_item_summaries",
     "safe_str",
     "split_module_id",

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -26,7 +26,6 @@ from mcp_server_polarion.models import (
     DocumentDetail,
     DocumentPart,
     DocumentSummary,
-    Hyperlink,
     LinkedWorkItemsList,
     LinkedWorkItemSummary,
     PaginatedResult,
@@ -40,7 +39,6 @@ from mcp_server_polarion.tools._helpers import (
     WI_DETAIL_FIELDS,
     WI_LIST_FIELDS,
     build_included_workitem_map,
-    build_work_item_summary_kwargs,
     compute_has_more,
     encode_path_segment,
     extract_relationship_id,
@@ -48,6 +46,7 @@ from mcp_server_polarion.tools._helpers import (
     extract_total_count,
     get_client,
     has_links_next,
+    parse_work_item_detail,
     parse_work_item_summaries,
     safe_str,
     split_module_id,
@@ -63,32 +62,6 @@ _VALID_PART_TYPES: Final[frozenset[str]] = frozenset(
 # ---------------------------------------------------------------------------
 # Read-specific helpers
 # ---------------------------------------------------------------------------
-
-
-def _parse_hyperlinks(value: object) -> list[Hyperlink]:
-    """Parse the ``attributes.hyperlinks`` field into ``Hyperlink`` models.
-
-    Polarion returns hyperlinks as a list of dicts with ``role``,
-    ``title``, and ``uri`` keys. Entries without a usable ``uri`` are
-    skipped to keep the response signal clean for the LLM.
-    """
-    if not isinstance(value, list):
-        return []
-    links: list[Hyperlink] = []
-    for entry in value:
-        if not isinstance(entry, dict):
-            continue
-        uri = safe_str(entry.get("uri", ""))
-        if not uri:
-            continue
-        links.append(
-            Hyperlink(
-                role=safe_str(entry.get("role", "")),
-                title=safe_str(entry.get("title", "")),
-                uri=uri,
-            )
-        )
-    return links
 
 
 @dataclass(frozen=True, slots=True)
@@ -1172,32 +1145,11 @@ async def get_work_item(
     data = response.get("data", {})
     if not isinstance(data, dict):
         data = {}
-    attrs = data.get("attributes", {})
-    if not isinstance(attrs, dict):
-        attrs = {}
-    rels = data.get("relationships", {})
-    if not isinstance(rels, dict):
-        rels = {}
 
-    desc_obj = attrs.get("description", {})
-    desc_html = ""
-    if isinstance(desc_obj, dict):
-        desc_html = safe_str(desc_obj.get("value", ""))
-
-    summary_kwargs = build_work_item_summary_kwargs(data)
-    if not summary_kwargs["id"]:
-        summary_kwargs["id"] = work_item_id
-
-    return WorkItemDetail(
-        **summary_kwargs,
-        description=html_to_markdown(desc_html),
+    return parse_work_item_detail(
+        data,
         project_id=project_id,
-        author_id=extract_short_id(extract_relationship_id(rels, "author")),
-        created=safe_str(attrs.get("created", "")),
-        resolution=safe_str(attrs.get("resolution", "")),
-        severity=safe_str(attrs.get("severity", "")),
-        outline_number=safe_str(attrs.get("outlineNumber", "")),
-        hyperlinks=_parse_hyperlinks(attrs.get("hyperlinks")),
+        fallback_id=work_item_id,
     )
 
 

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -1,15 +1,17 @@
 """Write MCP tools for Polarion ALM.
 
-Currently provides ``create_work_item`` and ``move_work_item_to_document``.
-All write tools follow the strict patterns documented in ``CLAUDE.md``:
-they convert Markdown input to sanitized HTML, build minimal request
-payloads (skipping unset fields rather than sending empty values), and
-map domain exceptions to user-facing ones at the tool layer.
+Currently provides ``create_work_item``, ``update_work_item``, and
+``move_work_item_to_document``. All write tools follow the strict
+patterns documented in ``CLAUDE.md``: they convert Markdown input to
+sanitized HTML, build minimal request payloads (skipping unset fields
+rather than sending empty values), and map domain exceptions to
+user-facing ones at the tool layer.
 """
 
 from __future__ import annotations
 
 from typing import cast
+from urllib.parse import urlencode
 
 from fastmcp import Context
 from pydantic import Field
@@ -24,12 +26,15 @@ from mcp_server_polarion.models import (
     JsonValue,
     WorkItemCreateResult,
     WorkItemMoveResult,
+    WorkItemUpdateResult,
 )
 from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools._helpers import (
+    WI_DETAIL_FIELDS,
     encode_path_segment,
     extract_short_id,
     get_client,
+    parse_work_item_detail,
     safe_str,
 )
 from mcp_server_polarion.utils import markdown_to_html, sanitize_html
@@ -115,6 +120,73 @@ def _extract_created_id(response: dict[str, object]) -> str | None:
     if not full_id:
         return None
     return extract_short_id(full_id)
+
+
+def _build_update_work_item_payload(  # noqa: PLR0913
+    *,
+    project_id: str,
+    work_item_id: str,
+    title: str | None,
+    description_html: str | None,
+    status: str | None,
+    priority: str | None,
+    severity: str | None,
+    due_date: str | None,
+    initial_estimate: str | None,
+    resolution: str | None,
+    hyperlinks: list[Hyperlink] | None,
+    assignee_ids: list[str] | None,
+) -> dict[str, JsonValue]:
+    """Build the JSON:API request body for ``PATCH /projects/{p}/workitems/{wi}``.
+
+    Mirrors ``_build_work_item_payload`` but produces a PATCH-shaped body:
+    ``data`` is a single resource object (not a list), with a required
+    ``id`` of the form ``"{project_id}/{work_item_id}"``. Only attaches
+    keys for values that are explicitly set — ``None``, empty strings,
+    and empty lists are skipped so we never overwrite Polarion attributes
+    with empty values on update.
+    """
+    attributes: dict[str, JsonValue] = {}
+    if title:
+        attributes["title"] = title
+    if description_html:
+        attributes["description"] = {
+            "type": "text/html",
+            "value": description_html,
+        }
+    if status:
+        attributes["status"] = status
+    if priority:
+        attributes["priority"] = priority
+    if severity:
+        attributes["severity"] = severity
+    if due_date:
+        attributes["dueDate"] = due_date
+    if initial_estimate:
+        attributes["initialEstimate"] = initial_estimate
+    if resolution:
+        attributes["resolution"] = resolution
+    if hyperlinks:
+        attributes["hyperlinks"] = [
+            {"role": h.role, "title": h.title, "uri": h.uri} for h in hyperlinks
+        ]
+
+    relationships: dict[str, JsonValue] = {}
+    if assignee_ids:
+        relationships["assignee"] = {
+            "data": [{"type": "users", "id": uid} for uid in assignee_ids]
+        }
+
+    item: dict[str, JsonValue] = {
+        "type": "workitems",
+        "id": f"{project_id}/{work_item_id}",
+    }
+    if attributes:
+        item["attributes"] = attributes
+    if relationships:
+        item["relationships"] = relationships
+
+    return {"data": item}
 
 
 def _build_move_to_document_payload(
@@ -346,6 +418,308 @@ async def create_work_item(  # noqa: PLR0913
         created=True,
         dry_run=False,
         work_item_id=new_id,
+        payload_preview=None,
+    )
+
+
+@mcp.tool(tags={"write"}, timeout=60.0)
+async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
+    ctx: Context,
+    project_id: str = Field(
+        min_length=1,
+        description=(
+            "Polarion project ID containing the work item to update. "
+            "Use ``list_projects`` to discover valid IDs."
+        ),
+    ),
+    work_item_id: str = Field(
+        min_length=1,
+        description=(
+            "Short ID of an EXISTING work item to update (e.g. 'MCPT-042'). "
+            "Use ``get_work_item`` or ``list_work_items`` to confirm the ID."
+        ),
+    ),
+    title: str | None = Field(
+        default=None,
+        description=("New work item title. Pass None (or omit) to leave unchanged."),
+    ),
+    description: str | None = Field(
+        default=None,
+        description=(
+            "New Markdown body. Converted to Polarion-safe HTML on write. "
+            "Pass None (or omit) to leave the description unchanged. "
+            "Note: empty string also leaves the field unchanged in v1 — "
+            "there is no way to clear an existing description via this tool."
+        ),
+    ),
+    status: str | None = Field(
+        default=None,
+        description=(
+            "New workflow status. To trigger a workflow transition with "
+            "side effects (e.g. setting resolution), prefer "
+            "``workflow_action`` over a raw status update."
+        ),
+    ),
+    priority: str | None = Field(
+        default=None,
+        description=(
+            "New priority value as a string (e.g. '50.0'). "
+            "WARNING: this Polarion server version silently coerces "
+            "unrecognised values to the project default."
+        ),
+    ),
+    severity: str | None = Field(
+        default=None,
+        description="New severity classification (e.g. 'major', 'critical').",
+    ),
+    due_date: str | None = Field(
+        default=None,
+        description="New due date in ISO-8601 format 'YYYY-MM-DD'.",
+    ),
+    initial_estimate: str | None = Field(
+        default=None,
+        description="New Polarion duration string, e.g. '5 1/2d', '1w 2d'.",
+    ),
+    resolution: str | None = Field(
+        default=None,
+        description=(
+            "New resolution outcome (e.g. 'fixed', 'wontfix'). Typically "
+            "set as part of closing a work item; consider using "
+            "``workflow_action`` instead so the project's workflow rules "
+            "apply."
+        ),
+    ),
+    hyperlinks: list[Hyperlink] | None = Field(  # noqa: B008
+        default=None,
+        description=(
+            "REPLACES the work item's hyperlink list. Pass the full new "
+            "list (not a delta). Pass None (or omit) to leave hyperlinks "
+            "unchanged."
+        ),
+    ),
+    assignee_ids: list[str] | None = Field(  # noqa: B008
+        default=None,
+        description=(
+            "REPLACES the assignee list with these short user IDs "
+            "(e.g. ['alice', 'bob']). Pass None (or omit) to leave "
+            "assignees unchanged."
+        ),
+    ),
+    workflow_action: str | None = Field(
+        default=None,
+        description=(
+            "Polarion workflow action ID to trigger as part of the update "
+            "(sent as the ``workflowAction`` query parameter, e.g. "
+            "'close', 'reopen'). Workflow actions run the project's "
+            "transition rules (which may set resolution, validate "
+            "required fields, etc.) — prefer this over editing ``status`` "
+            "directly when you want a real state transition."
+        ),
+    ),
+    change_type_to: str | None = Field(
+        default=None,
+        description=(
+            "When set, changes the work item's type as part of the update "
+            "(sent as the ``changeTypeTo`` query parameter). Use sparingly "
+            "— type changes can invalidate type-specific fields."
+        ),
+    ),
+    dry_run: bool = Field(
+        default=False,
+        description=(
+            "When True, build the JSON:API payload and return it via "
+            "``payload_preview`` (plus a flat ``changes`` summary) "
+            "without calling Polarion. Useful for verifying the request "
+            "shape before committing."
+        ),
+    ),
+) -> WorkItemUpdateResult:
+    """Update an existing Polarion work item.
+
+    Builds a JSON:API ``PATCH /projects/{projectId}/workitems/{workItemId}``
+    request from the supplied fields, optionally previewing it with
+    ``dry_run=True``. After the PATCH succeeds (Polarion returns 204
+    No Content), this tool issues a follow-up ``GET`` and returns the
+    fresh ``WorkItemDetail`` as ``current`` so the caller can confirm
+    the change applied.
+
+    Field semantics: ``None`` (or omitted) leaves the corresponding
+    field unchanged. Empty string and empty list are also treated as
+    "leave unchanged" — there is no way to clear an existing field
+    value via this tool in v1. To actually change a field, pass a
+    non-empty value.
+
+    Description handling: ``description`` is treated as Markdown,
+    converted via ``markdown_to_html`` (CommonMark + GFM tables), and
+    sanitized via ``sanitize_html`` before being stored as
+    ``{"type": "text/html", "value": "..."}``.
+
+    Replace-all semantics: when ``hyperlinks`` or ``assignee_ids`` is
+    provided, it REPLACES the work item's existing list — pass the full
+    new list, not a delta.
+
+    Workflow transitions: prefer ``workflow_action`` (e.g. 'close',
+    'reopen') over editing ``status`` directly. Workflow actions run
+    Polarion's project-defined transition rules, while a raw ``status``
+    edit bypasses them.
+
+    Free-form fields (``status``, ``priority``, ``severity``,
+    ``resolution``) are NOT strictly validated by this Polarion server
+    version — unrecognised values are silently coerced or stored verbatim.
+    Inspect existing work items with ``get_work_item`` and reuse their
+    values to avoid corrupting the project's enum space.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        work_item_id: Short ID of the work item to update.
+        title: Optional new title.
+        description: Optional new Markdown body.
+        status: Optional new workflow status.
+        priority: Optional new priority string.
+        severity: Optional new severity.
+        due_date: Optional new ISO-8601 date 'YYYY-MM-DD'.
+        initial_estimate: Optional new Polarion duration string.
+        resolution: Optional new resolution outcome.
+        hyperlinks: Optional REPLACEMENT hyperlink list.
+        assignee_ids: Optional REPLACEMENT assignee list.
+        workflow_action: Optional workflow action ID
+            (``workflowAction`` query parameter).
+        change_type_to: Optional new work-item type
+            (``changeTypeTo`` query parameter).
+        dry_run: When True, return preview without calling Polarion.
+
+    Returns:
+        WorkItemUpdateResult with:
+        - ``updated``: True on a successful real update, False when
+          ``dry_run=True``.
+        - ``dry_run``: Echo of the dry_run flag.
+        - ``current``: Post-update ``WorkItemDetail`` fetched after the
+          PATCH succeeds. None on dry-run.
+        - ``changes``: Map of tool parameter names to the new values
+          included in the PATCH (Python-typed, not JSON:API-shaped).
+          Excludes parameters that were left unchanged.
+        - ``payload_preview``: The JSON:API request body. Populated on
+          dry-run; None after a successful real update.
+
+    Raises:
+        ValueError: If no mutating fields are provided, or if the work
+            item / project is not found.
+        PermissionError: If the token lacks permissions to update the
+            work item.
+        RuntimeError: On other Polarion API errors.
+    """
+    changes: dict[str, JsonValue] = {}
+    if title:
+        changes["title"] = title
+    if description:
+        changes["description"] = description
+    if status:
+        changes["status"] = status
+    if priority:
+        changes["priority"] = priority
+    if severity:
+        changes["severity"] = severity
+    if due_date:
+        changes["due_date"] = due_date
+    if initial_estimate:
+        changes["initial_estimate"] = initial_estimate
+    if resolution:
+        changes["resolution"] = resolution
+    if hyperlinks:
+        changes["hyperlinks"] = [
+            {"role": h.role, "title": h.title, "uri": h.uri} for h in hyperlinks
+        ]
+    if assignee_ids:
+        changes["assignee_ids"] = list(assignee_ids)
+    if workflow_action:
+        changes["workflow_action"] = workflow_action
+    if change_type_to:
+        changes["change_type_to"] = change_type_to
+
+    if not changes:
+        raise ValueError(
+            "Nothing to update -- pass at least one of title, description, "
+            "status, priority, severity, due_date, initial_estimate, "
+            "resolution, hyperlinks, assignee_ids, workflow_action, or "
+            "change_type_to."
+        )
+
+    description_html = (
+        sanitize_html(markdown_to_html(description)) if description else None
+    )
+
+    payload = _build_update_work_item_payload(
+        project_id=project_id,
+        work_item_id=work_item_id,
+        title=title,
+        description_html=description_html,
+        status=status,
+        priority=priority,
+        severity=severity,
+        due_date=due_date,
+        initial_estimate=initial_estimate,
+        resolution=resolution,
+        hyperlinks=hyperlinks,
+        assignee_ids=assignee_ids,
+    )
+
+    if dry_run:
+        return WorkItemUpdateResult(
+            updated=False,
+            dry_run=True,
+            current=None,
+            changes=changes,
+            payload_preview=payload,
+        )
+
+    client = get_client(ctx)
+    base_path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/workitems/{encode_path_segment(work_item_id)}"
+    )
+    query_params: dict[str, str] = {}
+    if workflow_action:
+        query_params["workflowAction"] = workflow_action
+    if change_type_to:
+        query_params["changeTypeTo"] = change_type_to
+    patch_path = f"{base_path}?{urlencode(query_params)}" if query_params else base_path
+
+    try:
+        await client.patch(patch_path, json=cast(dict[str, object], payload))
+        response = await client.get(
+            base_path,
+            params={
+                "fields[workitems]": WI_DETAIL_FIELDS,
+                "include": "assignee",
+            },
+        )
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot update work item -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Work item '{work_item_id}' in project '{project_id}' not found. "
+            "Use `list_work_items` to discover valid IDs."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(f"Failed to update work item: {exc.message}") from exc
+
+    data = response.get("data", {})
+    if not isinstance(data, dict):
+        data = {}
+    current = parse_work_item_detail(
+        data,
+        project_id=project_id,
+        fallback_id=work_item_id,
+    )
+
+    return WorkItemUpdateResult(
+        updated=True,
+        dry_run=False,
+        current=current,
+        changes=changes,
         payload_preview=None,
     )
 

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -513,7 +513,12 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
             "'close', 'reopen'). Workflow actions run the project's "
             "transition rules (which may set resolution, validate "
             "required fields, etc.) — prefer this over editing ``status`` "
-            "directly when you want a real state transition."
+            "directly when you want a real state transition. "
+            "Action IDs are project-specific; if the supplied ID is not "
+            "configured for this project, Polarion responds with HTTP 400 "
+            "'workflow action not found'. Must be paired with at least "
+            "one body field (e.g. title) — Polarion rejects PATCH bodies "
+            "with no attributes or relationships."
         ),
     ),
     change_type_to: str | None = Field(
@@ -521,7 +526,11 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         description=(
             "When set, changes the work item's type as part of the update "
             "(sent as the ``changeTypeTo`` query parameter). Use sparingly "
-            "— type changes can invalidate type-specific fields."
+            "— type changes can invalidate type-specific fields and "
+            "RESET the workflow status to the new type's initial state "
+            "(observed: 'approved' task → defect → 'open'). Must be "
+            "paired with at least one body field for the same reason as "
+            "``workflow_action``."
         ),
     ),
     dry_run: bool = Field(
@@ -561,7 +570,12 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
     Workflow transitions: prefer ``workflow_action`` (e.g. 'close',
     'reopen') over editing ``status`` directly. Workflow actions run
     Polarion's project-defined transition rules, while a raw ``status``
-    edit bypasses them.
+    edit bypasses them. ``workflow_action`` and ``change_type_to`` MUST
+    be paired with at least one body field — Polarion rejects PATCH
+    bodies that have neither ``attributes`` nor ``relationships`` (HTTP
+    400 "At least one of the members is required"). When the only
+    intent is to trigger a transition, pair it with a no-op echo
+    (e.g. ``title=<existing title>``) or any other valid body field.
 
     Free-form fields (``status``, ``priority``, ``severity``,
     ``resolution``) are NOT strictly validated by this Polarion server
@@ -603,8 +617,9 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
           dry-run; None after a successful real update.
 
     Raises:
-        ValueError: If no mutating fields are provided, or if the work
-            item / project is not found.
+        ValueError: If no mutating fields are provided; if
+            ``workflow_action`` / ``change_type_to`` is supplied without
+            any body field; or if the work item / project is not found.
         PermissionError: If the token lacks permissions to update the
             work item.
         RuntimeError: On other Polarion API errors.
@@ -663,6 +678,21 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         hyperlinks=hyperlinks,
         assignee_ids=assignee_ids,
     )
+
+    # Polarion's PATCH endpoint rejects bodies with neither attributes
+    # nor relationships ("At least one of the members is required"),
+    # even when only the workflowAction / changeTypeTo query params are
+    # used. Catch this at the tool layer with an actionable message
+    # rather than letting Polarion 400.
+    payload_data = cast(dict[str, JsonValue], payload["data"])
+    if "attributes" not in payload_data and "relationships" not in payload_data:
+        raise ValueError(
+            "Polarion's PATCH endpoint requires at least one body field "
+            "(attribute or relationship) even when triggering "
+            "workflow_action or change_type_to. Pair the action with one "
+            "of: title, description, status, priority, severity, due_date, "
+            "initial_estimate, resolution, hyperlinks, or assignee_ids."
+        )
 
     if dry_run:
         return WorkItemUpdateResult(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -617,11 +617,13 @@ class TestWorkItemUpdateResult:
             dry_run=False,
             current=current,
             changes={"title": "New Title"},
+            payload_preview=None,
         )
         assert result.updated is True
         assert result.current is not None
         assert result.current.title == "Old Title"
         assert result.changes["title"] == "New Title"
+        assert result.payload_preview is None
 
     def test_dry_run(self):
         result = WorkItemUpdateResult(
@@ -629,9 +631,17 @@ class TestWorkItemUpdateResult:
             dry_run=True,
             current=None,
             changes={"status": "approved"},
+            payload_preview={
+                "data": {
+                    "type": "workitems",
+                    "id": "proj1/MCPT-001",
+                    "attributes": {"status": "approved"},
+                }
+            },
         )
         assert result.updated is False
         assert result.dry_run is True
+        assert result.payload_preview is not None
 
 
 # ---------------------------------------------------------------------------
@@ -800,6 +810,7 @@ class TestCrossModelIntegration:
                 project_id="proj1",
             ),
             changes={"title": "After", "status": "approved"},
+            payload_preview=None,
         )
         dumped = result.model_dump()
         assert dumped["current"]["title"] == "Before"

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -1215,17 +1215,50 @@ class TestUpdateWorkItemValidation:
         mock_client.patch.assert_not_called()
         mock_client.get.assert_not_called()
 
-    async def test_workflow_action_alone_passes_validation(
+    async def test_workflow_action_alone_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # workflow_action is enough on its own — no body field required.
+        # Polarion rejects PATCH bodies with no attributes/relationships,
+        # so workflow_action / change_type_to must be paired with at
+        # least one body field. Catch this at the tool layer.
+        with pytest.raises(ValueError, match="at least one body field"):
+            await _call_update(mock_ctx, workflow_action="close")
+        mock_client.patch.assert_not_called()
+        mock_client.get.assert_not_called()
+
+    async def test_change_type_to_alone_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        with pytest.raises(ValueError, match="at least one body field"):
+            await _call_update(mock_ctx, change_type_to="defect")
+        mock_client.patch.assert_not_called()
+
+    async def test_workflow_action_alone_dry_run_also_rejected(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Dry-run is rejected too — the payload that *would* be sent is
+        # invalid, so previewing it gives no useful signal.
+        with pytest.raises(ValueError, match="at least one body field"):
+            await _call_update(mock_ctx, workflow_action="close", dry_run=True)
+
+    async def test_workflow_action_with_title_passes(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Pairing the action with any body field satisfies Polarion.
+        mock_client.patch.return_value = {}
+        mock_client.get.return_value = _make_get_response()
+
         result = await _call_update(
             mock_ctx,
             workflow_action="close",
-            dry_run=True,
+            title="closing this WI",
         )
-        assert result.dry_run is True
-        assert result.changes == {"workflow_action": "close"}
+
+        assert result.updated is True
+        patch_path = mock_client.patch.call_args.args[0]
+        assert patch_path == "/projects/MyProj/workitems/MCPT-1?workflowAction=close"
+        body = mock_client.patch.call_args.kwargs["json"]
+        assert body["data"]["attributes"]["title"] == "closing this WI"
 
 
 # ---------------------------------------------------------------------------
@@ -1384,10 +1417,12 @@ class TestUpdateWorkItemHappyPath:
     async def test_workflow_action_appended_as_query_param(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
+        # workflow_action must be paired with a body field (see
+        # TestUpdateWorkItemValidation). Pair it with a title here.
         mock_client.patch.return_value = {}
         mock_client.get.return_value = _make_get_response()
 
-        await _call_update(mock_ctx, workflow_action="close")
+        await _call_update(mock_ctx, workflow_action="close", title="t")
 
         patch_path = mock_client.patch.call_args.args[0]
         assert patch_path == "/projects/MyProj/workitems/MCPT-1?workflowAction=close"
@@ -1402,7 +1437,7 @@ class TestUpdateWorkItemHappyPath:
         mock_client.patch.return_value = {}
         mock_client.get.return_value = _make_get_response()
 
-        await _call_update(mock_ctx, change_type_to="task")
+        await _call_update(mock_ctx, change_type_to="task", title="t")
 
         patch_path = mock_client.patch.call_args.args[0]
         assert patch_path == "/projects/MyProj/workitems/MCPT-1?changeTypeTo=task"

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -24,6 +24,7 @@ from mcp_server_polarion.models import (
     Hyperlink,
     WorkItemCreateResult,
     WorkItemMoveResult,
+    WorkItemUpdateResult,
 )
 from mcp_server_polarion.tools import write as _write_mod
 
@@ -31,7 +32,9 @@ from mcp_server_polarion.tools import write as _write_mod
 # (not a FunctionTool wrapper), so we reference them directly.
 create_work_item = _write_mod.create_work_item
 move_work_item_to_document = _write_mod.move_work_item_to_document
+update_work_item = _write_mod.update_work_item
 _build_move_to_document_payload = _write_mod._build_move_to_document_payload
+_build_update_work_item_payload = _write_mod._build_update_work_item_payload
 _build_work_item_payload = _write_mod._build_work_item_payload
 _extract_created_id = _write_mod._extract_created_id
 
@@ -46,6 +49,8 @@ def mock_client() -> AsyncMock:
     """Return a mock PolarionClient with async methods."""
     client = AsyncMock(spec=PolarionClient)
     client.post = AsyncMock()
+    client.patch = AsyncMock()
+    client.get = AsyncMock()
     return client
 
 
@@ -975,6 +980,554 @@ class TestMoveWorkItemToDocumentFieldValidation:
     def test_target_document_name_rejects_empty_string(self) -> None:
         with pytest.raises(ValidationError):
             self._adapter_for("target_document_name").validate_python("")
+
+    def test_work_item_id_accepts_non_empty(self) -> None:
+        assert self._adapter_for("work_item_id").validate_python("MCPT-1") == "MCPT-1"
+
+
+# ===========================================================================
+# update_work_item
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# _build_update_work_item_payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUpdateWorkItemPayload:
+    """Tests for the private ``_build_update_work_item_payload`` helper."""
+
+    def test_minimal_payload_with_only_title(self) -> None:
+        payload = _build_update_work_item_payload(
+            project_id="MyProj",
+            work_item_id="MCPT-1",
+            title="New title",
+            description_html=None,
+            status=None,
+            priority=None,
+            severity=None,
+            due_date=None,
+            initial_estimate=None,
+            resolution=None,
+            hyperlinks=None,
+            assignee_ids=None,
+        )
+
+        # PATCH body wraps `data` as a single object, not a list.
+        assert payload == {
+            "data": {
+                "type": "workitems",
+                "id": "MyProj/MCPT-1",
+                "attributes": {"title": "New title"},
+            }
+        }
+        item = cast(dict[str, object], payload["data"])
+        assert "relationships" not in item
+
+    def test_id_is_project_slash_work_item_id(self) -> None:
+        payload = _build_update_work_item_payload(
+            project_id="proj",
+            work_item_id="MCPT-99",
+            title="x",
+            description_html=None,
+            status=None,
+            priority=None,
+            severity=None,
+            due_date=None,
+            initial_estimate=None,
+            resolution=None,
+            hyperlinks=None,
+            assignee_ids=None,
+        )
+
+        item = cast(dict[str, object], payload["data"])
+        assert item["id"] == "proj/MCPT-99"
+
+    def test_skips_none_and_empty_string_fields(self) -> None:
+        payload = _build_update_work_item_payload(
+            project_id="MyProj",
+            work_item_id="MCPT-1",
+            title=None,
+            description_html="",
+            status="",
+            priority=None,
+            severity="",
+            due_date="",
+            initial_estimate=None,
+            resolution="",
+            hyperlinks=[],
+            assignee_ids=[],
+        )
+
+        # No attributes, no relationships — just the resource header.
+        item = cast(dict[str, object], payload["data"])
+        assert item == {"type": "workitems", "id": "MyProj/MCPT-1"}
+
+    def test_includes_description_block(self) -> None:
+        payload = _build_update_work_item_payload(
+            project_id="MyProj",
+            work_item_id="MCPT-1",
+            title=None,
+            description_html="<p>hi</p>",
+            status=None,
+            priority=None,
+            severity=None,
+            due_date=None,
+            initial_estimate=None,
+            resolution=None,
+            hyperlinks=None,
+            assignee_ids=None,
+        )
+
+        item = cast(dict[str, object], payload["data"])
+        attrs = cast(dict[str, object], item["attributes"])
+        assert attrs["description"] == {
+            "type": "text/html",
+            "value": "<p>hi</p>",
+        }
+
+    def test_assignee_ids_become_to_many_users_relationship(self) -> None:
+        payload = _build_update_work_item_payload(
+            project_id="MyProj",
+            work_item_id="MCPT-1",
+            title=None,
+            description_html=None,
+            status=None,
+            priority=None,
+            severity=None,
+            due_date=None,
+            initial_estimate=None,
+            resolution=None,
+            hyperlinks=None,
+            assignee_ids=["alice", "bob"],
+        )
+
+        item = cast(dict[str, object], payload["data"])
+        rels = cast(dict[str, object], item["relationships"])
+        assert rels["assignee"] == {
+            "data": [
+                {"type": "users", "id": "alice"},
+                {"type": "users", "id": "bob"},
+            ]
+        }
+
+    def test_hyperlinks_serialise_role_title_uri(self) -> None:
+        payload = _build_update_work_item_payload(
+            project_id="MyProj",
+            work_item_id="MCPT-1",
+            title=None,
+            description_html=None,
+            status=None,
+            priority=None,
+            severity=None,
+            due_date=None,
+            initial_estimate=None,
+            resolution=None,
+            hyperlinks=[
+                Hyperlink(role="ref_ext", title="Spec", uri="https://example.com"),
+            ],
+            assignee_ids=None,
+        )
+
+        item = cast(dict[str, object], payload["data"])
+        attrs = cast(dict[str, object], item["attributes"])
+        assert attrs["hyperlinks"] == [
+            {"role": "ref_ext", "title": "Spec", "uri": "https://example.com"},
+        ]
+
+    def test_all_optional_attrs_included_when_set(self) -> None:
+        payload = _build_update_work_item_payload(
+            project_id="MyProj",
+            work_item_id="MCPT-1",
+            title="t",
+            description_html=None,
+            status="open",
+            priority="50.0",
+            severity="major",
+            due_date="2026-05-31",
+            initial_estimate="5 1/2d",
+            resolution="fixed",
+            hyperlinks=None,
+            assignee_ids=None,
+        )
+
+        item = cast(dict[str, object], payload["data"])
+        attrs = cast(dict[str, object], item["attributes"])
+        assert attrs["title"] == "t"
+        assert attrs["status"] == "open"
+        assert attrs["priority"] == "50.0"
+        assert attrs["severity"] == "major"
+        assert attrs["dueDate"] == "2026-05-31"
+        assert attrs["initialEstimate"] == "5 1/2d"
+        assert attrs["resolution"] == "fixed"
+
+
+# ---------------------------------------------------------------------------
+# update_work_item — shared helpers for tool-level tests
+# ---------------------------------------------------------------------------
+
+
+async def _call_update(
+    mock_ctx: MagicMock, **overrides: object
+) -> WorkItemUpdateResult:
+    """Call ``update_work_item`` with safe defaults.
+
+    The tool's ``Field(...)`` defaults stay as ``FieldInfo`` objects when
+    invoked outside FastMCP, so every parameter must be passed
+    explicitly. This helper supplies plain Python defaults; tests
+    override only the parameters they care about.
+    """
+    defaults: dict[str, object] = {
+        "project_id": "MyProj",
+        "work_item_id": "MCPT-1",
+        "title": None,
+        "description": None,
+        "status": None,
+        "priority": None,
+        "severity": None,
+        "due_date": None,
+        "initial_estimate": None,
+        "resolution": None,
+        "hyperlinks": None,
+        "assignee_ids": None,
+        "workflow_action": None,
+        "change_type_to": None,
+        "dry_run": False,
+    }
+    defaults.update(overrides)
+    return await update_work_item(mock_ctx, **defaults)
+
+
+# ---------------------------------------------------------------------------
+# update_work_item — at-least-one-field validation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWorkItemValidation:
+    """Tests for the at-least-one-field guard in ``update_work_item``."""
+
+    async def test_no_fields_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        with pytest.raises(ValueError, match="Nothing to update"):
+            await _call_update(mock_ctx)
+        mock_client.patch.assert_not_called()
+        mock_client.get.assert_not_called()
+
+    async def test_workflow_action_alone_passes_validation(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # workflow_action is enough on its own — no body field required.
+        result = await _call_update(
+            mock_ctx,
+            workflow_action="close",
+            dry_run=True,
+        )
+        assert result.dry_run is True
+        assert result.changes == {"workflow_action": "close"}
+
+
+# ---------------------------------------------------------------------------
+# update_work_item — dry run
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWorkItemDryRun:
+    """Tests for ``update_work_item`` with ``dry_run=True``."""
+
+    async def test_dry_run_does_not_call_polarion(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await _call_update(
+            mock_ctx,
+            title="New title",
+            dry_run=True,
+        )
+
+        mock_client.patch.assert_not_called()
+        mock_client.get.assert_not_called()
+        assert isinstance(result, WorkItemUpdateResult)
+        assert result.updated is False
+        assert result.dry_run is True
+        assert result.current is None
+        assert result.changes == {"title": "New title"}
+        # payload_preview is populated on dry-run (mirrors create_work_item).
+        assert result.payload_preview is not None
+        item = cast(dict[str, object], result.payload_preview["data"])
+        assert item["id"] == "MyProj/MCPT-1"
+        attrs = cast(dict[str, object], item["attributes"])
+        assert attrs == {"title": "New title"}
+
+    async def test_changes_uses_python_typed_values_not_json_api_shape(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # description in `changes` is the original Markdown; the
+        # JSON:API HTML wrapping happens only in the wire payload preview.
+        result = await _call_update(
+            mock_ctx,
+            description="**bold**",
+            assignee_ids=["alice"],
+            dry_run=True,
+        )
+
+        assert result.changes == {
+            "description": "**bold**",
+            "assignee_ids": ["alice"],
+        }
+        # The wire-shaped preview holds the HTML-wrapped description.
+        assert result.payload_preview is not None
+        item = cast(dict[str, object], result.payload_preview["data"])
+        attrs = cast(dict[str, object], item["attributes"])
+        desc = cast(dict[str, object], attrs["description"])
+        assert desc["type"] == "text/html"
+
+
+# ---------------------------------------------------------------------------
+# update_work_item — happy path
+# ---------------------------------------------------------------------------
+
+
+def _make_get_response(
+    *,
+    work_item_id: str = "MCPT-1",
+    project_id: str = "MyProj",
+    title: str = "after",
+    status: str = "open",
+    description_html: str = "",
+    assignee_ids: list[str] | None = None,
+) -> dict[str, object]:
+    """Build a minimal JSON:API GET response for the follow-up fetch."""
+    rels: dict[str, object] = {}
+    if assignee_ids is not None:
+        rels["assignee"] = {
+            "data": [{"type": "users", "id": uid} for uid in assignee_ids]
+        }
+    attrs: dict[str, object] = {
+        "title": title,
+        "type": "task",
+        "status": status,
+        "priority": "50.0",
+        "updated": "2026-05-04T10:00:00Z",
+    }
+    if description_html:
+        attrs["description"] = {"type": "text/html", "value": description_html}
+    return {
+        "data": {
+            "type": "workitems",
+            "id": f"{project_id}/{work_item_id}",
+            "attributes": attrs,
+            "relationships": rels,
+        }
+    }
+
+
+class TestUpdateWorkItemHappyPath:
+    """Tests for a successful ``update_work_item`` call."""
+
+    async def test_returns_updated_with_post_update_state(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # PATCH returns {} on 204; GET returns the post-update detail.
+        mock_client.patch.return_value = {}
+        mock_client.get.return_value = _make_get_response(title="after")
+
+        result = await _call_update(mock_ctx, title="after")
+
+        assert isinstance(result, WorkItemUpdateResult)
+        assert result.updated is True
+        assert result.dry_run is False
+        assert result.current is not None
+        assert result.current.title == "after"
+        assert result.changes == {"title": "after"}
+        assert result.payload_preview is None
+
+    async def test_patch_called_with_correct_path_and_body(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        mock_client.get.return_value = _make_get_response()
+
+        await _call_update(
+            mock_ctx,
+            work_item_id="MCPT-42",
+            status="open",
+            assignee_ids=["alice"],
+        )
+
+        args, kwargs = mock_client.patch.call_args
+        assert args == ("/projects/MyProj/workitems/MCPT-42",)
+        body = kwargs["json"]
+        item = body["data"]
+        assert item["type"] == "workitems"
+        assert item["id"] == "MyProj/MCPT-42"
+        assert item["attributes"]["status"] == "open"
+        assert item["relationships"]["assignee"]["data"] == [
+            {"type": "users", "id": "alice"}
+        ]
+
+    async def test_followup_get_called_with_detail_fields(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        mock_client.get.return_value = _make_get_response()
+
+        await _call_update(mock_ctx, title="t")
+
+        args, kwargs = mock_client.get.call_args
+        assert args == ("/projects/MyProj/workitems/MCPT-1",)
+        params = kwargs["params"]
+        assert params["include"] == "assignee"
+        assert "title" in params["fields[workitems]"]
+        assert "description" in params["fields[workitems]"]
+
+    async def test_workflow_action_appended_as_query_param(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        mock_client.get.return_value = _make_get_response()
+
+        await _call_update(mock_ctx, workflow_action="close")
+
+        patch_path = mock_client.patch.call_args.args[0]
+        assert patch_path == "/projects/MyProj/workitems/MCPT-1?workflowAction=close"
+        # Follow-up GET uses the base path (no query) so we always read
+        # the canonical detail view.
+        get_path = mock_client.get.call_args.args[0]
+        assert get_path == "/projects/MyProj/workitems/MCPT-1"
+
+    async def test_change_type_to_appended_as_query_param(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        mock_client.get.return_value = _make_get_response()
+
+        await _call_update(mock_ctx, change_type_to="task")
+
+        patch_path = mock_client.patch.call_args.args[0]
+        assert patch_path == "/projects/MyProj/workitems/MCPT-1?changeTypeTo=task"
+
+    async def test_description_is_converted_and_sanitized(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        mock_client.get.return_value = _make_get_response()
+
+        await _call_update(
+            mock_ctx,
+            description="**bold** [link](https://example.com)",
+        )
+
+        body = mock_client.patch.call_args.kwargs["json"]
+        desc = body["data"]["attributes"]["description"]
+        assert desc["type"] == "text/html"
+        assert "<strong>bold</strong>" in desc["value"]
+        assert 'href="https://example.com"' in desc["value"]
+
+    async def test_description_strips_dangerous_link_schemes(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        mock_client.get.return_value = _make_get_response()
+
+        await _call_update(
+            mock_ctx,
+            description="[click](javascript:alert(1))",
+        )
+
+        body = mock_client.patch.call_args.kwargs["json"]
+        desc_html = body["data"]["attributes"]["description"]["value"]
+        assert 'href="javascript:' not in desc_html
+        assert "href='javascript:" not in desc_html
+
+    async def test_path_url_encodes_special_chars(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        mock_client.get.return_value = _make_get_response()
+
+        await _call_update(mock_ctx, project_id="My Proj", title="t")
+
+        assert (
+            mock_client.patch.call_args.args[0]
+            == "/projects/My%20Proj/workitems/MCPT-1"
+        )
+
+
+# ---------------------------------------------------------------------------
+# update_work_item — error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWorkItemErrorMapping:
+    """Tests that domain exceptions are mapped at the tool layer."""
+
+    async def test_patch_401_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await _call_update(mock_ctx, title="t")
+        mock_client.get.assert_not_called()
+
+    async def test_patch_404_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.side_effect = PolarionNotFoundError(
+            "not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await _call_update(mock_ctx, work_item_id="ghost", title="t")
+
+    async def test_patch_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.side_effect = PolarionError("boom", status_code=500)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await _call_update(mock_ctx, title="t")
+
+    async def test_followup_get_404_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # PATCH succeeds, but the follow-up GET 404s — surface it the
+        # same way (very rare race; mostly defensive).
+        mock_client.patch.return_value = {}
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await _call_update(mock_ctx, title="t")
+
+
+# ---------------------------------------------------------------------------
+# update_work_item — Pydantic Field constraints
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWorkItemFieldValidation:
+    """Verify ``min_length=1`` constraints attached to required parameters."""
+
+    @staticmethod
+    def _adapter_for(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(update_work_item)
+        sig = inspect.signature(update_work_item)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_project_id_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("project_id").validate_python("")
+
+    def test_work_item_id_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("work_item_id").validate_python("")
+
+    def test_project_id_accepts_non_empty(self) -> None:
+        assert self._adapter_for("project_id").validate_python("p") == "p"
 
     def test_work_item_id_accepts_non_empty(self) -> None:
         assert self._adapter_for("work_item_id").validate_python("MCPT-1") == "MCPT-1"


### PR DESCRIPTION
## Summary

Adds an `update_work_item` MCP tool that performs `PATCH /projects/{projectId}/workitems/{workItemId}` so AI assistants can edit existing Polarion work items (title, description, status, priority, hyperlinks, assignees, …) instead of having to delete-and-recreate. Rounds out the write surface alongside `create_work_item` (#10) and `move_work_item_to_document` (#11).

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- New `update_work_item` tool in `tools/write.py` (with private `_build_update_work_item_payload` helper). Supports updating `title`, `description` (Markdown→sanitized HTML), `status`, `priority`, `severity`, `due_date`, `initial_estimate`, `resolution`, `hyperlinks`, `assignee_ids`, plus the PATCH-only query params `workflow_action` and `change_type_to`. Honors `dry_run` for payload preview without mutation.
- Polarion returns 204 No Content; the tool issues a follow-up `GET` (with `WI_DETAIL_FIELDS` + `include=assignee`) and populates `WorkItemUpdateResult.current` with the post-update `WorkItemDetail` so the caller can verify the change applied.
- Factored `parse_hyperlinks` and the inline `WorkItemDetail` construction out of `tools/read.py` into shared helpers `parse_hyperlinks` / `parse_work_item_detail` in `tools/_helpers.py`. `get_work_item` now uses the shared helper too — no behavior change.
- Added `payload_preview: dict[str, JsonValue] | None` to `WorkItemUpdateResult` for dry-run parity with `WorkItemCreateResult`. Updated the `current` field description to reflect "post-update state".
- Comprehensive tests in `tests/tools/test_write.py`: payload helper (single-object data, id format, skip-empty semantics, hyperlinks/assignee shapes), at-least-one-field validation, dry-run, happy-path (path/body, follow-up GET, query-param wiring, Markdown→HTML), error mapping (auth/not-found/other on both PATCH and follow-up GET), and Pydantic field constraints.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [x] `dry_run=True` path verified for all write tools
- [x] `uv run pytest` passes locally (312 passed)
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check .` and `ruff format --check .` pass

```bash
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
```

E2E against `MCP_Test_Project` will be posted as a follow-up comment on this PR.

---

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [x] All new tool functions are `async def`
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] HTML converted via `html_to_markdown()` in read paths (follow-up GET)
- [x] HTML sanitized via `sanitize_html()` in write paths
- [ ] Any new list tool supports `page_size` and `page_number` pagination — N/A, not a list tool
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

---

## Notes for Reviewers

- **PATCH payload shape** differs from create: `data` is a single object (not a list), with a required `id` of `"{projectId}/{workItemId}"`. Captured in `_build_update_work_item_payload` and verified in tests.
- **Empty/None semantics**: empty string and empty list are treated as "leave unchanged" (same convention as `create_work_item`). There is no way to clear an existing field via this tool in v1; documented in the docstring as a known limitation.
- **Replace-all**: `hyperlinks` and `assignee_ids`, when supplied, replace the existing list — they are not deltas.
- **Workflow vs raw status**: docstring nudges the LLM toward `workflow_action` over a raw `status` edit so Polarion's transition rules apply (resolution, validation, etc.).
- **Heading work items** are server-locked for create/move per CLAUDE.md. PATCH behavior on headings is not currently documented and will be checked in the E2E run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
