### PR TITLE
feat(config): add POLARION_VERIFY_SSL toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ POLARION_URL=https://your-polarion-instance.com
 
 # Bearer token for Polarion REST API
 POLARION_TOKEN=your-personal-access-token
+
+# Verify TLS certificates (default true).
+# Set to false ONLY for self-signed certificates on trusted networks.
+# POLARION_VERIFY_SSL=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ CI runs: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 
 ## Architecture
 
-- **`core/`** — `client.py` (async httpx wrapper, 429/5xx backoff, post-mutation delay, maps responses to `PolarionError` / `PolarionAuthError` / `PolarionNotFoundError`), `config.py` (Pydantic settings: `POLARION_URL`, `POLARION_TOKEN`), `logging.py` (stderr-only configuration; called from server lifespan, never from tool code), `exceptions.py`. Every module obtains its logger via `logging.getLogger("mcp_server_polarion.<module>")`.
+- **`core/`** — `client.py` (async httpx wrapper, 429/5xx backoff, post-mutation delay, maps responses to `PolarionError` / `PolarionAuthError` / `PolarionNotFoundError`), `config.py` (Pydantic settings: `POLARION_URL`, `POLARION_TOKEN`, `POLARION_VERIFY_SSL`), `logging.py` (stderr-only configuration; called from server lifespan, never from tool code), `exceptions.py`. Every module obtains its logger via `logging.getLogger("mcp_server_polarion.<module>")`.
 - **`tools/`** — `read.py` (8 read tools incl. `read_document` for flowing Markdown), `write.py` (4 write tools, each with its `_build_*_payload` helper), `_helpers.py` (sparse-fieldset constants, JSON:API extractors, pagination helpers, custom-field merge).
 - **`utils/html.py`** — Markdown ↔ HTML (markdownify + BeautifulSoup4 sanitization).
 - **`models.py`** — Pydantic v2 models. `PaginatedResult[T]` wraps all list responses.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ No other installation is needed — `uvx mcp-server-polarion` downloads and runs
 |---|---|---|
 | `POLARION_URL` | Base URL of your Polarion instance | `https://polarion.example.com` |
 | `POLARION_TOKEN` | Personal Access Token for authentication | `your-personal-access-token` |
+| `POLARION_VERIFY_SSL` | Verify TLS certificates (default `true`). Set `false` for self-signed certs on trusted networks. | `true` |
 
 <details>
 <summary><b>VS Code (GitHub Copilot)</b></summary>
@@ -53,7 +54,8 @@ Add to `.vscode/mcp.json`:
       "args": ["mcp-server-polarion"],
       "env": {
         "POLARION_URL": "https://polarion.example.com",
-        "POLARION_TOKEN": "your-personal-access-token"
+        "POLARION_TOKEN": "your-personal-access-token",
+        "POLARION_VERIFY_SSL": "true"
       }
     }
   }
@@ -75,7 +77,8 @@ Add to `claude_desktop_config.json`:
       "args": ["mcp-server-polarion"],
       "env": {
         "POLARION_URL": "https://polarion.example.com",
-        "POLARION_TOKEN": "your-personal-access-token"
+        "POLARION_TOKEN": "your-personal-access-token",
+        "POLARION_VERIFY_SSL": "true"
       }
     }
   }
@@ -97,7 +100,8 @@ Add to Cursor MCP settings:
       "args": ["mcp-server-polarion"],
       "env": {
         "POLARION_URL": "https://polarion.example.com",
-        "POLARION_TOKEN": "your-personal-access-token"
+        "POLARION_TOKEN": "your-personal-access-token",
+        "POLARION_VERIFY_SSL": "true"
       }
     }
   }
@@ -115,6 +119,7 @@ Register via the `claude mcp add` command:
 claude mcp add mcp-server-polarion \
   -e POLARION_URL=https://polarion.example.com \
   -e POLARION_TOKEN=your-personal-access-token \
+  -e POLARION_VERIFY_SSL=true \
   -- uvx mcp-server-polarion
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ No other installation is needed — `uvx mcp-server-polarion` downloads and runs
 | `POLARION_TOKEN` | Personal Access Token for authentication | `your-personal-access-token` |
 | `POLARION_VERIFY_SSL` | Verify TLS certificates (default `true`). Set `false` for self-signed certs on trusted networks. | `true` |
 
+> MCP client `env` objects must use **string** values, so booleans are quoted (e.g. `"POLARION_VERIFY_SSL": "true"`). The server parses `"true"` / `"false"` into a real `bool`.
+
 <details>
 <summary><b>VS Code (GitHub Copilot)</b></summary>
 

--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -127,6 +127,7 @@ class PolarionClient:
                 "Accept": "application/json",
             },
             timeout=httpx.Timeout(_DEFAULT_TIMEOUT_SECONDS),
+            verify=config.polarion_verify_ssl,
         )
 
     # -- Context-manager interface -------------------------------------------

--- a/src/mcp_server_polarion/core/config.py
+++ b/src/mcp_server_polarion/core/config.py
@@ -18,6 +18,9 @@ class PolarionConfig(BaseSettings):
             '/polarion' context path).  Trailing slashes are accepted and
             will be stripped automatically.
         polarion_token: Personal access token for Bearer authentication.
