### PR TITLE
feat(tool): include all custom fields on WI & document reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,15 @@ JSON:API v1. Key paths: `/projects`, `/projects/{p}/workitems[?query=...]`, `/pr
 
 `fields[workitems]=title,type,status` removes **all** `relationships` from the response, not just other attributes. To receive a relationship, list its name explicitly (see `WI_LIST_FIELDS`). Forgetting this silently empties derived fields like `space_id`/`document_name`/`assignee_ids`/`author_id`.
 
-### Custom fields surface via the `customFields.@all` sparse-fieldset token
+### Custom fields surface inline under `attributes`, not under a `customFields` container
 
-Polarion projects define arbitrary custom fields per work-item type and per document type; field IDs differ per project and cannot be enumerated statically. Appending `,customFields.@all` to `fields[workitems]` / `fields[documents]` makes Polarion return all *populated* custom field values inline at `attributes.customFields` as a flat `{fieldId: value}` mapping. `WI_DETAIL_FIELDS` and `get_document` both include the token, surfacing values on `WorkItemDetail.custom_fields` and `DocumentDetail.custom_fields`. Values are heterogeneous: primitives (str/int/float/bool/list) plus `{type: 'text/html', value: '<...>'}` dicts for rich-text fields — kept raw, NOT converted to Markdown, so the shape round-trips back to Polarion unchanged. The `customFields` key is omitted entirely when no custom fields are populated, so consumers MUST tolerate its absence (`extract_custom_fields` defaults to `{}`).
+This Polarion server inlines project-defined custom fields as **top-level keys inside `attributes`** alongside standard fields — e.g. `attributes.asil`, `attributes.requirement_id` on a work item, `attributes.version`, `attributes.baseline_name` on a document. There is no nested `customFields` object, and the sparse-fieldset tokens `customFields.@all`, `@custom`, `@additional` are silently dropped (returning either nothing or `@basic` semantics). `@basic` itself returns only a fixed minimal set (`id, type, title, status, severity` for WIs) — too narrow to be useful for detail reads.
+
+To surface customs the MCP server uses `fields[workitems]=@all` (`WI_DETAIL_FIELDS`) and `fields[documents]=@all` (`DOC_DETAIL_FIELDS`), then filters out the canonical Polarion-defined attributes using the `STANDARD_WORKITEM_ATTRS` / `STANDARD_DOCUMENT_ATTRS` allowlists in `_helpers.py` (sourced verbatim from the Polarion REST OpenAPI schema). Anything not in the allowlist is exposed on `WorkItemDetail.custom_fields` / `DocumentDetail.custom_fields`. Values are heterogeneous: primitives (str/int/float/bool/list) plus `{type: 'text/html', value: '<...>'}` dicts for rich-text custom fields — kept raw, NOT converted to Markdown, so the shape round-trips back to Polarion unchanged.
+
+Caveat: a future Polarion release that ships new standard attributes would misclassify them as custom until the allowlist is updated.
+
+Side effect: `update_work_item`'s post-PATCH GET reuses `WI_DETAIL_FIELDS`, so `WorkItemUpdateResult.current.custom_fields` is populated automatically. `@all` also returns the full relationship set (19 to-one/to-many entries for WIs) rather than the previous curated four — only `links` come back without `include=`, so the bandwidth cost is moderate.
 
 ### To-many relationships need `include=`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ JSON:API v1. Key paths: `/projects`, `/projects/{p}/workitems[?query=...]`, `/pr
 
 `fields[workitems]=title,type,status` removes **all** `relationships` from the response, not just other attributes. To receive a relationship, list its name explicitly (see `WI_LIST_FIELDS`). Forgetting this silently empties derived fields like `space_id`/`document_name`/`assignee_ids`/`author_id`.
 
+### Custom fields surface via the `customFields.@all` sparse-fieldset token
+
+Polarion projects define arbitrary custom fields per work-item type and per document type; field IDs differ per project and cannot be enumerated statically. Appending `,customFields.@all` to `fields[workitems]` / `fields[documents]` makes Polarion return all *populated* custom field values inline at `attributes.customFields` as a flat `{fieldId: value}` mapping. `WI_DETAIL_FIELDS` and `get_document` both include the token, surfacing values on `WorkItemDetail.custom_fields` and `DocumentDetail.custom_fields`. Values are heterogeneous: primitives (str/int/float/bool/list) plus `{type: 'text/html', value: '<...>'}` dicts for rich-text fields — kept raw, NOT converted to Markdown, so the shape round-trips back to Polarion unchanged. The `customFields` key is omitted entirely when no custom fields are populated, so consumers MUST tolerate its absence (`extract_custom_fields` defaults to `{}`).
+
 ### To-many relationships need `include=`
 
 Polarion does not inline `data` for to-many relationships (e.g. `assignee`) — only `links` come back. Pass `"include": "assignee"` to populate `relationships.assignee.data`. To-one relationships (`module`, `author`, `project`) are inlined without `include`.

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -127,6 +127,18 @@ class DocumentDetail(BaseModel):
             "``include_content=True``; otherwise an empty string."
         ),
     )
+    custom_fields: dict[str, object] = Field(
+        default_factory=dict,
+        description=(
+            "User-defined custom fields configured per project and "
+            "document type. Keys are project-specific custom field IDs; "
+            "values are heterogeneous (string, int, float, bool, list, "
+            "or ``{'type': 'text/html', 'value': '<...>'}`` for rich-text "
+            "custom fields — kept raw, NOT converted to Markdown, so the "
+            "shape round-trips back to Polarion unchanged). Empty dict "
+            "when no custom fields are populated on the document."
+        ),
+    )
 
 
 class DocumentPart(BaseModel):

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -396,6 +396,19 @@ class WorkItemDetail(WorkItemSummary):
             "Empty list when none are set."
         ),
     )
