### PR TITLE
feat(tool): add read_document for flowing markdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ CI runs: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 ## Architecture
 
 - **`core/`** — `client.py` (async httpx wrapper, exponential backoff for 429/5xx, `write_delay` after each mutation, maps responses to `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (Pydantic settings reading `POLARION_URL`/`POLARION_TOKEN`), `exceptions.py`.
-- **`tools/`** — `read.py` (7 read tools), `write.py` (3 write tools: `create_work_item`, `update_work_item`, `move_work_item_to_document`; each preceded by its `_build_*_payload` helper), `_helpers.py` (sparse-fieldset constants `WI_LIST_FIELDS`/`WI_DETAIL_FIELDS`, JSON:API extractors, pagination helpers, `build_work_item_summary_kwargs` keeps `WorkItemDetail` a strict superset of `WorkItemSummary`).
+- **`tools/`** — `read.py` (8 read tools, including `read_document` which renders a document's parts as a single flowing Markdown stream), `write.py` (4 write tools: `create_work_item`, `update_work_item`, `move_work_item_to_document`, `update_document`; each preceded by its `_build_*_payload` helper), `_helpers.py` (sparse-fieldset constants `WI_LIST_FIELDS`/`WI_DETAIL_FIELDS`, JSON:API extractors, pagination helpers, `build_work_item_summary_kwargs` keeps `WorkItemDetail` a strict superset of `WorkItemSummary`).
 - **`utils/html.py`** — Markdown ↔ HTML conversion (markdownify + BeautifulSoup4 sanitization).
 - **`models.py`** — Pydantic v2 models. `PaginatedResult[T]` wraps all list responses.
 - **`server.py`** — FastMCP instance with lifespan that opens/closes `PolarionClient`.
@@ -67,8 +67,9 @@ Polarion Lucene does NOT index `description`, so `list_work_items` cannot filter
 | Goal | Tool | Notes |
 |---|---|---|
 | Find WIs by metadata (title/type/status) | `list_work_items` | Lucene query against `title`, `type`, `status`, etc. — not `description`. |
-| Read or scan a single document body in one shot | `get_document(include_content=True)` | Returns full `homePageContent` Markdown — no pagination. Heading text lives in WI titles, not here. |
-| Search inside a document including each embedded WI's body | `get_document_parts` | Each `workitem` part already carries `description` as Markdown — **no follow-up `get_work_item` call needed** when scanning bodies. Iterate pages and match `description` / `content` / `title`. |
+| Read the document end-to-end | `read_document` | Renders interleaved headings + embedded WI bodies + prose as flowing Markdown. Paginated by part (default 100/page). The canonical "let me read this doc" tool. |
+| Get document metadata only | `get_document` | Title/type/status. `include_content=True` returns the raw `homePageContent` source (incomplete for reading — heading text and embedded WI bodies live in separate work items, not in `homePageContent`; use this option for round-trip editing of the source, not for reading). |
+| Search inside a document with structural metadata | `get_document_parts` | Each `workitem` part carries `description` as Markdown — **no follow-up `get_work_item` call needed**. Use when you need part IDs (for `move_work_item_to_document`), heading levels, or per-WI status/type. For plain reading, prefer `read_document`. |
 
 ### Server-side validation is lenient on enum-like fields
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ claude mcp add mcp-server-polarion \
 |---|---|
 | `list_projects` | List all accessible Polarion projects (supports Lucene query filtering) |
 | `list_documents` | List documents in a project (with optional name/space filtering) |
-| `get_document` | Get full document content in Markdown |
-| `get_document_parts` | List structural parts with linked work item metadata (type, status, `external` flag) |
+| `read_document` | Render a document end-to-end as flowing Markdown |
+| `get_document` | Get document metadata (title / type / status); optionally returns the raw `homePageContent` source for round-trip editing |
+| `get_document_parts` | List structural parts with linked work-item metadata (type, status, `external` flag) — use for part IDs and structural traversal, not for reading |
 | `list_work_items` | Search work items with Lucene queries; results include priority, last-modified time, owning document, and assignees |
 | `get_work_item` | Get full work item details (description, author, created/updated timestamps, severity, resolution, outline number, hyperlinks) |
 | `get_linked_work_items` | Get forward and back links with each linked item's type, status, and owning document for traceability analysis |

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -215,6 +215,54 @@ class DocumentPart(BaseModel):
     )
 
 
+class DocumentReadResult(BaseModel):
+    """Rendered Markdown view of one page of document parts.
+
+    Returned by ``read_document``. Interleaves heading titles, embedded
+    work-item descriptions, and inline prose from a single page of
+    ``get_document_parts`` into a flowing Markdown stream suitable for
+    end-to-end reading by an LLM.
+
+    The output is read-only synthesis: it cannot be fed back to any
+    write tool because no update path accepts this shape. For round-trip
+    editing of the document body, fetch the raw source via
+    ``get_document(include_content=True)`` instead.
+    """
+
+    content: str = Field(
+        description=(
+            "Rendered Markdown for the parts on this page. "
+            "Empty placeholder paragraphs from Polarion are skipped, "
+            "and runs of blank lines are collapsed."
+        ),
+    )
+    part_count: int = Field(
+        description=(
+            "Number of document parts on this page (i.e. parts consumed "
+            "from ``get_document_parts``). Parts that produce no output "
+            "(empty placeholder paragraphs, ``toc``) still count toward "
+            "this — use it for pagination accounting, not chunk count."
+        ),
+    )
+    page: int = Field(
+        description="Current page number (1-based).",
+    )
+    page_size: int = Field(
+        description="Maximum number of parts per page.",
+    )
+    total_parts: int = Field(
+        description="Total number of parts across the entire document.",
+    )
+    has_more: bool = Field(
+        default=False,
+        description=(
+            "True when there are more pages of parts after this one. "
+            "Use to decide whether to call ``read_document`` again with "
+            "``page_number + 1``."
+        ),
+    )
+
+
 class WorkItemSummary(BaseModel):
     """Compact work-item representation for list and search results."""
 
@@ -592,6 +640,7 @@ __all__: list[str] = [
     "DocumentDetail",
     "DocumentPart",
     "DocumentPartCreateResult",
+    "DocumentReadResult",
     "DocumentSummary",
     "DocumentUpdateResult",
     "Hyperlink",

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -211,9 +211,10 @@ def _render_parts_to_markdown(parts: list[DocumentPart]) -> str:
     - ``workitem``: bold lead-in ``**{title}** (`{work_item_id}`)``
       followed by the description body. Falls back to bare backticked
       ID when both title and description are empty.
-    - ``normal`` / ``table`` / ``wikiblock``: ``content`` verbatim,
-      skipped when whitespace-only (matches the empty paragraphs Polarion
-      stores between parts).
+    - ``normal`` / ``wikiblock``: ``content`` verbatim, skipped when
+      whitespace-only (matches the empty paragraphs Polarion stores
+      between parts; tables stored as ``normal`` content flow through
+      this branch unchanged).
     - ``toc`` and unknown types: skipped.
 
     Chunks are joined with a blank line; runs of three or more newlines

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -1,6 +1,6 @@
 """Read-only MCP tools for querying Polarion ALM.
 
-Seven tools that retrieve projects, documents, work items, and their
+Eight tools that retrieve projects, documents, work items, and their
 relationships.  Every tool returns Pydantic models -- never raw
 ``dict`` -- and converts HTML descriptions to Markdown via
 ``html_to_markdown()``.
@@ -25,6 +25,7 @@ from mcp_server_polarion.core.exceptions import (
 from mcp_server_polarion.models import (
     DocumentDetail,
     DocumentPart,
+    DocumentReadResult,
     DocumentSummary,
     LinkedWorkItemSummary,
     PaginatedResult,
@@ -57,6 +58,11 @@ type _PartType = Literal["heading", "workitem", "normal", "toc", "wikiblock"]
 _VALID_PART_TYPES: Final[frozenset[str]] = frozenset(
     {"heading", "workitem", "normal", "toc", "wikiblock"},
 )
+
+# Defensive clamp for heading levels emitted by ``read_document``.
+# Polarion exposes 1-4, but ``_resolve_heading_level`` falls back to
+# regex-parsing ``<hN>`` which could in principle hit 5-6.
+_MAX_HEADING_LEVEL: Final[int] = 6
 
 # ---------------------------------------------------------------------------
 # Read-specific helpers
@@ -194,6 +200,46 @@ def _parse_document_part(
         external=bool(attrs.get("external", False)),
         next_part_id=next_short_id,
     )
+
+
+def _render_parts_to_markdown(parts: list[DocumentPart]) -> str:
+    """Interleave a page of parts into a single flowing Markdown string.
+
+    Rendering rules per ``DocumentPart.type``:
+
+    - ``heading``: ``{'#' * level} {title}``; level clamped to 1-6.
+    - ``workitem``: bold lead-in ``**{title}** (`{work_item_id}`)``
+      followed by the description body. Falls back to bare backticked
+      ID when both title and description are empty.
+    - ``normal`` / ``table`` / ``wikiblock``: ``content`` verbatim,
+      skipped when whitespace-only (matches the empty paragraphs Polarion
+      stores between parts).
+    - ``toc`` and unknown types: skipped.
+
+    Chunks are joined with a blank line; runs of three or more newlines
+    are collapsed to two for visual parity with ``get_document``.
+    """
+    chunks: list[str] = []
+    for part in parts:
+        if part.type == "heading":
+            level = max(1, min(part.level or 1, _MAX_HEADING_LEVEL))
+            chunks.append(f"{'#' * level} {part.title}")
+        elif part.type == "workitem":
+            if not part.title and not part.description:
+                chunks.append(f"`{part.work_item_id}`")
+            elif not part.description:
+                chunks.append(f"**{part.title}** (`{part.work_item_id}`)")
+            else:
+                chunks.append(
+                    f"**{part.title}** (`{part.work_item_id}`)\n\n{part.description}"
+                )
+        elif part.type in {"normal", "wikiblock"}:
+            if part.content.strip():
+                chunks.append(part.content)
+        # ``toc`` and any unknown type fall through silently.
+
+    joined = "\n\n".join(chunks)
+    return re.sub(r"\n{3,}", "\n\n", joined).strip()
 
 
 def _parse_linked_items(
@@ -670,13 +716,15 @@ async def get_document(
             "When True, also fetch and return the document's homePageContent "
             "as Markdown in the ``content`` field. Off by default because "
             "homePageContent can be large (tens of KB) and most callers only "
-            "need metadata. Note: Polarion stores actual document body in "
-            "work-item titles/descriptions — use ``get_document_parts`` for "
-            "the structured body."
+            "need metadata. NOTE: ``homePageContent`` contains only the inline "
+            "prose between parts — heading text and embedded work-item bodies "
+            "are stored in separate work items and are NOT included here. "
+            "For end-to-end reading use ``read_document``; this option is for "
+            "round-trip editing of the raw source."
         ),
     ),
 ) -> DocumentDetail:
-    """Get metadata (and optionally the body) for a Polarion document.
+    """Get metadata (and optionally the raw body source) for a Polarion document.
 
     Returns the document's title, type, and workflow status. By default
     the ``content`` field is empty; set ``include_content=True`` to also
@@ -685,10 +733,12 @@ async def get_document(
 
     **When to use which document tool**:
 
-    - Need the document body in one shot to scan/search for keywords?
-      Call this tool with ``include_content=True`` — a single request,
-      no pagination, returns the full Markdown body. This is the
-      preferred entry point for "find X in this document" workflows.
+    - Want to read or summarise the document body? Use ``read_document``
+      — it interleaves heading titles + embedded work-item bodies + prose
+      into a single Markdown stream. ``get_document(include_content=True)``
+      returns ``homePageContent`` only, which omits heading text and
+      embedded work-item bodies (Polarion stores those in separate work
+      items, not in ``homePageContent``).
     - Need the structured part list (heading levels, work-item IDs,
       embedded work-item descriptions)? Use ``get_document_parts``.
       Each ``workitem`` part already includes its ``description`` in
@@ -698,8 +748,9 @@ async def get_document(
 
     Polarion stores **heading text in work-item titles**, not in
     ``homePageContent``, so the home-page Markdown contains the
-    inline rich-text body but not the heading wording — pair with
-    ``get_document_parts`` when the heading text matters.
+    inline rich-text body but not the heading wording — call
+    ``read_document`` for the assembled body or ``get_document_parts``
+    when the structural metadata matters.
 
     Use ``list_documents`` first to discover valid space IDs and
     document names.
@@ -823,9 +874,10 @@ async def get_document_parts(  # noqa: PLR0913
     """List the structural parts (headings and work items) of a document.
 
     **Do NOT call this tool just to read or summarise a document body.**
-    For one-shot body retrieval prefer ``get_document(include_content=True)``
-    — it returns the full ``homePageContent`` Markdown in a single
-    request without paging.
+    For end-to-end reading prefer ``read_document`` — it interleaves
+    heading titles, embedded work-item bodies, and prose into a single
+    Markdown stream and skips the empty placeholder paragraphs Polarion
+    stores between parts.
 
     Returns the ordered list of part IDs, titles, types, and linked
     work-item metadata that make up a document's body. Use this tool
@@ -845,9 +897,9 @@ async def get_document_parts(  # noqa: PLR0913
 
     **Choosing between the document tools**:
 
-    - For a one-shot keyword search across the document body without
-      pagination, prefer ``get_document(include_content=True)`` —
-      faster when the document fits in one response.
+    - For end-to-end reading or summarising the document body, use
+      ``read_document`` — it returns rendered Markdown without the
+      structural metadata noise.
     - Use this tool when you need per-work-item descriptions, the
       ordered part list, or part IDs for moves.
 
@@ -961,6 +1013,111 @@ async def get_document_parts(  # noqa: PLR0913
     timeout=60.0,
     annotations={"readOnlyHint": True},
 )
+async def read_document(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(
+        description="Polarion project ID.",
+    ),
+    space_id: str = Field(
+        description=(
+            "Space ID that contains the document. "
+            "Use ``list_documents`` to discover valid IDs."
+        ),
+    ),
+    document_name: str = Field(
+        description=(
+            "Document name within the space "
+            "(e.g. 'Software Requirement Specification'). "
+            "Spaces in the name are handled automatically."
+        ),
+    ),
+    page_size: int = Field(
+        default=DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=100,
+        description="Number of parts per page (1-100, default 100).",
+    ),
+    page_number: int = Field(
+        default=1,
+        ge=1,
+        description="Page number to retrieve (1-based, default 1).",
+    ),
+) -> DocumentReadResult:
+    """Render a Polarion document end-to-end as flowing Markdown.
+
+    Paginates ``get_document_parts`` and interleaves heading titles,
+    embedded work-item descriptions, and inline prose into a single
+    Markdown stream — the canonical way for an LLM to read a document
+    body. Empty placeholder paragraphs that Polarion stores between
+    parts are skipped; runs of blank lines are collapsed.
+
+    **Use this for reading.** Other document tools have narrower jobs:
+
+    - ``get_document`` — title/type/status only (and the raw
+      ``homePageContent`` source via ``include_content=True``, which is
+      incomplete for reading because Polarion stores heading text and
+      embedded work-item bodies in *separate* work items rather than in
+      ``homePageContent``).
+    - ``get_document_parts`` — structural enumeration with per-part IDs,
+      heading levels, and work-item metadata. Use it when you need part
+      IDs for ``move_work_item_to_document`` or per-WI status/type, not
+      for end-to-end reading.
+
+    The output is read-only synthesis. It cannot be fed back to any
+    write tool because the rendered Markdown collapses Polarion's
+    placeholder structure (empty ``<h1>`` / ``<div>`` tags that
+    reference work items by ID); round-tripping it would orphan heading
+    work items and duplicate embedded bodies as inline prose.
+
+    Pagination maps 1:1 to ``get_document_parts``: each page covers
+    ``page_size`` parts (default 100). Use ``has_more`` to decide
+    whether to fetch the next page.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        space_id: Space ID containing the document.
+        document_name: Document name within the space.
+        page_size: Number of parts per page (1-100, default 100).
+        page_number: Page number to retrieve (1-based, default 1).
+
+    Returns:
+        DocumentReadResult with:
+        - ``content``: Rendered Markdown for the parts on this page.
+        - ``part_count``: Number of parts rendered.
+        - ``page`` / ``page_size`` / ``total_parts`` / ``has_more``:
+          pagination metadata propagated from ``get_document_parts``.
+
+    Raises:
+        ValueError: If the document, space, or project is not found.
+        PermissionError: If the token lacks permissions.
+        RuntimeError: On unexpected Polarion API errors.
+    """
+    # FastMCP 3.0's ``@mcp.tool()`` returns the original function unchanged,
+    # so direct invocation forwards both the fetch and the error mapping.
+    page = await get_document_parts(
+        ctx,
+        project_id=project_id,
+        space_id=space_id,
+        document_name=document_name,
+        page_size=page_size,
+        page_number=page_number,
+    )
+    return DocumentReadResult(
+        content=_render_parts_to_markdown(page.items),
+        part_count=len(page.items),
+        page=page.page,
+        page_size=page.page_size,
+        total_parts=page.total_count,
+        has_more=page.has_more,
+    )
+
+
+@mcp.tool(
+    tags={"read"},
+    timeout=60.0,
+    annotations={"readOnlyHint": True},
+)
 async def list_work_items(
     ctx: Context,
     project_id: str = Field(
@@ -1011,12 +1168,12 @@ async def list_work_items(
     you cannot filter by body text via ``query=``. For content search,
     pick the right document-scoped tool instead:
 
-    - Single-document body search (one shot, no pagination) →
-      ``get_document(include_content=True)`` returns the entire
-      ``homePageContent`` as Markdown.
-    - Document-scoped search that also covers each embedded
-      work-item's ``description`` → iterate ``get_document_parts``
-      pages; each ``workitem`` part already carries its description.
+    - End-to-end reading of a single document → ``read_document``
+      returns interleaved headings + embedded work-item bodies + prose
+      as flowing Markdown (paginated).
+    - Structural search that also covers each embedded work-item's
+      ``description`` → iterate ``get_document_parts`` pages; each
+      ``workitem`` part already carries its description.
 
     Use ``get_work_item`` only when you need the full detail of a
     specific WI that you've already located.

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -1,4 +1,4 @@
-"""Tests for the 7 read-only MCP tools.
+"""Tests for the 8 read-only MCP tools.
 
 Each tool is tested by calling the async function directly with a mock
 ``PolarionClient`` injected via a mock ``Context``.
@@ -6,10 +6,13 @@ Each tool is tested by calling the async function directly with a mock
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Iterator
+from typing import Annotated, get_type_hints
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import TypeAdapter, ValidationError
 
 from mcp_server_polarion.core.client import PolarionClient
 from mcp_server_polarion.core.exceptions import (
@@ -20,6 +23,7 @@ from mcp_server_polarion.core.exceptions import (
 from mcp_server_polarion.models import (
     DocumentDetail,
     DocumentPart,
+    DocumentReadResult,
     LinkedWorkItemSummary,
     PaginatedResult,
     ProjectSummary,
@@ -37,6 +41,7 @@ get_work_item = _read_mod.get_work_item
 list_documents = _read_mod.list_documents
 list_projects = _read_mod.list_projects
 list_work_items = _read_mod.list_work_items
+read_document = _read_mod.read_document
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1267,6 +1272,518 @@ class TestGetDocumentParts:
 
         assert len(result.items) == 2
         assert result.total_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# read_document
+# ---------------------------------------------------------------------------
+
+
+def _make_part(
+    *,
+    type_: str,
+    part_id: str = "polarion_x",
+    title: str = "",
+    content: str = "",
+    description: str = "",
+    level: int = 0,
+    work_item_id: str = "",
+) -> DocumentPart:
+    """Build a ``DocumentPart`` with sensible defaults for render-rule tests."""
+    return DocumentPart(
+        id=part_id,
+        title=title,
+        content=content,
+        type=type_,  # type: ignore[arg-type]
+        level=level,
+        description=description,
+        work_item_id=work_item_id,
+        work_item_type="",
+        work_item_status="",
+        external=False,
+        next_part_id="",
+    )
+
+
+def _stub_parts(
+    monkeypatch: pytest.MonkeyPatch, parts: list[DocumentPart]
+) -> AsyncMock:
+    """Replace ``get_document_parts`` with an AsyncMock returning *parts*.
+
+    Returns the mock so individual tests can assert call arguments. Page
+    metadata is derived from the part list so pagination defaults stay
+    sensible without each test having to spell them out.
+    """
+    stub = AsyncMock(
+        return_value=PaginatedResult[DocumentPart](
+            items=parts,
+            total_count=len(parts),
+            page=1,
+            page_size=100,
+            has_more=False,
+        )
+    )
+    monkeypatch.setattr(_read_mod, "get_document_parts", stub)
+    return stub
+
+
+class TestReadDocument:
+    """Tests for the ``read_document`` tool."""
+
+    # -- end-to-end wiring (exercises get_document_parts via client.get) --
+
+    async def test_end_to_end_renders_document(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Real fetch path: stub the HTTP layer, verify the rendered Markdown."""
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "document_parts",
+                    "id": "proj1/_default/SRS/heading_MCPT-001",
+                    "attributes": {
+                        "id": "heading_MCPT-001",
+                        "content": (
+                            '<h1 id="polarion_wiki macro'
+                            " name=module-workitem;"
+                            'params=id=MCPT-001"></h1>'
+                        ),
+                        "type": "heading",
+                    },
+                    "relationships": {
+                        "workItem": {
+                            "data": {"type": "workitems", "id": "proj1/MCPT-001"},
+                        },
+                    },
+                },
+                {
+                    "type": "document_parts",
+                    "id": "proj1/_default/SRS/workitem_MCPT-002",
+                    "attributes": {
+                        "id": "workitem_MCPT-002",
+                        "content": "",
+                        "type": "workitem",
+                    },
+                    "relationships": {
+                        "workItem": {
+                            "data": {"type": "workitems", "id": "proj1/MCPT-002"},
+                        },
+                    },
+                },
+                {
+                    "type": "document_parts",
+                    "id": "proj1/_default/SRS/polarion_1",
+                    "attributes": {
+                        "id": "polarion_1",
+                        "content": "<p>Some prose between the WI and a heading.</p>",
+                        "type": "normal",
+                    },
+                    "relationships": {},
+                },
+                {
+                    "type": "document_parts",
+                    "id": "proj1/_default/SRS/polarion_2",
+                    "attributes": {
+                        "id": "polarion_2",
+                        # Empty paragraph — should not appear in the render.
+                        "content": "<p></p>",
+                        "type": "normal",
+                    },
+                    "relationships": {},
+                },
+            ],
+            "included": [
+                {
+                    "type": "workitems",
+                    "id": "proj1/MCPT-001",
+                    "attributes": {
+                        "type": "heading",
+                        "title": "Introduction",
+                        "status": "open",
+                    },
+                },
+                {
+                    "type": "workitems",
+                    "id": "proj1/MCPT-002",
+                    "attributes": {
+                        "type": "requirement",
+                        "title": "Login Feature",
+                        "description": {
+                            "type": "text/html",
+                            "value": "<p>The system shall support login.</p>",
+                        },
+                        "status": "draft",
+                    },
+                },
+            ],
+            "meta": {"totalCount": 4},
+        }
+
+        result = await read_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="SRS",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert isinstance(result, DocumentReadResult)
+        assert result.part_count == 4
+        assert result.total_parts == 4
+        assert result.page == 1
+        assert result.page_size == 100
+        assert result.has_more is False
+
+        # Heading rendered at level 1, then workitem with bold lead-in
+        # plus its description, then prose. Empty paragraph is skipped.
+        assert result.content == (
+            "# Introduction\n"
+            "\n"
+            "**Login Feature** (`MCPT-002`)\n"
+            "\n"
+            "The system shall support login.\n"
+            "\n"
+            "Some prose between the WI and a heading."
+        )
+
+    async def test_pagination_params_forwarded_to_http(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """``page_size`` / ``page_number`` reach the underlying client.get call."""
+        mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
+
+        await read_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="Doc",
+            page_size=25,
+            page_number=3,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["page[size]"] == 25
+        assert kwargs["params"]["page[number]"] == 3
+
+    async def test_empty_document_returns_empty_content(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
+
+        result = await read_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="Empty",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == ""
+        assert result.part_count == 0
+        assert result.total_parts == 0
+        assert result.has_more is False
+
+    async def test_not_found_propagates_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Delegation to ``get_document_parts`` surfaces its ValueError verbatim."""
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await read_document(
+                mock_ctx,
+                project_id="proj1",
+                space_id="_default",
+                document_name="Missing",
+                page_size=100,
+                page_number=1,
+            )
+
+    # -- render-rule tests (isolated via monkeypatched get_document_parts) --
+
+    async def test_workitem_with_description_renders_lead_in_plus_body(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_parts(
+            monkeypatch,
+            [
+                _make_part(
+                    type_="workitem",
+                    title="Login Feature",
+                    description="The system shall support login.",
+                    work_item_id="MCPT-002",
+                ),
+            ],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == (
+            "**Login Feature** (`MCPT-002`)\n\nThe system shall support login."
+        )
+
+    async def test_workitem_without_description_renders_lead_in_only(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_parts(
+            monkeypatch,
+            [
+                _make_part(
+                    type_="workitem",
+                    title="Stub Requirement",
+                    description="",
+                    work_item_id="MCPT-099",
+                ),
+            ],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == "**Stub Requirement** (`MCPT-099`)"
+
+    async def test_workitem_empty_title_and_description_renders_bare_id(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defensive guard for sparse-data WIs (rare but observed)."""
+        _stub_parts(
+            monkeypatch,
+            [
+                _make_part(
+                    type_="workitem",
+                    title="",
+                    description="",
+                    work_item_id="MCPT-7",
+                ),
+            ],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == "`MCPT-7`"
+
+    async def test_empty_normal_parts_skipped(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Polarion's empty placeholder paragraphs (polarion_3, _4, ...) drop out."""
+        _stub_parts(
+            monkeypatch,
+            [
+                _make_part(type_="heading", title="Section", level=2),
+                _make_part(type_="normal", content="   "),  # whitespace-only
+                _make_part(type_="normal", content=""),
+                _make_part(type_="normal", content="Real content."),
+            ],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == "## Section\n\nReal content."
+
+    async def test_toc_parts_skipped(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_parts(
+            monkeypatch,
+            [
+                _make_part(type_="heading", title="Top", level=1),
+                _make_part(type_="toc", content=""),
+                _make_part(type_="normal", content="After TOC."),
+            ],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == "# Top\n\nAfter TOC."
+
+    async def test_wikiblock_content_emitted(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_parts(
+            monkeypatch,
+            [
+                _make_part(
+                    type_="wikiblock",
+                    content='```\n#documentPanel(true "approved")\n```',
+                ),
+            ],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == '```\n#documentPanel(true "approved")\n```'
+
+    async def test_heading_level_clamp_low(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``level=0`` (the model default for non-headings) becomes ``#``."""
+        _stub_parts(
+            monkeypatch,
+            [_make_part(type_="heading", title="Corrupt", level=0)],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == "# Corrupt"
+
+    async def test_heading_level_clamp_high(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``level`` above 6 clamps to ``######`` to stay valid Markdown."""
+        _stub_parts(
+            monkeypatch,
+            [_make_part(type_="heading", title="Deep", level=10)],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == "###### Deep"
+
+    async def test_newline_collapse(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Runs of 3+ blank lines from joined chunks collapse to a single blank."""
+        _stub_parts(
+            monkeypatch,
+            [
+                _make_part(type_="normal", content="A\n\n\n\nB"),
+                _make_part(type_="normal", content="C"),
+            ],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == "A\n\nB\n\nC"
+
+    async def test_pagination_metadata_propagated(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``page``/``page_size``/``total_parts``/``has_more`` echo inner page."""
+        stub = AsyncMock(
+            return_value=PaginatedResult[DocumentPart](
+                items=[_make_part(type_="normal", content="X")],
+                total_count=250,
+                page=2,
+                page_size=100,
+                has_more=True,
+            )
+        )
+        monkeypatch.setattr(_read_mod, "get_document_parts", stub)
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=2,
+        )
+
+        assert result.part_count == 1
+        assert result.total_parts == 250
+        assert result.page == 2
+        assert result.page_size == 100
+        assert result.has_more is True
+
+
+class TestReadDocumentFieldValidation:
+    """Verify Field constraints on ``read_document`` parameters.
+
+    Direct invocation bypasses FastMCP's JSON Schema gate; rebuild a
+    ``TypeAdapter`` from each parameter's annotation + ``FieldInfo`` to
+    prove the constraint is wired correctly.
+    """
+
+    @staticmethod
+    def _adapter_for(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(read_document)
+        sig = inspect.signature(read_document)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_page_size_rejects_above_max(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("page_size").validate_python(101)
+
+    def test_page_size_rejects_zero(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("page_size").validate_python(0)
+
+    def test_page_size_accepts_max(self) -> None:
+        assert self._adapter_for("page_size").validate_python(100) == 100
+
+    def test_page_number_rejects_zero(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("page_number").validate_python(0)
+
+    def test_page_number_accepts_one(self) -> None:
+        assert self._adapter_for("page_number").validate_python(1) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -1658,6 +1658,30 @@ class TestReadDocument:
 
         assert result.content == '```\n#documentPanel(true "approved")\n```'
 
+    async def test_empty_wikiblock_skipped(
+        self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Whitespace-only wikiblock is dropped, mirroring empty normal parts."""
+        _stub_parts(
+            monkeypatch,
+            [
+                _make_part(type_="heading", title="Top", level=1),
+                _make_part(type_="wikiblock", content="   \n  "),
+                _make_part(type_="normal", content="After block."),
+            ],
+        )
+
+        result = await read_document(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.content == "# Top\n\nAfter block."
+
     async def test_heading_level_clamp_low(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Adds a new `read_document` MCP tool that renders a Polarion document end-to-end as a flowing Markdown stream. This fills a gap where neither `get_document(include_content=True)` (returns only `homePageContent` — empty `<h1></h1>` and `<div></div>` placeholders, no heading text or embedded WI bodies) nor `get_document_parts` (structural enumeration with heavy JSON metadata) was a good fit for the common "let me read this document" use case.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Documentation update
- [ ] CI / tooling / dependency update


## Changes

- `src/mcp_server_polarion/tools/read.py` — new `read_document` tool that paginates `get_document_parts` (1:1 page mapping, default 100 parts/page) and interleaves heading titles, embedded work-item descriptions, prose, and wikiblocks into a single Markdown stream via the new `_render_parts_to_markdown` helper. Empty placeholder paragraphs that Polarion stores between parts (`polarion_3`, `polarion_4`, …) are skipped; runs of 3+ blank lines collapsed.
- `src/mcp_server_polarion/models.py` — new `DocumentReadResult` Pydantic model (`content` + pagination metadata).
- Docstring redirects on `get_document`, `get_document_parts`, and `list_work_items` — they previously steered LLMs toward `get_document(include_content=True)` for body reading, which is now known to return incomplete content. Updated to point at `read_document` instead.
- `CLAUDE.md` — refreshed the "Document content search — pick the right tool" table; corrected stale "7 read tools / 3 write tools" line in the Architecture section to "8 / 4" (also explicitly lists `update_document` from PR #14).
- `README.md` — added `read_document` row, clarified `get_document` (now metadata-focused) and `get_document_parts` (structural).
- `tests/tools/test_read.py` — new `TestReadDocument` (11 render-rule tests + 3 wiring/error tests using a stubbed `client.get`) and `TestReadDocumentFieldValidation` (5 `TypeAdapter`-based Field constraint tests for `page_size`/`page_number`).

## Why no write counterpart

`read_document` is read-only synthesis with no matching write tool. This is intentional: the rendered Markdown collapses Polarion's placeholder structure (the `<h1>` / `<div>` tags whose `id` attribute encodes `module-workitem;params=id=MCPT-XXX`). Round-tripping the rendered output to a write tool would orphan heading WIs and duplicate embedded WI bodies as inline prose. Making it impossible at the type level (no write tool accepts this shape) is a stronger guarantee than docstring warnings.

## Testing

- [x] Unit tests added (`TestReadDocument`, `TestReadDocumentFieldValidation` — 19 new test cases)
- [x] `uv run pytest` passes locally — 375 passed
- [x] `uv run mypy src/` passes — no issues found in 15 source files
- [x] `uv run ruff check . && uv run ruff format --check .` passes
- [x] **End-to-end smoke test** against the live `MCP_Test_Project / Design / Software Requirement Specification` document: all 7 headings (H1/H2/H3) render with text, embedded WIs (MCPT-528, MCPT-527, MCPT-542) appear with bold lead-ins, the merged-cell table from MCPT-542 renders rectangularly (`| 테스트 | 행 | 행 |`), empty `polarion_*` parts produce no output, `total_parts` and `has_more` propagate correctly.

> ⚠️ **Reviewer note — restart MCP server before live testing.** This project uses an editable install, so source changes are picked up by new processes immediately, but already-running MCP server processes cache imported modules and will return *stale* results until restarted. If you exercise the new tool via an MCP client and see incomplete output (e.g. broken table rendering), restart the MCP server first.

```bash
uv run pytest tests/tools/test_read.py::TestReadDocument tests/tools/test_read.py::TestReadDocumentFieldValidation -v
uv run pytest
```

## Golden Rule Compliance

- [x] No `print()` calls
- [x] `from __future__ import annotations` present (file already had it)
- [x] All tool inputs/outputs are Pydantic models — new `DocumentReadResult` model
- [x] New tool function is `async def`
- [x] Tool docstring follows Google style with Args / Returns / Raises
- [x] HTML conversion via `html_to_markdown()` happens upstream in `_parse_document_part`; `read_document` consumes already-Markdown fields
- [x] Pagination supported (`page_size` 1–100, `page_number` ≥1) and validated via `Field` constraints

## Notes for Reviewers

- The rendering rules live in `_render_parts_to_markdown` (pure function, easy to inspect).
- `read_document` calls `get_document_parts` directly. This works because FastMCP 3.0's `@mcp.tool()` returns the original function unchanged (per CLAUDE.md). Error mapping (PolarionNotFoundError → ValueError, etc.) is inherited.
- `part_count` field returns `len(page.items)` — i.e. parts consumed from `get_document_parts`, not chunks emitted (a part may be skipped if it's an empty paragraph or `toc`). The Field description explicitly calls this out so callers use it for pagination accounting.
- Out of scope (deferred): adding `content` support to `update_document`, `*_html` field naming conventions, and a `description_format` parameter on `get_work_item` — these were discussed during planning but intentionally postponed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)