+        polarion_verify_ssl: Whether to verify TLS certificates.  Default
+            ``True``.  Set ``False`` only for trusted internal instances
+            using self-signed certificates.
     """
 
     model_config = SettingsConfigDict(
@@ -34,6 +37,13 @@ class PolarionConfig(BaseSettings):
     )
     polarion_token: str = Field(
         description="Personal access token for Polarion REST API.",
+    )
+    polarion_verify_ssl: bool = Field(
+        default=True,
+        description=(
+            "Verify TLS certificates for HTTPS connections. Set to False only "
+            "for trusted internal Polarion instances using self-signed certificates."
+        ),
     )
 
     @property

--- a/src/mcp_server_polarion/server.py
+++ b/src/mcp_server_polarion/server.py
@@ -41,6 +41,12 @@ async def _lifespan(
     setup_logging()
     config = PolarionConfig()  # type: ignore[call-arg]
     logger.info("Connecting to Polarion at %s", config.polarion_url)
+    if not config.polarion_verify_ssl:
+        logger.warning(
+            "TLS certificate verification is DISABLED (POLARION_VERIFY_SSL=false). "
+            "Connections to %s are vulnerable to MITM. Use only on trusted networks.",
+            config.polarion_url,
+        )
 
     async with PolarionClient(config) as client:
         logger.info("Polarion client ready")

--- a/tests/core/test_client.py
+++ b/tests/core/test_client.py
@@ -6,6 +6,8 @@ is needed.  The client uses ``write_delay=0`` to avoid sleeping.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import httpx
 import pytest
 import respx
@@ -482,3 +484,18 @@ class TestConfigWiring:
             polarion_token="t",
         )
         assert config.base_api_url == "https://example.com/polarion/rest/v1"
+
+    def test_verify_ssl_default_true_passed_to_httpx(self) -> None:
+        with patch("mcp_server_polarion.core.client.httpx.AsyncClient") as spy:
+            PolarionClient(_config())
+        assert spy.call_args.kwargs["verify"] is True
+
+    def test_verify_ssl_false_passed_to_httpx(self) -> None:
+        config = PolarionConfig(
+            polarion_url="https://polarion.example.com",
+            polarion_token="test-token",
+            polarion_verify_ssl=False,
+        )
+        with patch("mcp_server_polarion.core.client.httpx.AsyncClient") as spy:
+            PolarionClient(config)
+        assert spy.call_args.kwargs["verify"] is False

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -47,6 +47,24 @@ class TestPolarionConfigLoading:
         with pytest.raises(ValidationError):
             PolarionConfig(_env_file=None)  # type: ignore[call-arg]
 
+    def test_verify_ssl_defaults_to_true(self) -> None:
+        config = PolarionConfig(
+            polarion_url="https://example.com",
+            polarion_token="t",
+        )
+        assert config.polarion_verify_ssl is True
+
+    def test_verify_ssl_reads_from_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("POLARION_URL", "https://example.com")
+        monkeypatch.setenv("POLARION_TOKEN", "t")
+        monkeypatch.setenv("POLARION_VERIFY_SSL", "false")
+
+        config = PolarionConfig()  # type: ignore[call-arg]
+        assert config.polarion_verify_ssl is False
+
 
 class TestBaseApiUrl:
     """Verify ``base_api_url`` property construction."""

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -47,10 +47,15 @@ class TestPolarionConfigLoading:
         with pytest.raises(ValidationError):
             PolarionConfig(_env_file=None)  # type: ignore[call-arg]
 
-    def test_verify_ssl_defaults_to_true(self) -> None:
+    def test_verify_ssl_defaults_to_true(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("POLARION_VERIFY_SSL", raising=False)
         config = PolarionConfig(
             polarion_url="https://example.com",
             polarion_token="t",
+            _env_file=None,  # type: ignore[call-arg]
         )
         assert config.polarion_verify_ssl is True
 


### PR DESCRIPTION
## Summary

Adds an optional TLS verification toggle so the server can connect to internal Polarion instances using self-signed certificates. Default is `true` (strict verification) — no behavior change for existing users.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- Add `polarion_verify_ssl: bool = True` field to `PolarionConfig` — mapped to the `POLARION_VERIFY_SSL` env var.
- Pass `verify=config.polarion_verify_ssl` to `httpx.AsyncClient(...)` in `PolarionClient`.
- Emit a single stderr warning from the server lifespan when verification is disabled (MITM risk).
- Docs: README env table, all four host setup examples (VS Code / Claude Desktop / Cursor / Claude Code), `.env.example`, and `CLAUDE.md` settings list.
- Tests (4 new): config default stays `True`, env loads `POLARION_VERIFY_SSL=false`, client passes `verify` through to httpx in both states.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [x] `uv run pytest` passes locally (466 passed)
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
```

---

## Notes

- Field is named `polarion_verify_ssl` (matching the existing `polarion_url` / `polarion_token` prefix convention) because pydantic-settings derives the env var by uppercasing the field name verbatim — a bare `verify_ssl` field would only read `VERIFY_SSL`, not `POLARION_VERIFY_SSL`.
- Custom CA bundle paths, mTLS, and proxy options are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