+    custom_fields: dict[str, object] = Field(
+        default_factory=dict,
+        description=(
+            "User-defined custom fields configured per project and "
+            "work-item type. Keys are project-specific custom field IDs "
+            "(e.g. 'riskLevel', 'effortHours'); values are heterogeneous "
+            "(string, int, float, bool, list, or "
+            "``{'type': 'text/html', 'value': '<...>'}`` for rich-text "
+            "custom fields — kept raw, NOT converted to Markdown, so the "
+            "shape round-trips back to Polarion unchanged). Empty dict "
+            "when no custom fields are populated on the work item."
+        ),
+    )
 
 
 class LinkedWorkItemSummary(BaseModel):

--- a/src/mcp_server_polarion/tools/_helpers.py
+++ b/src/mcp_server_polarion/tools/_helpers.py
@@ -45,16 +45,75 @@ DEFAULT_PAGE_SIZE: Final[int] = 100
 
 # Sparse fieldsets for list / detail endpoints.
 WI_LIST_FIELDS: Final[str] = "title,type,status,priority,updated,module,assignee"
-# ``customFields.@all`` is a Polarion sparse-fieldset token that returns all
-# populated custom field values inline at ``attributes.customFields``. Without
-# it the server omits every custom field, so the LLM never sees project-specific
-# fields configured per work-item type. Tokens must be appended (NOT replace
-# other fields) — listing only ``customFields.@all`` would hide every standard
-# attribute.
-WI_DETAIL_FIELDS: Final[str] = (
-    "title,description,type,status,priority,updated,"
-    "created,resolution,severity,outlineNumber,hyperlinks,"
-    "module,assignee,author,customFields.@all"
+# Detail fetches use the bare ``@all`` token because this Polarion server
+# inlines custom fields as top-level keys under ``attributes`` (e.g.
+# ``attributes.asil``, ``attributes.requirement_id``) rather than nesting
+# them under a ``customFields`` container. The ``customFields.@all`` /
+# ``@custom`` / ``@additional`` tokens are silently dropped on this server —
+# only ``@all`` surfaces the inline custom attributes. Relationships still
+# come back, so existing module/assignee/author parsing keeps working.
+WI_DETAIL_FIELDS: Final[str] = "@all"
+# Same situation for documents — ``@all`` is the only token that exposes
+# project-defined custom document attributes (e.g. ``version``,
+# ``baseline_name``). The slight per-request cost (``homePageContent``
+# always travels over the wire) is paid in network bytes only; the tool
+# layer still hides the body from the LLM when ``include_content=False``.
+DOC_DETAIL_FIELDS: Final[str] = "@all"
+
+# Canonical standard attribute names per the Polarion REST OpenAPI schema.
+# Used by ``extract_custom_fields`` as an allowlist: anything appearing in
+# a response's ``attributes`` that is NOT in this set is treated as a
+# project-defined custom field. Sourced verbatim from the OpenAPI workitem
+# schema; a future Polarion release that adds new standard attributes
+# would misclassify them as custom until this set is updated.
+STANDARD_WORKITEM_ATTRS: Final[frozenset[str]] = frozenset(
+    {
+        "id",
+        "type",
+        "title",
+        "description",
+        "status",
+        "priority",
+        "severity",
+        "resolution",
+        "resolvedOn",
+        "created",
+        "updated",
+        "outlineNumber",
+        "dueDate",
+        "plannedStart",
+        "plannedEnd",
+        "initialEstimate",
+        "remainingEstimate",
+        "timeSpent",
+        "hyperlinks",
+    }
+)
+
+# Canonical standard document attribute names per the Polarion REST
+# OpenAPI schema. Mirrors ``STANDARD_WORKITEM_ATTRS`` for the document
+# resource type.
+STANDARD_DOCUMENT_ATTRS: Final[frozenset[str]] = frozenset(
+    {
+        "id",
+        "title",
+        "type",
+        "status",
+        "homePageContent",
+        "moduleFolder",
+        "moduleName",
+        "outlineNumbering",
+        "renderingLayouts",
+        "structureLinkRole",
+        "usesOutlineNumbering",
+        "autoSuspect",
+        "branchedWithInitializedFields",
+        "branchedWithQuery",
+        "derivedFields",
+        "derivedFromLinkRole",
+        "created",
+        "updated",
+    }
 )
 
 # ---------------------------------------------------------------------------
@@ -309,20 +368,29 @@ def build_work_item_summary_kwargs(
     }
 
 
-def extract_custom_fields(attrs: dict[str, object]) -> dict[str, object]:
-    """Extract the ``customFields`` map from a JSON:API attributes dict.
+def extract_custom_fields(
+    attrs: dict[str, object],
+    standard: frozenset[str],
+) -> dict[str, object]:
+    """Return the inline custom-field subset of a JSON:API attributes dict.
 
-    Polarion returns custom fields under ``attributes.customFields`` as a
-    flat ``{fieldId: value}`` mapping when the sparse fieldset includes
-    the ``customFields.@all`` token. Values may be primitives (str / int /
-    float / bool / list) or rich-text dicts of the form
-    ``{"type": "text/html", "value": "<...>"}`` — both are returned
-    verbatim so callers can round-trip them back to Polarion unchanged.
+    This Polarion server inlines project-defined custom fields as
+    top-level keys inside ``attributes`` (e.g. ``attributes.asil``,
+    ``attributes.requirement_id``) — there is no ``customFields``
+    container, and the ``customFields.@all`` / ``@custom`` sparse-fieldset
+    tokens are silently ignored. Callers fetch with ``fields[...]=@all``
+    so every populated attribute comes back, then pass the resulting
+    ``attributes`` dict here together with the standard-attribute
+    allowlist for the resource type (``STANDARD_WORKITEM_ATTRS`` or
+    ``STANDARD_DOCUMENT_ATTRS``). Anything not in the allowlist is
+    reported as a custom field.
+
+    Values are returned verbatim — primitives (str / int / float / bool /
+    list) and rich-text dicts of the form
+    ``{"type": "text/html", "value": "<...>"}`` both pass through so the
+    shape round-trips back to Polarion unchanged on a future PATCH.
     """
-    value = attrs.get("customFields")
-    if isinstance(value, dict):
-        return value
-    return {}
+    return {k: v for k, v in attrs.items() if k not in standard}
 
 
 def parse_hyperlinks(value: object) -> list[Hyperlink]:
@@ -400,7 +468,7 @@ def parse_work_item_detail(
         severity=safe_str(attrs.get("severity", "")),
         outline_number=safe_str(attrs.get("outlineNumber", "")),
         hyperlinks=parse_hyperlinks(attrs.get("hyperlinks")),
-        custom_fields=extract_custom_fields(attrs),
+        custom_fields=extract_custom_fields(attrs, STANDARD_WORKITEM_ATTRS),
     )
 
 
@@ -453,6 +521,9 @@ def parse_work_item_summaries(
 
 __all__: list[str] = [
     "DEFAULT_PAGE_SIZE",
+    "DOC_DETAIL_FIELDS",
+    "STANDARD_DOCUMENT_ATTRS",
+    "STANDARD_WORKITEM_ATTRS",
     "WI_DETAIL_FIELDS",
     "WI_LIST_FIELDS",
     "build_included_workitem_map",

--- a/src/mcp_server_polarion/tools/_helpers.py
+++ b/src/mcp_server_polarion/tools/_helpers.py
@@ -45,10 +45,16 @@ DEFAULT_PAGE_SIZE: Final[int] = 100
 
 # Sparse fieldsets for list / detail endpoints.
 WI_LIST_FIELDS: Final[str] = "title,type,status,priority,updated,module,assignee"
+# ``customFields.@all`` is a Polarion sparse-fieldset token that returns all
+# populated custom field values inline at ``attributes.customFields``. Without
+# it the server omits every custom field, so the LLM never sees project-specific
+# fields configured per work-item type. Tokens must be appended (NOT replace
+# other fields) — listing only ``customFields.@all`` would hide every standard
+# attribute.
 WI_DETAIL_FIELDS: Final[str] = (
     "title,description,type,status,priority,updated,"
     "created,resolution,severity,outlineNumber,hyperlinks,"
-    "module,assignee,author"
+    "module,assignee,author,customFields.@all"
 )
 
 # ---------------------------------------------------------------------------
@@ -303,6 +309,22 @@ def build_work_item_summary_kwargs(
     }
 
 
+def extract_custom_fields(attrs: dict[str, object]) -> dict[str, object]:
+    """Extract the ``customFields`` map from a JSON:API attributes dict.
+
+    Polarion returns custom fields under ``attributes.customFields`` as a
+    flat ``{fieldId: value}`` mapping when the sparse fieldset includes
+    the ``customFields.@all`` token. Values may be primitives (str / int /
+    float / bool / list) or rich-text dicts of the form
+    ``{"type": "text/html", "value": "<...>"}`` — both are returned
+    verbatim so callers can round-trip them back to Polarion unchanged.
+    """
+    value = attrs.get("customFields")
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
 def parse_hyperlinks(value: object) -> list[Hyperlink]:
     """Parse the ``attributes.hyperlinks`` field into ``Hyperlink`` models.
 
@@ -378,6 +400,7 @@ def parse_work_item_detail(
         severity=safe_str(attrs.get("severity", "")),
         outline_number=safe_str(attrs.get("outlineNumber", "")),
         hyperlinks=parse_hyperlinks(attrs.get("hyperlinks")),
+        custom_fields=extract_custom_fields(attrs),
     )
 
 
@@ -436,6 +459,7 @@ __all__: list[str] = [
     "build_work_item_summary_kwargs",
     "compute_has_more",
     "encode_path_segment",
+    "extract_custom_fields",
     "extract_relationship_id",
     "extract_relationship_ids",
     "extract_short_id",

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -36,6 +36,8 @@ from mcp_server_polarion.models import (
 from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools._helpers import (
     DEFAULT_PAGE_SIZE,
+    DOC_DETAIL_FIELDS,
+    STANDARD_DOCUMENT_ATTRS,
     WI_DETAIL_FIELDS,
     WI_LIST_FIELDS,
     build_included_workitem_map,
@@ -792,17 +794,17 @@ async def get_document(
         f"/documents/{encoded_name}"
     )
 
-    # ``customFields.@all`` is always requested so the document's
-    # project-specific custom fields flow through, regardless of whether
-    # the caller also asked for the home-page body.
-    fields = "title,type,status,customFields.@all"
-    if include_content:
-        fields = f"{fields},homePageContent"
-
+    # ``@all`` is the only sparse-fieldset token this Polarion server
+    # honours for surfacing inline custom document attributes (e.g.
+    # ``version``, ``baseline_name``). Explicit field lists silently drop
+    # them; ``customFields.@all`` / ``@custom`` are no-ops on this server.
+    # The bandwidth cost — ``homePageContent`` always travels over the
+    # wire — is paid in network bytes only; the tool still hides the body
+    # from the LLM when ``include_content=False``.
     try:
         response = await client.get(
             path,
-            params={"fields[documents]": fields},
+            params={"fields[documents]": DOC_DETAIL_FIELDS},
         )
     except PolarionNotFoundError as exc:
         raise ValueError(
@@ -847,7 +849,7 @@ async def get_document(
         type=safe_str(attrs.get("type", "")),
         status=safe_str(attrs.get("status", "")),
         content=content_md,
-        custom_fields=extract_custom_fields(attrs),
+        custom_fields=extract_custom_fields(attrs, STANDARD_DOCUMENT_ATTRS),
     )
 
 

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -1309,6 +1309,11 @@ async def get_work_item(
           with ``role``, ``title``, ``uri`` fields.
         - ``description``: Full description in Markdown.
         - ``project_id``: Containing project.
+        - ``custom_fields``: User-defined custom fields as a
+          ``{fieldId: value}`` dict. Keys vary per project and work-item
+          type; values are returned verbatim (primitives or
+          ``{type: 'text/html', value: '<...>'}`` for rich-text fields).
+          Empty dict when no custom fields are populated.
 
     Raises:
         ValueError: If the work item or project is not found.

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -41,6 +41,7 @@ from mcp_server_polarion.tools._helpers import (
     build_included_workitem_map,
     compute_has_more,
     encode_path_segment,
+    extract_custom_fields,
     extract_relationship_id,
     extract_short_id,
     extract_total_count,
@@ -772,6 +773,11 @@ async def get_document(
         - ``status``: Workflow status (e.g. 'draft').
         - ``content``: Document body in Markdown — only populated when
         - ``include_content=True``, otherwise empty.
+        - ``custom_fields``: User-defined custom fields as a
+          ``{fieldId: value}`` dict. Keys vary per project and document
+          type; values are returned verbatim (primitives or
+          ``{type: 'text/html', value: '<...>'}`` for rich-text fields).
+          Empty dict when no custom fields are populated.
 
     Raises:
         ValueError: If the document, space, or project is not found.
@@ -786,7 +792,10 @@ async def get_document(
         f"/documents/{encoded_name}"
     )
 
-    fields = "title,type,status"
+    # ``customFields.@all`` is always requested so the document's
+    # project-specific custom fields flow through, regardless of whether
+    # the caller also asked for the home-page body.
+    fields = "title,type,status,customFields.@all"
     if include_content:
         fields = f"{fields},homePageContent"
 
@@ -838,6 +847,7 @@ async def get_document(
         type=safe_str(attrs.get("type", "")),
         status=safe_str(attrs.get("status", "")),
         content=content_md,
+        custom_fields=extract_custom_fields(attrs),
     )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -398,6 +398,30 @@ class TestWorkItemDetail:
         assert detail.severity == ""
         assert detail.outline_number == ""
         assert detail.hyperlinks == []
+        assert detail.custom_fields == {}
+
+    def test_custom_fields_round_trip_heterogeneous_values(self):
+        # Custom-field values are intentionally `object`-typed: primitives
+        # and rich-text `{type: text/html, value: ...}` dicts must both
+        # survive a serialization round-trip unchanged.
+        rich = {"type": "text/html", "value": "<p>note</p>"}
+        detail = WorkItemDetail(
+            id="MCPT-542",
+            title="With customs",
+            type="requirement",
+            status="approved",
+            description="body",
+            project_id="proj1",
+            custom_fields={
+                "riskLevel": "high",
+                "effortHours": 8.0,
+                "approved": True,
+                "richNote": rich,
+            },
+        )
+        restored = WorkItemDetail.model_validate(detail.model_dump())
+        assert restored.custom_fields == detail.custom_fields
+        assert restored.custom_fields["richNote"] == rich
 
     def test_detail_specific_fields(self):
         detail = WorkItemDetail(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -183,6 +183,21 @@ class TestDocumentDetail:
         with pytest.raises(ValidationError):
             DocumentDetail()  # type: ignore[call-arg]
 
+    def test_custom_fields_default_empty(self):
+        d = DocumentDetail(title="Doc", content="")
+        assert d.custom_fields == {}
+
+    def test_custom_fields_round_trip(self):
+        rich = {"type": "text/html", "value": "<p>x</p>"}
+        d = DocumentDetail(
+            title="Doc",
+            content="",
+            custom_fields={"reviewedBy": "alice", "richNote": rich},
+        )
+        restored = DocumentDetail.model_validate(d.model_dump())
+        assert restored.custom_fields == d.custom_fields
+        assert restored.custom_fields["richNote"] == rich
+
 
 # ---------------------------------------------------------------------------
 # DocumentPart

--- a/tests/tools/test_helpers.py
+++ b/tests/tools/test_helpers.py
@@ -1,0 +1,105 @@
+"""Direct unit tests for shared tool helpers.
+
+The bulk of `_helpers.py` is exercised transitively through `test_read.py`
+and `test_write.py` against `mock_client` fixtures. This module adds
+focused tests for helpers whose contract is worth pinning directly —
+currently just `extract_custom_fields`, whose allowlist semantics drive
+how custom Polarion fields flow back to the LLM.
+"""
+
+from __future__ import annotations
+
+from mcp_server_polarion.tools._helpers import (
+    STANDARD_DOCUMENT_ATTRS,
+    STANDARD_WORKITEM_ATTRS,
+    extract_custom_fields,
+)
+
+
+class TestExtractCustomFields:
+    """Tests for `extract_custom_fields(attrs, standard)`."""
+
+    def test_returns_only_non_standard_keys(self) -> None:
+        attrs: dict[str, object] = {
+            "title": "T",
+            "type": "task",
+            "status": "open",
+            "asil": "B",
+            "requirement_id": "REQ-1",
+        }
+        assert extract_custom_fields(attrs, STANDARD_WORKITEM_ATTRS) == {
+            "asil": "B",
+            "requirement_id": "REQ-1",
+        }
+
+    def test_empty_when_attrs_are_all_standard(self) -> None:
+        attrs: dict[str, object] = {
+            "title": "T",
+            "type": "task",
+            "status": "open",
+            "priority": "50.0",
+        }
+        assert extract_custom_fields(attrs, STANDARD_WORKITEM_ATTRS) == {}
+
+    def test_empty_attrs_dict(self) -> None:
+        assert extract_custom_fields({}, STANDARD_WORKITEM_ATTRS) == {}
+
+    def test_preserves_rich_text_value_verbatim(self) -> None:
+        # Rich-text Polarion fields arrive as {type, value} dicts; the
+        # helper must NOT convert them to Markdown, so they round-trip
+        # back to Polarion unchanged on a future PATCH.
+        rich = {"type": "text/html", "value": "<p>x</p>"}
+        attrs: dict[str, object] = {"title": "T", "verification_criteria": rich}
+        result = extract_custom_fields(attrs, STANDARD_WORKITEM_ATTRS)
+        assert result == {"verification_criteria": rich}
+        # Same object identity — no defensive copy.
+        assert result["verification_criteria"] is rich
+
+    def test_preserves_heterogeneous_value_types(self) -> None:
+        attrs: dict[str, object] = {
+            "title": "T",
+            "custom_str": "s",
+            "custom_int": 42,
+            "custom_float": 1.5,
+            "custom_bool": True,
+            "custom_list": [1, 2, 3],
+            "custom_dict": {"nested": "value"},
+        }
+        assert extract_custom_fields(attrs, STANDARD_WORKITEM_ATTRS) == {
+            "custom_str": "s",
+            "custom_int": 42,
+            "custom_float": 1.5,
+            "custom_bool": True,
+            "custom_list": [1, 2, 3],
+            "custom_dict": {"nested": "value"},
+        }
+
+    def test_document_allowlist_filters_document_attrs(self) -> None:
+        # Verifies the same helper works for documents with the
+        # document-specific allowlist; document-only standard keys
+        # (e.g. homePageContent, moduleFolder) must be filtered out.
+        attrs: dict[str, object] = {
+            "title": "Doc",
+            "type": "req_specification",
+            "status": "draft",
+            "homePageContent": {"type": "text/html", "value": "<p/>"},
+            "moduleFolder": "Design",
+            # Customs on this project's documents:
+            "version": "0.0",
+            "baseline_name": "release-2026Q1",
+        }
+        assert extract_custom_fields(attrs, STANDARD_DOCUMENT_ATTRS) == {
+            "version": "0.0",
+            "baseline_name": "release-2026Q1",
+        }
+
+    def test_allowlist_swap_changes_classification(self) -> None:
+        # A key that is standard for one resource type may be custom on
+        # another. ``autoSuspect`` is a standard document attribute but
+        # NOT a standard WI attribute — so swapping the allowlist flips
+        # how it's classified.
+        attrs: dict[str, object] = {"autoSuspect": False}
+        assert extract_custom_fields(attrs, STANDARD_DOCUMENT_ATTRS) == {}
+        assert extract_custom_fields(attrs, STANDARD_WORKITEM_ATTRS) == {
+            "autoSuspect": False,
+        }

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -800,6 +800,7 @@ class TestGetDocument:
         assert result.status == "approved"
         assert "SRS" in result.content
         assert "<p>" not in result.content
+        assert result.custom_fields == {}
 
     async def test_include_content_false_omits_content(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -989,6 +990,102 @@ class TestGetDocument:
         assert "##" not in result.content
         assert "Intro paragraph" in result.content
         assert "Detail text" in result.content
+
+    async def test_custom_fields_populated_from_response(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """customFields dict on the response flows through verbatim."""
+        rich_value = {"type": "text/html", "value": "<p>note</p>"}
+        mock_client.get.return_value = {
+            "data": {
+                "id": "proj1/_default/SRS",
+                "attributes": {
+                    "title": "SRS",
+                    "type": "req_specification",
+                    "status": "approved",
+                    "customFields": {
+                        "reviewedBy": "alice",
+                        "complianceLevel": 3,
+                        "richNote": rich_value,
+                    },
+                },
+            },
+        }
+
+        result = await get_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="SRS",
+            include_content=False,
+        )
+
+        # Raw passthrough: rich-text values stay as the original
+        # {type, value} dict — they are NOT converted to Markdown.
+        assert result.custom_fields == {
+            "reviewedBy": "alice",
+            "complianceLevel": 3,
+            "richNote": rich_value,
+        }
+
+    async def test_custom_fields_empty_when_missing(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Absent customFields key → empty dict, never None or KeyError."""
+        mock_client.get.return_value = {
+            "data": {
+                "attributes": {
+                    "title": "Plain Doc",
+                    "type": "generic",
+                    "status": "draft",
+                },
+            },
+        }
+
+        result = await get_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="Plain",
+            include_content=False,
+        )
+
+        assert result.custom_fields == {}
+
+    async def test_sparse_fieldset_requests_custom_fields_token(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """``customFields.@all`` MUST be in fields[documents] regardless of
+        include_content."""
+        mock_client.get.return_value = {
+            "data": {
+                "attributes": {"title": "x", "type": "generic", "status": "draft"},
+            },
+        }
+
+        # include_content=False path
+        await get_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="A",
+            include_content=False,
+        )
+        _, kwargs_a = mock_client.get.call_args
+        assert "customFields.@all" in kwargs_a["params"]["fields[documents]"]
+
+        # include_content=True path — must still include the token
+        await get_document(
+            mock_ctx,
+            project_id="proj1",
+            space_id="_default",
+            document_name="B",
+            include_content=True,
+        )
+        _, kwargs_b = mock_client.get.call_args
+        fields_b = kwargs_b["params"]["fields[documents]"]
+        assert "customFields.@all" in fields_b
+        assert "homePageContent" in fields_b
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -805,7 +805,12 @@ class TestGetDocument:
     async def test_include_content_false_omits_content(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """include_content=False → body skipped, metadata still populated."""
+        """include_content=False → body skipped even when API echoes it.
+
+        With ``fields[documents]=@all`` the wire always carries
+        ``homePageContent``; the tool layer is responsible for hiding it
+        from the LLM unless asked.
+        """
         mock_client.get.return_value = {
             "data": {
                 "attributes": {
@@ -813,8 +818,6 @@ class TestGetDocument:
                     "title": "SRS",
                     "type": "req_specification",
                     "status": "draft",
-                    # Even if the API echoes homePageContent (it shouldn't,
-                    # since we don't request it), the tool must ignore it.
                     "homePageContent": {
                         "type": "text/html",
                         "value": "<p>should be ignored</p>",
@@ -836,17 +839,10 @@ class TestGetDocument:
         assert result.status == "draft"
         assert result.content == ""
 
-        _, kwargs = mock_client.get.call_args
-        fields = kwargs["params"]["fields[documents]"]
-        assert "title" in fields
-        assert "type" in fields
-        assert "status" in fields
-        assert "homePageContent" not in fields
-
-    async def test_include_content_requests_homepage_field(
+    async def test_include_content_renders_homepage(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """With include_content=True, homePageContent is requested."""
+        """include_content=True → homePageContent rendered into result.content."""
         mock_client.get.return_value = {
             "data": {
                 "attributes": {
@@ -869,9 +865,6 @@ class TestGetDocument:
             include_content=True,
         )
 
-        _, kwargs = mock_client.get.call_args
-        fields = kwargs["params"]["fields[documents]"]
-        assert "homePageContent" in fields
         assert "body" in result.content
 
     async def test_encodes_document_name_with_spaces(
@@ -994,20 +987,21 @@ class TestGetDocument:
     async def test_custom_fields_populated_from_response(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """customFields dict on the response flows through verbatim."""
+        """Inline non-standard attributes flow through as ``custom_fields``."""
         rich_value = {"type": "text/html", "value": "<p>note</p>"}
         mock_client.get.return_value = {
             "data": {
                 "id": "proj1/_default/SRS",
                 "attributes": {
+                    # Standard attrs — present but excluded from custom_fields.
                     "title": "SRS",
                     "type": "req_specification",
                     "status": "approved",
-                    "customFields": {
-                        "reviewedBy": "alice",
-                        "complianceLevel": 3,
-                        "richNote": rich_value,
-                    },
+                    # Inline custom attributes — top-level keys.
+                    "description": rich_value,
+                    "version": "1.0",
+                    "version_history": [{"version": "1.0", "author": "alice"}],
+                    "baseline_name": "release-2026Q1",
                 },
             },
         }
@@ -1020,18 +1014,18 @@ class TestGetDocument:
             include_content=False,
         )
 
-        # Raw passthrough: rich-text values stay as the original
-        # {type, value} dict — they are NOT converted to Markdown.
+        # Raw passthrough: rich-text and structured values stay verbatim.
         assert result.custom_fields == {
-            "reviewedBy": "alice",
-            "complianceLevel": 3,
-            "richNote": rich_value,
+            "description": rich_value,
+            "version": "1.0",
+            "version_history": [{"version": "1.0", "author": "alice"}],
+            "baseline_name": "release-2026Q1",
         }
 
-    async def test_custom_fields_empty_when_missing(
+    async def test_custom_fields_empty_when_only_standard_attrs(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Absent customFields key → empty dict, never None or KeyError."""
+        """All-standard attributes → empty custom_fields dict."""
         mock_client.get.return_value = {
             "data": {
                 "attributes": {
@@ -1052,18 +1046,16 @@ class TestGetDocument:
 
         assert result.custom_fields == {}
 
-    async def test_sparse_fieldset_requests_custom_fields_token(
+    async def test_sparse_fieldset_uses_all_token(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``customFields.@all`` MUST be in fields[documents] regardless of
-        include_content."""
+        """``fields[documents]=@all`` is sent regardless of include_content."""
         mock_client.get.return_value = {
             "data": {
                 "attributes": {"title": "x", "type": "generic", "status": "draft"},
             },
         }
 
-        # include_content=False path
         await get_document(
             mock_ctx,
             project_id="proj1",
@@ -1072,9 +1064,8 @@ class TestGetDocument:
             include_content=False,
         )
         _, kwargs_a = mock_client.get.call_args
-        assert "customFields.@all" in kwargs_a["params"]["fields[documents]"]
+        assert kwargs_a["params"]["fields[documents]"] == "@all"
 
-        # include_content=True path — must still include the token
         await get_document(
             mock_ctx,
             project_id="proj1",
@@ -1083,9 +1074,7 @@ class TestGetDocument:
             include_content=True,
         )
         _, kwargs_b = mock_client.get.call_args
-        fields_b = kwargs_b["params"]["fields[documents]"]
-        assert "customFields.@all" in fields_b
-        assert "homePageContent" in fields_b
+        assert kwargs_b["params"]["fields[documents]"] == "@all"
 
 
 # ---------------------------------------------------------------------------
@@ -2333,21 +2322,22 @@ class TestGetWorkItem:
     async def test_custom_fields_populated_from_response(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """customFields dict on the response flows through verbatim."""
+        """Inline non-standard attributes flow through as ``custom_fields``."""
         rich_value = {"type": "text/html", "value": "<p>note</p>"}
         mock_client.get.return_value = {
             "data": {
                 "id": "proj1/MCPT-542",
                 "attributes": {
+                    # Standard attrs — present but excluded from custom_fields.
                     "title": "WI with customs",
-                    "type": "requirement",
+                    "type": "softwarerequirement",
                     "status": "approved",
-                    "customFields": {
-                        "riskLevel": "high",
-                        "effortHours": 8.0,
-                        "approved": True,
-                        "richNote": rich_value,
-                    },
+                    "priority": "50.0",
+                    # Inline custom attributes — top-level keys, not nested.
+                    "asil": "B",
+                    "reqType": "user",
+                    "requirement_id": "REQ-42",
+                    "verification_criteria": rich_value,
                 },
             },
         }
@@ -2361,16 +2351,16 @@ class TestGetWorkItem:
         # Raw passthrough: rich-text values stay as the original
         # {type, value} dict — they are NOT converted to Markdown.
         assert result.custom_fields == {
-            "riskLevel": "high",
-            "effortHours": 8.0,
-            "approved": True,
-            "richNote": rich_value,
+            "asil": "B",
+            "reqType": "user",
+            "requirement_id": "REQ-42",
+            "verification_criteria": rich_value,
         }
 
-    async def test_custom_fields_empty_when_missing(
+    async def test_custom_fields_empty_when_only_standard_attrs(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Absent customFields key → empty dict, never None or KeyError."""
+        """All-standard attributes → empty custom_fields dict."""
         mock_client.get.return_value = {
             "data": {
                 "id": "proj1/MCPT-100",
@@ -2390,10 +2380,10 @@ class TestGetWorkItem:
 
         assert result.custom_fields == {}
 
-    async def test_sparse_fieldset_requests_custom_fields_token(
+    async def test_sparse_fieldset_uses_all_token(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """The ``customFields.@all`` token MUST be in fields[workitems]."""
+        """``fields[workitems]=@all`` is the only token that surfaces customs."""
         mock_client.get.return_value = {
             "data": {
                 "id": "proj1/MCPT-1",
@@ -2408,8 +2398,7 @@ class TestGetWorkItem:
         )
 
         _, kwargs = mock_client.get.call_args
-        fields = kwargs["params"]["fields[workitems]"]
-        assert "customFields.@all" in fields
+        assert kwargs["params"]["fields[workitems]"] == "@all"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -2139,6 +2139,7 @@ class TestGetWorkItem:
         assert "log in" in result.description
         assert "<p>" not in result.description
         assert result.project_id == "proj1"
+        assert result.custom_fields == {}
 
     async def test_defect_severity_and_open_resolution(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -2231,6 +2232,87 @@ class TestGetWorkItem:
         call_path = mock_client.get.call_args[0][0]
         expected = "/projects/proj1/workitems/MCPT-010"
         assert call_path == expected
+
+    async def test_custom_fields_populated_from_response(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """customFields dict on the response flows through verbatim."""
+        rich_value = {"type": "text/html", "value": "<p>note</p>"}
+        mock_client.get.return_value = {
+            "data": {
+                "id": "proj1/MCPT-542",
+                "attributes": {
+                    "title": "WI with customs",
+                    "type": "requirement",
+                    "status": "approved",
+                    "customFields": {
+                        "riskLevel": "high",
+                        "effortHours": 8.0,
+                        "approved": True,
+                        "richNote": rich_value,
+                    },
+                },
+            },
+        }
+
+        result = await get_work_item(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-542",
+        )
+
+        # Raw passthrough: rich-text values stay as the original
+        # {type, value} dict — they are NOT converted to Markdown.
+        assert result.custom_fields == {
+            "riskLevel": "high",
+            "effortHours": 8.0,
+            "approved": True,
+            "richNote": rich_value,
+        }
+
+    async def test_custom_fields_empty_when_missing(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Absent customFields key → empty dict, never None or KeyError."""
+        mock_client.get.return_value = {
+            "data": {
+                "id": "proj1/MCPT-100",
+                "attributes": {
+                    "title": "No customs",
+                    "type": "task",
+                    "status": "open",
+                },
+            },
+        }
+
+        result = await get_work_item(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-100",
+        )
+
+        assert result.custom_fields == {}
+
+    async def test_sparse_fieldset_requests_custom_fields_token(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """The ``customFields.@all`` token MUST be in fields[workitems]."""
+        mock_client.get.return_value = {
+            "data": {
+                "id": "proj1/MCPT-1",
+                "attributes": {"title": "x", "type": "task", "status": "open"},
+            },
+        }
+
+        await get_work_item(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-1",
+        )
+
+        _, kwargs = mock_client.get.call_args
+        fields = kwargs["params"]["fields[workitems]"]
+        assert "customFields.@all" in fields
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -1415,8 +1415,10 @@ class TestUpdateWorkItemHappyPath:
         assert args == ("/projects/MyProj/workitems/MCPT-1",)
         params = kwargs["params"]
         assert params["include"] == "assignee"
-        assert "title" in params["fields[workitems]"]
-        assert "description" in params["fields[workitems]"]
+        # WI_DETAIL_FIELDS is the bare ``@all`` token so inline custom
+        # fields surface on ``current.custom_fields``; this assertion
+        # pins that semantics (changing it would silently drop customs).
+        assert params["fields[workitems]"] == "@all"
 
     async def test_workflow_action_appended_as_query_param(
         self, mock_ctx: MagicMock, mock_client: AsyncMock

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -1420,6 +1420,30 @@ class TestUpdateWorkItemHappyPath:
         # pins that semantics (changing it would silently drop customs).
         assert params["fields[workitems]"] == "@all"
 
+    async def test_current_carries_custom_fields_from_post_patch_get(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Polarion inlines customs as top-level attrs; this WI happens to
+        # have ``asil`` and ``requirement_id`` populated. The post-PATCH
+        # GET reuses ``parse_work_item_detail`` so they must land on
+        # ``result.current.custom_fields`` automatically — guarding the
+        # cross-tool inheritance the fix relies on.
+        mock_client.patch.return_value = {}
+        get_response = _make_get_response(title="after")
+        data = cast(dict[str, object], get_response["data"])
+        attrs = cast(dict[str, object], data["attributes"])
+        attrs["asil"] = "B"
+        attrs["requirement_id"] = "REQ-42"
+        mock_client.get.return_value = get_response
+
+        result = await _call_update(mock_ctx, title="after")
+
+        assert result.current is not None
+        assert result.current.custom_fields == {
+            "asil": "B",
+            "requirement_id": "REQ-42",
+        }
+
     async def test_workflow_action_appended_as_query_param(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:


### PR DESCRIPTION
## Summary

Surfaces project-defined Polarion **custom fields** on `WorkItemDetail` and `DocumentDetail` as a new `custom_fields: dict[str, object]` field, so the LLM sees fields like `asil`, `requirement_id`, `version`, `baseline_name` without project-specific schema discovery.

This Polarion server inlines customs as **top-level keys under `attributes`** (alongside `title`/`status`/etc.) — there is no nested `customFields` container, and the `customFields.@all` / `@custom` / `@additional` sparse-fieldset tokens are silently dropped. The implementation therefore uses `fields[*]=@all` and filters standard attributes out via canonical OpenAPI-sourced allowlists.

Phase 1 scope: read-only, two detail tools (`get_work_item` and `get_document`). Write paths and list/embedded views are deliberately out of scope.

> ⚠️ Commit history note: the first three commits (bf5b8c6, 3b5bc8d, 7134ca4) attempted a `customFields.@all` token that this server doesn't honour — they returned `custom_fields: {}` in every live call. **Commit 6b46091 is the fix** that switches to `@all` + allowlist filtering and was verified end-to-end against the testdrive Polarion (see the e2e comment below). Consider **squash-on-merge** to flatten this history.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Documentation update
- [ ] CI / tooling / dependency update
---

## Changes

- `WorkItemDetail.custom_fields` and `DocumentDetail.custom_fields` added (`dict[str, object]`, `default_factory=dict`). Values stay verbatim — rich-text customs come back as `{type: 'text/html', value: '<...>'}` dicts so they round-trip on a future PATCH.
- `WI_DETAIL_FIELDS` and the `get_document` sparse fieldset both use the bare `@all` token. `WI_LIST_FIELDS` is unchanged (list views stay slim).
- New `STANDARD_WORKITEM_ATTRS` and `STANDARD_DOCUMENT_ATTRS` `frozenset[str]` allowlists in `_helpers.py`, sourced verbatim from the Polarion REST OpenAPI workitem/document schemas. New `extract_custom_fields(attrs, standard)` filters anything not in the allowlist as a custom field.
- `update_work_item`'s post-PATCH GET inherits the fix automatically via the shared `parse_work_item_detail`, so `WorkItemUpdateResult.current.custom_fields` is populated — pinned by a new test.
- Tool docstrings updated; CLAUDE.md "Polarion API & Gotchas" gains a corrected entry explaining the inline-attribute behaviour, the `@all` requirement, and the allowlist caveat.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [x] `dry_run=True` path verified for all write tools (unchanged; existing tests still pass)
- [x] `uv run pytest` passes locally — **392 passed**
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check . && uv run ruff format --check .` clean

New tests:
- `tests/tools/test_helpers.py` (new file) — direct unit tests for `extract_custom_fields`: allowlist filtering, empty cases, heterogeneous value types, rich-text identity, allowlist swap.
- `tests/tools/test_read.py::TestGetWorkItem` — three tests covering populated inline customs, all-standard case, and `fields[workitems]=@all` sparse-fieldset assertion.
- `tests/tools/test_read.py::TestGetDocument` — same three for documents (token assertion checks both `include_content` paths).
- `tests/tools/test_write.py::TestUpdateWorkItemHappyPath::test_current_carries_custom_fields_from_post_patch_get` — pins the post-PATCH GET inheriting custom fields onto `result.current.custom_fields`.
- `tests/test_models.py::TestWorkItemDetail` / `TestDocumentDetail` — default-empty and heterogeneous round-trip tests.

\`\`\`bash
uv run pytest                         # 392 passed
uv run ruff check . && uv run ruff format --check . && uv run mypy src/
\`\`\`

End-to-end against testdrive Polarion confirmed live customs surface for MCPT-542 (`asil`, `reqType`, `requirement_id`, `verification_criteria`) and Design/SRS (`version`, `baseline_name`, `description`, `version_history`). See the e2e comment on this PR for the full payloads.

---

## Golden Rule Compliance

- [x] No \`print()\` calls
- [x] \`from __future__ import annotations\` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw \`dict\`)
- [x] All new tool functions are \`async def\` (no new tools added — only existing ones extended)
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] HTML converted via \`html_to_markdown()\` in read paths (rich-text custom-field values are intentionally NOT converted — kept raw for round-trip)
- [x] HTML sanitized via \`markdown_to_html()\` + \`sanitize_html()\` in write paths (unchanged)
- [x] Any new list tool supports \`page_size\` and \`page_number\` pagination (n/a — no new list tools)
- [x] No secrets hardcoded — env vars via \`pydantic-settings\` only

---

## Trade-offs / Risks

- **`@all` over-fetches** — for WIs, the response now carries all 19 relationship link-stubs (vs the previous 4); for documents, \`homePageContent\` always travels over the wire even when \`include_content=False\`. The tool still hides the body from the LLM, so LLM-visible payload size is unchanged; network bytes grow moderately. Acceptable for phase 1; revisit if reported.
- **Allowlist staleness** — if a future Polarion release adds new standard attributes, they will be misclassified as custom until \`STANDARD_*_ATTRS\` is bumped. Documented in CLAUDE.md.

---

## Notes for Reviewers

- **5 commits** on this branch. Consider squash-on-merge:
  1. \`feat(tool): include all custom fields on get_work_item\` *(broken — `customFields.@all` is silently dropped)*
  2. \`feat(tool): include all custom fields on get_document\` *(same)*
  3. \`docs(meta): note customFields.@all sparse-fieldset token\` *(same)*
  4. **\`fix(tool): surface inline custom attributes via @all\`** ← the fix that actually works
  5. \`test(tool): pin extract_custom_fields contract and PATCH-GET inheritance\`
- Custom field values stay as `dict[str, object]` (per CLAUDE.md "no `typing.Any`" rule). Rich-text customs preserve `{type, value}` shape unchanged for future write-path round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)