### PR TITLE
fix(meta): prevent runaway eval agents

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -61,6 +61,24 @@ EVAL_MODEL=ollama_chat/qwen3.5:9b-mlx uv run python -m evals.run
 
 `temperature` is pinned to 0 to keep the zero-tolerance gate stable.
 
+## Runaway protection
+
+Local models can loop indefinitely without producing a final answer. Each case
+is bounded by two limits; hitting either yields an `<agent-error: ...>` output
+that the gate treats as **fail** (fail-closed).
+
+| Env var             | Default | Cap                                                       |
+| ------------------- | ------- | --------------------------------------------------------- |
+| `EVAL_MAX_CYCLES`   | `10`    | Model calls per case (`BeforeModelCallEvent` hook count). |
+| `EVAL_CASE_TIMEOUT` | `120`   | Wall-clock seconds (`asyncio.wait_for`).                  |
+
+For slow CPU inference raise `EVAL_CASE_TIMEOUT`:
+
+```bash
+EVAL_MAX_CYCLES=10 EVAL_CASE_TIMEOUT=600 \
+  EVAL_MODEL=ollama_chat/gemma4:e4b uv run python -m evals.run
+```
+
 ## CI
 
 - **Hard gate** — the `evals` job in

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -17,11 +17,13 @@ from __future__ import annotations
 
 import asyncio
 import os
+from collections.abc import Callable
 from typing import Any
 
 import respx
 from fastmcp import Client
 from strands import Agent
+from strands.hooks import BeforeModelCallEvent
 from strands_evals import Case
 from strands_evals.types import TaskOutput
 
@@ -31,6 +33,12 @@ from mcp_server_polarion.server import mcp
 from .fake_polarion import POLARION_HOST, PROJECT, FakePolarion
 from .mcp_bridge import TrajectoryRecorder, build_agent_tools
 from .model import build_model
+
+# Hard caps to prevent runaway agents (e.g. local models that loop indefinitely).
+# _MAX_CYCLES counts BeforeModelCallEvent firings; _CASE_TIMEOUT_SECONDS is a
+# wall-clock ceiling for the entire invoke_async call.
+_MAX_CYCLES: int = int(os.environ.get("EVAL_MAX_CYCLES", "10"))
+_CASE_TIMEOUT_SECONDS: float = float(os.environ.get("EVAL_CASE_TIMEOUT", "120"))
 
 # Deliberately generic: it must NOT teach the agent the Tier-1 rules, or the
 # eval would test the prompt rather than the tool docstrings (the only guard).
@@ -64,19 +72,60 @@ def _set_polarion_env() -> None:
     os.environ["POLARION_TOKEN"] = "fake-token"
 
 
+def _make_cycle_guard(
+    max_cycles: int,
+) -> tuple[Callable[[BeforeModelCallEvent], None], Callable[[], int]]:
+    """Build a model-call counter hook + an inspector for the final count.
+
+    The hook flips ``stop_event_loop`` once the count exceeds *max_cycles*.
+    The caller reads the inspector after invoke to fail-closed on a forced
+    stop: a clean ``stop_event_loop`` would otherwise return whatever partial
+    text the agent emitted, which could be empty and silently pass.
+    """
+    count = 0
+
+    def hook(event: BeforeModelCallEvent) -> None:
+        nonlocal count
+        count += 1
+        if count > max_cycles:
+            rs: dict[str, object] = event.invocation_state.setdefault(
+                "request_state", {}
+            )
+            rs["stop_event_loop"] = True
+
+    def get_count() -> int:
+        return count
+
+    return hook, get_count
+
+
 async def _run_case_async(case: Case, recorder: TrajectoryRecorder) -> str:
     async with Client(mcp) as mcp_client:
         tools = await build_agent_tools(mcp_client, recorder)
+        cycle_hook, cycle_count = _make_cycle_guard(_MAX_CYCLES)
         agent = Agent(
             model=build_model(),
             tools=tools,
             system_prompt=SYSTEM_PROMPT,
+            hooks=[cycle_hook],
         )
         try:
