### PR TITLE
fix(utils): preserve attachment imgs on read

### DIFF
--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -119,6 +119,12 @@ def _fill_empty_img_alt(html: str) -> str:
     to the filename portion of ``src`` (the segment after the first ``:``), and
     drop ``title`` so the output stays ``![alt](src)`` without a redundant title
     inside the parentheses.
+
+    The src-filename fallback is skipped for absolute URLs (``://`` present),
+    since the post-colon segment of ``https://host/path`` is the authority plus
+    path — not a filename — and would produce a misleading alt like
+    ``![//host/path](https://host/path)``.  External imgs without alt or title
+    therefore emit as ``![](src)`` instead.
     """
     if "<img" not in html.lower():
         return html
@@ -132,7 +138,7 @@ def _fill_empty_img_alt(html: str) -> str:
         title_raw = img.attrs.get("title", "")
         title = title_raw if isinstance(title_raw, str) else ""
         label = title.strip()
-        if not label:
+        if not label and "://" not in src:
             _, sep, after = src.partition(":")
             label = after if sep else src
         if label:

--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -102,8 +102,44 @@ def html_to_markdown(html: str) -> str:
     if not html or not html.strip():
         return ""
     expanded = _expand_merged_table_cells(html)
-    result: str = markdownify(expanded, heading_style="ATX", strip=["img"])
+    rewritten = _fill_empty_img_alt(expanded)
+    result: str = markdownify(rewritten, heading_style="ATX")
     return result.strip()
+
+
+def _fill_empty_img_alt(html: str) -> str:
+    """Populate empty ``alt`` on ``<img>`` so markdownify emits a readable label.
+
+    ``markdownify`` outputs ``![](src "title")`` when ``alt`` is empty.  In a UI
+    renderer a broken image with empty alt shows no inline fallback text, so a
+    user reading the surrounding Markdown loses any signal about the attachment.
+    Polarion stores image attachments inline as ``<img src="attachment:..."/>``
+    or ``<img src="workitemimg:..."/>`` and typically puts the original filename
+    on ``title`` rather than ``alt``; promote ``title`` to ``alt``, falling back
+    to the filename portion of ``src`` (the segment after the first ``:``), and
+    drop ``title`` so the output stays ``![alt](src)`` without a redundant title
+    inside the parentheses.
+    """
+    if "<img" not in html.lower():
+        return html
+    soup = BeautifulSoup(html, "html.parser")
+    for img in soup.find_all("img"):
+        existing_alt = img.attrs.get("alt", "")
+        if isinstance(existing_alt, str) and existing_alt.strip():
+            continue
+        src_raw = img.attrs.get("src", "")
+        src = src_raw if isinstance(src_raw, str) else ""
+        title_raw = img.attrs.get("title", "")
+        title = title_raw if isinstance(title_raw, str) else ""
+        label = title.strip()
+        if not label:
+            _, sep, after = src.partition(":")
+            label = after if sep else src
+        if label:
+            img["alt"] = label
+        if "title" in img.attrs:
+            del img.attrs["title"]
+    return str(soup)
 
 
 def _expand_merged_table_cells(html: str) -> str:

--- a/tests/utils/test_html.py
+++ b/tests/utils/test_html.py
@@ -109,12 +109,54 @@ class TestHtmlToMarkdown:
         assert "$100" in result
         assert "&" in result
 
-    def test_img_stripped(self) -> None:
-        html = '<p>Before <img src="pic.jpg"/> After</p>'
+    def test_empty_alt_filled_from_title(self) -> None:
+        """``<img title="X" src="...">`` (no alt) becomes ``![X](src)``.
+
+        Polarion stores the upload filename in ``title``; promoting it to
+        ``alt`` and dropping ``title`` keeps the rendered Markdown to a single
+        canonical label without a redundant ``"X"`` inside the parentheses.
+        """
+        html = '<img src="attachment:1-shot.png" title="shot.png"/>'
+        result = html_to_markdown(html)
+        assert "![shot.png](attachment:1-shot.png)" in result
+        assert '"shot.png"' not in result
+
+    def test_empty_alt_filled_from_src_filename(self) -> None:
+        """No alt, no title -> alt derived from the segment after ``:`` in src.
+
+        Real Polarion descriptions occasionally carry attachment imgs without
+        a title attribute (e.g. when pasted from the clipboard); the filename
+        portion of ``src`` is the only readable label available.
+        """
+        html = (
+            '<img src="attachment:1-screenshot-20260512-142738-1.png" '
+            'style="max-width: 650px;"/>'
+        )
+        result = html_to_markdown(html)
+        assert (
+            "![1-screenshot-20260512-142738-1.png]"
+            "(attachment:1-screenshot-20260512-142738-1.png)" in result
+        )
+
+    def test_existing_alt_preserved(self) -> None:
+        """An img that already carries a non-empty alt is left alone."""
+        html = '<img alt="My picture" src="workitemimg:1-foo.png" title="foo.png"/>'
+        result = html_to_markdown(html)
+        assert "![My picture](workitemimg:1-foo.png" in result
+
+    def test_non_attachment_img_passes_through(self) -> None:
+        """External imgs are no longer filtered — markdownify emits them verbatim.
+
+        The previous attachment-prefix whitelist filtered out external URLs as
+        a defensive measure, but smoke tests showed Polarion descriptions never
+        contain them in practice, and filtering added complexity without value.
+        Let markdownify render them so the caller can see what was there.
+        """
+        html = '<p>Before <img src="https://example.com/pic.jpg"/> After</p>'
         result = html_to_markdown(html)
         assert "Before" in result
         assert "After" in result
-        assert "img" not in result.lower()
+        assert "https://example.com/pic.jpg" in result
 
     def test_nested_formatting(self) -> None:
         html = "<p><strong><em>bold italic</em></strong></p>"

--- a/tests/utils/test_html.py
+++ b/tests/utils/test_html.py
@@ -156,7 +156,9 @@ class TestHtmlToMarkdown:
         result = html_to_markdown(html)
         assert "Before" in result
         assert "After" in result
-        assert "https://example.com/pic.jpg" in result
+        # Lock the exact emitted form: src is preserved on a bare ![](src) since
+        # the external img carries no alt or title to promote.
+        assert "![](https://example.com/pic.jpg)" in result
 
     def test_nested_formatting(self) -> None:
         html = "<p><strong><em>bold italic</em></strong></p>"


### PR DESCRIPTION
## Summary

Polarion stores embedded screenshots as `<img src="workitemimg:..."/>` or `<img src="attachment:..."/>` in a work-item description. The previous `html_to_markdown` passed `strip=["img"]` to markdownify, which discarded these tags entirely — every attached screenshot disappeared on read, leaving an LLM consumer with no signal the WI carried visual content. This PR drops `strip` and adds a slim `_fill_empty_img_alt` pass so each img survives conversion with a human-readable `![filename](src)` form.

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- Drop `strip=["img"]` from the `markdownify` call in `html_to_markdown` so attachment imgs are no longer erased.
- Add `_fill_empty_img_alt` helper that promotes a Polarion `<img title="filename" src="workitemimg:..."/>` to `<img alt="filename" src="..."/>` and strips the now-redundant `title`. Falls back to the filename portion of `src` (the segment after `:`) when `title` is absent, and leaves imgs that already carry a non-empty `alt` untouched.
- Update `tests/utils/test_html.py`: replace the six earlier attachment-specific cases with three focused ones (`test_empty_alt_filled_from_title`, `test_empty_alt_filled_from_src_filename`, `test_existing_alt_preserved`) plus `test_non_attachment_img_passes_through` documenting that external imgs are no longer filtered.

---

## Testing

- [x] Unit tests added / updated (`tests/utils/test_html.py`)
- [x] `uv run pytest` passes locally (422 passed)
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check . && uv run ruff format --check .` passes

```bash
uv run pytest -q
uv run ruff check . && uv run ruff format --check . && uv run mypy src/
```

Live in-process verification against `MCPT-543/544/545/546/547` raw descriptions on `testdrive.polarion.com` confirmed:

| WI | Output |
|---|---|
| MCPT-543 | `![screenshot-20260512-142738-0.png](workitemimg:1-screenshot-20260512-142738-0.png)` |
| MCPT-544 | two `![filename](src)` lines |
| MCPT-545 (no title) | `![1-screenshot-20260512-142738-1.png](attachment:1-screenshot-20260512-142738-1.png)` — alt filled from src filename |
| MCPT-546 / MCPT-547 | `![test.png](workitemimg:1-test.png)` / `![Polarion_Test.pptx](workitemimg:1-Polarion_Test.pptx)` |

No write paths are touched — `sanitize_html` still unwraps `<img>` in `markdown_to_html` outputs, so a read → modify → write round-trip will still drop attachment refs. That can be addressed in a follow-up PR by allowlisting attachment-prefixed `<img>` in `sanitize_html`.

---

## Golden Rule Compliance

- [x] No `print()` calls
- [x] `from __future__ import annotations` already present
- [x] No raw `dict` returns added
- [x] No new tool functions added
- [x] No new write tools added
- [x] No `Any` introduced