### PR TITLE
chore(git): enforce commit message length

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Enforce the commit-message rules from .github/CONTRIBUTING.md:
+#   - subject ≤ 50 chars
+#   - body contains exactly 2 bullets, each ≤ 120 chars
+# Activate locally with: git config core.hooksPath .githooks
+
+set -e
+
+msg_file="$1"
+first_line=$(head -n 1 "$msg_file")
+
+case "$first_line" in
+    "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"amend! "*) exit 0 ;;
+esac
+
+clean=$(grep -v '^#' "$msg_file" | sed -e 's/[[:space:]]*$//')
+
+subject=$(printf '%s\n' "$clean" | awk 'NF { print; exit }')
+subject_len=${#subject}
+if [ "$subject_len" -gt 50 ]; then
+    printf 'commit-msg: subject is %d chars (limit: 50)\n  %s\n' \
+        "$subject_len" "$subject" >&2
+    exit 1
+fi
+
+bullets=$(printf '%s\n' "$clean" | awk '
+    subject_seen && /^- / { print }
+    NF && !subject_seen { subject_seen = 1 }
+')
+
+bullet_count=0
+if [ -n "$bullets" ]; then
+    bullet_count=$(printf '%s\n' "$bullets" | grep -c '^- ' || true)
+fi
+
+if [ "$bullet_count" -ne 2 ]; then
+    printf 'commit-msg: body must contain exactly 2 bullets (- ...), found %d\n' \
+        "$bullet_count" >&2
+    exit 1
+fi
+
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    line_len=${#line}
+    if [ "$line_len" -gt 120 ]; then
+        printf 'commit-msg: bullet is %d chars (limit: 120)\n  %s\n' \
+            "$line_len" "$line" >&2
+        exit 1
+    fi
+done <<< "$bullets"
+
+exit 0

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -118,6 +118,16 @@ fix(utils): preserve attachment imgs on read
 | `docs(git): update readme`                       | Missing mandatory blank line and 2-bullet body          |
 | `- Why: ...` / `- What: ...`                     | Drop the literal `Why:` / `What:` prefixes              |
 
+### Enforcement
+
+The repo ships a `commit-msg` hook in [`.githooks/`](../.githooks/commit-msg) that mechanically enforces the subject and bullet length limits. Enable it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook rejects any commit whose subject exceeds 50 chars or whose body does not contain exactly two bullets ≤120 chars each. Merge / revert / fixup / squash / amend autosquash subjects are skipped.
+
 ---
 
 ## 3. Pull Request Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,5 +115,6 @@ Branch strategy, full commit rules, and PR workflow are in [.github/CONTRIBUTING
 - **Commits**:
   - Subject: `type(scope): summary` — lowercase imperative, ≤50 chars, no period. Types: `feat | fix | docs | refactor | perf | test | ci | chore`. Scopes: `tool | server | transport | config | deps | utils | model | project | meta | git`.
   - Body: blank line + **exactly 2 bullets** (motivation, then change) — no `Why:` / `What:` prefixes. Each bullet ≤120 chars.
+  - **Length is strict** — before staging, draft the subject/bullets into a file and run `awk '{print length}' <file>` to verify. The `.githooks/commit-msg` validator (enable once per clone: `git config core.hooksPath .githooks`) rejects oversize commits mechanically. The PR-title length budget on a squash merge is 50 minus the auto-appended ` (#NNN)` suffix.
 - **PR Type of Change checklist** ([.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md)): flip `[ ]` → `[x]` for matching items; do not delete unchecked options.
 - **Force push** allowed on feature branches only after explicit user authorization. Never force-push to `main`.


### PR DESCRIPTION
## Summary

Adds a `commit-msg` git hook that mechanically enforces the subject (≤50 chars) and bullet (exactly 2, each ≤120 chars) length rules already written in [CONTRIBUTING.md](.github/CONTRIBUTING.md). Background: those written limits were violated twice in a row on the recent #29 refactor branch, which then required a one-time force-push to `main` to amend the squashed commit subject and body. Prose alone wasn't enough.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Documentation update
- [x] CI / tooling / dependency update

## Changes

- `.githooks/commit-msg` — bash validator. Subject >50 chars → reject. Body bullet count ≠ 2 → reject. Any bullet >120 chars → reject. Merge / revert / fixup / squash / amend subjects skip validation.
- `.github/CONTRIBUTING.md` — new **Enforcement** subsection under "Commit Message Rules" with the one-liner `git config core.hooksPath .githooks` to activate.
- `CLAUDE.md` — adds a bullet under **Commits** explicitly telling future contributors (human or LLM) to verify length before staging and to enable the hook.

## Testing

Hook was exercised on 5 fixtures before committing:

| Case | Expected | Result |
|---|---|---|
| Subject 51 chars | reject | reject (`subject is 51 chars`) |
| Bullet 121 chars | reject | reject (`bullet is 123 chars`) |
| 1 bullet only | reject | reject (`found 1`) |
| Valid message + Co-Authored-By trailer | accept | accept |
| `Merge branch ...` subject | skip | skip |

The commit on this branch was authored under the hook, so it self-validates.

- [x] `uv run pytest` passes locally
- [x] `uv run mypy src/` passes
- [x] `uv run ruff check src tests` passes

## Golden Rule Compliance

N/A — no Python source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)