### PR TITLE
refactor(meta): enforce comment style rules

### DIFF
--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -145,8 +145,6 @@ class PolarionClient:
             self._request_lock = asyncio.Lock()
         return self._request_lock
 
-    # -- Context-manager interface -------------------------------------------
-
     async def __aenter__(self) -> PolarionClient:
         return self
 
@@ -354,8 +352,6 @@ class PolarionClient:
             "Unexpected retry loop exit",
             status_code=0,
         )
-
-    # -- Error mapping -------------------------------------------------------
 
     @staticmethod
     def _map_status_to_error(response: httpx.Response) -> PolarionError:

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -26,10 +26,6 @@ type JsonValue = (
     str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
 )
 
-# ---------------------------------------------------------------------------
-# Generic pagination wrapper
-# ---------------------------------------------------------------------------
-
 
 class PaginatedResult[T](BaseModel):
     """Paginated response wrapper used by all list tools.
@@ -45,11 +41,6 @@ class PaginatedResult[T](BaseModel):
     has_more: bool = Field(default=False, description="True if more pages follow.")
 
 
-# ---------------------------------------------------------------------------
-# Read models — summaries and details
-# ---------------------------------------------------------------------------
-
-
 class ProjectSummary(BaseModel):
     """Summary of a Polarion project returned by ``list_projects``."""
 
@@ -57,27 +48,21 @@ class ProjectSummary(BaseModel):
     name: str
     active: bool = Field(
         default=True,
-        description="False means archived; skip these when picking a target.",
+        description="False means archived.",
     )
 
 
 class EnumOption(BaseModel):
     """Single enum option returned by ``list_document_enum_options``.
 
-    Captures only the attributes useful when an LLM picks a value before a
-    write call. The Polarion schema carries several more fields (color,
-    iconURL, columnWidth, createDefect, limited, minValue, oppositeName,
-    parent, requiresSignatureForTestCaseExecution, templateWorkItem) that
-    are intentionally not surfaced; add them on demand if a future caller
-    needs them.
+    Surfaces only the attributes an LLM needs to pick a value before a
+    write call. Other Polarion option fields (color, iconURL, columnWidth,
+    createDefect, limited, minValue, oppositeName, parent,
+    requiresSignatureForTestCaseExecution, templateWorkItem) are not
+    exposed.
     """
 
-    id: str = Field(
-        description=(
-            "Option id -- pass this verbatim to write tools (e.g. 'open',"
-            " 'systemReqSpecification')."
-        ),
-    )
+    id: str = Field(description="Option id; pass verbatim to write tools.")
     name: str = Field(description="Human-readable display name.")
     description: str = Field(
         default="",
@@ -85,18 +70,15 @@ class EnumOption(BaseModel):
     )
     default: bool = Field(
         default=False,
-        description="True if Polarion uses this option when none is specified.",
+        description="True when this option is the project default.",
     )
     hidden: bool = Field(
         default=False,
-        description=(
-            "True if the option is hidden in the UI;"
-            " avoid selecting unless explicitly needed."
-        ),
+        description="True when the option is hidden in the UI.",
     )
     terminal: bool = Field(
         default=False,
-        description="For status fields: True if this is a workflow end-state.",
+        description="For status fields, True for workflow end-states.",
     )
 
 
@@ -104,88 +86,71 @@ class DocumentSummary(BaseModel):
     """Summary of a Polarion document returned by ``list_documents``."""
 
     space_id: str = Field(
-        description=(
-            "Space identifier that contains the document (e.g. '_default', 'Design')."
-        ),
+        description="Space containing the document (e.g. '_default').",
     )
     document_name: str = Field(
-        description=(
-            "Document name within the space"
-            " (e.g. 'Software Requirement Specification')."
-        ),
+        description="Document name within the space.",
     )
 
 
 class DocumentDetail(BaseModel):
-    """Full details of a Polarion document returned by ``get_document``."""
+    """Full details of a Polarion document returned by ``get_document``.
 
