### PR TITLE
feat(tool): add create_document_comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | `delete_work_item_links` | Delete one or more outgoing links from a source work item |
 | `move_work_item_to_document` | Attach a work item to a document at a chosen position |
 | `move_work_item_from_document` | Detach a work item from its document |
+| `create_document_comments` | Add one or more comments or replies to a document |
 
 ## Example Prompts
 

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -641,6 +641,37 @@ class DocumentComment(BaseModel):
     )
 
 
+class DocumentCommentSpec(BaseModel):
+    """One comment to create via ``create_document_comments``."""
+
+    text: str = Field(
+        min_length=1,
+        description="Comment body text.",
+    )
+    text_format: Literal["text/html", "text/plain"] = Field(
+        default="text/plain",
+        description="MIME type of ``text`` ('text/plain' or 'text/html').",
+    )
+    resolved: bool | None = Field(
+        default=None,
+        description="Initial resolved state; omit to let Polarion default to False.",
+    )
+    author_id: str | None = Field(
+        default=None,
+        description=(
+            "User ID of the comment author; omit to default to the authenticated user."
+        ),
+    )
+    parent_comment_id: str | None = Field(
+        default=None,
+        description=(
+            "Short comment ID for replies (e.g. 'c42' from "
+            "``list_document_comments``). Omit for a top-level comment. "
+            "The tool composes the full path internally."
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Write-result models
 # ---------------------------------------------------------------------------
@@ -720,6 +751,31 @@ class CommentResult(BaseModel):
             "JSON:API request payload that was (or would be) sent. "
             "Usually populated for dry-run previews and may be None "
             "after a successful real operation."
+        ),
+    )
+
+
+class DocumentCommentsCreateResult(BaseModel):
+    """Result of a ``create_document_comments`` operation."""
+
+    created: bool = Field(
+        description=(
+            "True if comments were actually created. False when dry_run is True."
+        ),
+    )
+    dry_run: bool = Field(
+        description="Whether this was a dry-run (preview only, no mutation).",
+    )
+    comment_ids: list[str] = Field(
+        description=(
+            "Short IDs of the created comments in the order returned by Polarion. "
+            "Empty when dry_run is True."
+        ),
+    )
+    payload_preview: dict[str, JsonValue] | None = Field(
+        description=(
+            "JSON:API request payload that was (or would be) sent. "
+            "Populated for dry-run previews; None after a successful real operation."
         ),
     )
 

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -3,11 +3,12 @@
 Currently provides ``create_work_item``, ``update_work_item``,
 ``move_work_item_to_document``, ``update_document``,
 ``create_document``, ``create_work_item_links``,
