### PR TITLE
feat(tool): SQL prefix in list_work_items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Applies to ALL comments / docstrings (tool docstrings, helpers, inline, CLAUDE.m
 - **HTML payloads**: stored as `{"type": "text/html", "value": "..."}`.
 - **Linked work item IDs**: 5 segments — derive the target via `relationships.workItem.data.id`, never by parsing.
 - **Module IDs**: 3 segments and document names may contain `/`, so always use `split_module_id` (splits on the first two slashes only).
-- **Lucene**: trailing wildcards (`title:SRS*`) work; leading wildcards return HTTP 400. The `module` field is not indexed.
+- **Lucene**: trailing wildcards (`title:SRS*`) work; leading wildcards return HTTP 400. The `module` field is not indexed. Workaround: pass `query="SQL:(...)"` to `list_work_items` for native SQL — module-scoped joins via `POLARION.REL_MODULE_WORKITEM` and leading-wildcard `LIKE` both work. See the `list_work_items` docstring for the template.
 - **Server limits**: ≤3 API calls/second, no concurrent requests; `PolarionClient` retries 429/5xx with backoff but does NOT serialize client-side.
 
 ### JSON:API quirks

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -1353,7 +1353,8 @@ async def list_work_items(
 
     Pass a Lucene ``query`` (`type:requirement`, `status:approved AND
     type:requirement`, `title:SRS*`) or omit it for all work items. Leading
-    wildcards (`*foo*`) return HTTP 400. ``module`` is not indexed.
+    wildcards (`*foo*`) return HTTP 400. ``module`` is not indexed — see
+    *SQL prefix* below for the workaround.
 
     Description body text is NOT indexed — for content search, scan
     ``read_document_parts`` (each ``workitem`` part already carries its

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -1333,8 +1333,8 @@ async def list_work_items(
     query: str | None = Field(
         default=None,
         description=(
-            "Optional Lucene filter (e.g. 'type:requirement', 'title:SRS*'); "
-            "trailing wildcards only."
+            "Optional Lucene filter (e.g. 'type:requirement', 'title:SRS*') "
+            "OR a 'SQL:(...)' prefix for native SQL."
         ),
     ),
     page_size: int = Field(
@@ -1359,10 +1359,30 @@ async def list_work_items(
     ``read_document_parts`` (each ``workitem`` part already carries its
     description) or use ``read_document`` for end-to-end reading.
 
+    **SQL prefix.** If ``query`` starts with ``SQL:(``, Polarion runs it as
+    native SQL against the schema (tables: ``POLARION.WORKITEM``,
+    ``POLARION.MODULE``, ``POLARION.PROJECT``, ``POLARION.REL_MODULE_WORKITEM``).
+    This unlocks two Lucene-impossible patterns: module-scoped lookup
+    (``module`` column is not indexed by Lucene) and leading-wildcard ``LIKE``
+    (``C_TITLE LIKE '%foo%'`` works; Lucene rejects ``*foo*``). Escape ``'``
+    as ``''`` inside string literals to avoid breaking out of the SQL string.
+    ``C_DESCRIPTION LIKE`` does NOT match — body content is stored as a
+    CLOB outside this column; use ``read_document_parts`` for body search.
+
+    Module-scoped template (returns work items belonging to one document)::
+
+        SQL:(SELECT item.* FROM POLARION.WORKITEM item, POLARION.MODULE doc,
+        POLARION.PROJECT proj WHERE proj.C_ID = '<project>'
+        AND doc.FK_PROJECT = proj.C_PK AND doc.C_MODULEFOLDER = '<space>'
+        AND doc.C_ID = '<document>' AND EXISTS (SELECT rel1.*
+        FROM POLARION.REL_MODULE_WORKITEM rel1
+        WHERE rel1.FK_URI_MODULE = doc.C_URI
+        AND rel1.FK_URI_WORKITEM = item.C_URI))
+
     Args:
         ctx: MCP tool context (injected automatically).
         project_id: Polarion project ID.
-        query: Optional Lucene filter.
+        query: Optional Lucene filter, OR a ``SQL:(...)`` prefix for native SQL.
         page_size: Items per page (1-100, default 100).
         page_number: 1-based page number (default 1).
 
@@ -1374,7 +1394,7 @@ async def list_work_items(
     Raises:
         ValueError: Project not found.
         PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors (incl. bad Lucene syntax).
+        RuntimeError: Other Polarion API errors (incl. bad Lucene or SQL syntax).
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -2882,8 +2882,6 @@ class TestListWorkItems:
     async def test_sql_prefix_query_passed_verbatim(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # The wire path forwards `query` unchanged, so a `SQL:(...)` prefix
-        # reaches Polarion as-is and is dispatched as native SQL server-side.
         sql_query = (
             "SQL:(SELECT item.* FROM POLARION.WORKITEM item "
             "WHERE item.C_TYPE = 'requirement')"

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -2879,6 +2879,31 @@ class TestListWorkItems:
         _, kwargs = mock_client.get.call_args
         assert "query" not in kwargs["params"]
 
+    async def test_sql_prefix_query_passed_verbatim(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # The wire path forwards `query` unchanged, so a `SQL:(...)` prefix
+        # reaches Polarion as-is and is dispatched as native SQL server-side.
+        sql_query = (
+            "SQL:(SELECT item.* FROM POLARION.WORKITEM item "
+            "WHERE item.C_TYPE = 'requirement')"
+        )
+        mock_client.get.return_value = {
+            "data": [],
+            "meta": {"totalCount": 0},
+        }
+
+        await list_work_items(
+            mock_ctx,
+            project_id="proj1",
+            query=sql_query,
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["query"] == sql_query
+
     async def test_query_returns_matching_items(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:


### PR DESCRIPTION
## Summary

Polarion's REST `query` parameter accepts a `SQL:(...)` prefix in addition to Lucene; the server dispatches it as native SQL against the schema. This unlocks two patterns Lucene cannot express:

1. **Module-scoped work item lookup** — Lucene's `module` field is not indexed.
2. **Leading-wildcard `LIKE`** — Lucene `*foo*` returns HTTP 400; SQL `LIKE '%foo%'` works.

The wire path already forwards `query` verbatim, so the feature was reachable but undiscoverable — no docstring or CLAUDE.md note pointed at it. This PR exposes it through **docstring + one CLAUDE.md line only**, with no new tool and no helper.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Extend the `list_work_items` docstring with a SQL prefix section, a module-scoped template, and a tightened `query` Field description (`src/mcp_server_polarion/tools/read.py`).
- Add a one-line cross-reference to the Lucene constraint in `CLAUDE.md` pointing at the SQL workaround.
- Add a passthrough regression test asserting a `SQL:(...)` query reaches the wire unchanged (`tests/tools/test_read.py`).

Runtime behavior is unchanged — `params["query"] = query` already passed SQL prefixes through. The PR is intentionally metadata + a regression guard only.

## Testing

- [x] Unit test added (`tests/tools/test_read.py::TestListWorkItems::test_sql_prefix_query_passed_verbatim`)
- [x] `uv run pytest` passes locally (502 passed)
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
```

Live smoke against Polarion `MCP_Test_Project`:

1. `query="SQL:(SELECT item.* FROM POLARION.WORKITEM item WHERE item.C_TYPE = 'requirement')"` returns the same 3 items as Lucene `type:requirement`.
2. Module-scoped 4-table JOIN (`POLARION.WORKITEM` × `MODULE` × `PROJECT` × `REL_MODULE_WORKITEM`, scoped to `Requirements / Project Scope`) returns 5 items, all with `space_id="Requirements"` and `document_name="Project Scope"`.
3. `query="SQL:(... C_TITLE LIKE '%Schema%')"` (leading wildcard) returns 2 items (`MCPT-527`, `MCPT-528`) — a pattern Lucene rejects with HTTP 400.

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [x] All new tool functions are `async def` (no new tools added; docstring extension only)
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] Synthesis read paths convert HTML → Markdown via `html_to_markdown()` (unchanged)
- [x] Greenfield write paths convert Markdown → HTML (unchanged)
- [x] Round-trip pairs pass raw Polarion HTML verbatim (unchanged)
- [x] Any new list tool supports `page_size` and `page_number` pagination (no new list tool)
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

## Notes for Reviewers

- No Python helper was added. The LLM cannot call Python helpers, so only the docstring template carries runtime value; a helper would add drift risk against the docstring with no offsetting benefit (YAGNI). If a future internal code path needs module-scoped SQL construction, the helper can be added then.
- Escaping `'` as `''` inside SQL string literals is the LLM's responsibility — the docstring states this explicitly.
- Known gotcha called out in the docstring: `C_DESCRIPTION LIKE` does not match — body content is stored as a CLOB outside that column. Use `read_document_parts` for body text search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
