### PR TITLE
fix(model): drop recursive alias in results

### DIFF
--- a/src/mcp_server_polarion/models.py
+++ b/src/mcp_server_polarion/models.py
@@ -16,12 +16,17 @@ Models are organised into three categories:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-# Recursive JSON-safe type alias.  Constrains payload previews and change
-# maps to values that are guaranteed to round-trip through JSON-RPC.
+# Recursive JSON-safe alias for internal payload builders. Result-model
+# fields below intentionally surface payload previews as
+# `Mapping[str, object]` instead of `dict[str, JsonValue]`: the recursive
+# alias emits a `$defs/JsonValue` self-reference that the FastMCP client's
+# `json_schema_to_type` cannot rebuild, producing an unresolved
+# `ForwardRef('Root')` TypeAdapter and noisy errors on every write call.
 type JsonValue = (
     str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
 )
@@ -474,7 +479,7 @@ class WorkItemCreateResult(BaseModel):
     work_item_id: str | None = Field(
         description="ID of the new work item (e.g. 'MCPT-042'); None on dry-run.",
     )
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         description="JSON:API payload sent or previewed; None after real ops.",
     )
 
@@ -487,10 +492,10 @@ class WorkItemUpdateResult(BaseModel):
     current: WorkItemDetail | None = Field(
         description="Post-PATCH state for verification; None on dry-run.",
     )
-    changes: dict[str, JsonValue] = Field(
+    changes: Mapping[str, object] = Field(
         description="Map of field names to their new values in the PATCH.",
     )
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         description="JSON:API payload sent or previewed; None after real ops.",
     )
 
@@ -503,7 +508,7 @@ class DocumentCommentsCreateResult(BaseModel):
     comment_ids: list[str] = Field(
         description="Short IDs in Polarion's return order; empty on dry-run.",
     )
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         description="JSON:API payload sent or previewed; None after real ops.",
     )
 
@@ -519,7 +524,7 @@ class DocumentCommentUpdateResult(BaseModel):
     resolved: bool = Field(
         description="The resolved value sent (or that would be sent).",
     )
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         description="JSON:API payload sent or previewed; None after real ops.",
     )
 
@@ -560,7 +565,7 @@ class WorkItemLinksCreateResult(BaseModel):
         default_factory=list,
         description="Composite 5-segment link ids in input order; empty on dry-run.",
     )
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         default=None,
         description="JSON:API payload sent or previewed; None after real ops.",
     )
@@ -581,7 +586,7 @@ class WorkItemLinksDeleteResult(BaseModel):
         default_factory=list,
         description="Composite 5-segment ids reconstructed from the request refs.",
     )
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         default=None,
         description="JSON:API payload sent or previewed; None after real ops.",
     )
@@ -631,7 +636,7 @@ class WorkItemLinkUpdateResult(BaseModel):
     link_id: str = Field(
         description="Composite 5-segment id computed from inputs.",
     )
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         description="JSON:API PATCH body; None after real ops.",
     )
 
@@ -641,7 +646,7 @@ class WorkItemMoveResult(BaseModel):
 
     moved: bool = Field(description="True on a real move; False on dry-run.")
     dry_run: bool = Field(description="Whether this was a dry-run.")
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         description="Request payload sent or previewed; None after real ops.",
     )
 
@@ -654,7 +659,7 @@ class DocumentCreateResult(BaseModel):
     document_name: str | None = Field(
         description="Module name of the new document; None on dry-run.",
     )
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         description="JSON:API payload sent or previewed; None after real ops.",
     )
 
@@ -664,7 +669,7 @@ class DocumentUpdateResult(BaseModel):
 
     updated: bool = Field(description="True on a real PATCH; False on dry-run.")
     dry_run: bool = Field(description="Whether this was a dry-run.")
