### PR TITLE
feat(tool): add create_document write tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ CI runs: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 ## Architecture
 
 - **`core/`** — `client.py` (async httpx wrapper, 429/5xx backoff, post-mutation delay, maps responses to `PolarionError` / `PolarionAuthError` / `PolarionNotFoundError`), `config.py` (Pydantic settings: `POLARION_URL`, `POLARION_TOKEN`, `POLARION_VERIFY_SSL`), `logging.py` (stderr-only configuration; called from server lifespan, never from tool code), `exceptions.py`. Every module obtains its logger via `logging.getLogger("mcp_server_polarion.<module>")`.
-- **`tools/`** — `read.py` (11 read tools incl. `read_document` for flowing Markdown, `read_work_item` for a single work item's Markdown body, and `list_document_enum_options` / `list_work_item_enum_options` for resolving valid enum ids before writes), `write.py` (4 write tools, each with its `_build_*_payload` helper), `_helpers.py` (sparse-fieldset constants, JSON:API extractors, pagination helpers, custom-field merge).
+- **`tools/`** — `read.py` (11 read tools incl. `read_document` for flowing Markdown, `read_work_item` for a single work item's Markdown body, and `list_document_enum_options` / `list_work_item_enum_options` for resolving valid enum ids before writes), `write.py` (5 write tools, each with its `_build_*_payload` helper), `_helpers.py` (sparse-fieldset constants, JSON:API extractors, pagination helpers, custom-field merge).
 - **`utils/html.py`** — Markdown ↔ HTML (markdownify + BeautifulSoup4 sanitization).
 - **`models.py`** — Pydantic v2 models. `PaginatedResult[T]` wraps all list responses.
 - **`server.py`** — FastMCP instance with lifespan that opens/closes `PolarionClient`.
@@ -34,7 +34,7 @@ CI runs: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 - All functions: full type annotations + `from __future__ import annotations`. All tool functions: `async def`. All tool returns: Pydantic models, never raw `dict`.
 - **Body fields are asymmetric by tool purpose**:
   - **Round-trip pair** (lossless): `get_*(include_*_html=True)` returns raw Polarion HTML; matching `update_*(*_html=...)` accepts the same shape verbatim — no sanitization, no Markdown conversion. XSS filtering is delegated to Polarion's renderer, so never route untrusted input through these parameters.
-  - **Greenfield create** (Markdown): `create_work_item(description=...)` accepts Markdown; runs through `markdown_to_html` + `sanitize_html` before storage.
+  - **Greenfield create** (Markdown): `create_work_item(description=...)` and `create_document(home_page_content=...)` accept Markdown; both run through `markdown_to_html` + `sanitize_html` before storage. After creation the round-trip pair switches to raw HTML (`update_work_item(description_html=...)` / `update_document(home_page_content_html=...)`) — the two formats never mix.
   - **Synthesis paths** (Markdown): `read_document` / `read_document_parts` / `read_work_item` convert HTML→Markdown via `html_to_markdown()`. Output is READ-ONLY — feeding it back to a write tool loses Polarion-specific markup.
 - **Write payloads** — skip `None`/empty values; Polarion may interpret empty as "clear default". JSON:API resource POSTs (`/workitems`) wrap in `{"data": [...]}`; **action endpoints** (`.../actions/<name>`) take a flat object — do NOT wrap. The `cast(dict[str, object], payload)` shim at the `client.post(json=...)` call site is intentional (dict invariance vs `JsonValue`).
 - Every list tool must support `page_size` (max 100) and `page_number`; return `PaginatedResult[T]` with `has_more`.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | `create_work_item` | Create a new work item |
 | `update_work_item` | Update an existing work item |
 | `move_work_item_to_document` | Move an existing work item into a Polarion document at a specific outline position |
+| `create_document` | Create a new document in a space with optional Markdown body |
 | `update_document` | Update document metadata (title / status / type), optionally the body (`home_page_content_html`), and apply workflow actions |
 
 ## Example Prompts

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -753,6 +753,32 @@ class WorkItemMoveResult(BaseModel):
     )
 
 
+class DocumentCreateResult(BaseModel):
+    """Result of a ``create_document`` operation."""
+
+    created: bool = Field(
+        description=(
+            "True if the document was actually created. False when dry_run is True."
+        ),
+    )
+    dry_run: bool = Field(
+        description="Whether this was a dry-run (preview only, no mutation).",
+    )
+    document_name: str | None = Field(
+        description=(
+            "Module name of the created document (e.g. 'MySpecV1'). "
+            "None when dry_run is True."
+        ),
+    )
+    payload_preview: dict[str, JsonValue] | None = Field(
+        description=(
+            "JSON:API request payload that was (or would be) sent. "
+            "Usually populated for dry-run previews and may be None "
+            "after a successful real operation."
+        ),
+    )
+
+
 class DocumentUpdateResult(BaseModel):
     """Result of an ``update_document`` operation."""
 
@@ -775,6 +801,7 @@ class DocumentUpdateResult(BaseModel):
 
 __all__: list[str] = [
     "CommentResult",
+    "DocumentCreateResult",
     "DocumentDetail",
     "DocumentPart",
     "DocumentPartCreateResult",

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -121,12 +121,11 @@ def _build_work_item_payload(  # noqa: PLR0913
     return {"data": [item]}
 
 
-def _extract_created_id(response: dict[str, object]) -> str | None:
-    """Extract the short work-item ID from a 201 create response.
+def _extract_first_resource_id(response: dict[str, object]) -> str | None:
+    """Pull the first resource ID out of a JSON:API ``{"data": [...]}`` body.
 
-    Polarion returns ``{"data": [{"type": "workitems",
-    "id": "projectId/MCPT-042", ...}]}``.  Returns the short ID
-    (``"MCPT-042"``) or ``None`` if the response shape is unexpected.
+    Returns ``None`` when ``data`` is missing, not a non-empty list, or its
+    first entry has no ``id`` string.
     """
     data = response.get("data")
     if not isinstance(data, list) or not data:
@@ -135,9 +134,35 @@ def _extract_created_id(response: dict[str, object]) -> str | None:
     if not isinstance(first, dict):
         return None
     full_id = safe_str(first.get("id", ""))
-    if not full_id:
+    return full_id or None
+
+
+def _extract_created_id(response: dict[str, object]) -> str | None:
+    """Extract the short work-item ID from a 201 create response.
+
+    Polarion returns ``{"data": [{"type": "workitems",
+    "id": "projectId/MCPT-042", ...}]}``.  Returns the short ID
+    (``"MCPT-042"``) or ``None`` if the response shape is unexpected.
+    """
+    full_id = _extract_first_resource_id(response)
+    if full_id is None:
         return None
     return extract_short_id(full_id)
+
+
+def _extract_created_module_name(response: dict[str, object]) -> str | None:
+    """Extract the document name from a 201 document-create response.
+
+    Polarion returns ``{"data": [{"type": "documents",
+    "id": "projectId/spaceId/documentName", ...}]}`` where
+    ``documentName`` itself may contain ``/``. Returns the document-name
+    segment or ``None`` if the response shape is unexpected.
+    """
+    full_id = _extract_first_resource_id(response)
+    if full_id is None:
+        return None
+    _, document_name = split_module_id(full_id)
+    return document_name or None
 
 
 def _build_update_work_item_payload(  # noqa: PLR0913
@@ -1314,12 +1339,7 @@ async def create_document(  # noqa: PLR0913
     except PolarionError as exc:
         raise RuntimeError(f"Failed to create document: {exc.message}") from exc
 
-    new_name: str | None = None
-    data = response.get("data")
-    if isinstance(data, list) and data and isinstance(data[0], dict):
-        _, extracted = split_module_id(safe_str(data[0].get("id", "")))
-        new_name = extracted or None
-
+    new_name = _extract_created_module_name(response)
     if new_name is None:
         raise RuntimeError(
             "Polarion accepted the create request but returned no document name. "

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -1,11 +1,12 @@
 """Write MCP tools for Polarion ALM.
 
 Currently provides ``create_work_item``, ``update_work_item``,
-``move_work_item_to_document``, and ``update_document``. All write
-tools follow the strict patterns documented in ``CLAUDE.md``: they
-convert Markdown input to sanitized HTML, build minimal request
-payloads (skipping unset fields rather than sending empty values),
-and map domain exceptions to user-facing ones at the tool layer.
+``move_work_item_to_document``, ``update_document``, and
+``create_document``. All write tools follow the strict patterns
+documented in ``CLAUDE.md``: they convert Markdown input to sanitized
+HTML, build minimal request payloads (skipping unset fields rather
+than sending empty values), and map domain exceptions to user-facing
+ones at the tool layer.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
+    DocumentCreateResult,
     DocumentUpdateResult,
     Hyperlink,
     JsonValue,
@@ -40,6 +42,7 @@ from mcp_server_polarion.tools._helpers import (
     merge_custom_fields,
     parse_work_item_detail,
     safe_str,
+    split_module_id,
 )
 from mcp_server_polarion.utils import markdown_to_html, sanitize_html
 
@@ -291,6 +294,46 @@ def _build_update_document_payload(  # noqa: PLR0913
         item["attributes"] = attributes
 
     return {"data": item}
+
+
+def _build_create_document_payload(  # noqa: PLR0913
+    *,
+    module_name: str,
+    title: str,
+    type: str,
+    home_page_content_html: str,
+    status: str | None,
+    custom_fields: dict[str, object] | None = None,
+) -> dict[str, JsonValue]:
+    """Build the JSON:API request body for ``POST .../spaces/{s}/documents``.
+
+    Mirrors ``_build_work_item_payload``'s POST shape: ``data`` is a
+    single-element list with ``type=documents`` and inline ``attributes``.
+    Only attaches keys for values that are explicitly set -- ``None`` and
+    empty strings are skipped so we never overwrite Polarion defaults
+    with empty values on creation. ``custom_fields`` entries are inlined
+    into ``attributes`` alongside the standard fields via
+    ``merge_custom_fields``; colliding keys raise ``ValueError``.
+    """
+    attributes: dict[str, JsonValue] = {
+        "moduleName": module_name,
+        "title": title,
+        "type": type,
+    }
+    if status:
+        attributes["status"] = status
+    if home_page_content_html:
+        attributes["homePageContent"] = {
+            "type": "text/html",
+            "value": home_page_content_html,
+        }
+    merge_custom_fields(attributes, custom_fields, STANDARD_DOCUMENT_ATTRIBUTES)
+
+    item: dict[str, JsonValue] = {
+        "type": "documents",
+        "attributes": attributes,
+    }
+    return {"data": [item]}
 
 
 # ---------------------------------------------------------------------------
@@ -1117,5 +1160,175 @@ async def update_document(  # noqa: PLR0913
     return DocumentUpdateResult(
         updated=True,
         dry_run=False,
+        payload_preview=None,
+    )
+
+
+@mcp.tool(
+    tags={"write"},
+    timeout=60.0,
+    annotations={
+        # Pure additive operation per MCP spec -- creates a new document without
+        # mutating existing data, so destructiveHint is False. Not idempotent
+        # because retrying with the same module_name returns HTTP 409.
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+async def create_document(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(min_length=1, description="Polarion project ID."),
+    space_id: str = Field(
+        min_length=1,
+        description="Space ID (use '_default' for the default space).",
+    ),
+    module_name: str = Field(
+        min_length=1,
+        description=(
+            "Polarion document identifier (e.g. 'MySpecV1'); "
+            "must be unique within ``space_id`` and appears in the document URL."
+        ),
+    ),
+    title: str = Field(
+        min_length=1,
+        description="Human-readable document title (required, non-empty).",
+    ),
+    type: str = Field(
+        min_length=1,
+        description="Document type (e.g. 'req_specification', 'generic').",
+    ),
+    status: str | None = Field(
+        default=None,
+        description=(
+            "Optional initial workflow status (project default applies if omitted)."
+        ),
+    ),
+    home_page_content: str | None = Field(
+        default=None,
+        max_length=MAX_BODY_HTML_LEN,
+        description="Optional Markdown body; converted to sanitized HTML on write.",
+    ),
+    custom_fields: dict[str, object] | None = Field(  # noqa: B008
+        default=None,
+        description=(
+            "Optional custom fields keyed by Polarion field ID; "
+            "rich-text values must be ``{'type':'text/html','value':...}``."
+        ),
+    ),
+    dry_run: bool = Field(
+        default=False,
+        description="When True, return payload preview without calling Polarion.",
+    ),
+) -> DocumentCreateResult:
+    """Create a new Polarion document in a space.
+
+    Greenfield document creation. The document starts empty (or with the
+    optional ``home_page_content`` body) and headings / work item parts
+    can be added later via ``update_document`` and
+    ``move_work_item_to_document``.
+
+    Format asymmetry: ``home_page_content`` here is Markdown (converted
+    to sanitized HTML on write) because greenfield authoring is natural
+    for LLMs. After creation the round-trip pair is
+    ``get_document(include_homepage_content_html=True)`` ↔
+    ``update_document(home_page_content_html=...)`` which speaks raw HTML
+    verbatim. The two formats never mix.
+
+    ``module_name`` is Polarion's persistent identifier within the space
+    and is used in every subsequent URL (``get_document``,
+    ``update_document``, etc.). It must be unique within ``space_id``;
+    a duplicate name causes Polarion to return HTTP 409, surfaced here
+    as ``RuntimeError``.
+
+    Polarion does NOT validate enum membership server-side. Unknown
+    ``type`` / ``status`` ids are stored verbatim as ghost values that
+    look real on later reads but never match Lucene queries. Resolve
+    valid ids first via ``list_document_enum_options(project_id,
+    field_id, document_type)``. ``custom_fields`` is the same story:
+    unknown field IDs silently persist as ghost attributes -- pass keys
+    taken from a prior ``get_document``.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        space_id: Space ID containing the new document.
+        module_name: Polarion document identifier (unique within space).
+        title: Human-readable document title.
+        type: Document type.
+        status: Optional initial workflow status.
+        home_page_content: Optional Markdown body.
+        custom_fields: Optional custom-field dict.
+        dry_run: When True, return payload preview only.
+
+    Returns:
+        DocumentCreateResult with ``created``, ``dry_run``,
+        ``document_name`` (None on dry-run), and ``payload_preview``
+        (populated on dry-run; None on real create).
+
+    Raises:
+        ValueError: Project or space not found, or custom-field key
+            collides with a standard Polarion attribute.
+        PermissionError: Token lacks permission.
+        RuntimeError: Other Polarion API errors (including duplicate
+            ``module_name``), or accepted-but-no-ID response.
+    """
+    home_page_content_html = (
+        sanitize_html(markdown_to_html(home_page_content)) if home_page_content else ""
+    )
+
+    payload = _build_create_document_payload(
+        module_name=module_name,
+        title=title,
+        type=type,
+        home_page_content_html=home_page_content_html,
+        status=status,
+        custom_fields=custom_fields,
+    )
+
+    if dry_run:
+        return DocumentCreateResult(
+            created=False,
+            dry_run=True,
+            document_name=None,
+            payload_preview=payload,
+        )
+
+    client = get_client(ctx)
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/spaces/{encode_path_segment(space_id)}/documents"
+    )
+    try:
+        response = await client.post(path, json=cast(dict[str, object], payload))
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot create document -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Project '{project_id}' or space '{space_id}' not found. "
+            "Use `list_projects` and `list_documents` to discover valid IDs."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(f"Failed to create document: {exc.message}") from exc
+
+    new_name: str | None = None
+    data = response.get("data")
+    if isinstance(data, list) and data and isinstance(data[0], dict):
+        _, extracted = split_module_id(safe_str(data[0].get("id", "")))
+        new_name = extracted or None
+
+    if new_name is None:
+        raise RuntimeError(
+            "Polarion accepted the create request but returned no document name. "
+            "The document may or may not exist; verify with list_documents."
+        )
+
+    return DocumentCreateResult(
+        created=True,
+        dry_run=False,
+        document_name=new_name,
         payload_preview=None,
     )

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -21,6 +21,7 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
+    DocumentCreateResult,
     DocumentUpdateResult,
     Hyperlink,
     WorkItemCreateResult,
@@ -32,10 +33,12 @@ from mcp_server_polarion.tools import write as _write_mod
 
 # In FastMCP 3.0, @mcp.tool returns the original function unchanged
 # (not a FunctionTool wrapper), so we reference them directly.
+create_document = _write_mod.create_document
 create_work_item = _write_mod.create_work_item
 move_work_item_to_document = _write_mod.move_work_item_to_document
 update_document = _write_mod.update_document
 update_work_item = _write_mod.update_work_item
+_build_create_document_payload = _write_mod._build_create_document_payload
 _build_move_to_document_payload = _write_mod._build_move_to_document_payload
 _build_update_document_payload = _write_mod._build_update_document_payload
 _build_update_work_item_payload = _write_mod._build_update_work_item_payload
@@ -2638,3 +2641,502 @@ class TestUpdateDocumentPitfallDocumentation:
             "update_document docstring must surface that the work item's module "
             "relationship stays unset after a macro <div> injection"
         )
+
+
+# ===========================================================================
+# create_document
+# ===========================================================================
+
+
+class TestBuildCreateDocumentPayload:
+    """Tests for the private ``_build_create_document_payload`` helper."""
+
+    def test_minimal_payload_has_only_required_attrs(self) -> None:
+        payload = _build_create_document_payload(
+            module_name="MySpec",
+            title="My Spec",
+            type="req_specification",
+            home_page_content_html="",
+            status=None,
+        )
+
+        assert payload == {
+            "data": [
+                {
+                    "type": "documents",
+                    "attributes": {
+                        "moduleName": "MySpec",
+                        "title": "My Spec",
+                        "type": "req_specification",
+                    },
+                }
+            ]
+        }
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attributes = cast(dict[str, object], item["attributes"])
+        assert "status" not in attributes
+        assert "homePageContent" not in attributes
+
+    def test_status_attached_when_set(self) -> None:
+        payload = _build_create_document_payload(
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            home_page_content_html="",
+            status="draft",
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attributes = cast(dict[str, object], item["attributes"])
+        assert attributes["status"] == "draft"
+
+    def test_home_page_content_wrapped_as_html_block(self) -> None:
+        payload = _build_create_document_payload(
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            home_page_content_html="<p>Hi</p>",
+            status=None,
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attributes = cast(dict[str, object], item["attributes"])
+        assert attributes["homePageContent"] == {
+            "type": "text/html",
+            "value": "<p>Hi</p>",
+        }
+
+    def test_skips_none_status_and_empty_body(self) -> None:
+        payload = _build_create_document_payload(
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            home_page_content_html="",
+            status=None,
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attributes = cast(dict[str, object], item["attributes"])
+        assert set(attributes.keys()) == {"moduleName", "title", "type"}
+
+    def test_custom_fields_inlined_alongside_standard_attrs(self) -> None:
+        payload = _build_create_document_payload(
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            home_page_content_html="",
+            status=None,
+            custom_fields={"projectOwner": "alice", "phase": "design"},
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attributes = cast(dict[str, object], item["attributes"])
+        assert attributes["projectOwner"] == "alice"
+        assert attributes["phase"] == "design"
+
+    def test_custom_fields_collision_with_standard_attr_raises(self) -> None:
+        with pytest.raises(ValueError, match="title"):
+            _build_create_document_payload(
+                module_name="MySpec",
+                title="t",
+                type="generic",
+                home_page_content_html="",
+                status=None,
+                custom_fields={"title": "duplicate"},
+            )
+
+
+class TestCreateDocumentDryRun:
+    """Tests for ``create_document`` with ``dry_run=True``."""
+
+    async def test_dry_run_returns_payload_without_calling_post(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_document(
+            mock_ctx,
+            project_id="MyProj",
+            space_id="_default",
+            module_name="MySpec",
+            title="Dry test",
+            type="req_specification",
+            status=None,
+            home_page_content=None,
+            custom_fields=None,
+            dry_run=True,
+        )
+
+        mock_client.post.assert_not_called()
+        assert isinstance(result, DocumentCreateResult)
+        assert result.dry_run is True
+        assert result.created is False
+        assert result.document_name is None
+        assert result.payload_preview is not None
+        assert isinstance(result.payload_preview, dict)
+        item = cast(list[dict[str, object]], result.payload_preview["data"])[0]
+        attributes = cast(dict[str, object], item["attributes"])
+        assert attributes == {
+            "moduleName": "MySpec",
+            "title": "Dry test",
+            "type": "req_specification",
+        }
+
+
+class TestCreateDocumentHappyPath:
+    """Tests for a successful ``create_document`` call."""
+
+    async def test_returns_document_name_on_201(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [
+                {
+                    "type": "documents",
+                    "id": "MyProj/_default/MySpec",
+                    "links": {"self": "..."},
+                }
+            ]
+        }
+
+        result = await create_document(
+            mock_ctx,
+            project_id="MyProj",
+            space_id="_default",
+            module_name="MySpec",
+            title="Real",
+            type="req_specification",
+            status=None,
+            home_page_content=None,
+            custom_fields=None,
+            dry_run=False,
+        )
+
+        assert isinstance(result, DocumentCreateResult)
+        assert result.created is True
+        assert result.dry_run is False
+        assert result.document_name == "MySpec"
+        assert result.payload_preview is None
+
+    async def test_post_called_with_correct_path_and_body(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "documents", "id": "MyProj/_default/MySpec"}]
+        }
+
+        await create_document(
+            mock_ctx,
+            project_id="MyProj",
+            space_id="_default",
+            module_name="MySpec",
+            title="t",
+            type="req_specification",
+            status="draft",
+            home_page_content=None,
+            custom_fields=None,
+            dry_run=False,
+        )
+
+        args, kwargs = mock_client.post.call_args
+        assert args == ("/projects/MyProj/spaces/_default/documents",)
+        body = kwargs["json"]
+        item = body["data"][0]
+        assert item["type"] == "documents"
+        assert item["attributes"]["moduleName"] == "MySpec"
+        assert item["attributes"]["title"] == "t"
+        assert item["attributes"]["type"] == "req_specification"
+        assert item["attributes"]["status"] == "draft"
+
+    async def test_path_url_encodes_special_chars(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "documents", "id": "Proj With Space/My Space/MySpec"}]
+        }
+
+        await create_document(
+            mock_ctx,
+            project_id="Proj With Space",
+            space_id="My Space",
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            status=None,
+            home_page_content=None,
+            custom_fields=None,
+            dry_run=False,
+        )
+
+        args, _ = mock_client.post.call_args
+        assert args == ("/projects/Proj%20With%20Space/spaces/My%20Space/documents",)
+
+    async def test_home_page_content_markdown_converted_and_sanitized(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "documents", "id": "MyProj/_default/MySpec"}]
+        }
+
+        await create_document(
+            mock_ctx,
+            project_id="MyProj",
+            space_id="_default",
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            status=None,
+            home_page_content="**bold** [link](https://example.com)",
+            custom_fields=None,
+            dry_run=False,
+        )
+
+        _, kwargs = mock_client.post.call_args
+        body = kwargs["json"]["data"][0]["attributes"]["homePageContent"]
+        assert body["type"] == "text/html"
+        assert "<strong>bold</strong>" in body["value"]
+        assert 'href="https://example.com"' in body["value"]
+
+    async def test_home_page_content_strips_dangerous_link_schemes(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "documents", "id": "MyProj/_default/MySpec"}]
+        }
+
+        await create_document(
+            mock_ctx,
+            project_id="MyProj",
+            space_id="_default",
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            status=None,
+            home_page_content="[click](javascript:alert(1))",
+            custom_fields=None,
+            dry_run=False,
+        )
+
+        _, kwargs = mock_client.post.call_args
+        body_html = kwargs["json"]["data"][0]["attributes"]["homePageContent"]["value"]
+        assert 'href="javascript:' not in body_html
+        assert "href='javascript:" not in body_html
+
+    async def test_document_name_with_slashes_extracted_correctly(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """``split_module_id`` preserves slashes in the document_name segment."""
+        mock_client.post.return_value = {
+            "data": [{"type": "documents", "id": "MyProj/_default/Folder/Sub/Doc"}]
+        }
+
+        result = await create_document(
+            mock_ctx,
+            project_id="MyProj",
+            space_id="_default",
+            module_name="Folder/Sub/Doc",
+            title="t",
+            type="generic",
+            status=None,
+            home_page_content=None,
+            custom_fields=None,
+            dry_run=False,
+        )
+
+        assert result.document_name == "Folder/Sub/Doc"
+
+
+class TestCreateDocumentErrorMapping:
+    """Tests that domain exceptions are mapped at the tool layer."""
+
+    async def test_401_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await create_document(
+                mock_ctx,
+                project_id="MyProj",
+                space_id="_default",
+                module_name="MySpec",
+                title="t",
+                type="generic",
+                status=None,
+                home_page_content=None,
+                custom_fields=None,
+                dry_run=False,
+            )
+
+    async def test_404_raises_value_error_mentioning_project_and_space(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionNotFoundError(
+            "not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="space") as exc_info:
+            await create_document(
+                mock_ctx,
+                project_id="ghost",
+                space_id="ghost_space",
+                module_name="MySpec",
+                title="t",
+                type="generic",
+                status=None,
+                home_page_content=None,
+                custom_fields=None,
+                dry_run=False,
+            )
+        assert "ghost" in str(exc_info.value)
+        assert "ghost_space" in str(exc_info.value)
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionError("conflict", status_code=409)
+
+        with pytest.raises(RuntimeError, match="conflict"):
+            await create_document(
+                mock_ctx,
+                project_id="MyProj",
+                space_id="_default",
+                module_name="MySpec",
+                title="t",
+                type="generic",
+                status=None,
+                home_page_content=None,
+                custom_fields=None,
+                dry_run=False,
+            )
+
+
+class TestCreateDocumentResponseParsing:
+    """Tests for unexpected 2xx response shapes from Polarion."""
+
+    async def test_empty_data_array_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {"data": []}
+
+        with pytest.raises(RuntimeError, match="no document name"):
+            await create_document(
+                mock_ctx,
+                project_id="MyProj",
+                space_id="_default",
+                module_name="MySpec",
+                title="t",
+                type="generic",
+                status=None,
+                home_page_content=None,
+                custom_fields=None,
+                dry_run=False,
+            )
+
+    async def test_data_not_a_list_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {"data": {"id": "MyProj/_default/MySpec"}}
+
+        with pytest.raises(RuntimeError, match="no document name"):
+            await create_document(
+                mock_ctx,
+                project_id="MyProj",
+                space_id="_default",
+                module_name="MySpec",
+                title="t",
+                type="generic",
+                status=None,
+                home_page_content=None,
+                custom_fields=None,
+                dry_run=False,
+            )
+
+    async def test_two_segment_id_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """``split_module_id`` returns ``('','')`` for under-3-segment IDs."""
+        mock_client.post.return_value = {
+            "data": [{"type": "documents", "id": "MyProj/MySpec"}]
+        }
+
+        with pytest.raises(RuntimeError, match="no document name"):
+            await create_document(
+                mock_ctx,
+                project_id="MyProj",
+                space_id="_default",
+                module_name="MySpec",
+                title="t",
+                type="generic",
+                status=None,
+                home_page_content=None,
+                custom_fields=None,
+                dry_run=False,
+            )
+
+
+class TestCreateDocumentFieldValidation:
+    """Verify ``min_length`` / ``max_length`` constraints on parameters."""
+
+    @staticmethod
+    def _adapter_for(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(create_document)
+        sig = inspect.signature(create_document)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_project_id_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("project_id").validate_python("")
+
+    def test_space_id_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("space_id").validate_python("")
+
+    def test_module_name_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("module_name").validate_python("")
+
+    def test_module_name_accepts_non_empty(self) -> None:
+        assert self._adapter_for("module_name").validate_python("MySpec") == "MySpec"
+
+    def test_title_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("title").validate_python("")
+
+    def test_type_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("type").validate_python("")
+
+    def test_home_page_content_rejects_overlong_input(self) -> None:
+        adapter = self._adapter_for("home_page_content")
+        assert adapter.validate_python("hello") == "hello"
+        with pytest.raises(ValidationError):
+            adapter.validate_python("x" * (2_000_000 + 1))
+
+
+class TestCreateDocumentRegistration:
+    """The tool must be registered on the FastMCP server instance."""
+
+    async def test_create_document_tool_registered(self) -> None:
+        tools = await mcp.list_tools()
+        assert any(tool.name == "create_document" for tool in tools)
+
+
+class TestCreateDocumentDocstringGuidance:
+    """Verify enum-resolution and ghost-write guidance lives in the docstring.
+
+    Per CLAUDE.md, the write tools' docstrings are the only enforcement
+    against ghost-enum writes — the server does not validate enum IDs.
+    """
+
+    def test_docstring_mentions_list_document_enum_options(self) -> None:
+        document = create_document.__doc__ or ""
+        assert "list_document_enum_options" in document
+
+    def test_docstring_mentions_ghost_writes(self) -> None:
+        document = create_document.__doc__ or ""
+        assert "ghost" in document.lower()
+
+    def test_docstring_mentions_module_name_uniqueness(self) -> None:
+        document = create_document.__doc__ or ""
+        assert "unique" in document.lower()
+        assert "409" in document or "conflict" in document.lower()


### PR DESCRIPTION
## Summary

Adds a new `create_document` write tool that wraps Polarion REST `POST /projects/{projectId}/spaces/{spaceId}/documents`. Until now the MCP server had no greenfield document creation path — only `update_document` for existing documents. This closes that gap so LLM agents can author entire specs end-to-end.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- `models.py`: new `DocumentCreateResult` (mirrors `WorkItemCreateResult` with `document_name` field) + `__all__` registration.
- `tools/write.py`: new `_build_create_document_payload` helper (JSON:API POST shape with `data` as a list) and `create_document` `@mcp.tool` async function. Body input is Markdown (greenfield convention) — converted via `markdown_to_html` + `sanitize_html`. Response's 3-segment ID (`projectId/spaceId/documentName`) is parsed with the existing `split_module_id` so document names containing `/` round-trip cleanly.
- `tests/tools/test_write.py`: 30 new tests covering payload builder, dry-run, happy path (URL encoding, Markdown→HTML, dangerous link stripping, slash-bearing document names), error mapping (401/404/other), response parsing edge cases, field-validation constraints via `TypeAdapter`, FastMCP registration, and docstring guidance (ghost-enum warning, `list_document_enum_options` pointer, module_name uniqueness).

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [x] `dry_run=True` path verified for all write tools
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run ruff check . && uv run ruff format --check . && uv run mypy src/
uv run pytest  # 532 passed (30 new)
```

---

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [x] All new tool functions are `async def`
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] Synthesis read paths (`read_document`, `read_document_parts`) convert HTML → Markdown via `html_to_markdown()`
- [x] Greenfield write paths (`create_work_item(description=...)`) convert Markdown → HTML via `markdown_to_html()` + `sanitize_html()`
- [x] Round-trip pairs (`get_*(include_*_html=True)` ↔ `update_*(*_html=...)`) pass raw Polarion HTML verbatim — no Markdown conversion, no sanitization
- [x] Any new list tool supports `page_size` and `page_number` pagination
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

---

## Notes for Reviewers

- **Body input format**: deliberately Markdown (`home_page_content`) rather than raw HTML, matching `create_work_item(description=...)` and the CLAUDE.md "greenfield create = Markdown" rule. The round-trip pair for later edits is `get_document(include_homepage_content_html=True)` ↔ `update_document(home_page_content_html=...)`.
- **Attribute surface kept minimal**: matches `update_document` (title / type / status / home_page_content / custom_fields). `outlineNumbering`, `renderingLayouts`, `autoSuspect`, `structureLinkRole`, `usesOutlineNumbering` are intentionally excluded — callers needing them can follow up with `update_document`.
- **`module_name` collisions**: Polarion returns HTTP 409 on duplicate names within a space. This surfaces as `RuntimeError` via the existing `PolarionError → RuntimeError` mapping and is documented in the docstring.
- **Ghost-enum guard**: the docstring instructs callers to resolve `type` / `status` via `list_document_enum_options` before writing, since Polarion stores unknown enum IDs verbatim with no server-side validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)