### PR TITLE
ci(meta): auto-merge dependabot minor/patch

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,41 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Flag major updates for manual review
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: gh pr edit "$PR_URL" --add-label major-update
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Request review on major updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-major'
+          && (github.event.action == 'opened' || github.event.action == 'reopened')
+        run: gh pr edit "$PR_URL" --add-reviewer devemberx
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Manually rebasing and merging every Dependabot PR is high-friction under this repo's ruleset (required signatures + strict up-to-date status checks). This adds a workflow that auto-merges low-risk bumps and routes risky ones to review.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [x] CI / tooling / dependency update

---

## Changes

- Add `.github/workflows/dependabot-auto-merge.yml` triggered on Dependabot `pull_request` events.
- Patch/minor updates: enable squash auto-merge (`gh pr merge --auto --squash`), gated on the `test` check.
- Major updates: apply `major-update` label and request `@devemberx` as reviewer instead of merging.

---

## Testing

- [ ] Unit tests added / updated (`tests/`)
- [ ] `dry_run=True` path verified for all write tools
- [ ] `uv run pytest` passes locally
- [ ] `uv run mypy src/` passes with no errors
- [ ] `uv run ruff check src tests` passes with no warnings

Workflow-only change (no source touched). Validated against the active `project-main` ruleset: GitHub-generated squash commits are signed (satisfies required signatures), and Dependabot auto-rebases keep PRs current for the strict status-check policy. End-to-end behavior verifies once merged and the next Dependabot PR opens.

---

## Notes for Reviewers

- Repo auto-merge is now enabled and the `major-update` label was created — both prerequisites for this workflow.
- Auto-merged squash commits use Dependabot's default PR title as the subject and do not follow the 2-bullet commit-body convention; the local `commit-msg` hook does not run on server-side squash, so merges are not blocked.