-    payload_preview: dict[str, JsonValue] | None = Field(
+    payload_preview: Mapping[str, object] | None = Field(
         description="JSON:API payload sent or previewed; None after real ops.",
     )
 

--- a/tests/test_mcp_transport.py
+++ b/tests/test_mcp_transport.py
@@ -201,3 +201,31 @@ class TestEndToEndInvocation:
         assert "payload_preview" in body
         assert body["payload_preview"]["data"][0]["type"] == "workitems"
         assert body["payload_preview"]["data"][0]["attributes"]["title"] == "smoke"
+
+    async def test_create_work_item_dry_run_materialises_result_data(
+        self,
+        mcp_client: _MCPClient,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # Regression guard: result-model fields with recursive type aliases
+        # produce a `$defs` self-reference that fastmcp 3.3.1's
+        # json_schema_to_type cannot rebuild, leaving result.data unmaterialised
+        # and logging "Error parsing structured content" on every write call.
+        with caplog.at_level("WARNING", logger="fastmcp"):
+            result = await mcp_client.call_tool(
+                "create_work_item",
+                {
+                    "project_id": "MCP_Test_Project",
+                    "title": "smoke",
+                    "type": "task",
+                    "dry_run": True,
+                },
+            )
+
+        assert not any(
+            "Error parsing structured content" in rec.message for rec in caplog.records
+        )
+        assert result.data is not None
+        assert result.data.dry_run is True
+        assert result.data.work_item_id is None
+        assert result.data.payload_preview is not None


### PR DESCRIPTION
## Summary

The Tier-1 eval workflow (`evals.yml`) logged the following error on every write-tool call made through the in-memory `fastmcp.Client(mcp)`:

```
[Client-xxxx] Error parsing structured content:
`TypeAdapter[ForwardRef('Root')]` is not fully defined; ...
```

Root cause: our result models expose `payload_preview` / `changes` as `dict[str, JsonValue]`, and `JsonValue` is a recursive type alias. Pydantic emits a `$defs/JsonValue` self-reference for the field, and fastmcp 3.3.1's `json_schema_to_type` converter (`fastmcp/utilities/json_schema_type.py:460-465`) treats `#/$defs/...` local self-references as `ForwardRef` placeholders without ever registering or rebuilding them. The resulting `TypeAdapter[ForwardRef('Root')]` then fails `validate_python`. FastMCP swallows the exception, so trajectories still complete, but the noise pollutes every release-gate log.

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- `models.py`: switch result-model `payload_preview` (10 fields) and `WorkItemUpdateResult.changes` from `dict[str, JsonValue]` to `Mapping[str, object]`. Pydantic emits a flat `additionalProperties: true` schema instead of a `$defs/JsonValue` self-reference, so the fastmcp converter no longer produces an unresolved `ForwardRef`.
- Internal payload builders in `tools/write.py` and `tools/_helpers.py` keep the recursive `dict[str, JsonValue]` typing — `Mapping` is covariant, so passing `dict[str, JsonValue]` into a `Mapping[str, object]` parameter is allowed and no call site needed an update.
- Updated the comment on the `JsonValue` alias to spell out why the result-model fields use a different surface type.

---

## Testing

- [ ] Unit tests added / updated (`tests/`)
- [x] `dry_run=True` path verified for all write tools
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run mypy src/                                  # Success: no issues found in 15 source files
uv run ruff check . && uv run ruff format --check .
uv run pytest -q                                  # 793 passed in 16.80s
```

Additionally, drove the in-memory `fastmcp.Client(mcp)` against `create_work_item(dry_run=True)` while capturing the FastMCP logger — the "Error parsing structured content" message no longer fires, and `result.data` is correctly materialised as a dataclass.

---

## Golden Rule Compliance

- [x] No `print()` calls — all logging goes to `stderr` via `logging`
- [x] `from __future__ import annotations` present in every modified module
- [x] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [x] All new tool functions are `async def`
- [x] Tool docstrings follow Google style with Args / Returns / Raises
- [x] Synthesis read paths (`read_document`, `read_document_parts`) convert HTML → Markdown via `html_to_markdown()`
- [x] Greenfield write paths (`create_work_item(description=...)`) convert Markdown → HTML via `markdown_to_html()` + `sanitize_html()`
- [x] Round-trip pairs (`get_*(include_*_html=True)` ↔ `update_*(*_html=...)`) pass raw Polarion HTML verbatim — no Markdown conversion, no sanitization
- [x] Any new list tool supports `page_size` and `page_number` pagination
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

---

## Notes for Reviewers

The wire format is unchanged: Pydantic v2 coerces `Mapping[str, object]` inputs to `dict` at construction, so consumers still receive a plain JSON object. The JSON schema is what shifts — `payload_preview` now serialises to `{"type": "object", "additionalProperties": true}` and the `$defs/JsonValue` entry disappears, which is what unblocks the fastmcp client.

This is a one-line workaround for an upstream fastmcp bug. Filing an issue upstream is the right longer-term fix, but the local change lets the Tier-1 gate run clean immediately.

Generated with Claude Code
