### PR TITLE
fix(meta): backoff eval calls on 429

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -63,14 +63,18 @@ EVAL_MODEL=ollama_chat/qwen3.5:9b-mlx uv run python -m evals.run
 
 ## Runaway protection
 
-Local models can loop indefinitely without producing a final answer. Each case
-is bounded by two limits; hitting either yields an `<agent-error: ...>` output
-that the gate treats as **fail** (fail-closed).
+Local models can loop indefinitely without producing a final answer, and
+cloud providers can return 429 when TPM/RPM is exhausted. Each case is
+bounded by case-level limits (fail-closed via `<agent-error: ...>`) and the
+LiteLLM call itself does exponential backoff on transient errors before
+giving up.
 
-| Env var             | Default | Cap                                                       |
-| ------------------- | ------- | --------------------------------------------------------- |
-| `EVAL_MAX_CYCLES`   | `10`    | Model calls per case (`BeforeModelCallEvent` hook count). |
-| `EVAL_CASE_TIMEOUT` | `120`   | Wall-clock seconds (`asyncio.wait_for`).                  |
+| Env var             | Default | Cap                                                                              |
+| ------------------- | ------- | -------------------------------------------------------------------------------- |
+| `EVAL_MAX_CYCLES`   | `10`    | Model calls per case (`BeforeModelCallEvent` hook count).                        |
+| `EVAL_CASE_TIMEOUT` | `120`   | Wall-clock seconds (`asyncio.wait_for`).                                         |
+| `EVAL_NUM_RETRIES`  | `10`    | LiteLLM retries on 429 / RateLimitError / Timeout (exponential backoff ≤10s/sleep). |
+| `EVAL_LLM_TIMEOUT`  | `60`    | Wall-clock seconds for one model call (LiteLLM `timeout`).                       |
 
 For slow CPU inference raise `EVAL_CASE_TIMEOUT`:
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -65,15 +65,15 @@ EVAL_MODEL=ollama_chat/qwen3.5:9b-mlx uv run python -m evals.run
 
 Local models can loop indefinitely without producing a final answer, and
 cloud providers can return 429 when TPM/RPM is exhausted. Each case is
-bounded by case-level limits (fail-closed via `<agent-error: ...>`) and the
-LiteLLM call itself does exponential backoff on transient errors before
-giving up.
+bounded by case-level limits (fail-closed via `<agent-error: ...>`), and a
+single model call retries transient 429 / network errors with exponential
+backoff (handled by the OpenAI SDK underneath LiteLLM) before giving up.
 
 | Env var             | Default | Cap                                                                              |
 | ------------------- | ------- | -------------------------------------------------------------------------------- |
 | `EVAL_MAX_CYCLES`   | `10`    | Model calls per case (`BeforeModelCallEvent` hook count).                        |
 | `EVAL_CASE_TIMEOUT` | `120`   | Wall-clock seconds (`asyncio.wait_for`).                                         |
-| `EVAL_NUM_RETRIES`  | `10`    | LiteLLM retries on 429 / RateLimitError / Timeout (exponential backoff ≤10s/sleep). |
+| `EVAL_NUM_RETRIES`  | `10`    | LiteLLM `num_retries`; OpenAI SDK sleeps `min(0.5·2ⁿ, 8)s` with ±25 % jitter, or honours `Retry-After` if present. |
 | `EVAL_LLM_TIMEOUT`  | `60`    | Wall-clock seconds for one model call (LiteLLM `timeout`).                       |
 
 For slow CPU inference raise `EVAL_CASE_TIMEOUT`:

--- a/evals/README.md
+++ b/evals/README.md
@@ -76,6 +76,12 @@ backoff (handled by the OpenAI SDK underneath LiteLLM) before giving up.
 | `EVAL_NUM_RETRIES`  | `10`    | LiteLLM `num_retries`; OpenAI SDK sleeps `min(0.5·2ⁿ, 8)s` with ±25 % jitter, or honours `Retry-After` if present. |
 | `EVAL_LLM_TIMEOUT`  | `60`    | Wall-clock seconds for one model call (LiteLLM `timeout`).                       |
 
+`EVAL_LLM_TIMEOUT` is per attempt — worst-case wall-clock for one model
+call is `EVAL_NUM_RETRIES × EVAL_LLM_TIMEOUT` when every attempt times out
+without a fast 429 response. Raise `EVAL_CASE_TIMEOUT` in lockstep when
+bumping either, or the case fail-closes via `asyncio.wait_for` before the
+retry budget is exhausted.
+
 For slow CPU inference raise `EVAL_CASE_TIMEOUT`:
 
 ```bash

--- a/evals/README.md
+++ b/evals/README.md
@@ -83,7 +83,7 @@ EVAL_MAX_CYCLES=10 EVAL_CASE_TIMEOUT=600 \
   EVAL_MODEL=ollama_chat/gemma4:e4b uv run python -m evals.run
 ```
 
-## CI
+## Release pipeline
 
 - **Hard gate** — the `evals` job in
   [`publish.yml`](../.github/workflows/publish.yml) runs on tag push, and