-    title: str = Field(
-        description="Document title.",
-    )
+    ``content_html`` is the round-trip pair for
+    ``update_document(home_page_content_html=...)`` — populated only when
+    ``include_homepage_content_html=True``. It is the inline prose only;
+    heading text and embedded work-item bodies live in separate work items,
+    so ``read_document`` is the assembled-body view.
+
+    ``custom_fields`` mirrors the keys configured on the document type:
+    rich-text values stay as ``{'type': 'text/html', 'value': '<...>'}``
+    dicts so the shape round-trips back unchanged.
+    """
+
+    title: str = Field(description="Document title.")
     type: str = Field(
         default="",
-        description=(
-            "Document type (e.g. 'req_specification', 'test_specification'). "
-            "Empty string when the server does not report a type."
-        ),
+        description="Document type (e.g. 'req_specification').",
     )
     status: str = Field(
         default="",
-        description=(
-            "Document workflow status (e.g. 'draft', 'approved'). "
-            "Empty string when the server does not report a status."
-        ),
+        description="Document workflow status (e.g. 'draft', 'approved').",
     )
     content_html: str = Field(
         default="",
-        description=(
-            "Document body (homePageContent) as raw Polarion HTML. Only "
-            "populated when ``get_document`` is called with "
-            "``include_homepage_content_html=True``; otherwise an empty "
-            "string. The same shape round-trips back through "
-            "``update_document(home_page_content_html=...)`` without "
-            "lossy Markdown conversion. NOTE: incomplete for end-to-end "
-            "reading — heading text and embedded work-item bodies live in "
-            "separate work items, not in homePageContent; use "
-            "``read_document`` for the assembled body."
-        ),
+        description="Raw Polarion HTML body; empty unless the read flag was True.",
     )
     custom_fields: dict[str, object] = Field(
         default_factory=dict,
-        description=(
-            "User-defined custom fields configured per project and "
-            "document type. Keys are project-specific custom field IDs; "
-            "values are heterogeneous (string, int, float, bool, list, "
-            "or ``{'type': 'text/html', 'value': '<...>'}`` for rich-text "
-            "custom fields — kept raw, NOT converted to Markdown, so the "
-            "shape round-trips back to Polarion unchanged). Empty dict "
-            "when no custom fields are populated on the document."
-        ),
+        description="Project-defined custom fields keyed by field ID.",
     )
 
 
 class DocumentPart(BaseModel):
-    """A single part (heading or work item) within a Polarion document."""
+    """A single part (heading or work item) within a Polarion document.
+
+    Field population varies by ``type``:
+
+    * ``heading`` — text in ``title``, depth in ``level``, ``work_item_*``
+      fields point at the heading work item.
+    * ``workitem`` — body in ``description`` (Markdown), metadata on
+      ``work_item_*``, ``content`` empty.
+    * ``normal`` / ``wikiblock`` — body in ``content`` (Markdown).
+    * ``toc`` / ``tof`` / ``page_break`` — widget placeholders, all body
+      fields empty. ``tof`` and ``page_break`` are inferred from the part
+      ID prefix because Polarion reports both as plain ``normal``.
+
+    Use ``id`` as ``previous_part_id`` / ``next_part_id`` when calling
+    ``move_work_item_to_document``. ``work_item_id`` plugs straight into
+    ``get_work_item`` / ``list_work_item_links``.
+    """
 
     id: str = Field(
-        description=(
-            "Short part identifier within the document "
-            "(e.g. 'heading_MCPT-001', 'workitem_MCPT-042', 'polarion_1'). "
-            "Use this as ``next_part_id`` (insert before) or "
-            "``previous_part_id`` (insert after) when calling "
-            "``move_work_item_to_document``."
-        ),
+        description="Short part identifier (e.g. 'workitem_MCPT-042').",
     )
-    title: str = Field(
-        description="Part title or heading text.",
-    )
+    title: str = Field(description="Part title or heading text.")
     content: str = Field(
-        description=(
-            "Part body in Markdown. Populated for 'normal' and 'wikiblock' "
-            "parts; empty for 'heading' (text in ``title``, depth in "
-            "``level``), 'workitem' (body in ``description``), and the "
-            "'toc' / 'tof' / 'page_break' widget placeholders."
-        ),
+        description="Part body in Markdown; empty unless body lives here.",
     )
     type: Literal[
         "heading",
@@ -195,77 +160,37 @@ class DocumentPart(BaseModel):
         "wikiblock",
         "tof",
         "page_break",
-    ] = Field(
-        description=(
-            "Part type: 'heading', 'workitem', 'normal' (rich text), "
-            "'toc' (table of contents widget), 'wikiblock' (wiki macro "
-            "block), 'tof' (table of figures widget), or 'page_break'. "
-            "'tof' and 'page_break' are inferred from the part ID prefix "
-            "because Polarion reports both as plain 'normal'."
-        ),
-    )
+    ] = Field(description="Part type; see class docstring for body-field mapping.")
     level: int = Field(
-        description=(
-            "Heading level (1-4) for heading parts. "
-            "0 for work-item parts that have no heading level."
-        ),
+        description="Heading level (1-4) for heading parts; 0 otherwise.",
     )
     description: str = Field(
         default="",
-        description=(
-            "Work item description converted to Markdown. "
-            "Only populated for 'workitem'-type parts. "
-            "Empty for headings and other part types."
-        ),
+        description="Linked work item body as Markdown; only set on 'workitem' parts.",
     )
     work_item_id: str = Field(
         default="",
-        description=(
-            "Short Work Item ID of the linked work item "
-            "(e.g. 'MCPT-001'). Populated for 'workitem' and 'heading' "
-            "parts; empty for other part types. Use this directly with "
-            "``get_work_item`` or ``list_work_item_links``."
-        ),
+        description="Linked Work Item ID; empty unless 'workitem' / 'heading'.",
     )
     work_item_type: str = Field(
         default="",
-        description=(
-            "Type of the linked work item (e.g. 'requirement', "
-            "'testCase', 'risk'). Populated for 'workitem' and 'heading' "
-            "parts; empty otherwise."
-        ),
+        description="Linked work item type; empty unless 'workitem' / 'heading'.",
     )
     work_item_status: str = Field(
         default="",
-        description=(
-            "Workflow status of the linked work item "
-            "(e.g. 'draft', 'approved'). Populated for 'workitem' and "
-            "'heading' parts; empty otherwise."
-        ),
+        description="Linked work item status; empty unless 'workitem' / 'heading'.",
     )
     external: bool = Field(
         default=False,
-        description=(
-            "True when this part references a work item from another "
-            "project (re-used content). Such parts are typically "
-            "read-only — editing must be done in the source project."
-        ),
+        description="True when the part is re-used from another project (read-only).",
     )
     outline_number: str = Field(
         default="",
-        description=(
-            "Hierarchical position inside the document (e.g. '1.2.3'). "
-            "Populated for 'heading' and 'workitem' parts when Polarion "
-            "has assigned one; empty for prose and widget parts."
-        ),
+        description="Hierarchical position (e.g. '1.2.3'); empty for prose / widgets.",
     )
     next_part_id: str = Field(
         default="",
-        description=(
-            "Short ID of the next part in document order "
-            "(e.g. 'workitem_MCPT-002'). "
-            "Empty string when this is the last part."
-        ),
+        description="Short ID of the next part; empty on the last part.",
     )
 
 
@@ -281,192 +206,115 @@ class DocumentReadResult(BaseModel):
     write tool because no update path accepts this shape. For round-trip
     editing of the document body, fetch the raw source via
     ``get_document(include_homepage_content_html=True)`` instead.
+
+    ``part_count`` reflects parts consumed from ``read_document_parts``
+    on this page — including widget placeholders that produce no output
+    — so use it for pagination accounting, not chunk count.
     """
 
-    content: str = Field(
-        description=(
-            "Rendered Markdown for the parts on this page. "
-            "Empty placeholder paragraphs from Polarion are skipped, "
-            "and runs of blank lines are collapsed."
-        ),
-    )
-    part_count: int = Field(
-        description=(
-            "Number of document parts on this page (i.e. parts consumed "
-            "from ``read_document_parts``). Parts that produce no output "
-            "(empty placeholder paragraphs, ``toc``) still count toward "
-            "this — use it for pagination accounting, not chunk count."
-        ),
-    )
-    page: int = Field(
-        description="Current page number (1-based).",
-    )
-    page_size: int = Field(
-        description="Maximum number of parts per page.",
-    )
-    total_parts: int = Field(
-        description="Total number of parts across the entire document.",
-    )
+    content: str = Field(description="Rendered Markdown for this page.")
+    part_count: int = Field(description="Number of parts consumed on this page.")
+    page: int = Field(description="Current page number (1-based).")
+    page_size: int = Field(description="Maximum number of parts per page.")
+    total_parts: int = Field(description="Total parts across the entire document.")
     has_more: bool = Field(
         default=False,
-        description=(
-            "True when there are more pages of parts after this one. "
-            "Use to decide whether to call ``read_document`` again with "
-            "``page_number + 1``."
-        ),
+        description="True when more pages of parts follow.",
     )
 
 
 class WorkItemSummary(BaseModel):
-    """Compact work-item representation for list and search results."""
+    """Compact work-item representation for list and search results.
 
-    id: str = Field(
-        description="Work Item ID (e.g. 'MCPT-001').",
-    )
-    title: str = Field(
-        description="Work Item title.",
-    )
-    type: str = Field(
-        description=(
-            "Work Item type (e.g. 'requirement', 'task', 'testCase', 'defect')."
-        ),
-    )
-    status: str = Field(
-        description="Work Item workflow status (e.g. 'draft', 'approved').",
-    )
+    ``space_id`` + ``document_name`` together address the containing
+    document (both empty when the work item is free-floating); pass them
+    to ``get_document`` / ``read_document_parts``.
+    """
+
+    id: str = Field(description="Work Item ID (e.g. 'MCPT-001').")
+    title: str = Field(description="Work Item title.")
+    type: str = Field(description="Work Item type (e.g. 'requirement', 'testCase').")
+    status: str = Field(description="Workflow status (e.g. 'draft', 'approved').")
     priority: str = Field(
         default="",
-        description=(
-            "Polarion priority value as a string (e.g. '90.0'). "
-            "Empty when the server does not report a priority."
-        ),
+        description="Priority value as a string (e.g. '90.0'); empty when unset.",
     )
     updated: str = Field(
         default="",
-        description=(
-            "ISO-8601 timestamp of the last modification "
-            "(e.g. '2026-04-29T10:23:00Z'). Empty when not reported."
-        ),
+        description="ISO-8601 last-modified timestamp; empty when unreported.",
     )
     space_id: str = Field(
         default="",
-        description=(
-            "Space that contains the document this work item belongs to. "
-            "Empty when the work item is not part of any document."
-        ),
+        description="Containing document's space; empty when free-floating.",
     )
     document_name: str = Field(
         default="",
-        description=(
-            "Name of the document this work item belongs to. "
-            "Empty when the work item is not part of any document. "
-            "Use with ``space_id`` to call ``get_document`` / "
-            "``read_document_parts``."
-        ),
+        description="Containing document name; empty when free-floating.",
     )
     assignee_ids: list[str] = Field(
         default_factory=list,
-        description=(
-            "Short user IDs of the assignees (e.g. ['alice', 'bob']). "
-            "Empty list when the work item has no assignee."
-        ),
+        description="Short user IDs of assignees; empty list when unassigned.",
     )
 
 
 class Hyperlink(BaseModel):
     """A single external hyperlink attached to a work item."""
 