-            result = await agent.invoke_async(case.input)
-            return _extract_text(result)
+            result = await asyncio.wait_for(
+                agent.invoke_async(case.input),
+                timeout=_CASE_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            return (
+                f"{AGENT_ERROR_PREFIX} TimeoutError: "
+                f"case exceeded {_CASE_TIMEOUT_SECONDS:.0f}s>"
+            )
         except Exception as exc:
             return f"{AGENT_ERROR_PREFIX} {type(exc).__name__}: {exc}>"
+        if cycle_count() > _MAX_CYCLES:
+            return (
+                f"{AGENT_ERROR_PREFIX} CycleGuard: exceeded {_MAX_CYCLES} model cycles>"
+            )
+        return _extract_text(result)
 
 
 def run_case(case: Case) -> TaskOutput:

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -37,8 +37,10 @@ from .model import build_model
 # Hard caps to prevent runaway agents (e.g. local models that loop indefinitely).
 # _MAX_CYCLES counts BeforeModelCallEvent firings; _CASE_TIMEOUT_SECONDS is a
 # wall-clock ceiling for the entire invoke_async call.
-_MAX_CYCLES: int = int(os.environ.get("EVAL_MAX_CYCLES", "10"))
-_CASE_TIMEOUT_SECONDS: float = float(os.environ.get("EVAL_CASE_TIMEOUT", "120"))
+_MAX_CYCLES: int = max(1, int(os.environ.get("EVAL_MAX_CYCLES", "10")))
+_CASE_TIMEOUT_SECONDS: float = max(
+    1.0, float(os.environ.get("EVAL_CASE_TIMEOUT", "120"))
+)
 
 # Deliberately generic: it must NOT teach the agent the Tier-1 rules, or the
 # eval would test the prompt rather than the tool docstrings (the only guard).


### PR DESCRIPTION
## Summary

Local model evals (Gemma, etc.) currently loop indefinitely because Strands
`Agent` has no built-in iteration cap and `run_case` calls `invoke_async`
without a wall-clock timeout. This PR adds two layered bounds plus a
fail-closed exit so the gate cannot silently pass on a forced stop.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- `evals/harness/runner.py`: `_make_cycle_guard` returns a `BeforeModelCallEvent`
  hook that flips `stop_event_loop` once the count exceeds `EVAL_MAX_CYCLES`
  (default **10** — 7 Tier-1 cases need at most ~6 calls, so 10 gives ~67%
  headroom), plus an inspector the caller checks after `invoke_async`.
- `_run_case_async` wraps the call in `asyncio.wait_for(timeout=EVAL_CASE_TIMEOUT)`
  (default **120s**) and emits `AGENT_ERROR_PREFIX` for both the timeout path
  and the cycle-cap path. The gate already maps that prefix to FAIL in
  `_evaluate_once` — fail-closed.
- `evals/README.md`: new "Runaway protection" section documenting both env
  vars and CPU-inference guidance.

## Out of scope (upstream)

Two errors that surface in the same logs are **not** fixable at our layer:

- `TypeAdapter[ForwardRef('Root')] is not fully defined` — FastMCP's
  `json_schema_to_type` returns an unresolved `ForwardRef` for self-referential
  schemas; `Client` exposes no validation toggle. Benign:
  `structured_content` still returns. Upstream FastMCP issue.
- `reasoningContent is not supported in multi-turn conversations` — Strands
  routes Claude `thinking` blocks through Chat Completions history. Gemma
  emits no thinking blocks so it never triggers there; Claude-only.

## Testing

- [ ] Unit tests added / updated (`tests/`)
- [ ] `dry_run=True` path verified for all write tools
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

Notes:
- No new unit tests; behaviour requires Strands hook mocking and is covered by the smoke run below.
- Harness-only change, no write tools touched (`dry_run` N/A).
- `tests/evals/` 32/32 pass. Unrelated transport/config failures are pre-existing on `main` (local `.env` leaking `OPEN_API_KEY` into `PolarionConfig`).

### Smoke (gemma4:e4b via Ollama)

| Run | Result |
| --- | --- |
| `EVAL_MODEL=ollama_chat/gemma4:e4b ... --case T1-READONLY --runs 1` | PASS — 5 tool calls, terminated naturally well under timeout. |
| Same case with `EVAL_MAX_CYCLES=1` (forced) | FAIL with `<agent-error: CycleGuard: exceeded 1 model cycles>` — confirms fail-closed. |

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [ ] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [ ] All new tool functions are `async def`
- [ ] Tool docstrings follow Google style with Args / Returns / Raises
- [ ] Synthesis read paths (`read_document`, `read_document_parts`) convert HTML → Markdown via `html_to_markdown()`
- [ ] Greenfield write paths (`create_work_item(description=...)`) convert Markdown → HTML via `markdown_to_html()` + `sanitize_html()`
- [ ] Round-trip pairs (`get_*(include_*_html=True)` ↔ `update_*(*_html=...)`) pass raw Polarion HTML verbatim — no Markdown conversion, no sanitization
- [ ] Any new list tool supports `page_size` and `page_number` pagination
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

## Notes for Reviewers

The cycle guard inspector pattern (closure returning `(hook, get_count)`)
was chosen over a class-with-`__call__` because Strands hook dispatch
relies on function-signature introspection; a plain function is the
safest contract.

`_MAX_CYCLES` was tuned to **10** after inspecting all 7 Tier-1 cases —
T1-ENUM-FIRST is the hottest at ~6 realistic calls. 20 was too lax,
15 still lets a stuck loop chew several extra LLM round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