-``delete_work_item_links``, and ``update_work_item_links``. All write
-tools follow the strict patterns documented in ``CLAUDE.md``: they
-convert Markdown input to sanitized HTML, build minimal request payloads
-(skipping unset fields rather than sending empty values), and map
-domain exceptions to user-facing ones at the tool layer.
+``delete_work_item_links``, ``update_work_item_links``, and
+``create_document_comments``. All write tools follow the strict
+patterns documented in ``CLAUDE.md``: they convert Markdown input to
+sanitized HTML, build minimal request payloads (skipping unset fields
+rather than sending empty values), and map domain exceptions to
+user-facing ones at the tool layer.
 """
 
 from __future__ import annotations
@@ -24,6 +25,8 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
+    DocumentCommentsCreateResult,
+    DocumentCommentSpec,
     DocumentCreateResult,
     DocumentUpdateResult,
     Hyperlink,
@@ -508,6 +511,52 @@ def _build_create_document_payload(  # noqa: PLR0913
         "attributes": attributes,
     }
     return {"data": [item]}
+
+
+def _build_document_comments_payload(
+    *,
+    specs: list[DocumentCommentSpec],
+    project_id: str,
+    space_id: str,
+    document_name: str,
+) -> dict[str, JsonValue]:
+    """Build the JSON:API request body for POST .../documents/{d}/comments.
+
+    Builds one resource object per spec. Only attaches ``resolved`` when
+    explicitly set (None = omit). ``author`` and ``parentComment``
+    relationships are omitted when None. ``parent_comment_id`` is
+    composed into the full path form ``proj/space/doc/commentId``
+    required by the Polarion API, so callers pass the short ID from
+    ``list_document_comments``.
+    """
+    items: list[JsonValue] = []
+    for spec in specs:
+        attributes: dict[str, JsonValue] = {
+            "text": {"type": spec.text_format, "value": spec.text},
+        }
+        if spec.resolved is not None:
+            attributes["resolved"] = spec.resolved
+
+        relationships: dict[str, JsonValue] = {}
+        if spec.author_id is not None:
+            relationships["author"] = {"data": {"id": spec.author_id, "type": "users"}}
+        if spec.parent_comment_id is not None:
+            full_parent = (
+                f"{project_id}/{space_id}/{document_name}/{spec.parent_comment_id}"
+            )
+            relationships["parentComment"] = {
+                "data": {"id": full_parent, "type": "document_comments"}
+            }
+
+        item: dict[str, JsonValue] = {
+            "type": "document_comments",
+            "attributes": attributes,
+        }
+        if relationships:
+            item["relationships"] = relationships
+        items.append(item)
+
+    return {"data": items}
 
 
 # ---------------------------------------------------------------------------
@@ -2029,5 +2078,146 @@ async def update_work_item_links(
         link_ids=succeeded,
         failed_link_id=None,
         failed_reason=None,
+        payload_preview=None,
+    )
+
+
+@mcp.tool(
+    tags={"write"},
+    timeout=60.0,
+    annotations={
+        # Pure additive operation — creates new comments without mutating
+        # existing data, so destructiveHint is False. Not idempotent
+        # because retrying with the same input creates duplicate comments.
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+async def create_document_comments(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(description="Polarion project ID."),
+    space_id: str = Field(
+        min_length=1,
+        description="Space ID (use '_default' for the default space).",
+    ),
+    document_name: str = Field(
+        min_length=1,
+        description="Document name within ``space_id``.",
+    ),
+    comments: list[DocumentCommentSpec] = Field(  # noqa: B008
+        min_length=1,
+        description="One or more comments to create in a single request.",
+    ),
+    dry_run: bool = Field(
+        default=False,
+        description="When True, return payload preview without calling Polarion.",
+    ),
+) -> DocumentCommentsCreateResult:
+    """Create one or more comments on a Polarion document in a single request.
+
+    All comments in ``comments`` are sent in a single POST to
+    ``/projects/{p}/spaces/{s}/documents/{d}/comments``.  Polarion
+    returns a 201 with the IDs of all created comments.
+
+    **Thread model**: a comment with ``parent_comment_id=None`` is a
+    top-level review comment.  To reply to an existing comment, set
+    ``parent_comment_id`` to the short ID returned in
+    ``list_document_comments`` (e.g. ``'c42'``); the tool composes the
+    full four-segment path ``proj/space/doc/c42`` that the Polarion API
+    requires.
+
+    **Text format**: ``'text/plain'`` (default) stores the body
+    verbatim.  Use ``'text/html'`` for HTML-formatted bodies — the HTML
+    is sent as-is, no sanitization.
+
+    **resolved**: omitting the field (``None``) lets Polarion default to
+    ``False``; pass ``True`` to create a pre-resolved comment.
+
+    **author_id**: omit to have Polarion use the authenticated token's
+    user.
+
+    This operation is NOT idempotent — retrying with the same input
+    creates duplicate comments.
+
+    Args:
+        ctx: MCP tool context (injected automatically).
+        project_id: Polarion project ID.
+        space_id: Space ID (use '_default' for the default space).
+        document_name: Document name within ``space_id``.
+        comments: One or more ``DocumentCommentSpec`` objects, each with
+            ``text``, ``text_format``, ``resolved``, ``author_id``, and
+            ``parent_comment_id``.
+        dry_run: When True, build and return the payload preview without
+            calling Polarion.
+
+    Returns:
+        ``DocumentCommentsCreateResult`` with:
+
+        - ``created`` — True on success; False on dry-run.
+        - ``dry_run`` — mirrors the input flag.
+        - ``comment_ids`` — short IDs (last path segment) of the created
+          comments in Polarion's return order; empty on dry-run.
+        - ``payload_preview`` — JSON:API body sent (or that would be
+          sent); populated on dry-run, None after a real operation.
+
+    Raises:
+        ValueError: Project, space, or document not found.
+        PermissionError: Token lacks permission to create comments.
+        RuntimeError: Other Polarion API errors.
+    """
+    payload = _build_document_comments_payload(
+        specs=comments,
+        project_id=project_id,
+        space_id=space_id,
+        document_name=document_name,
+    )
+
+    if dry_run:
+        return DocumentCommentsCreateResult(
+            created=False,
+            dry_run=True,
+            comment_ids=[],
+            payload_preview=payload,
+        )
+
+    client = get_client(ctx)
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/spaces/{encode_path_segment(space_id)}"
+        f"/documents/{encode_path_segment(document_name)}"
+        "/comments"
+    )
+    try:
+        response = await client.post(path, json=cast(dict[str, object], payload))
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot create document comments -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Document '{document_name}' (space '{space_id}',"
+            f" project '{project_id}') not found."
+            " Use `list_documents` to discover valid IDs."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to create document comments: {exc.message}"
+        ) from exc
+
+    raw_data = response.get("data", []) if isinstance(response, dict) else []
+    comment_ids: list[str] = []
+    if isinstance(raw_data, list):
+        for entry in raw_data:
+            if isinstance(entry, dict):
+                full_id = safe_str(entry.get("id", ""))
+                if full_id:
+                    comment_ids.append(extract_short_id(full_id))
+
+    return DocumentCommentsCreateResult(
+        created=True,
+        dry_run=False,
+        comment_ids=comment_ids,
         payload_preview=None,
     )

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -2215,6 +2215,12 @@ async def create_document_comments(  # noqa: PLR0913
                 if full_id:
                     comment_ids.append(extract_short_id(full_id))
 
+    if not comment_ids:
+        raise RuntimeError(
+            "Polarion returned no comment IDs after creation."
+            " The POST may have succeeded — verify with `list_document_comments`."
+        )
+
     return DocumentCommentsCreateResult(
         created=True,
         dry_run=False,

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -21,6 +21,7 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
+    DocumentCommentSpec,
     DocumentCreateResult,
     DocumentUpdateResult,
     Hyperlink,
@@ -40,6 +41,7 @@ from mcp_server_polarion.tools import write as _write_mod
 # In FastMCP 3.0, @mcp.tool returns the original function unchanged
 # (not a FunctionTool wrapper), so we reference them directly.
 create_document = _write_mod.create_document
+create_document_comments = _write_mod.create_document_comments
 create_work_item = _write_mod.create_work_item
 create_work_item_links = _write_mod.create_work_item_links
 delete_work_item_links = _write_mod.delete_work_item_links
@@ -51,6 +53,7 @@ update_work_item_links = _write_mod.update_work_item_links
 _build_create_document_payload = _write_mod._build_create_document_payload
 _build_create_links_payload = _write_mod._build_create_links_payload
 _build_delete_links_payload = _write_mod._build_delete_links_payload
+_build_document_comments_payload = _write_mod._build_document_comments_payload
 _build_move_to_document_payload = _write_mod._build_move_to_document_payload
 _build_update_document_payload = _write_mod._build_update_document_payload
 _build_update_link_payload = _write_mod._build_update_link_payload
@@ -2796,6 +2799,15 @@ class TestWriteToolAnnotations:
                     "openWorldHint": True,
                 },
             ),
+            (
+                "create_document_comments",
+                {
+                    "readOnlyHint": False,
+                    "destructiveHint": False,
+                    "idempotentHint": False,
+                    "openWorldHint": True,
+                },
+            ),
         ],
     )
     async def test_write_tool_annotation(
@@ -4345,3 +4357,391 @@ class TestUpdateWorkItemLinksFieldValidation:
         )
         assert spec.revision == "HEAD"
         assert spec.suspect is None
+
+
+# ---------------------------------------------------------------------------
+# create_document_comments tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDocumentCommentsPayload:
+    """Unit tests for the private ``_build_document_comments_payload`` helper."""
+
+    def test_single_plain_text_spec(self) -> None:
+        payload = _build_document_comments_payload(
+            specs=[DocumentCommentSpec(text="hello")],
+            project_id="Proj",
+            space_id="Space",
+            document_name="Doc",
+        )
+        data = payload["data"]
+        assert isinstance(data, list)
+        assert len(data) == 1
+        item = data[0]
+        assert isinstance(item, dict)
+        assert item["type"] == "document_comments"
+        attrs = item["attributes"]
+        assert isinstance(attrs, dict)
+        assert attrs["text"] == {"type": "text/plain", "value": "hello"}
+        assert "resolved" not in attrs
+        assert "relationships" not in item
+
+    def test_multiple_specs_produce_multiple_items(self) -> None:
+        payload = _build_document_comments_payload(
+            specs=[
+                DocumentCommentSpec(text="first"),
+                DocumentCommentSpec(text="second"),
+            ],
+            project_id="P",
+            space_id="S",
+            document_name="D",
+        )
+        assert len(payload["data"]) == 2  # type: ignore[arg-type]
+
+    def test_resolved_true_in_attributes(self) -> None:
+        payload = _build_document_comments_payload(
+            specs=[DocumentCommentSpec(text="t", resolved=True)],
+            project_id="P",
+            space_id="S",
+            document_name="D",
+        )
+        attrs = payload["data"][0]["attributes"]  # type: ignore[index]
+        assert attrs["resolved"] is True  # type: ignore[index]
+
+    def test_resolved_false_in_attributes(self) -> None:
+        """Explicit False must be sent, not silently omitted like None."""
+        payload = _build_document_comments_payload(
+            specs=[DocumentCommentSpec(text="t", resolved=False)],
+            project_id="P",
+            space_id="S",
+            document_name="D",
+        )
+        attrs = payload["data"][0]["attributes"]  # type: ignore[index]
+        assert attrs["resolved"] is False  # type: ignore[index]
+
+    def test_resolved_none_omits_key(self) -> None:
+        payload = _build_document_comments_payload(
+            specs=[DocumentCommentSpec(text="t", resolved=None)],
+            project_id="P",
+            space_id="S",
+            document_name="D",
+        )
+        attrs = payload["data"][0]["attributes"]  # type: ignore[index]
+        assert "resolved" not in attrs  # type: ignore[operator]
+
+    def test_author_relationship(self) -> None:
+        payload = _build_document_comments_payload(
+            specs=[DocumentCommentSpec(text="t", author_id="alice")],
+            project_id="P",
+            space_id="S",
+            document_name="D",
+        )
+        item = payload["data"][0]  # type: ignore[index]
+        assert isinstance(item, dict)
+        assert item["relationships"]["author"] == {  # type: ignore[index]
+            "data": {"id": "alice", "type": "users"}
+        }
+
+    def test_parent_comment_full_path_composed(self) -> None:
+        """Short parent_comment_id is expanded to the full 4-segment path."""
+        payload = _build_document_comments_payload(
+            specs=[DocumentCommentSpec(text="t", parent_comment_id="c1")],
+            project_id="Proj",
+            space_id="Space",
+            document_name="Doc",
+        )
+        item = payload["data"][0]  # type: ignore[index]
+        assert isinstance(item, dict)
+        rel = item["relationships"]["parentComment"]  # type: ignore[index]
+        assert rel == {"data": {"id": "Proj/Space/Doc/c1", "type": "document_comments"}}
+
+    def test_both_relationships_present(self) -> None:
+        payload = _build_document_comments_payload(
+            specs=[
+                DocumentCommentSpec(text="t", author_id="bob", parent_comment_id="c5")
+            ],
+            project_id="P",
+            space_id="S",
+            document_name="D",
+        )
+        item = payload["data"][0]  # type: ignore[index]
+        assert isinstance(item, dict)
+        rels = item["relationships"]
+        assert "author" in rels  # type: ignore[operator]
+        assert "parentComment" in rels  # type: ignore[operator]
+
+    def test_html_format_preserved(self) -> None:
+        payload = _build_document_comments_payload(
+            specs=[DocumentCommentSpec(text="<b>bold</b>", text_format="text/html")],
+            project_id="P",
+            space_id="S",
+            document_name="D",
+        )
+        text_field = payload["data"][0]["attributes"]["text"]  # type: ignore[index]
+        assert text_field["type"] == "text/html"  # type: ignore[index]
+
+    def test_payload_wrapped_in_array(self) -> None:
+        payload = _build_document_comments_payload(
+            specs=[DocumentCommentSpec(text="t")],
+            project_id="P",
+            space_id="S",
+            document_name="D",
+        )
+        assert isinstance(payload["data"], list)
+        assert len(payload["data"]) == 1  # type: ignore[arg-type]
+
+
+class TestCreateDocumentCommentsDryRun:
+    """Verify dry_run returns preview without calling Polarion."""
+
+    async def test_dry_run_no_post_call(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_document_comments(
+            mock_ctx,
+            project_id="P",
+            space_id="S",
+            document_name="D",
+            comments=[DocumentCommentSpec(text="hello")],
+            dry_run=True,
+        )
+        mock_client.post.assert_not_called()
+        assert result.dry_run is True
+        assert result.created is False
+        assert result.comment_ids == []
+
+    async def test_dry_run_payload_preview_populated(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_document_comments(
+            mock_ctx,
+            project_id="P",
+            space_id="S",
+            document_name="D",
+            comments=[
+                DocumentCommentSpec(text="first"),
+                DocumentCommentSpec(text="second"),
+            ],
+            dry_run=True,
+        )
+        assert result.payload_preview is not None
+        assert isinstance(result.payload_preview["data"], list)
+        assert len(result.payload_preview["data"]) == 2  # type: ignore[arg-type]
+
+    async def test_dry_run_with_relationships(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_document_comments(
+            mock_ctx,
+            project_id="P",
+            space_id="S",
+            document_name="D",
+            comments=[
+                DocumentCommentSpec(
+                    text="reply", author_id="bob", parent_comment_id="c5"
+                )
+            ],
+            dry_run=True,
+        )
+        assert result.payload_preview is not None
+        item = result.payload_preview["data"][0]  # type: ignore[index]
+        assert isinstance(item, dict)
+        assert "author" in item["relationships"]  # type: ignore[index]
+        assert "parentComment" in item["relationships"]  # type: ignore[index]
+
+
+class TestCreateDocumentCommentsHappyPath:
+    """Verify successful creation extracts and returns short comment IDs."""
+
+    async def test_returns_short_comment_ids(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [
+                {"type": "document_comments", "id": "p/s/d/c42"},
+                {"type": "document_comments", "id": "p/s/d/c43"},
+            ]
+        }
+        result = await create_document_comments(
+            mock_ctx,
+            project_id="p",
+            space_id="s",
+            document_name="d",
+            comments=[
+                DocumentCommentSpec(text="first"),
+                DocumentCommentSpec(text="second"),
+            ],
+            dry_run=False,
+        )
+        assert result.created is True
+        assert result.dry_run is False
+        assert result.comment_ids == ["c42", "c43"]
+        assert result.payload_preview is None
+
+    async def test_post_called_with_correct_path(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "document_comments", "id": "Proj/_default/Doc/c1"}]
+        }
+        await create_document_comments(
+            mock_ctx,
+            project_id="Proj",
+            space_id="_default",
+            document_name="Doc",
+            comments=[DocumentCommentSpec(text="hello")],
+            dry_run=False,
+        )
+        call_args = mock_client.post.call_args
+        expected_path = "/projects/Proj/spaces/_default/documents/Doc/comments"
+        assert call_args[0][0] == expected_path
+
+    async def test_path_url_encodes_spaces(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "document_comments", "id": "P/My%20Space/My%20Doc/c1"}]
+        }
+        await create_document_comments(
+            mock_ctx,
+            project_id="P",
+            space_id="My Space",
+            document_name="My Doc",
+            comments=[DocumentCommentSpec(text="hi")],
+            dry_run=False,
+        )
+        call_args = mock_client.post.call_args
+        assert "My%20Space" in call_args[0][0]
+        assert "My%20Doc" in call_args[0][0]
+
+    async def test_post_body_multiple_items(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [
+                {"type": "document_comments", "id": "P/S/D/c1"},
+                {"type": "document_comments", "id": "P/S/D/c2"},
+            ]
+        }
+        await create_document_comments(
+            mock_ctx,
+            project_id="P",
+            space_id="S",
+            document_name="D",
+            comments=[
+                DocumentCommentSpec(text="one"),
+                DocumentCommentSpec(text="two"),
+            ],
+            dry_run=False,
+        )
+        body = mock_client.post.call_args[1]["json"]
+        assert len(body["data"]) == 2
+
+    async def test_resolved_true_sent_in_payload(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "document_comments", "id": "P/S/D/c1"}]
+        }
+        await create_document_comments(
+            mock_ctx,
+            project_id="P",
+            space_id="S",
+            document_name="D",
+            comments=[DocumentCommentSpec(text="done", resolved=True)],
+            dry_run=False,
+        )
+        body = mock_client.post.call_args[1]["json"]
+        assert body["data"][0]["attributes"]["resolved"] is True
+
+
+class TestCreateDocumentCommentsErrors:
+    """Verify domain exceptions map to the correct public exceptions."""
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionAuthError("auth", status_code=401)
+        with pytest.raises(PermissionError, match="POLARION_TOKEN"):
+            await create_document_comments(
+                mock_ctx,
+                project_id="P",
+                space_id="S",
+                document_name="D",
+                comments=[DocumentCommentSpec(text="hi")],
+                dry_run=False,
+            )
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionNotFoundError(
+            "not found", status_code=404
+        )
+        with pytest.raises(ValueError, match="list_documents"):
+            await create_document_comments(
+                mock_ctx,
+                project_id="P",
+                space_id="S",
+                document_name="D",
+                comments=[DocumentCommentSpec(text="hi")],
+                dry_run=False,
+            )
+
+    async def test_other_polarion_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionError("boom", status_code=500)
+        with pytest.raises(RuntimeError, match="boom"):
+            await create_document_comments(
+                mock_ctx,
+                project_id="P",
+                space_id="S",
+                document_name="D",
+                comments=[DocumentCommentSpec(text="hi")],
+                dry_run=False,
+            )
+
+
+class TestCreateDocumentCommentsFieldValidation:
+    """Verify Field constraints on create_document_comments and DocumentCommentSpec.
+
+    FastMCP enforces ``min_length`` via JSON Schema at the MCP protocol
+    layer before the tool function is invoked; calling the function
+    directly bypasses that gate.  We rebuild a ``TypeAdapter`` from each
+    parameter's annotation + ``FieldInfo`` to prove the constraint is
+    wired correctly at the schema layer.
+    """
+
+    @staticmethod
+    def _adapter_for(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(create_document_comments)
+        sig = inspect.signature(create_document_comments)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_space_id_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("space_id").validate_python("")
+
+    def test_space_id_accepts_non_empty(self) -> None:
+        assert self._adapter_for("space_id").validate_python("_default") == "_default"
+
+    def test_document_name_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("document_name").validate_python("")
+
+    def test_document_name_accepts_non_empty(self) -> None:
+        assert self._adapter_for("document_name").validate_python("MySRS") == "MySRS"
+
+    def test_spec_text_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            DocumentCommentSpec(text="")
+
+    def test_spec_text_accepts_non_empty(self) -> None:
+        spec = DocumentCommentSpec(text="hello")
+        assert spec.text == "hello"
+
+    def test_spec_default_text_format_is_plain(self) -> None:
+        spec = DocumentCommentSpec(text="hello")
+        assert spec.text_format == "text/plain"

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -4634,8 +4634,8 @@ class TestCreateDocumentCommentsHappyPath:
             ],
             dry_run=False,
         )
-        body = mock_client.post.call_args[1]["json"]
-        assert len(body["data"]) == 2
+        body = mock_client.post.call_args[1]["json"]  # type: ignore[index]
+        assert len(body["data"]) == 2  # type: ignore[index]
 
     async def test_resolved_true_sent_in_payload(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -4702,6 +4702,21 @@ class TestCreateDocumentCommentsErrors:
                 dry_run=False,
             )
 
+    async def test_empty_response_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """201 with no IDs must raise rather than silently return created=True."""
+        mock_client.post.return_value = {}
+        with pytest.raises(RuntimeError, match="no comment IDs"):
+            await create_document_comments(
+                mock_ctx,
+                project_id="P",
+                space_id="S",
+                document_name="D",
+                comments=[DocumentCommentSpec(text="hi")],
+                dry_run=False,
+            )
+
 
 class TestCreateDocumentCommentsFieldValidation:
     """Verify Field constraints on create_document_comments and DocumentCommentSpec.