--- a/evals/harness/model.py
+++ b/evals/harness/model.py
@@ -7,7 +7,9 @@ the ``EVAL_MODEL`` env var, no code change:
     EVAL_MODEL=ollama/qwen2.5-coder:7b       # local (set EVAL_MODEL_BASE_URL)
 
 ``temperature`` is pinned to 0.0 to minimise run-to-run flakiness so the
-zero-tolerance gate stays stable.
+zero-tolerance gate stays stable. ``EVAL_NUM_RETRIES`` / ``EVAL_LLM_TIMEOUT``
+forward to LiteLLM so transient 429/RateLimitError from cloud providers gets
+absorbed by exponential backoff rather than failing the case.
 """
 
 from __future__ import annotations
@@ -41,5 +43,9 @@ def build_model() -> LiteLLMModel:
     return LiteLLMModel(
         client_args=client_args or None,
         model_id=model_id,
-        params={"temperature": 0.0},
+        params={
+            "temperature": 0.0,
+            "num_retries": max(0, int(os.environ.get("EVAL_NUM_RETRIES", "10"))),
+            "timeout": max(1.0, float(os.environ.get("EVAL_LLM_TIMEOUT", "60"))),
+        },
     )


### PR DESCRIPTION
## Summary

Tier-1 evals runs 70 LLM calls (7 cases × 10 runs) serially against gpt-4o-mini, which has a 200K-TPM organization-wide limit. The bucket exhausts within ~1–2 cases and every subsequent run dies on RateLimitError before reaching policy evaluation — masking real eval signal as infrastructure noise (most recent failed run: [26581330406](https://github.com/devemberx/mcp-server-polarion/actions/runs/26581330406)).

Forward `num_retries` and `timeout` through LiteLLM `params`. LiteLLM propagates `num_retries` to `max_retries` on the OpenAI SDK call ([litellm/main.py:1380-1381](https://github.com/BerriAI/litellm/blob/main/litellm/main.py#L1380-L1381) and downstream), and the OpenAI Python SDK then applies exponential backoff on each retry — `sleep_seconds = min(INITIAL_RETRY_DELAY · 2ⁿ, MAX_RETRY_DELAY)` (constants: `0.5s` / `8.0s`) times a `1 − 0.25·random()` jitter factor, with `Retry-After` honoured if `0 < value ≤ 60s` ([openai/_base_client.py:771-793](https://github.com/openai/openai-python/blob/main/src/openai/_base_client.py#L771-L793)). With `EVAL_NUM_RETRIES=10` the cumulative sleep budget is ~42-55 s (post-jitter), enough to cross a TPM minute window.

Both knobs are env-gated (`EVAL_NUM_RETRIES=10`, `EVAL_LLM_TIMEOUT=60`) following the existing `EVAL_MAX_CYCLES` / `EVAL_CASE_TIMEOUT` pattern.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- `evals/harness/model.py`: add `num_retries` / `timeout` to `LiteLLMModel` `params`, env-gated via `EVAL_NUM_RETRIES` (default 10) and `EVAL_LLM_TIMEOUT` (default 60).
- `evals/README.md`: extend Runaway protection table with the two new env vars; intro updated to mention cloud 429 alongside local model loops, and the table cell points to the actual OpenAI SDK backoff formula.

## Testing

- [ ] Unit tests added / updated (`tests/`)
- [ ] `dry_run=True` path verified for all write tools
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run ruff check src tests
uv run ruff format --check src tests
uv run mypy src/
uv run pytest -q
```

## Golden Rule Compliance

- [ ] No `print()` calls — all logging goes to `stderr` via `logging`
- [ ] `from __future__ import annotations` present in every modified module
- [ ] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [ ] All new tool functions are `async def`
- [ ] Tool docstrings follow Google style with Args / Returns / Raises
- [ ] Synthesis read paths (`read_document`, `read_document_parts`) convert HTML → Markdown via `html_to_markdown()`
- [ ] Greenfield write paths (`create_work_item(description=...)`) convert Markdown → HTML via `markdown_to_html()` + `sanitize_html()`
- [ ] Round-trip pairs (`get_*(include_*_html=True)` ↔ `update_*(*_html=...)`) pass raw Polarion HTML verbatim — no Markdown conversion, no sanitization
- [ ] Any new list tool supports `page_size` and `page_number` pagination
- [x] No secrets hardcoded — env vars via `pydantic-settings` only

## Notes for Reviewers

- Builds on [`e019f0a` hotfix](https://github.com/devemberx/mcp-server-polarion/commit/e019f0a) (HookProvider wrap) — that fix got past the constructor crash, exposing the underlying TPM issue this PR addresses.
- `publish.yml` gate stays at 10 runs (composite action default unchanged); only the manual `Tier-1 Evals` workflow needs `runs=5` to land cleanly inside the minute window.
- Post-merge verification: trigger `Tier-1 Evals` on main with `gh workflow run evals.yml --ref main -f runs=5` and confirm GATE = PASS (or fails with genuine policy violations, not RateLimitError chains).
