### PR TITLE
fix(utils): expand merged table cells on read

### DIFF
--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -14,6 +14,7 @@ Document content) as HTML.  These utilities ensure:
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Final
 
 from bs4 import BeautifulSoup, Tag
@@ -93,8 +94,109 @@ def html_to_markdown(html: str) -> str:
     """
     if not html or not html.strip():
         return ""
-    result: str = markdownify(html, heading_style="ATX", strip=["img"])
+    expanded = _expand_merged_table_cells(html)
+    result: str = markdownify(expanded, heading_style="ATX", strip=["img"])
     return result.strip()
+
+
+def _expand_merged_table_cells(html: str) -> str:
+    """Rectangularize tables by duplicating ``colspan``/``rowspan`` cells.
+
+    ``markdownify`` 1.2.2 renders ``colspan`` extra columns as empty cells
+    (losing the merged value's association with those columns) and silently
+    drops ``rowspan`` entirely (producing GFM rows whose cell count disagrees
+    with the header — a structurally broken table).  Pre-process the HTML so
+    that every spanned cell is duplicated into each grid position it covered;
+    the resulting table is rectangular and ``markdownify`` emits valid GFM.
+    """
+    if "<table" not in html.lower():
+        return html
+    soup = BeautifulSoup(html, "html.parser")
+    for table in soup.find_all("table"):
+        _rectangularize_table(table)
+    return str(soup)
+
+
+def _rectangularize_table(table: Tag) -> None:
+    """Walk one ``<table>`` and replace span attributes with duplicated cells.
+
+    The cell at logical position (row, col) carrying ``colspan=N rowspan=M``
+    is replaced with ``N*M`` copies at consecutive positions
+    ``(row..row+M-1, col..col+N-1)``.  Reservations from earlier rows shift
+    later rows' fresh cells rightward so the column index stays correct.
+    """
+    rows: list[Tag] = [
+        tr for tr in table.find_all("tr") if tr.find_parent("table") is table
+    ]
+    if not rows:
+        return
+
+    # reservations[i][col] holds a clone scheduled to occupy (i, col),
+    # propagated from a rowspan in an earlier row.
+    reservations: list[dict[int, Tag]] = [{} for _ in rows]
+
+    for row_idx, row in enumerate(rows):
+        original_cells: list[Tag] = [
+            cell for cell in row.find_all(["td", "th"]) if cell.find_parent("tr") is row
+        ]
+
+        layout: dict[int, Tag] = dict(reservations[row_idx])
+        col_idx = 0
+
+        for cell in original_cells:
+            while col_idx in layout:
+                col_idx += 1
+
+            colspan = _get_span(cell, "colspan")
+            rowspan = _get_span(cell, "rowspan")
+
+            for attr in ("colspan", "rowspan"):
+                if attr in cell.attrs:
+                    del cell.attrs[attr]
+
+            layout[col_idx] = cell
+            for j in range(1, colspan):
+                layout[col_idx + j] = _clone_cell(cell)
+
+            for k in range(1, rowspan):
+                target = row_idx + k
+                if target >= len(rows):
+                    break
+                for j in range(colspan):
+                    reservations[target][col_idx + j] = _clone_cell(cell)
+
+            col_idx += colspan
+
+        # Rebuild the row in column order; row.clear() drops original cells
+        # plus any inter-cell whitespace, which markdownify ignores anyway.
+        row.clear()
+        for col in sorted(layout):
+            row.append(layout[col])
+
+
+def _get_span(cell: Tag, attr_name: str) -> int:
+    """Return the colspan/rowspan as an int in ``[1, 1000]``.
+
+    Mirrors ``markdownify``'s own clamp.  Missing, non-string, or
+    non-numeric values fall back to 1.
+    """
+    raw = cell.attrs.get(attr_name)
+    if isinstance(raw, list):
+        raw = raw[0] if raw else ""
+    if not isinstance(raw, str):
+        return 1
+    raw = raw.strip()
+    if not raw.isdigit():
+        return 1
+    return max(1, min(1000, int(raw)))
+
+
+def _clone_cell(cell: Tag) -> Tag:
+    clone: Tag = deepcopy(cell)
+    for attr in ("colspan", "rowspan"):
+        if attr in clone.attrs:
+            del clone.attrs[attr]
+    return clone
 
 
 def markdown_to_html(text: str) -> str:

--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -69,6 +69,13 @@ _DECOMPOSE_TAGS: Final[frozenset[str]] = frozenset({"script", "style"})
 # (javascript:, data:, vbscript:, etc.) is stripped to prevent stored XSS.
 _SAFE_URL_SCHEMES: Final[frozenset[str]] = frozenset({"http", "https", "mailto"})
 
+# Upper bound on cells materialised for a single merged-cell expansion
+# (``colspan * rowspan``).  Per-attribute clamp is 1000, so without this
+# total bound an adversarial ``colspan="1000" rowspan="1000"`` would yield
+# 1M tag clones for a single cell.  10k cells comfortably accommodates any
+# realistic Polarion table while keeping worst-case allocation bounded.
+_MAX_CELLS_PER_MERGE: Final[int] = 10_000
+
 # markdown-it-py renderer: CommonMark base + GFM tables.
 # html_block and html_inline are disabled so that raw HTML embedded in
 # LLM/user-supplied Markdown cannot bypass sanitization.
@@ -144,28 +151,38 @@ def _rectangularize_table(table: Tag) -> None:
         col_idx = 0
 
         for cell in original_cells:
-            while col_idx in layout:
-                col_idx += 1
-
             colspan = _get_span(cell, "colspan")
             rowspan = _get_span(cell, "rowspan")
+
+            # Bound total expansion per merge to keep worst-case allocation
+            # proportional to realistic table sizes.  Drop rowspan first
+            # (rows are typically scarcer than columns in Polarion content).
+            if colspan * rowspan > _MAX_CELLS_PER_MERGE:
+                rowspan = max(1, _MAX_CELLS_PER_MERGE // colspan)
 
             for attr in ("colspan", "rowspan"):
                 if attr in cell.attrs:
                     del cell.attrs[attr]
 
-            layout[col_idx] = cell
-            for j in range(1, colspan):
-                layout[col_idx + j] = _clone_cell(cell)
+            # Place the original + colspan duplicates one column at a time,
+            # skipping positions already reserved by a rowspan from above.
+            # The cell may therefore land at non-contiguous column indices —
+            # the same behaviour browsers exhibit when a colspan is pushed
+            # past a rowspan reservation.
+            placed_cols: list[int] = []
+            for j in range(colspan):
+                while col_idx in layout:
+                    col_idx += 1
+                layout[col_idx] = cell if j == 0 else _clone_cell(cell)
+                placed_cols.append(col_idx)
+                col_idx += 1
 
             for k in range(1, rowspan):
                 target = row_idx + k
                 if target >= len(rows):
                     break
-                for j in range(colspan):
-                    reservations[target][col_idx + j] = _clone_cell(cell)
-
-            col_idx += colspan
+                for placed_col in placed_cols:
+                    reservations[target][placed_col] = _clone_cell(cell)
 
         # Rebuild the row in column order; row.clear() drops original cells
         # plus any inter-cell whitespace, which markdownify ignores anyway.
@@ -192,6 +209,13 @@ def _get_span(cell: Tag, attr_name: str) -> int:
 
 
 def _clone_cell(cell: Tag) -> Tag:
+    """Return a detached deep copy of ``cell`` with span attributes stripped.
+
+    ``deepcopy`` on a ``bs4.Tag`` yields a fresh subtree (children, text,
+    inline formatting) without a parent reference, so the copy can be
+    attached elsewhere in the soup.  Span attributes are removed defensively
+    even though ``_rectangularize_table`` already strips them on the source.
+    """
     clone: Tag = deepcopy(cell)
     for attr in ("colspan", "rowspan"):
         if attr in clone.attrs:

--- a/tests/utils/test_html.py
+++ b/tests/utils/test_html.py
@@ -122,6 +122,112 @@ class TestHtmlToMarkdown:
         assert "bold italic" in result
 
 
+class TestHtmlToMarkdownMergedCells:
+    """Tables with ``colspan``/``rowspan`` must produce rectangular GFM."""
+
+    @staticmethod
+    def _table_rows(markdown: str) -> list[list[str]]:
+        rows: list[list[str]] = []
+        for line in markdown.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("|"):
+                continue
+            inner = stripped.strip("|")
+            if set(inner.replace("|", "").strip()) <= {"-", " ", ":"}:
+                continue  # GFM separator row
+            rows.append([cell.strip() for cell in inner.split("|")])
+        return rows
+
+    def test_table_colspan_duplicates_value(self) -> None:
+        html = (
+            "<table><thead><tr><th>A</th><th>B</th><th>C</th></tr></thead>"
+            '<tbody><tr><td colspan="2">Merged</td><td>Z</td></tr>'
+            "<tr><td>1</td><td>2</td><td>3</td></tr></tbody></table>"
+        )
+        result = html_to_markdown(html)
+        rows = self._table_rows(result)
+        assert len(rows) == 3, result
+        assert all(len(r) == 3 for r in rows), result
+        assert rows[1] == ["Merged", "Merged", "Z"]
+        assert rows[2] == ["1", "2", "3"]
+
+    def test_table_rowspan_duplicates_value(self) -> None:
+        html = (
+            "<table><thead><tr><th>A</th><th>B</th></tr></thead>"
+            '<tbody><tr><td rowspan="2">Merged</td><td>X</td></tr>'
+            "<tr><td>Y</td></tr></tbody></table>"
+        )
+        result = html_to_markdown(html)
+        rows = self._table_rows(result)
+        assert len(rows) == 3, result
+        assert all(len(r) == 2 for r in rows), result
+        assert rows[1] == ["Merged", "X"]
+        assert rows[2] == ["Merged", "Y"]
+
+    def test_table_colspan_and_rowspan(self) -> None:
+        html = (
+            "<table><thead><tr><th>H1</th><th>H2</th><th>H3</th></tr></thead>"
+            "<tbody>"
+            '<tr><td colspan="2" rowspan="2">Big</td><td>A</td></tr>'
+            "<tr><td>B</td></tr>"
+            "<tr><td>1</td><td>2</td><td>3</td></tr>"
+            "</tbody></table>"
+        )
+        result = html_to_markdown(html)
+        rows = self._table_rows(result)
+        assert len(rows) == 4, result
+        assert all(len(r) == 3 for r in rows), result
+        assert rows[1] == ["Big", "Big", "A"]
+        assert rows[2] == ["Big", "Big", "B"]
+        assert rows[3] == ["1", "2", "3"]
+
+    def test_table_rowspan_after_normal_cell(self) -> None:
+        html = (
+            "<table><thead><tr><th>A</th><th>B</th></tr></thead>"
+            "<tbody>"
+            '<tr><td>P</td><td rowspan="2">Tall</td></tr>'
+            "<tr><td>Q</td></tr>"
+            "</tbody></table>"
+        )
+        result = html_to_markdown(html)
+        rows = self._table_rows(result)
+        assert len(rows) == 3, result
+        assert all(len(r) == 2 for r in rows), result
+        assert rows[1] == ["P", "Tall"]
+        assert rows[2] == ["Q", "Tall"]
+
+    def test_table_no_merge_unchanged(self) -> None:
+        html = (
+            "<table><thead><tr><th>A</th><th>B</th></tr></thead>"
+            "<tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+        )
+        result = html_to_markdown(html)
+        rows = self._table_rows(result)
+        assert rows == [["A", "B"], ["1", "2"]], result
+
+    def test_table_invalid_span_falls_back_to_one(self) -> None:
+        html = (
+            '<table><tbody><tr><td colspan="abc" rowspan="">X</td>'
+            "<td>Y</td></tr></tbody></table>"
+        )
+        result = html_to_markdown(html)
+        rows = self._table_rows(result)
+        assert rows == [["X", "Y"]], result
+
+    def test_table_rowspan_overflow_silently_clipped(self) -> None:
+        # rowspan claims 5 rows but only 2 exist — extra reservations dropped.
+        html = (
+            "<table><thead><tr><th>A</th><th>B</th></tr></thead>"
+            '<tbody><tr><td rowspan="5">Tall</td><td>X</td></tr>'
+            "<tr><td>Y</td></tr></tbody></table>"
+        )
+        result = html_to_markdown(html)
+        rows = self._table_rows(result)
+        assert len(rows) == 3, result
+        assert all(len(r) == 2 for r in rows), result
+        assert rows[2] == ["Tall", "Y"]
+
+
 # ---------------------------------------------------------------------------
 # markdown_to_html
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_html.py
+++ b/tests/utils/test_html.py
@@ -227,6 +227,75 @@ class TestHtmlToMarkdownMergedCells:
         assert all(len(r) == 2 for r in rows), result
         assert rows[2] == ["Tall", "Y"]
 
+    def test_table_colspan_skips_rowspan_reservation(self) -> None:
+        """A colspan cell pushed past a previous row's rowspan must not
+        overwrite the reservation — it should land at non-contiguous columns
+        (matching browser rendering)."""
+        # Row 0: A | B(rowspan=2) | C
+        # Row 1: D(colspan=2) — should occupy cols 0 and 2 (col 1 reserved)
+        # Row 2: E | F | G
+        html = (
+            "<table><tbody>"
+            '<tr><td>A</td><td rowspan="2">B</td><td>C</td></tr>'
+            '<tr><td colspan="2">D</td></tr>'
+            "<tr><td>E</td><td>F</td><td>G</td></tr>"
+            "</tbody></table>"
+        )
+        result = html_to_markdown(html)
+        rows = self._table_rows(result)
+        assert len(rows) == 3, result
+        assert all(len(r) == 3 for r in rows), result
+        assert rows[0] == ["A", "B", "C"]
+        # B's rowspan clone sits between D and D's duplicate.
+        assert rows[1] == ["D", "B", "D"]
+        assert rows[2] == ["E", "F", "G"]
+
+    def test_table_merged_cell_preserves_inline_formatting(self) -> None:
+        """deepcopy must replicate inline formatting tags into duplicates."""
+        html = (
+            "<table><tbody>"
+            '<tr><td colspan="2"><strong>bold</strong></td><td>X</td></tr>'
+            "<tr><td>1</td><td>2</td><td>3</td></tr>"
+            "</tbody></table>"
+        )
+        result = html_to_markdown(html)
+        # Markdownify renders <strong> as **bold**; both duplicates carry it.
+        assert result.count("**bold**") == 2, result
+
+    def test_nested_table_each_rectangularized(self) -> None:
+        """Outer and inner tables expand merges independently."""
+        html = (
+            "<table><tbody>"
+            "<tr><td>"
+            "<table><tbody>"
+            '<tr><td colspan="2">INNER</td></tr>'
+            "<tr><td>x</td><td>y</td></tr>"
+            "</tbody></table>"
+            "</td>"
+            '<td colspan="2">OUTER</td></tr>'
+            "<tr><td>p</td><td>q</td><td>r</td></tr>"
+            "</tbody></table>"
+        )
+        result = html_to_markdown(html)
+        assert result.count("INNER") >= 2, result
+        assert result.count("OUTER") >= 2, result
+
+    def test_table_pathological_span_product_bounded(self) -> None:
+        """colspan*rowspan is clamped to keep worst-case allocation bounded."""
+        # Per-attr clamp is 1000 each — without the product clamp this would
+        # try to materialise 1M tag clones.  With _MAX_CELLS_PER_MERGE=10000
+        # it stays bounded; we just assert the call returns in reasonable
+        # time and the first row carries the merged value.
+        html = (
+            '<table><tbody><tr><td colspan="1000" rowspan="1000">M</td>'
+            "<td>Z</td></tr></tbody></table>"
+        )
+        result = html_to_markdown(html)
+        rows = self._table_rows(result)
+        # Sanity: call returned (would OOM/hang without clamp), first cell is M.
+        assert rows, result
+        assert rows[0][0] == "M"
+
 
 # ---------------------------------------------------------------------------
 # markdown_to_html


### PR DESCRIPTION
## Summary

`html_to_markdown` produced broken Markdown tables whenever Polarion HTML contained a `<table>` with `colspan` or `rowspan`. `markdownify` 1.2.2 leaves `colspan` extra columns empty (losing the merged value's association with those columns) and drops `rowspan` entirely (yielding rows whose cell count disagrees with the header — a structurally invalid GFM table). This affected `get_document(include_content=True)`, `get_document_parts`, and `get_work_item`.

The fix pre-rectangularizes every `<table>` before handing it to `markdownify`: each `colspan="N" rowspan="M"` cell is duplicated into all `N×M` grid positions it covered, then the span attributes are stripped. The resulting table is rectangular and `markdownify` emits a valid GFM table with the merged value visible at every position. Write-path sanitization is unchanged — Polarion still receives raw `colspan`/`rowspan` on writes.

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- Add `_expand_merged_table_cells` (and `_rectangularize_table` / `_get_span` / `_clone_cell` helpers) in `src/mcp_server_polarion/utils/html.py`; called from `html_to_markdown` before `markdownify`.
- Track propagated rowspans via a per-row `reservations` grid so cells in subsequent rows land at the correct column index even when stacked merges are present.
- Add `TestHtmlToMarkdownMergedCells` (6 tests) covering colspan, rowspan, combined merge, rowspan after a normal cell, no-merge regression, malformed span values, and rowspan overflow.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [ ] `dry_run=True` path verified for all write tools  *(N/A — read-path fix only)*
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src --strict` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run pytest                                    # 351 passed
uv run pytest tests/utils/test_html.py -v        # 70 passed (incl. 6 new)
uv run ruff check . && uv run ruff format --check .
uv run mypy src/                                 # Success: no issues found in 15 source files
```

**Live verification** against `MCP_Test_Project` (Software Requirement Specification → MCPT-542). Identical 3-column rectangular Markdown produced by all three read tools:

```
| 테스트 | 행 | 행 |
| --- | --- | --- |
| 열 | 잘 읽히는지 테스트1 | 잘 읽히는지 테스트3 |
| 열 | 잘 읽히는지 테스트2 | 잘 읽히는지 테스트3 |
```

| Tool | Field |
|---|---|
| `get_document(include_content=true)` | `content` (homePageContent) |
| `get_document_parts` | `workitem_MCPT-542.description` and standalone `table_6.content` |
| `get_work_item(MCPT-542)` | `description` |

Original HTML (inferred): header `테스트 \| 행(colspan=2)`; body row 1 `열(rowspan=2) \| 테스트1 \| 테스트3(rowspan=2)`; body row 2 `테스트2`. Both spans are now correctly duplicated across every covered position, and every row has 3 cells.

---

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)  *(N/A — utils-only change)*
- [x] All new tool functions are `async def`  *(N/A — utils-only change)*
- [x] Tool docstrings follow Google style with Args / Returns / Raises  *(helpers are private; module-level docstring updated)*
- [x] HTML converted via `html_to_markdown()` in read paths
- [x] HTML sanitized via `markdown_to_html()` / `sanitize_html()` in write paths  *(unchanged)*
- [x] Any new list tool supports `page_size` and `page_number` pagination  *(N/A)*
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

---

## Notes for Reviewers

- The fix duplicates merged-cell text into every spanned position rather than placing it in the first cell + leaving the rest empty. This was an intentional product call: keeping the value present in every row/column it covers helps the LLM find it when scanning either by row or by column.
- Behaviour of merged cells on the **write path** is intentionally unchanged. `sanitize_html` still preserves `colspan`/`rowspan` (verified by the existing `test_table_cell_span_attributes_preserved`), so Polarion receives the original merge structure when callers pass HTML through the write tools.
- `_clone_cell` uses `copy.deepcopy` on a `bs4.Tag`. This works on the project's bs4 pin but is the line to revisit if a future bs4 version regresses deep-copy support — fallback would be serialize-and-reparse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)