@@ -4745,3 +4760,13 @@ class TestCreateDocumentCommentsFieldValidation:
     def test_spec_default_text_format_is_plain(self) -> None:
         spec = DocumentCommentSpec(text="hello")
         assert spec.text_format == "text/plain"
+
+    def test_comments_rejects_empty_list(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("comments").validate_python([])
+
+    def test_comments_accepts_non_empty_list(self) -> None:
+        specs = [{"text": "hello"}]
+        result = self._adapter_for("comments").validate_python(specs)
+        assert isinstance(result, list)
+        assert len(result) == 1


### PR DESCRIPTION
## Summary

Adds `create_document_comments` — a bulk write tool that POSTs one or more comments to `POST /projects/{p}/spaces/{s}/documents/{d}/comments`.

`list_document_comments` (read) already existed; this PR completes the read/write symmetry for document review workflows.

## Design

- **Bulk**: accepts `list[DocumentCommentSpec]` (min 1) — all created in a single Polarion POST, mirroring the API's native array body.
- **Text format**: `text/plain` (default) or `text/html`; sent verbatim, no Markdown conversion.
- **Resolved tri-state**: `None` omits the field (Polarion defaults to `False`); explicit `True`/`False` sends the value.
- **Author**: omit to let Polarion use the authenticated token's user.
- **Replies**: `parent_comment_id` accepts the short ID returned by `list_document_comments`; the tool composes the full 4-segment path internally.
- **dry_run**: returns payload preview without calling Polarion.
- **ID extraction**: uses `extract_short_id` on the returned IDs — consistent with `DocumentComment.id` in read results.

## Changes

| File | Change |
|---|---|
| `models.py` | Add `DocumentCommentSpec` (input) and `DocumentCommentsCreateResult` (output) |
| `tools/write.py` | Add `_build_document_comments_payload()` helper + `create_document_comments` tool |
| `tests/tools/test_write.py` | 5 new test classes (28 tests) covering payload builder, dry-run, happy path, errors, field validation |
| `README.md` | Add `create_document_comments` to Write tools table |

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)