### PR TITLE
feat(tool): add list_document_enum_options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ CI runs: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 ## Architecture
 
 - **`core/`** — `client.py` (async httpx wrapper, 429/5xx backoff, post-mutation delay, maps responses to `PolarionError` / `PolarionAuthError` / `PolarionNotFoundError`), `config.py` (Pydantic settings: `POLARION_URL`, `POLARION_TOKEN`, `POLARION_VERIFY_SSL`), `logging.py` (stderr-only configuration; called from server lifespan, never from tool code), `exceptions.py`. Every module obtains its logger via `logging.getLogger("mcp_server_polarion.<module>")`.
-- **`tools/`** — `read.py` (9 read tools incl. `read_document` for flowing Markdown and `read_work_item` for a single WI's Markdown body), `write.py` (4 write tools, each with its `_build_*_payload` helper), `_helpers.py` (sparse-fieldset constants, JSON:API extractors, pagination helpers, custom-field merge).
+- **`tools/`** — `read.py` (10 read tools incl. `read_document` for flowing Markdown, `read_work_item` for a single WI's Markdown body, and `list_document_enum_options` for resolving valid enum ids before writes), `write.py` (4 write tools, each with its `_build_*_payload` helper), `_helpers.py` (sparse-fieldset constants, JSON:API extractors, pagination helpers, custom-field merge).
 - **`utils/html.py`** — Markdown ↔ HTML (markdownify + BeautifulSoup4 sanitization).
 - **`models.py`** — Pydantic v2 models. `PaginatedResult[T]` wraps all list responses.
 - **`server.py`** — FastMCP instance with lifespan that opens/closes `PolarionClient`.
@@ -70,7 +70,7 @@ Applies to ALL comments / docstrings (tool docstrings, helpers, inline, CLAUDE.m
 
 **`/backlinkedworkitems` is not supported on this server.** `get_linked_work_items` returns one direction per call: forward links use `/projects/{p}/workitems/{wi}/linkedworkitems`; back links fall back to a `query=linkedWorkItems:{wi}` search that does not expose the originating role, so back items return with `role=None`. Call twice when both directions are needed.
 
-**Server-side enum validation is lenient.** Polarion does NOT strictly validate `type` / `status` / `priority` / `severity` on create — unrecognised values are silently coerced (`priority="not_a_number"` → project default) or stored verbatim (`type="not_a_real_type"` → ghost type). Use `Literal[...]` on Pydantic Fields for closed sets that matter.
+**Server-side enum validation is lenient.** Polarion does NOT strictly validate `type` / `status` / `priority` / `severity` on create — unrecognised values are silently coerced (`priority="not_a_number"` → project default) or stored verbatim (`type="not_a_real_type"` → ghost type). Use `Literal[...]` on Pydantic Fields for closed sets that matter. For document fields the same `getAvailableOptions` action is wrapped by `list_document_enum_options` (instance and type endpoints return identical sets — workflow transitions are NOT filtered by current state, only enum-set membership). An unknown `doc_type` silently falls back to the `~` (no-type) set there too — verify the type id from a prior `get_document` before trusting the result.
 
 ### Custom fields surface inline under `attributes`
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ claude mcp add mcp-server-polarion \
 | `read_document` | Render a document end-to-end as flowing Markdown |
 | `get_document` | Get document metadata (title / type / status); optionally returns the raw `homePageContent` source for round-trip editing |
 | `read_document_parts` | List structural parts with linked work-item metadata (type, status, `external` flag) — use for part IDs and structural traversal, not for reading |
+| `list_document_enum_options` | List the valid enum values (id / name / default / hidden / terminal) for a document field on a given document type — resolve allowed `status` / `type` / custom enum ids before calling `update_document` |
 | `list_work_items` | Search work items with Lucene queries; results include priority, last-modified time, owning document, and assignees |
 | `get_work_item` | Get full work item details (description, author, created/updated timestamps, severity, resolution, outline number, hyperlinks); body is raw Polarion HTML for round-trip editing |
 | `read_work_item` | Same metadata as `get_work_item`, with the body rendered as Markdown instead of raw HTML — read-only synthesis for LLM consumption |

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -61,6 +61,45 @@ class ProjectSummary(BaseModel):
     )
 
 
+class EnumOption(BaseModel):
+    """Single enum option returned by ``list_document_enum_options``.
+
+    Captures only the attributes useful when an LLM picks a value before a
+    write call. The Polarion schema carries several more fields (color,
+    iconURL, columnWidth, createDefect, limited, minValue, oppositeName,
+    parent, requiresSignatureForTestCaseExecution, templateWorkItem) that
+    are intentionally not surfaced; add them on demand if a future caller
+    needs them.
+    """
+
+    id: str = Field(
+        description=(
+            "Option id -- pass this verbatim to write tools (e.g. 'open',"
+            " 'systemReqSpecification')."
+        ),
+    )
+    name: str = Field(description="Human-readable display name.")
+    description: str = Field(
+        default="",
+        description="Option description; empty when Polarion has none.",
+    )
+    default: bool = Field(
+        default=False,
+        description="True if Polarion uses this option when none is specified.",
+    )
+    hidden: bool = Field(
+        default=False,
+        description=(
+            "True if the option is hidden in the UI;"
+            " avoid selecting unless explicitly needed."
+        ),
+    )
+    terminal: bool = Field(
+        default=False,
+        description="For status fields: True if this is a workflow end-state.",
+    )
+
+
 class DocumentSummary(BaseModel):
     """Summary of a Polarion document returned by ``list_documents``."""
 

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -36,6 +36,7 @@ from mcp_server_polarion.models import (
     DocumentPart,
     DocumentReadResult,
     DocumentSummary,
+    EnumOption,
     LinkedWorkItemSummary,
     PaginatedResult,
     ProjectSummary,
@@ -847,6 +848,140 @@ async def get_document(
         status=safe_str(attrs.get("status", "")),
         content_html=content_html,
         custom_fields=extract_custom_fields(attrs, STANDARD_DOCUMENT_ATTRS),
+    )
+
+
+def _build_enum_option(entry: dict[str, object]) -> EnumOption:
+    def _bool(key: str) -> bool:
+        value = entry.get(key)
+        return value if isinstance(value, bool) else False
+
+    return EnumOption(
+        id=safe_str(entry.get("id", "")),
+        name=safe_str(entry.get("name", "")),
+        description=safe_str(entry.get("description", "")),
+        default=_bool("default"),
+        hidden=_bool("hidden"),
+        terminal=_bool("terminal"),
+    )
+
+
+@mcp.tool(
+    tags={"read"},
+    timeout=60.0,
+    annotations={"readOnlyHint": True},
+)
+async def list_document_enum_options(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(description="Polarion project ID."),
+    field_id: str = Field(
+        description=("Field id (e.g. 'status', 'type', or a custom field id)."),
+    ),
+    doc_type: str = Field(
+        description=(
+            "Document type id (e.g. 'systemReqSpecification')."
+            " Pass '~' for type-agnostic options."
+        ),
+    ),
+    page_size: int = Field(
+        default=DEFAULT_PAGE_SIZE,
+        ge=1,
+        le=100,
+        description="Number of options per page (1-100, default 100).",
+    ),
+    page_number: int = Field(
+        default=1,
+        ge=1,
+        description="Page number to retrieve (1-based, default 1).",
+    ),
+) -> PaginatedResult[EnumOption]:
+    """List valid enum options for a document field of the given document type.
+
+    Call this before ``update_document`` when you need to pick a value
+    for a document's ``status`` / ``type`` / custom enum field. Polarion
+    validates these values leniently on write -- unknown ids are silently
+    coerced or stored verbatim -- so resolve them first. This tool covers
+    DOCUMENT fields only; work-item fields use a separate endpoint and
+    are not surfaced here.
+
+    Returns the FULL enum set for the field on the given doc type.
+    Workflow transitions are NOT filtered by the document's current
+    state; that is a separate Polarion endpoint not exposed here.
+    ``doc_type='~'`` returns the type-agnostic option set. An unknown
+    ``doc_type`` is silently treated as ``~`` by Polarion with no error,
+    so verify the type id (e.g. via ``get_document``) before trusting
+    the result.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        field_id: Field id whose options to list.
+        doc_type: Document type id, or '~' for type-agnostic.
+        page_size: Items per page (1-100, default 100).
+        page_number: 1-based page number (default 1).
+
+    Returns:
+        PaginatedResult of ``EnumOption`` items with:
+        - ``id``: Option id to pass back to write tools.
+        - ``name``: Human-readable display name.
+        - ``description``: Option description; empty when Polarion has none.
+        - ``default``: True if Polarion uses this option as the default.
+        - ``hidden``: True if the option is hidden in the UI.
+        - ``terminal``: For status fields, True for workflow end-states.
+
+    Raises:
+        ValueError: Project, field, or document type not found.
+        PermissionError: Token lacks permission.
+        RuntimeError: Other Polarion API errors.
+    """
+    client = get_client(ctx)
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/documents/fields/{encode_path_segment(field_id)}"
+        "/actions/getAvailableOptions"
+    )
+    params: dict[str, str | int] = {
+        "type": doc_type,
+        "page[size]": page_size,
+        "page[number]": page_number,
+    }
+    try:
+        response = await client.get(path, params=params)
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"No enum options for field '{field_id}' on document type "
+            f"'{doc_type}' in project '{project_id}'."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot list document enum options"
+            " -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to list enum options for field '{field_id}': {exc.message}"
+        ) from exc
+
+    data = response.get("data", [])
+    items: list[EnumOption] = []
+    if isinstance(data, list):
+        for entry in data:
+            if isinstance(entry, dict):
+                items.append(_build_enum_option(entry))
+
+    raw_total = extract_total_count(response)
+    total = raw_total
+    if total <= 0 and items:
+        total = (page_number - 1) * page_size + len(items)
+
+    return PaginatedResult[EnumOption](
+        items=items,
+        total_count=total,
+        page=page_number,
+        page_size=page_size,
+        has_more=compute_has_more(
+            response, raw_total, page_number, page_size, len(items)
+        ),
     )
 
 

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -1,6 +1,6 @@
 """Read-only MCP tools for querying Polarion ALM.
 
-Nine tools that retrieve projects, documents, work items, and their
+Ten tools that retrieve projects, documents, work items, and their
 relationships.  Every tool returns Pydantic models -- never raw ``dict``.
 
 Body fields use two different formats depending on the tool's purpose:

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -24,6 +24,7 @@ from mcp_server_polarion.models import (
     DocumentDetail,
     DocumentPart,
     DocumentReadResult,
+    EnumOption,
     LinkedWorkItemSummary,
     PaginatedResult,
     ProjectSummary,
@@ -36,6 +37,7 @@ from mcp_server_polarion.tools import read as _read_mod
 # In FastMCP 3.0, @mcp.tool returns the original function unchanged
 # (not a FunctionTool wrapper), so we reference them directly.
 get_document = _read_mod.get_document
+list_document_enum_options = _read_mod.list_document_enum_options
 read_document_parts = _read_mod.read_document_parts
 get_linked_work_items = _read_mod.get_linked_work_items
 get_work_item = _read_mod.get_work_item
@@ -1061,6 +1063,268 @@ class TestGetDocument:
         )
         _, kwargs_b = mock_client.get.call_args
         assert kwargs_b["params"]["fields[documents]"] == "@all"
+
+
+_STATUS_DATA: list[dict[str, object]] = [
+    {
+        "id": "draft",
+        "name": "Draft",
+        "description": "Initial state",
+        "default": True,
+        "hidden": False,
+        "terminal": False,
+    },
+    {
+        "id": "inreview",
+        "name": "In Review",
+        "default": False,
+        "hidden": False,
+        "terminal": False,
+    },
+    {
+        "id": "approved",
+        "name": "Approved",
+        "default": False,
+        "hidden": False,
+        "terminal": True,
+    },
+]
+
+
+class TestListDocumentEnumOptions:
+    """Tests for the ``list_document_enum_options`` tool."""
+
+    async def test_returns_enum_options(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": _STATUS_DATA,
+            "meta": {"totalCount": 3},
+        }
+
+        result = await list_document_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            doc_type="systemReqSpecification",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert len(result.items) == 3
+        assert result.total_count == 3
+        assert result.has_more is False
+        first = result.items[0]
+        assert isinstance(first, EnumOption)
+        assert first.id == "draft"
+        assert first.name == "Draft"
+        assert first.description == "Initial state"
+        assert first.default is True
+        assert first.terminal is False
+        assert result.items[2].terminal is True
+
+    async def test_request_path_and_params(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await list_document_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            doc_type="systemReqSpecification",
+            page_size=50,
+            page_number=2,
+        )
+
+        args, kwargs = mock_client.get.call_args
+        assert args[0] == (
+            "/projects/MCP_Test_Project"
+            "/documents/fields/status"
+            "/actions/getAvailableOptions"
+        )
+        params = kwargs["params"]
+        assert params["type"] == "systemReqSpecification"
+        assert params["page[size]"] == 50
+        assert params["page[number]"] == 2
+
+    async def test_type_agnostic_tilde_passes_through(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await list_document_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            doc_type="~",
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["type"] == "~"
+
+    async def test_missing_optional_fields_default(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [{"id": "open", "name": "Open"}],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_document_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            doc_type="systemReqSpecification",
+            page_size=100,
+            page_number=1,
+        )
+
+        opt = result.items[0]
+        assert opt.id == "open"
+        assert opt.description == ""
+        assert opt.default is False
+        assert opt.hidden is False
+        assert opt.terminal is False
+
+    async def test_non_bool_flag_falls_back_to_false(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "id": "weird",
+                    "name": "Weird",
+                    "default": "true",
+                    "hidden": 1,
+                    "terminal": None,
+                }
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_document_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            doc_type="systemReqSpecification",
+            page_size=100,
+            page_number=1,
+        )
+
+        opt = result.items[0]
+        assert opt.default is False
+        assert opt.hidden is False
+        assert opt.terminal is False
+
+    async def test_pagination_has_more(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": _STATUS_DATA * 34,  # 102 entries; trimmed below by assert
+            "meta": {"totalCount": 150},
+        }
+
+        result = await list_document_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            doc_type="systemReqSpecification",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.total_count == 150
+        assert result.has_more is True
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found",
+            status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="No enum options"):
+            await list_document_enum_options(
+                mock_ctx,
+                project_id="MCP_Test_Project",
+                field_id="nope",
+                doc_type="systemReqSpecification",
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError(
+            "Unauthorized",
+            status_code=401,
+        )
+
+        with pytest.raises(PermissionError, match="POLARION_TOKEN"):
+            await list_document_enum_options(
+                mock_ctx,
+                project_id="MCP_Test_Project",
+                field_id="status",
+                doc_type="systemReqSpecification",
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_generic_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError(
+            "Server error",
+            status_code=500,
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to list enum options"):
+            await list_document_enum_options(
+                mock_ctx,
+                project_id="MCP_Test_Project",
+                field_id="status",
+                doc_type="systemReqSpecification",
+                page_size=100,
+                page_number=1,
+            )
+
+
+class TestListDocumentEnumOptionsFieldValidation:
+    """Verify Field constraints on ``list_document_enum_options`` parameters."""
+
+    @staticmethod
+    def _adapter_for(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(list_document_enum_options)
+        sig = inspect.signature(list_document_enum_options)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_page_size_rejects_above_max(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("page_size").validate_python(101)
+
+    def test_page_size_accepts_max(self) -> None:
+        assert self._adapter_for("page_size").validate_python(100) == 100
+
+    def test_page_size_rejects_zero(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("page_size").validate_python(0)
+
+    def test_page_number_rejects_zero(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("page_number").validate_python(0)
 
 
 class TestReadDocumentParts:


### PR DESCRIPTION
## Summary

Adds a read-only MCP tool that resolves the valid enum ids for a document field on a given document type, so LLM-driven writes can pick correct `status` / `type` / custom enum values up front rather than relying on Polarion's lenient server-side validation (which silently coerces unknown ids or stores them verbatim as ghost values).

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- New `list_document_enum_options(project_id, field_id, doc_type, page_size, page_number)` tool wrapping `GET /projects/{p}/documents/fields/{f}/actions/getAvailableOptions?type={t}`. Mirrors `list_projects` shape; returns `PaginatedResult[EnumOption]`.
- New `EnumOption` Pydantic model surfacing the LLM-useful subset of the API (`id`, `name`, `description`, `default`, `hidden`, `terminal`). Other schema fields (`color`, `iconURL`, `templateWorkItem`, ...) are intentionally not exposed; easy to add later.
- 9 unit tests + 4 field-validation tests for the new tool (`TestListDocumentEnumOptions`, `TestListDocumentEnumOptionsFieldValidation`).
- README tool table + CLAUDE.md architecture line bumped from 9 → 10 read tools; the "Server-side enum validation is lenient" gotcha now cross-references the new tool.

### Why only the type-form endpoint

Polarion exposes both an instance-form (`/spaces/.../documents/.../fields/.../actions/getAvailableOptions`) and a type-form. Direct verification against testdrive on 2026-05-17 confirmed they return identical sets given the same `docType` (no workflow-state filtering on either — that's a separate `getAvailableActions`-style endpoint, not exposed here). The type-form is shorter, caches better, and works without a specific document existing, so only it is surfaced. Same finding applies to work-item enum endpoints — a sibling tool can be added later if needed.

---

## Testing

- [x] Unit tests added / updated (`tests/tools/test_read.py`)
- [ ] `dry_run=True` path verified for all write tools — not applicable (read tool)
- [x] `uv run pytest` passes locally — 488/488
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run ruff check . && uv run ruff format --check . && uv run mypy src/
uv run pytest tests/tools/test_read.py::TestListDocumentEnumOptions tests/tools/test_read.py::TestListDocumentEnumOptionsFieldValidation -v
uv run pytest -q
```

### Live E2E (testdrive.polarion.com / project `MCP_Test_Project`)

| Call | Expected ids | Observed ids | Result |
|---|---|---|---|
| `field_id=status, doc_type=systemReqSpecification` | 5: draft, inreview, reviewed, approved, rejected | identical, `total_count=5`, `has_more=False` | OK |
| `field_id=status, doc_type=riskSpecification` | 3: draft, published, obsolete | identical, `total_count=3` | OK |
| `field_id=status, doc_type=~` | 3: draft, published, obsolete | identical | OK |
| `field_id=type, doc_type=systemReqSpecification` | 7 doc-type ids incl. `generic` | identical, `generic` is the only `default=True` option | OK |
| `field_id=status, doc_type=nonexistent_type` | error or empty | no error — Polarion silently returns the `~` set | documented in docstring |
| `project_id=No_Such_Project` | ValueError | `ValueError: No enum options for field 'status' on document type 'systemReqSpecification' in project 'No_Such_Project'.` | OK |

Note on testdrive config: `status` enums return `default=False, terminal=False` for every option — testdrive's workflow config simply doesn't mark them. Not a tool bug.

---

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [x] All new tool functions are `async def`
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] Synthesis read paths (`read_document`, `read_document_parts`) convert HTML → Markdown via `html_to_markdown()`
- [x] Greenfield write paths (`create_work_item(description=...)`) convert Markdown → HTML via `markdown_to_html()` + `sanitize_html()`
- [x] Round-trip pairs (`get_*(include_*_html=True)` ↔ `update_*(*_html=...)`) pass raw Polarion HTML verbatim — no Markdown conversion, no sanitization
- [x] Any new list tool supports `page_size` and `page_number` pagination
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

---

## Notes for Reviewers

- The `_build_enum_option` helper lives in `read.py` (mirrors the local-helper pattern for `_parse_document_part`); no `_helpers.py` change was needed because the response is flat `{data, meta, links}` and the existing `extract_total_count` / `compute_has_more` apply directly.
- An unknown `doc_type` is silently treated by Polarion as `~` (no error). The docstring tells callers to verify the type id via `get_document` first. Worth a glance if reviewers feel a stronger client-side guard is warranted (e.g. cross-check against `get_document`'s `type`), but that would couple this tool to an extra round-trip.
- The work-item-side equivalent (`list_work_item_enum_options`) is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)