-    role: str = Field(
-        description=("Hyperlink role identifier (e.g. 'ref_ext', 'implementation')."),
-    )
+    role: str = Field(description="Hyperlink role id (e.g. 'ref_ext').")
     title: str = Field(
         default="",
-        description="Human-readable link title. Empty when not provided.",
+        description="Human-readable link title; empty when unset.",
     )
-    uri: str = Field(
-        description="Target URI of the hyperlink.",
-    )
+    uri: str = Field(description="Target URI of the hyperlink.")
 
 
 class WorkItemDetail(WorkItemSummary):
     """Full work-item details returned by ``get_work_item``.
 
     Extends ``WorkItemSummary`` with the description, project context,
-    and detail-only metadata (authorship, resolution, severity,
-    outline position, external hyperlinks).
+    and detail-only metadata (authorship, resolution, severity, outline
+    position, external hyperlinks).
+
+    ``description_html`` is the round-trip pair for
+    ``update_work_item(description_html=...)`` and must never pass through
+    a Markdown converter or sanitizer — doing so strips Polarion-specific
+    spans and breaks the round-trip. ``custom_fields`` keeps rich-text
+    values as ``{'type': 'text/html', 'value': '<...>'}`` dicts so the
+    shape round-trips back unchanged.
     """
 
     description_html: str = Field(
         default="",
-        description=(
-            "Raw Polarion HTML body for the round-trip pair "
-            "``get_work_item(include_description_html=True)`` → "
-            "``update_work_item(description_html=...)``. Empty when the "
-            "work item has no description or when the read flag was "
-            "False. Never feed through a Markdown converter or sanitizer "
-            "(would strip Polarion-specific spans and break the round-trip)."
-        ),
+        description="Raw Polarion HTML body; empty unless the read flag was True.",
     )
-    project_id: str = Field(
-        description="Project that contains this work item.",
-    )
+    project_id: str = Field(description="Project that contains this work item.")
     author_id: str = Field(
         default="",
-        description=(
-            "Short user ID of the author (e.g. 'alice'). "
-            "Empty when the server does not report an author."
-        ),
+        description="Short user ID of the author; empty when unreported.",
     )
     created: str = Field(
         default="",
-        description=(
-            "ISO-8601 timestamp of the work item creation "
-            "(e.g. '2026-04-29T10:23:00Z'). Empty when not reported."
-        ),
+        description="ISO-8601 creation timestamp; empty when unreported.",
     )
     resolution: str = Field(
         default="",
-        description=(
-            "Resolution outcome for closed/done work items "
-            "(e.g. 'fixed', 'wontfix', 'duplicate'). "
-            "Empty for unresolved or non-closeable items."
-        ),
+        description="Resolution outcome (e.g. 'fixed'); empty when unresolved.",
     )
     severity: str = Field(
         default="",
-        description=(
-            "Severity classification, primarily used for defects "
-            "(e.g. 'blocker', 'critical', 'major'). "
-            "Empty for non-defect types."
-        ),
+        description="Severity classification (e.g. 'critical'); empty for non-defects.",
     )
     outline_number: str = Field(
         default="",
-        description=(
-            "Hierarchical position inside the containing document "
-            "(e.g. '1.2.3'). Empty when the work item is not part of "
-            "a document or has no assigned outline number."
-        ),
+        description="Hierarchical position (e.g. '1.2.3'); empty outside a document.",
     )
     hyperlinks: list[Hyperlink] = Field(
         default_factory=list,
-        description=(
-            "External hyperlinks attached to this work item. "
-            "Empty list when none are set."
-        ),
+        description="External hyperlinks attached to this work item.",
     )
     custom_fields: dict[str, object] = Field(
         default_factory=dict,
-        description=(
-            "User-defined custom fields configured per project and "
-            "work-item type. Keys are project-specific custom field IDs "
-            "(e.g. 'riskLevel', 'effortHours'); values are heterogeneous "
-            "(string, int, float, bool, list, or "
-            "``{'type': 'text/html', 'value': '<...>'}`` for rich-text "
-            "custom fields — kept raw, NOT converted to Markdown, so the "
-            "shape round-trips back to Polarion unchanged). Empty dict "
-            "when no custom fields are populated on the work item."
-        ),
+        description="Project-defined custom fields keyed by field ID.",
     )
 
 
@@ -480,46 +328,36 @@ class WorkItemRead(WorkItemSummary):
     markup). For round-trip editing, use
     ``get_work_item(include_description_html=True)`` paired with
     ``update_work_item(description_html=...)``.
+
+    ``custom_fields`` keeps rich-text values as
+    ``{'type': 'text/html', 'value': '<...>'}`` dicts so this dict alone
+    can be copied back into ``update_work_item(custom_fields=...)``.
     """
 
     description: str = Field(
         default="",
-        description=(
-            "Work-item body rendered as Markdown. Empty when the item has "
-            "no description. Read-only; do NOT feed to ``update_work_item``."
-        ),
+        description="Body as Markdown; read-only — do NOT feed to update_work_item.",
     )
-    project_id: str = Field(
-        description="Project that contains this work item.",
-    )
+    project_id: str = Field(description="Project that contains this work item.")
     author_id: str = Field(
         default="",
-        description="Short user ID of the author; empty when not reported.",
+        description="Short user ID of the author; empty when unreported.",
     )
     created: str = Field(
         default="",
-        description="ISO-8601 creation timestamp; empty when not reported.",
+        description="ISO-8601 creation timestamp; empty when unreported.",
     )
     resolution: str = Field(
         default="",
-        description=(
-            "Resolution outcome for closed items (e.g. 'fixed', 'wontfix'); "
-            "empty otherwise."
-        ),
+        description="Resolution outcome (e.g. 'fixed'); empty when unresolved.",
     )
     severity: str = Field(
         default="",
-        description=(
-            "Severity classification, used for defects (e.g. 'blocker', "
-            "'critical'); empty otherwise."
-        ),
+        description="Severity classification (e.g. 'critical'); empty for non-defects.",
     )
     outline_number: str = Field(
         default="",
-        description=(
-            "Hierarchical position inside the containing document "
-            "(e.g. '1.2.3'); empty when not part of a document."
-        ),
+        description="Hierarchical position (e.g. '1.2.3'); empty outside a document.",
     )
     hyperlinks: list[Hyperlink] = Field(
         default_factory=list,
@@ -527,12 +365,7 @@ class WorkItemRead(WorkItemSummary):
     )
     custom_fields: dict[str, object] = Field(
         default_factory=dict,
-        description=(
-            "User-defined custom fields as ``{fieldId: value}``. Rich-text "
-            "values stay raw as ``{'type': 'text/html', 'value': '<...>'}`` "
-            "dicts so this dict alone may be copied back into "
-            "``update_work_item(custom_fields=...)``."
-        ),
+        description="Project-defined custom fields keyed by field ID.",
     )
 
 
@@ -541,64 +374,37 @@ class WorkItemLink(BaseModel):
 
     ``direction='forward'`` is an outgoing link (this work item links to
     the target); ``'back'`` is an incoming link (the target links to this
-    work item).
+    work item). The back-direction Lucene fallback does not expose the
+    originating role, so ``role`` is ``None`` for every back-direction
+    item. ``suspect`` marks links whose target changed since the link
+    was last reviewed; it is only meaningful in the forward direction.
     """
 
-    id: str = Field(
-        description="Linked Work Item ID (e.g. 'MCPT-002').",
-    )
-    title: str = Field(
-        description="Linked Work Item title.",
-    )
+    id: str = Field(description="Linked Work Item ID (e.g. 'MCPT-002').")
+    title: str = Field(description="Linked Work Item title.")
     role: str | None = Field(
         default=None,
-        description=(
-            "Link role (e.g. 'parent', 'relates_to', 'verifies'); "
-            "``None`` for back-direction links."
-        ),
+        description="Link role (e.g. 'parent'); None on back-direction links.",
     )
     direction: Literal["forward", "back"] = Field(
-        description=(
-            "'forward' for outgoing links (this work item links to the target). "
-            "'back' for incoming links (the target links to this work item)."
-        )
+        description="'forward' for outgoing links, 'back' for incoming.",
     )
-    suspect: bool = Field(
-        description=(
-            "Whether the link is marked as suspect. "
-            "Suspect links indicate that the linked item has changed "
-            "since the link was last reviewed."
-        ),
-    )
+    suspect: bool = Field(description="True when the link is marked as suspect.")
     type: str = Field(
         default="",
-        description=(
-            "Type of the linked work item (e.g. 'requirement', "
-            "'testCase'). Empty when the server does not report a type."
-        ),
+        description="Linked work item type; empty when unreported.",
     )
     status: str = Field(
         default="",
-        description=(
-            "Workflow status of the linked work item "
-            "(e.g. 'draft', 'approved'). Empty when the server does not "
-            "report a status."
-        ),
+        description="Linked work item workflow status; empty when unreported.",
     )
     space_id: str = Field(
         default="",
-        description=(
-            "Space that contains the document the linked work item "
-            "belongs to. Empty when not module-bound."
-        ),
+        description="Linked item's document space; empty when not module-bound.",
     )
     document_name: str = Field(
         default="",
-        description=(
-            "Name of the document the linked work item belongs to. "
-            "Empty when not module-bound. Use with ``space_id`` to call "
-            "``get_document`` / ``read_document_parts``."
-        ),
+        description="Linked item's document name; empty when not module-bound.",
     )
 
 
@@ -617,23 +423,20 @@ class DocumentComment(BaseModel):
     created: str = Field(description="ISO-8601 creation timestamp.")
     resolved: bool = Field(
         default=False,
-        description="True when the comment has been marked resolved.",
+        description="True when the comment is marked resolved.",
     )
-    text: str = Field(
-        default="",
-        description="Comment body verbatim; format signalled by ``text_format``.",
-    )
+    text: str = Field(default="", description="Comment body verbatim.")
     text_format: Literal["text/html", "text/plain"] = Field(
         default="text/html",
         description="MIME type of ``text`` as reported by Polarion.",
     )
     author_id: str | None = Field(
         default=None,
-        description="User ID of the comment author; ``None`` when unknown.",
+        description="User ID of the author; None when unknown.",
     )
     parent_comment_id: str | None = Field(
         default=None,
-        description="Parent comment ID for replies; ``None`` for top-level comments.",
+        description="Parent comment ID for replies; None on top-level.",
     )
     child_comment_ids: list[str] = Field(
         default_factory=list,
@@ -642,186 +445,106 @@ class DocumentComment(BaseModel):
 
 
 class DocumentCommentSpec(BaseModel):
-    """One comment to create via ``create_document_comments``."""
+    """One comment to create via ``create_document_comments``.
 
-    text: str = Field(
-        min_length=1,
-        description="Comment body text.",
-    )
+    ``parent_comment_id`` is the short ID from ``list_document_comments``
+    (omit for top-level); the tool composes the full path internally.
+    Omit ``author_id`` to default to the authenticated token's user;
+    omit ``resolved`` to let Polarion default to False.
+    """
+
+    text: str = Field(min_length=1, description="Comment body text.")
     text_format: Literal["text/html", "text/plain"] = Field(
         default="text/plain",
-        description="MIME type of ``text`` ('text/plain' or 'text/html').",
+        description="MIME type of ``text``.",
     )
-    resolved: bool | None = Field(
-        default=None,
-        description="Initial resolved state; omit to let Polarion default to False.",
-    )
-    author_id: str | None = Field(
-        default=None,
-        description=(
-            "User ID of the comment author; omit to default to the authenticated user."
-        ),
-    )
+    resolved: bool | None = Field(default=None, description="Initial resolved state.")
+    author_id: str | None = Field(default=None, description="Author user ID.")
     parent_comment_id: str | None = Field(
         default=None,
-        description=(
-            "Short comment ID for replies (e.g. 'c42' from "
-            "``list_document_comments``). Omit for a top-level comment. "
-            "The tool composes the full path internally."
-        ),
+        description="Short comment ID for replies; omit for top-level.",
     )
-
-
-# ---------------------------------------------------------------------------
-# Write-result models
-# ---------------------------------------------------------------------------
 
 
 class WorkItemCreateResult(BaseModel):
     """Result of a ``create_work_item`` operation."""
 
-    created: bool = Field(
-        description=(
-            "True if the work item was actually created. False when dry_run is True."
-        ),
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    created: bool = Field(description="True on a real create; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     work_item_id: str | None = Field(
-        description=(
-            "ID of the created work item (e.g. 'MCPT-042'). None when dry_run is True."
-        ),
+        description="ID of the new work item (e.g. 'MCPT-042'); None on dry-run.",
     )
     payload_preview: dict[str, JsonValue] | None = Field(
-        description=(
-            "JSON:API request payload that was (or would be) sent. "
-            "Usually populated for dry-run previews and may be None "
-            "after a successful real operation."
-        ),
+        description="JSON:API payload sent or previewed; None after real ops.",
     )
 
 
 class WorkItemUpdateResult(BaseModel):
     """Result of an ``update_work_item`` operation."""
 
-    updated: bool = Field(
-        description=(
-            "True if the work item was actually updated. False when dry_run is True."
-        ),
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    updated: bool = Field(description="True on a real update; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     current: WorkItemDetail | None = Field(
-        description=(
-            "Post-update state of the work item, fetched after the PATCH "
-            "succeeds. Included so the LLM can verify the change applied. "
-            "None on dry-run."
-        ),
+        description="Post-PATCH state for verification; None on dry-run.",
     )
     changes: dict[str, JsonValue] = Field(
-        description="Map of field names to their new values in the PATCH payload.",
+        description="Map of field names to their new values in the PATCH.",
     )
     payload_preview: dict[str, JsonValue] | None = Field(
-        description=(
-            "JSON:API request payload that was (or would be) sent. "
-            "Usually populated for dry-run previews and may be None "
-            "after a successful real operation."
-        ),
+        description="JSON:API payload sent or previewed; None after real ops.",
     )
 
 
 class DocumentCommentsCreateResult(BaseModel):
     """Result of a ``create_document_comments`` operation."""
 
-    created: bool = Field(
-        description=(
-            "True if comments were actually created. False when dry_run is True."
-        ),
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    created: bool = Field(description="True on a real create; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     comment_ids: list[str] = Field(
-        description=(
-            "Short IDs of the created comments in the order returned by Polarion. "
-            "Empty when dry_run is True."
-        ),
+        description="Short IDs in Polarion's return order; empty on dry-run.",
     )
     payload_preview: dict[str, JsonValue] | None = Field(
-        description=(
-            "JSON:API request payload that was (or would be) sent. "
-            "Populated for dry-run previews; None after a successful real operation."
-        ),
+        description="JSON:API payload sent or previewed; None after real ops.",
     )
 
 
 class DocumentCommentUpdateResult(BaseModel):
     """Result of an ``update_document_comment`` operation."""
 
-    updated: bool = Field(
-        description=(
-            "True if the comment was actually patched. False when dry_run is True."
-        ),
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    updated: bool = Field(description="True on a real PATCH; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     comment_id: str | None = Field(
-        description=(
-            "Short comment ID that was patched (e.g. 'c42'). None when dry_run is True."
-        ),
+        description="Short comment ID patched (e.g. 'c42'); None on dry-run.",
     )
     resolved: bool = Field(
-        description=(
-            "The ``resolved`` value that was sent (or would be sent) to Polarion."
-        ),
+        description="The resolved value sent (or that would be sent).",
     )
     payload_preview: dict[str, JsonValue] | None = Field(
-        description=(
-            "JSON:API request payload that was (or would be) sent. "
-            "Populated for dry-run previews; None after a successful real operation."
-        ),
+        description="JSON:API payload sent or previewed; None after real ops.",
     )
 
 
 class WorkItemLinkSpec(BaseModel):
     """One link to create under a source work item."""
 
-    role: str = Field(
-        min_length=1,
-        description="Link role id (e.g. 'parent', 'relates_to', 'verifies').",
-    )
-    target_work_item_id: str = Field(
-        min_length=1,
-        description="Target work item ID (the link's incoming endpoint).",
-    )
+    role: str = Field(min_length=1, description="Link role id (e.g. 'parent').")
+    target_work_item_id: str = Field(min_length=1, description="Target work item ID.")
     target_project_id: str | None = Field(
         default=None,
         description="Target's project; defaults to the source's project.",
     )
-    suspect: bool = Field(
-        default=False,
-        description="Mark the link as suspect (target changed since last review).",
-    )
+    suspect: bool = Field(default=False, description="Mark the link as suspect.")
     revision: str | None = Field(
         default=None,
-        description="Optional revision pin (current HEAD when omitted).",
+        description="Optional revision pin; defaults to current HEAD.",
     )
 
 
 class WorkItemLinkRef(BaseModel):
     """One existing link identified for deletion."""
 
-    role: str = Field(
-        min_length=1,
-        description="Link role id of the existing link; must match exactly.",
-    )
-    target_work_item_id: str = Field(
-        min_length=1,
-        description="Target work item ID (the link's incoming endpoint).",
-    )
+    role: str = Field(min_length=1, description="Link role id; must match exactly.")
+    target_work_item_id: str = Field(min_length=1, description="Target work item ID.")
     target_project_id: str | None = Field(
         default=None,
         description="Target's project; defaults to the source's project.",
@@ -831,55 +554,36 @@ class WorkItemLinkRef(BaseModel):
 class WorkItemLinksCreateResult(BaseModel):
     """Result of a ``create_work_item_links`` operation."""
 
-    created: bool = Field(
-        description="True if Polarion accepted the bulk create. False on dry_run.",
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    created: bool = Field(description="True on a real create; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     link_ids: list[str] = Field(
         default_factory=list,
-        description=(
-            "Composite 5-segment link ids"
-            " (``<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>``)"
-            " returned by Polarion, in input order; empty on dry-run."
-        ),
+        description="Composite 5-segment link ids in input order; empty on dry-run.",
     )
     payload_preview: dict[str, JsonValue] | None = Field(
         default=None,
-        description=(
-            "JSON:API payload that was (or would be) sent;"
-            " populated for dry-run, None after a real create."
-        ),
+        description="JSON:API payload sent or previewed; None after real ops.",
     )
 
 
 class WorkItemLinksDeleteResult(BaseModel):
-    """Result of a ``delete_work_item_links`` operation."""
+    """Result of a ``delete_work_item_links`` operation.
 
-    deleted: bool = Field(
-        description="True if Polarion accepted the bulk delete. False on dry_run.",
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    ``link_ids`` echoes the REQUEST — Polarion silently ignores body-level
+    refs that do not match an existing link, so the echo is not a list of
+    what was actually deleted. Cross-check with ``list_work_item_links``
+    if exact accounting is required.
+    """
+
+    deleted: bool = Field(description="True on a real delete; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     link_ids: list[str] = Field(
         default_factory=list,
-        description=(
-            "Composite 5-segment link ids REQUESTED for deletion, in input"
-            " order, reconstructed from the input refs. Polarion silently"
-            " ignores body-level refs that do not match an existing link,"
-            " so this echoes the request -- not necessarily what was"
-            " actually deleted. Cross-check with ``list_work_item_links``"
-            " if exact accounting is required."
-        ),
+        description="Composite 5-segment ids reconstructed from the request refs.",
     )
     payload_preview: dict[str, JsonValue] | None = Field(
         default=None,
-        description=(
-            "JSON:API payload that was (or would be) sent;"
-            " populated for dry-run, None after a real delete."
-        ),
+        description="JSON:API payload sent or previewed; None after real ops.",
     )
 
 
@@ -893,25 +597,19 @@ class WorkItemLinkUpdateSpec(BaseModel):
     that Polarion rejects with HTTP 400.
     """
 
-    role: str = Field(
-        min_length=1,
-        description="Link role id of the existing link; must match exactly.",
-    )
-    target_work_item_id: str = Field(
-        min_length=1,
-        description="Target work item ID (the link's incoming endpoint).",
-    )
+    role: str = Field(min_length=1, description="Link role id; must match exactly.")
+    target_work_item_id: str = Field(min_length=1, description="Target work item ID.")
     target_project_id: str | None = Field(
         default=None,
         description="Target's project; defaults to the source's project.",
     )
     suspect: bool | None = Field(
         default=None,
-        description="New suspect flag value; None leaves it unchanged.",
+        description="New suspect flag; None leaves it unchanged.",
     )
     revision: str | None = Field(
         default=None,
-        description="New revision pin; None leaves the existing pin unchanged.",
+        description="New revision pin; None leaves it unchanged.",
     )
 
     @model_validator(mode="after")
@@ -928,87 +626,46 @@ class WorkItemLinkUpdateSpec(BaseModel):
 class WorkItemLinkUpdateResult(BaseModel):
     """Result of an ``update_work_item_links`` operation."""
 
-    updated: bool = Field(
-        description="True if the link was patched. False on dry-run.",
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    updated: bool = Field(description="True on a real PATCH; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     link_id: str = Field(
-        description="Composite 5-segment id of the link (computed from inputs).",
+        description="Composite 5-segment id computed from inputs.",
     )
     payload_preview: dict[str, JsonValue] | None = Field(
-        description=(
-            "JSON:API PATCH body; populated on dry-run, None after a real call."
-        ),
+        description="JSON:API PATCH body; None after real ops.",
     )
 
 
 class WorkItemMoveResult(BaseModel):
     """Result of a ``move_work_item_to_document`` or sibling move-document call."""
 
-    moved: bool = Field(
-        description=(
-            "True if the work item was actually moved (into the target "
-            "document for moveToDocument, or detached to free-floating for "
-            "moveFromDocument). False when dry_run is True."
-        ),
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    moved: bool = Field(description="True on a real move; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     payload_preview: dict[str, JsonValue] | None = Field(
-        description=(
-            "Request payload that was (or would be) sent. "
-            "Usually populated for dry-run previews and may be None "
-            "after a successful real operation."
-        ),
+        description="Request payload sent or previewed; None after real ops.",
     )
 
 
 class DocumentCreateResult(BaseModel):
     """Result of a ``create_document`` operation."""
 
-    created: bool = Field(
-        description=(
-            "True if the document was actually created. False when dry_run is True."
-        ),
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    created: bool = Field(description="True on a real create; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     document_name: str | None = Field(
-        description=(
-            "Module name of the created document (e.g. 'MySpecV1'). "
-            "None when dry_run is True."
-        ),
+        description="Module name of the new document; None on dry-run.",
     )
     payload_preview: dict[str, JsonValue] | None = Field(
-        description=(
-            "JSON:API request payload that was (or would be) sent. "
-            "Usually populated for dry-run previews and may be None "
-            "after a successful real operation."
-        ),
+        description="JSON:API payload sent or previewed; None after real ops.",
     )
 
 
 class DocumentUpdateResult(BaseModel):
     """Result of an ``update_document`` operation."""
 
-    updated: bool = Field(
-        description=(
-            "True if the document metadata was actually patched. "
-            "False when dry_run is True."
-        ),
-    )
-    dry_run: bool = Field(
-        description="Whether this was a dry-run (preview only, no mutation).",
-    )
+    updated: bool = Field(description="True on a real PATCH; False on dry-run.")
+    dry_run: bool = Field(description="Whether this was a dry-run.")
     payload_preview: dict[str, JsonValue] | None = Field(
-        description=(
-            "JSON:API request payload that was (or would be) sent. "
-            "Populated for dry-run; None after a successful real update."
-        ),
+        description="JSON:API payload sent or previewed; None after real ops.",
     )
 
 

--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -74,7 +74,7 @@ class EnumOption(BaseModel):
     )
     hidden: bool = Field(
         default=False,
-        description="True when the option is hidden in the UI.",
+        description="True when the option is hidden in the UI; avoid selecting.",
     )
     terminal: bool = Field(
         default=False,

--- a/src/mcp_server_polarion/tools/_helpers.py
+++ b/src/mcp_server_polarion/tools/_helpers.py
@@ -45,10 +45,6 @@ class WorkItemSummaryKwargs(TypedDict):
     assignee_ids: list[str]
 
 
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
 # Polarion enforces a hard cap of 100 server-side.
 DEFAULT_PAGE_SIZE: Final[int] = 100
 
@@ -123,10 +119,6 @@ STANDARD_DOCUMENT_ATTRIBUTES: Final[frozenset[str]] = frozenset(
         "updated",
     }
 )
-
-# ---------------------------------------------------------------------------
-# Functions
-# ---------------------------------------------------------------------------
 
 
 def get_client(ctx: Context) -> PolarionClient:
@@ -454,8 +446,8 @@ def merge_custom_fields(
       the rest of the codebase's "skip None/empty" convention. Falsy
       non-``None`` values (``""``, ``0``, ``False``, ``[]``) are sent
       through verbatim because they may be meaningful custom-field
-      values. Polarion may interpret some of those as "clear"; clearing
-      semantics are intentionally out of scope for this phase.
+      values. Polarion may interpret some of those as "clear"; the tool
+      layer does not expose an explicit clearing path.
 
     Aliasing: values are stored under ``attributes`` by reference — no
     defensive copy. Callers must NOT mutate the ``customs`` dict (or any

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -1,18 +1,13 @@
 """Read-only MCP tools for querying Polarion ALM.
 
-Eleven tools that retrieve projects, documents, work items, and their
-relationships.  Every tool returns Pydantic models -- never raw ``dict``.
+Body fields use one of two formats depending on the tool's purpose:
 
-Body fields use two different formats depending on the tool's purpose:
-
-* **Round-trip paths** -- ``get_work_item`` and ``get_document`` return
-  raw Polarion HTML (``description_html``, ``content_html``). Same shape
-  round-trips back through the matching ``update_*`` tool without lossy
-  Markdown conversion.
-* **Synthesis paths** -- ``read_document`` and ``read_document_parts``
-  convert HTML to Markdown via ``html_to_markdown()`` for LLM
-  consumption. Output from these tools is read-only and cannot be fed
-  back to write tools.
+* **Round-trip paths** (``get_work_item``, ``get_document``) return raw
+  Polarion HTML so the value round-trips through the matching ``update_*``
+  tool without lossy Markdown conversion.
+* **Synthesis paths** (``read_document``, ``read_document_parts``,
+  ``read_work_item``) convert HTML to Markdown for LLM consumption; the
+  output is read-only and cannot be fed back to write tools.
 """
 
 from __future__ import annotations
@@ -520,11 +515,6 @@ async def _discover_documents(
     sorted_docs = sorted(documents)
     store_cached_documents(project_id, sorted_docs)
     return sorted_docs
-
-
-# ---------------------------------------------------------------------------
-# Read tools
-# ---------------------------------------------------------------------------
 
 
 @mcp.tool(
@@ -1280,8 +1270,8 @@ async def read_document(  # noqa: PLR0913
         PermissionError: Token lacks permission.
         RuntimeError: Other Polarion API errors.
     """
-    # FastMCP 3.0's ``@mcp.tool()`` returns the original function unchanged,
-    # so direct invocation forwards both the fetch and the error mapping.
+    # ``@mcp.tool()`` returns the original function unchanged, so direct
+    # invocation forwards both the fetch and the error mapping.
     page = await read_document_parts(
         ctx,
         project_id=project_id,
@@ -1656,10 +1646,10 @@ async def read_work_item(
         PermissionError: If the token lacks permissions.
         RuntimeError: On unexpected Polarion API errors.
     """
-    # Delegate fetch + error mapping to ``get_work_item``; FastMCP 3.0's
-    # ``@mcp.tool`` returns the original function unchanged, so the call
-    # forwards directly. Pulling the raw HTML lets the converter run
-    # without an extra round trip.
+    # Delegate fetch + error mapping to ``get_work_item``; ``@mcp.tool``
+    # returns the original function unchanged, so the call forwards
+    # directly. Pulling the raw HTML lets the converter run without an
+    # extra round trip.
     detail = await get_work_item(
         ctx,
         project_id=project_id,

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -56,8 +56,8 @@ from mcp_server_polarion.tools._helpers import (
 from mcp_server_polarion.utils import markdown_to_html, sanitize_html, stamp_block_ids
 
 # Caps tool-layer body payloads so a prompt-injected caller cannot ship a
-# multi-megabyte blob to Polarion. 2 MiB leaves roughly two orders of
-# magnitude of headroom over a realistic document body.
+# multi-megabyte blob to Polarion. Observed real document bodies stay
+# under ~30 KB, so 2 MiB leaves ~70x headroom.
 MAX_BODY_HTML_LEN: Final[int] = 2_000_000
 
 

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -1,15 +1,10 @@
 """Write MCP tools for Polarion ALM.
 
-Currently provides ``create_work_item``, ``update_work_item``,
-``move_work_item_to_document``, ``update_document``,
-``create_document``, ``create_work_item_links``,
-``delete_work_item_links``, ``update_work_item_links``,
-``create_document_comments``, and ``update_document_comment``. All
-write tools follow the strict
-patterns documented in ``CLAUDE.md``: they convert Markdown input to
-sanitized HTML, build minimal request payloads (skipping unset fields
-rather than sending empty values), and map domain exceptions to
-user-facing ones at the tool layer.
+All write tools follow the same patterns: greenfield Markdown bodies are
+converted to sanitized HTML before send, round-trip HTML bodies pass
+through verbatim, request payloads skip unset fields rather than sending
+empty values, and domain exceptions are mapped to user-facing ones at
+the tool layer.
 """
 
 from __future__ import annotations
@@ -61,13 +56,9 @@ from mcp_server_polarion.tools._helpers import (
 from mcp_server_polarion.utils import markdown_to_html, sanitize_html, stamp_block_ids
 
 # Caps tool-layer body payloads so a prompt-injected caller cannot ship a
-# multi-megabyte blob to Polarion. Observed real document bodies stay
-# under ~30 KB, so 2 MiB leaves ~70x headroom.
+# multi-megabyte blob to Polarion. 2 MiB leaves roughly two orders of
+# magnitude of headroom over a realistic document body.
 MAX_BODY_HTML_LEN: Final[int] = 2_000_000
-
-# ---------------------------------------------------------------------------
-# Private helpers
-# ---------------------------------------------------------------------------
 
 
 def _build_work_item_payload(  # noqa: PLR0913
@@ -590,11 +581,6 @@ def _build_document_comment_update_payload(
     }
 
 
-# ---------------------------------------------------------------------------
-# Write tools
-# ---------------------------------------------------------------------------
-
-
 @mcp.tool(
     tags={"write"},
     timeout=60.0,
@@ -881,8 +867,8 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
 
     PATCHes the supplied fields and follows up with a GET so the caller
     can confirm the change in ``current``. ``None`` / empty string /
-    empty list all mean ``leave unchanged`` — there is no way to clear
-    a field via this tool in v1.
+    empty list all mean ``leave unchanged`` — this tool exposes no path
+    to clear a field.
 
     ``description_html`` is RAW Polarion HTML, sent verbatim with no
     sanitization, so XSS/script filtering is delegated to Polarion's
@@ -1088,10 +1074,9 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
     tags={"write"},
     timeout=60.0,
     annotations={
-        # idempotentHint=False: the moveToDocument action endpoint is not
-        # verified to be safe on repeat — a second call against an already-
-        # moved work item may 400 instead of no-opping (per Polarion's heading-move
-        # behaviour, see CLAUDE.md). Conservative until confirmed.
+        # idempotentHint=False: repeating moveToDocument against an
+        # already-moved work item may 400 instead of no-opping, so the
+        # action is treated as non-idempotent.
         "readOnlyHint": False,
         "destructiveHint": True,
         "idempotentHint": False,
@@ -1155,17 +1140,14 @@ async def move_work_item_to_document(  # noqa: PLR0913
     with ``read_document_parts``.
 
     Side effect: this server auto-creates an outgoing link from the
-    moved work item to its enclosing section heading (role depends on
-    project config -- observed ``relates_to`` on
-    ``MCP_Test_Project / E2E_WriteFlow_20260525``, ``parent`` on the
-    older ``MCP_Test_Project / Software Requirement Specification``).
-    The auto-link appears in ``list_work_item_links(direction="forward")``
-    after the move and is silently removed by
-    ``move_work_item_from_document``. The role collides with any
-    same-role link you then try to create from the same source -- see
-    the "phantom success" note on ``create_work_item_links``. Querying
-    forward links on a known-attached work item is the only reliable
-    way to discover which role this project uses.
+    moved work item to its enclosing section heading. The role is
+    project-configurable (commonly ``parent`` or ``relates_to``), so
+    discover it by inspecting forward links on a known-attached work
+    item in the same project. The auto-link appears in
+    ``list_work_item_links(direction="forward")`` after the move and is
+    silently removed by ``move_work_item_from_document``. The role
+    collides with any same-role link created from the same source --
+    see the "phantom success" note on ``create_work_item_links``.
 
     Args:
         ctx: MCP tool context (injected automatically).

--- a/tests/core/test_client.py
+++ b/tests/core/test_client.py
@@ -28,21 +28,11 @@ from mcp_server_polarion.core.exceptions import (
 BASE = "https://polarion.example.com/polarion/rest/v1"
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _config() -> PolarionConfig:
     return PolarionConfig(
         polarion_url="https://polarion.example.com",
         polarion_token="test-token",
     )
-
-
-# ---------------------------------------------------------------------------
-# 1. Authentication — Bearer token in default headers
-# ---------------------------------------------------------------------------
 
 
 class TestAuthentication:
@@ -74,11 +64,6 @@ class TestAuthentication:
 
             request = route.calls.last.request
             assert request.headers["content-type"] == "application/json"
-
-
-# ---------------------------------------------------------------------------
-# 2. Successful responses
-# ---------------------------------------------------------------------------
 
 
 class TestSuccessfulResponses:
@@ -217,11 +202,6 @@ class TestSuccessfulResponses:
                 result = await client.get("/some/list")
 
             assert result == {"data": [1, 2, 3]}
-
-
-# ---------------------------------------------------------------------------
-# 3. Error mapping
-# ---------------------------------------------------------------------------
 
 
 class TestErrorMapping:
@@ -383,11 +363,6 @@ class TestErrorMapping:
         assert len(detail_part) <= _MAX_ERROR_DETAIL_LEN
 
 
-# ---------------------------------------------------------------------------
-# 4. Transport / network errors
-# ---------------------------------------------------------------------------
-
-
 class TestTransportErrors:
     """Verify that httpx transport errors are wrapped in PolarionError."""
 
@@ -410,11 +385,6 @@ class TestTransportErrors:
             async with PolarionClient(_config(), write_delay=0) as client:
                 with pytest.raises(PolarionError, match="transport error"):
                     await client.get("/projects")
-
-
-# ---------------------------------------------------------------------------
-# 5. Exponential-backoff retry
-# ---------------------------------------------------------------------------
 
 
 class TestRetry:
@@ -590,11 +560,6 @@ class TestSerialization:
         )
 
 
-# ---------------------------------------------------------------------------
-# 6. Context-manager & close
-# ---------------------------------------------------------------------------
-
-
 class TestContextManager:
     """Verify async context-manager protocol."""
 
@@ -611,11 +576,6 @@ class TestContextManager:
         client = PolarionClient(_config(), write_delay=0)
         await client.close()
         assert client.is_closed
-
-
-# ---------------------------------------------------------------------------
-# 8. Config → base_url wiring
-# ---------------------------------------------------------------------------
 
 
 class TestConfigWiring:

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -69,11 +69,6 @@ class TestExceptionRaiseAndCatch:
             raise PolarionNotFoundError("gone", status_code=404)
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 @contextmanager
 def _raises_polarion_error(
     expected_type: type[PolarionError],

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -36,8 +36,8 @@ from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools import _helpers as _helpers_mod
 from mcp_server_polarion.tools import read as _read_mod
 
-# In FastMCP 3.0, @mcp.tool returns the original function unchanged
-# (not a FunctionTool wrapper), so we reference them directly.
+# ``@mcp.tool`` returns the original function unchanged (not a FunctionTool
+# wrapper), so the tool callables are referenced directly.
 get_document = _read_mod.get_document
 list_document_comments = _read_mod.list_document_comments
 list_document_enum_options = _read_mod.list_document_enum_options

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -40,8 +40,8 @@ from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools import _helpers as _helpers_mod
 from mcp_server_polarion.tools import write as _write_mod
 
-# In FastMCP 3.0, @mcp.tool returns the original function unchanged
-# (not a FunctionTool wrapper), so we reference them directly.
+# ``@mcp.tool`` returns the original function unchanged (not a FunctionTool
+# wrapper), so the tool callables are referenced directly.
 create_document = _write_mod.create_document
 create_document_comments = _write_mod.create_document_comments
 create_work_item = _write_mod.create_work_item
@@ -706,11 +706,6 @@ class TestCreateWorkItemFieldValidation:
             adapter.validate_python("x" * (2_000_000 + 1))
 
 
-# ===========================================================================
-# move_work_item_to_document
-# ===========================================================================
-
-
 class TestBuildMoveToDocumentPayload:
     """Tests for the private ``_build_move_to_document_payload`` helper."""
 
@@ -1035,11 +1030,6 @@ class TestMoveWorkItemToDocumentFieldValidation:
         assert self._adapter_for("work_item_id").validate_python("MCPT-1") == "MCPT-1"
 
 
-# ===========================================================================
-# move_work_item_from_document
-# ===========================================================================
-
-
 class TestMoveWorkItemFromDocumentDryRun:
     """Tests for ``move_work_item_from_document`` with ``dry_run=True``."""
 
@@ -1196,11 +1186,6 @@ class TestMoveWorkItemFromDocumentFieldValidation:
 
     def test_work_item_id_accepts_non_empty(self) -> None:
         assert self._adapter_for("work_item_id").validate_python("MCPT-1") == "MCPT-1"
-
-
-# ===========================================================================
-# update_work_item
-# ===========================================================================
 
 
 class TestBuildUpdateWorkItemPayload:
@@ -2053,11 +2038,6 @@ class TestUpdateWorkItemFieldValidation:
         # 2 MiB + 1 char is rejected.
         with pytest.raises(ValidationError):
             adapter.validate_python("x" * (2_000_000 + 1))
-
-
-# ===========================================================================
-# update_document
-# ===========================================================================
 
 
 class TestBuildUpdateDocumentPayload:
@@ -2919,11 +2899,6 @@ class TestUpdateDocumentPitfallDocumentation:
             "update_document docstring must surface that the work item's module "
             "relationship stays unset after a macro <div> injection"
         )
-
-
-# ===========================================================================
-# create_document
-# ===========================================================================
 
 
 class TestBuildCreateDocumentPayload:
@@ -4444,11 +4419,6 @@ class TestUpdateWorkItemLinksFieldValidation:
         assert result.updated is True
 
 
-# ---------------------------------------------------------------------------
-# create_document_comments tests
-# ---------------------------------------------------------------------------
-
-
 class TestBuildDocumentCommentsPayload:
     """Unit tests for the private ``_build_document_comments_payload`` helper."""
 
@@ -4855,11 +4825,6 @@ class TestCreateDocumentCommentsFieldValidation:
         result = self._adapter_for("comments").validate_python(specs)
         assert isinstance(result, list)
         assert len(result) == 1
-
-
-# ---------------------------------------------------------------------------
-# update_document_comment
-# ---------------------------------------------------------------------------
 
 
 class TestBuildDocumentCommentUpdatePayload:

--- a/tests/utils/test_html.py
+++ b/tests/utils/test_html.py
@@ -13,10 +13,6 @@ from mcp_server_polarion.utils.html import (
     stamp_block_ids,
 )
 
-# ---------------------------------------------------------------------------
-# html_to_markdown
-# ---------------------------------------------------------------------------
-
 
 class TestHtmlToMarkdown:
     """Verify HTML → Markdown conversion."""
@@ -441,11 +437,6 @@ class TestHtmlToMarkdownPolarionRteLinks:
         assert "polarion:Design/Bracket%20%5BDoc%5D" in result
 
 
-# ---------------------------------------------------------------------------
-# markdown_to_html
-# ---------------------------------------------------------------------------
-
-
 class TestMarkdownToHtml:
     """Verify Markdown → HTML conversion."""
 
@@ -545,11 +536,6 @@ class TestMarkdownToHtml:
         # html_inline rule is disabled → inline HTML is HTML-escaped, not live
         assert "<a onclick=" not in result  # no executable attribute
         assert "&lt;a" in result  # tag is safely encoded as text
-
-
-# ---------------------------------------------------------------------------
-# sanitize_html
-# ---------------------------------------------------------------------------
 
 
 class TestSanitizeHtml:
@@ -699,11 +685,6 @@ class TestSanitizeHtml:
         assert "<font>" not in result
         assert "<marquee>" not in result
         assert "Text" in result
-
-
-# ---------------------------------------------------------------------------
-# Round-trip consistency
-# ---------------------------------------------------------------------------
 
 
 class TestRoundTrip:


### PR DESCRIPTION
## Summary

Sweeps ~90 sites where source comments violated the Comment & Docstring Style rules in [CLAUDE.md](../blob/main/CLAUDE.md). No behavior changes — purely comments, docstrings, and Pydantic `Field(description=...)` text.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- **Banner-divider sandwiches removed** (56 occurrences) — `# ---` / `# ===` triple-line section headers across `models.py`, `tools/{read,write,_helpers}.py`, `core/client.py`, and 4 test modules.
- **`NOTE:` prefix eliminated** — `DocumentDetail.content_html` description rewritten as a plain sentence.
- **Dev-narrative scrubbed** — `"in v1"`, `"verified to be safe on repeat ... Conservative until confirmed"`, `"observed `relates_to` on `MCP_Test_Project / E2E_WriteFlow_20260525`"`, `"clearing semantics are intentionally out of scope for this phase"`, and `"Observed real document bodies stay under ~30 KB"` all rephrased as declarative statements.
- **Field descriptions condensed to one line** — every multi-line `Field(description=...)` in `models.py` (worst offenders: `DocumentDetail.content_html`/`custom_fields`, `WorkItemDetail.description_html`/`custom_fields`, `DocumentPart.*`, `WorkItemLinksDeleteResult.link_ids`) compressed; nuance hoisted into the surrounding class docstring where it is still LLM-visible via the result schema.
- **Module docstring trimmed** — `tools/read.py` no longer claims a stale tool count, and `tools/write.py` drops the "Currently provides ..." enumeration of every tool name.
- **`FastMCP 3.0` version anchor genericized** in 3 spots (`tools/read.py` x2, `tests/tools/test_{read,write}.py` x2) — the `@mcp.tool` pass-through behavior is stated without naming the major version.

## Testing

- [x] Unit tests added / updated (`tests/`) — only banner removals in tests; no logic touched.
- [x] `dry_run=True` path verified for all write tools — covered by the existing 708-test suite.
- [x] `uv run pytest` passes locally — `708 passed in 16.13s`.
- [x] `uv run mypy src/` passes with no errors.
- [x] `uv run ruff check src tests` passes with no warnings.

```bash
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)