### PR TITLE
refactor(tool): extract TTL caches into _cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 ## Architecture
 
 - **`core/`** — `client.py` (async httpx wrapper, 429/5xx backoff, post-mutation delay, maps to `PolarionError` / `PolarionAuthError` / `PolarionNotFoundError`), `config.py` (Pydantic settings: `POLARION_URL`, `POLARION_TOKEN`, `POLARION_VERIFY_SSL`), `logging.py` (stderr-only, called from server lifespan), `exceptions.py`. Every module: `logging.getLogger("mcp_server_polarion.<module>")`.
-- **`tools/`** — `read.py` (12 read tools), `write.py` (11 write tools, each with its `_build_*_payload` helper as the unit-testable seam), `_helpers.py` (sparse-fieldset constants, JSON:API extractors, pagination, custom-field merge).
+- **`tools/`** — `read.py` (12 read tools), `write.py` (11 write tools, each with its `_build_*_payload` helper as the unit-testable seam), `_helpers.py` (sparse-fieldset constants, JSON:API extractors, pagination, custom-field merge), `_cache.py` (generic `TTLCache[K, V]` primitive + all cache state — document-discovery, enum-option, and observed custom-field-key caches — behind get/store/record wrappers).
 - **`utils/html.py`** — Markdown ↔ HTML (markdownify + BeautifulSoup4 sanitization) plus `stamp_block_ids` for write-side anchor injection.
 - **`models.py`** — Pydantic v2. `PaginatedResult[T]` wraps all list responses.
 - **`server.py`** — FastMCP instance with lifespan that opens/closes `PolarionClient`.

--- a/src/mcp_server_polarion/tools/_cache.py
+++ b/src/mcp_server_polarion/tools/_cache.py
@@ -1,0 +1,207 @@
+"""In-process TTL caches shared across tool implementations.
+
+Tools repeatedly resolve the same near-static project facts within a single
+session -- the documents in a project, the valid option ids for an enum
+field, the custom-field keys observed on a work item or document. Re-fetching
+each on every call would burn the server's tight request budget (<=3 req/s,
+no client-side concurrency), so each is memoised behind a short-lived cache.
+
+This module owns all cache state. Tool logic (request shaping, JSON:API
+extraction, write guards) lives elsewhere and reaches the caches only through
+the typed get / store / record wrappers below, keeping cache lifetime and
+key shape in one place.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Final, Literal
+
+
+def _now() -> float:
+    """Monotonic clock seam; patched wholesale in tests to drive TTL expiry."""
+    return time.monotonic()
+
+
+@dataclass(frozen=True, slots=True)
+class _Entry[V]:
+    expires_at: float
+    value: V
+
+
+class TTLCache[K, V]:
+    """Hashable-keyed cache whose entries expire ``ttl_seconds`` after a set.
+
+    Single-process and single-threaded (the server issues no concurrent
+    requests). Expiry is lazy -- a key is dropped only when next accessed past
+    its deadline -- so a bounded key space never accumulates dead entries
+    beyond that bound.
+    """
+
+    def __init__(self, ttl_seconds: float) -> None:
+        self._ttl = ttl_seconds
+        self._entries: dict[K, _Entry[V]] = {}
+
+    def get(self, key: K) -> V | None:
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        if _now() >= entry.expires_at:
+            self._entries.pop(key, None)
+            return None
+        return entry.value
+
+    def set(self, key: K, value: V) -> None:
+        self._entries[key] = _Entry(expires_at=_now() + self._ttl, value=value)
+
+    def invalidate(self, key: K) -> None:
+        self._entries.pop(key, None)
+
+    def clear(self) -> None:
+        self._entries.clear()
+
+
+Resource = Literal["workitems", "documents"]
+
+# Enum options and custom-field schema are project config, near-static within
+# a session. The binding TTL constraint is not freshness but the ghost-safety
+# window: if an admin removes an option mid-session, a stale entry keeps
+# accepting the now-invalid value until expiry. 60s keeps that window short
+# while staying well inside the <=3 req/s budget.
+_GUARD_TTL_SECONDS: Final[float] = 60.0
+
+# The document listing is mutable: a freshly created document must surface
+# within ~1 minute, and ``create_document`` invalidates the entry on write.
+# Same ceiling, different reason -- freshness rather than ghost-safety.
+_DOCUMENT_LIST_TTL_SECONDS: Final[float] = 60.0
+
+# project_id -> tuple of (space_id, document_name) pairs.
+_document_list_cache: TTLCache[str, tuple[tuple[str, str], ...]] = TTLCache(
+    _DOCUMENT_LIST_TTL_SECONDS
+)
+# (project, resource, field, type) -> valid option ids.
+_enum_option_cache: TTLCache[tuple[str, Resource, str, str], frozenset[str]] = TTLCache(
+    _GUARD_TTL_SECONDS
+)
+# (project, work_item_type) -> custom-field keys seen on get_work_item.
+_work_item_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
+    _GUARD_TTL_SECONDS
+)
+# (project, space, document) -> custom-field keys seen on get_document.
+_document_custom_key_cache: TTLCache[tuple[str, str, str], frozenset[str]] = TTLCache(
+    _GUARD_TTL_SECONDS
+)
+
+
+def get_cached_documents(project_id: str) -> list[tuple[str, str]] | None:
+    """Return the cached document list for *project_id* or ``None``."""
+    cached = _document_list_cache.get(project_id)
+    return list(cached) if cached is not None else None
+
+
+def store_cached_documents(
+    project_id: str,
+    documents: list[tuple[str, str]],
+) -> None:
+    """Cache *documents* for *project_id* for ``_DOCUMENT_LIST_TTL_SECONDS``."""
+    _document_list_cache.set(project_id, tuple(documents))
+
+
+def invalidate_documents_cache(project_id: str) -> None:
+    """Drop the cached document list for *project_id*, if any."""
+    _document_list_cache.invalidate(project_id)
+
+
+def get_cached_enum_options(
+    project_id: str,
+    resource: Resource,
+    field_id: str,
+    type_id: str,
+) -> frozenset[str] | None:
+    """Return cached valid option ids for the field/type, or ``None`` on miss."""
+    return _enum_option_cache.get((project_id, resource, field_id, type_id))
+
+
+def store_cached_enum_options(
+    project_id: str,
+    resource: Resource,
+    field_id: str,
+    type_id: str,
+    option_ids: frozenset[str],
+) -> None:
+    """Cache the valid option ids for the field/type for ``_GUARD_TTL_SECONDS``."""
+    _enum_option_cache.set((project_id, resource, field_id, type_id), option_ids)
+
+
+def _record_custom_keys[KT: tuple[str, ...]](
+    cache: TTLCache[KT, frozenset[str]],
+    key: KT,
+    keys: Iterable[str],
+) -> None:
+    """Union *keys* (filtered to non-empty strings) into the cached set at *key*."""
+    new_keys = frozenset(k for k in keys if isinstance(k, str) and k)
+    cache.set(key, (cache.get(key) or frozenset()) | new_keys)
+
+
+def get_work_item_custom_keys(
+    project_id: str,
+    work_item_type: str,
+) -> frozenset[str] | None:
+    """Return keys seen on this ``(project, work_item_type)``, or ``None``."""
+    return _work_item_custom_key_cache.get((project_id, work_item_type))
+
+
+def record_work_item_custom_field_keys(
+    project_id: str,
+    work_item_type: str,
+    keys: Iterable[str],
+) -> None:
+    """Merge *keys* into the per-``(project, work_item_type)`` observed set.
+
+    Called from ``get_work_item`` so a later ``update_work_item`` can validate
+    ``custom_fields`` against ids the caller has actually seen. Empty *keys*
+    still records the type as observed, so no inline fetch is needed later.
+    """
+    _record_custom_keys(_work_item_custom_key_cache, (project_id, work_item_type), keys)
+
+
+def get_document_custom_keys(
+    project_id: str,
+    space_id: str,
+    document_name: str,
+) -> frozenset[str] | None:
+    """Return keys seen on this ``(project, space, document)``, or ``None``."""
+    return _document_custom_key_cache.get((project_id, space_id, document_name))
+
+
+def record_document_custom_field_keys(
+    project_id: str,
+    space_id: str,
+    document_name: str,
+    keys: Iterable[str],
+) -> None:
+    """Merge *keys* into the per-``(project, space, document)`` observed set.
+
+    Called from ``get_document`` so a later ``update_document`` can validate
+    ``custom_fields`` against ids the caller has actually seen.
+    """
+    _record_custom_keys(
+        _document_custom_key_cache, (project_id, space_id, document_name), keys
+    )
+
+
+__all__ = [
+    "Resource",
+    "TTLCache",
+    "get_cached_documents",
+    "get_cached_enum_options",
+    "get_document_custom_keys",
+    "get_work_item_custom_keys",
+    "invalidate_documents_cache",
+    "record_document_custom_field_keys",
+    "record_work_item_custom_field_keys",
+    "store_cached_documents",
+    "store_cached_enum_options",
+]

--- a/src/mcp_server_polarion/tools/_helpers.py
+++ b/src/mcp_server_polarion/tools/_helpers.py
@@ -13,8 +13,6 @@ inside ``read_document_parts``) and lives in ``tools.read``.
 from __future__ import annotations
 
 import re
-import time
-from dataclasses import dataclass
 from typing import Final, Literal, TypedDict, cast
 from urllib.parse import quote
 
@@ -655,49 +653,6 @@ def build_document_comment(item: dict[str, object]) -> DocumentComment:
     )
 
 
-# Document-discovery TTL cache (in-process, keyed by project_id).
-# A short TTL keeps paginated `list_documents` calls cheap while ensuring
-# newly-created documents appear within ~1 minute. ``create_document`` calls
-# ``invalidate_documents_cache`` to clear the entry immediately on write.
-_CACHE_TTL_SECONDS: Final[float] = 60.0
-
-
-@dataclass(frozen=True, slots=True)
-class _DocCacheEntry:
-    expires_at: float
-    documents: tuple[tuple[str, str], ...]
-
-
-_documents_cache: dict[str, _DocCacheEntry] = {}
-
-
-def get_cached_documents(project_id: str) -> list[tuple[str, str]] | None:
-    """Return the cached document list for *project_id* or ``None``."""
-    entry = _documents_cache.get(project_id)
-    if entry is None:
-        return None
-    if time.monotonic() >= entry.expires_at:
-        _documents_cache.pop(project_id, None)
-        return None
-    return list(entry.documents)
-
-
-def store_cached_documents(
-    project_id: str,
-    documents: list[tuple[str, str]],
-) -> None:
-    """Cache *documents* for *project_id* for ``_CACHE_TTL_SECONDS``."""
-    _documents_cache[project_id] = _DocCacheEntry(
-        expires_at=time.monotonic() + _CACHE_TTL_SECONDS,
-        documents=tuple(documents),
-    )
-
-
-def invalidate_documents_cache(project_id: str) -> None:
-    """Drop the cached document list for *project_id*, if any."""
-    _documents_cache.pop(project_id, None)
-
-
 __all__: list[str] = [
     "DEFAULT_PAGE_SIZE",
     "DOCUMENT_COMMENT_LIST_FIELDS",
@@ -717,17 +672,14 @@ __all__: list[str] = [
     "extract_relationship_ids",
     "extract_short_id",
     "extract_total_count",
-    "get_cached_documents",
     "get_client",
     "has_links_next",
-    "invalidate_documents_cache",
     "merge_custom_fields",
     "parse_hyperlinks",
     "parse_work_item_detail",
     "parse_work_item_summaries",
     "safe_str",
     "split_module_id",
-    "store_cached_documents",
     "summary_to_back_link",
     "validate_work_item_id_for_lucene",
 ]

--- a/src/mcp_server_polarion/tools/read.py
+++ b/src/mcp_server_polarion/tools/read.py
@@ -40,6 +40,10 @@ from mcp_server_polarion.models import (
     WorkItemSummary,
 )
 from mcp_server_polarion.server import mcp
+from mcp_server_polarion.tools._cache import (
+    get_cached_documents,
+    store_cached_documents,
+)
 from mcp_server_polarion.tools._enum_guard import record_custom_keys_from_get
 from mcp_server_polarion.tools._helpers import (
     DEFAULT_PAGE_SIZE,
@@ -57,13 +61,11 @@ from mcp_server_polarion.tools._helpers import (
     extract_relationship_id,
     extract_short_id,
     extract_total_count,
-    get_cached_documents,
     get_client,
     parse_work_item_detail,
     parse_work_item_summaries,
     safe_str,
     split_module_id,
-    store_cached_documents,
     summary_to_back_link,
     validate_work_item_id_for_lucene,
 )

--- a/src/mcp_server_polarion/tools/write.py
+++ b/src/mcp_server_polarion/tools/write.py
@@ -41,6 +41,7 @@ from mcp_server_polarion.models import (
     WorkItemUpdateResult,
 )
 from mcp_server_polarion.server import mcp
+from mcp_server_polarion.tools._cache import invalidate_documents_cache
 from mcp_server_polarion.tools._enum_guard import (
     guard_document_enums,
     guard_update_custom_field_keys,
@@ -54,7 +55,6 @@ from mcp_server_polarion.tools._helpers import (
     encode_path_segment,
     extract_short_id,
     get_client,
-    invalidate_documents_cache,
     merge_custom_fields,
     parse_work_item_detail,
     safe_str,

--- a/tests/tools/test_cache.py
+++ b/tests/tools/test_cache.py
@@ -1,0 +1,229 @@
+"""Tests for ``tools/_cache.py``.
+
+Covers the ``TTLCache`` primitive (hit / miss / overwrite / lazy expiry /
+invalidate / clear) and the typed get / store / record wrappers the tool
+layer reaches the caches through. TTL expiry is driven by patching the
+module-level ``_now`` clock seam.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server_polarion.tools import _cache as cache_mod
+from mcp_server_polarion.tools._cache import (
+    TTLCache,
+    get_cached_documents,
+    get_cached_enum_options,
+    get_document_custom_keys,
+    get_work_item_custom_keys,
+    invalidate_documents_cache,
+    record_document_custom_field_keys,
+    record_work_item_custom_field_keys,
+    store_cached_documents,
+    store_cached_enum_options,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    """Start each test with every module-level cache cold."""
+    cache_mod._document_list_cache.clear()
+    cache_mod._enum_option_cache.clear()
+    cache_mod._work_item_custom_key_cache.clear()
+    cache_mod._document_custom_key_cache.clear()
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Patch the cache clock to a controllable list-wrapped value."""
+    now = [1000.0]
+    monkeypatch.setattr(cache_mod, "_now", lambda: now[0])
+    return now
+
+
+class TestTTLCachePrimitive:
+    """Behaviour of the generic ``TTLCache`` independent of any wrapper."""
+
+    def test_miss_returns_none(self) -> None:
+        cache: TTLCache[str, int] = TTLCache(60.0)
+
+        assert cache.get("absent") is None
+
+    def test_set_then_get_hits(self) -> None:
+        cache: TTLCache[str, int] = TTLCache(60.0)
+        cache.set("k", 7)
+
+        assert cache.get("k") == 7
+
+    def test_set_overwrites_value_and_resets_deadline(self, clock: list[float]) -> None:
+        cache: TTLCache[str, int] = TTLCache(60.0)
+        cache.set("k", 1)
+        clock[0] += 30.0
+        cache.set("k", 2)
+        clock[0] += 40.0  # 70s since first set, only 40s since second
+
+        assert cache.get("k") == 2
+
+    def test_entry_expires_after_ttl(self, clock: list[float]) -> None:
+        cache: TTLCache[str, int] = TTLCache(60.0)
+        cache.set("k", 1)
+
+        clock[0] += 61.0
+        assert cache.get("k") is None
+
+    def test_entry_live_at_exactly_below_ttl(self, clock: list[float]) -> None:
+        cache: TTLCache[str, int] = TTLCache(60.0)
+        cache.set("k", 1)
+
+        clock[0] += 59.9
+        assert cache.get("k") == 1
+
+    def test_expiry_is_inclusive_at_deadline(self, clock: list[float]) -> None:
+        cache: TTLCache[str, int] = TTLCache(60.0)
+        cache.set("k", 1)
+
+        clock[0] += 60.0  # _now >= expires_at drops the entry
+        assert cache.get("k") is None
+
+    def test_invalidate_drops_one_key(self) -> None:
+        cache: TTLCache[str, int] = TTLCache(60.0)
+        cache.set("a", 1)
+        cache.set("b", 2)
+
+        cache.invalidate("a")
+
+        assert cache.get("a") is None
+        assert cache.get("b") == 2
+
+    def test_invalidate_absent_key_is_a_no_op(self) -> None:
+        cache: TTLCache[str, int] = TTLCache(60.0)
+
+        cache.invalidate("absent")  # must not raise
+
+    def test_clear_drops_everything(self) -> None:
+        cache: TTLCache[str, int] = TTLCache(60.0)
+        cache.set("a", 1)
+        cache.set("b", 2)
+
+        cache.clear()
+
+        assert cache.get("a") is None
+        assert cache.get("b") is None
+
+
+class TestDocumentListCache:
+    """The mutable document-discovery listing wrappers."""
+
+    def test_store_then_get_returns_a_list_copy(self) -> None:
+        store_cached_documents("P", [("_default", "Doc")])
+
+        cached = get_cached_documents("P")
+        assert cached == [("_default", "Doc")]
+        # A mutation of the returned list must not corrupt the cache.
+        assert cached is not None
+        cached.append(("_default", "Other"))
+        assert get_cached_documents("P") == [("_default", "Doc")]
+
+    def test_miss_returns_none(self) -> None:
+        assert get_cached_documents("absent") is None
+
+    def test_invalidate_drops_the_project(self) -> None:
+        store_cached_documents("P", [("_default", "Doc")])
+
+        invalidate_documents_cache("P")
+
+        assert get_cached_documents("P") is None
+
+    def test_expiry_uses_document_list_ttl(self, clock: list[float]) -> None:
+        store_cached_documents("P", [("_default", "Doc")])
+
+        clock[0] += cache_mod._DOCUMENT_LIST_TTL_SECONDS + 1.0
+        assert get_cached_documents("P") is None
+
+
+class TestEnumOptionCache:
+    """Enum-option id wrappers keyed by (project, resource, field, type)."""
+
+    def test_store_then_get_hits(self) -> None:
+        store_cached_enum_options(
+            "P", "workitems", "severity", "task", frozenset({"high", "low"})
+        )
+
+        assert get_cached_enum_options("P", "workitems", "severity", "task") == (
+            frozenset({"high", "low"})
+        )
+
+    def test_keys_are_distinct_per_axis(self) -> None:
+        store_cached_enum_options(
+            "P", "workitems", "severity", "task", frozenset({"high"})
+        )
+
+        assert get_cached_enum_options("P", "workitems", "severity", "bug") is None
+        assert get_cached_enum_options("P", "documents", "severity", "task") is None
+        assert get_cached_enum_options("P", "workitems", "status", "task") is None
+
+    def test_expiry_uses_guard_ttl(self, clock: list[float]) -> None:
+        store_cached_enum_options(
+            "P", "workitems", "severity", "task", frozenset({"high"})
+        )
+
+        clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
+        assert get_cached_enum_options("P", "workitems", "severity", "task") is None
+
+
+class TestWorkItemCustomKeyRecord:
+    """``record_work_item_custom_field_keys`` union semantics + reads."""
+
+    def test_record_then_get(self) -> None:
+        record_work_item_custom_field_keys("P", "task", ["risk"])
+
+        assert get_work_item_custom_keys("P", "task") == frozenset({"risk"})
+
+    def test_record_merges_across_calls(self) -> None:
+        record_work_item_custom_field_keys("P", "task", ["k1"])
+        record_work_item_custom_field_keys("P", "task", ["k2", "k1"])
+
+        assert get_work_item_custom_keys("P", "task") == frozenset({"k1", "k2"})
+
+    def test_record_filters_non_string_and_empty(self) -> None:
+        record_work_item_custom_field_keys("P", "task", ["k1", "", "k2"])
+
+        assert get_work_item_custom_keys("P", "task") == frozenset({"k1", "k2"})
+
+    def test_empty_keys_still_records_the_type_as_observed(self) -> None:
+        record_work_item_custom_field_keys("P", "task", [])
+
+        assert get_work_item_custom_keys("P", "task") == frozenset()
+
+    def test_miss_returns_none(self) -> None:
+        assert get_work_item_custom_keys("P", "never_seen") is None
+
+    def test_expiry(self, clock: list[float]) -> None:
+        record_work_item_custom_field_keys("P", "task", ["k1"])
+
+        clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
+        assert get_work_item_custom_keys("P", "task") is None
+
+
+class TestDocumentCustomKeyRecord:
+    """``record_document_custom_field_keys`` keyed by (project, space, doc)."""
+
+    def test_record_then_get(self) -> None:
+        record_document_custom_field_keys("P", "_default", "Doc", ["doc_risk"])
+
+        assert get_document_custom_keys("P", "_default", "Doc") == (
+            frozenset({"doc_risk"})
+        )
+
+    def test_keyed_by_space_and_document(self) -> None:
+        record_document_custom_field_keys("P", "_default", "Doc", ["doc_risk"])
+
+        assert get_document_custom_keys("P", "other_space", "Doc") is None
+        assert get_document_custom_keys("P", "_default", "Other") is None
+
+    def test_record_merges_across_calls(self) -> None:
+        record_document_custom_field_keys("P", "_default", "Doc", ["a"])
+        record_document_custom_field_keys("P", "_default", "Doc", ["b"])
+
+        assert get_document_custom_keys("P", "_default", "Doc") == frozenset({"a", "b"})

--- a/tests/tools/test_read.py
+++ b/tests/tools/test_read.py
@@ -33,7 +33,7 @@ from mcp_server_polarion.models import (
     WorkItemRead,
 )
 from mcp_server_polarion.server import mcp
-from mcp_server_polarion.tools import _helpers as _helpers_mod
+from mcp_server_polarion.tools import _cache as _cache_mod
 from mcp_server_polarion.tools import read as _read_mod
 
 # ``@mcp.tool`` returns the original function unchanged (not a FunctionTool
@@ -341,9 +341,9 @@ class TestListDocuments:
         Several tests reuse ``project_id='proj1'``, so without this the
         first test would poison subsequent tests via cache hits.
         """
-        _helpers_mod._documents_cache.clear()
+        _cache_mod._document_list_cache.clear()
         yield
-        _helpers_mod._documents_cache.clear()
+        _cache_mod._document_list_cache.clear()
 
     async def test_extracts_documents_from_modules(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -687,13 +687,13 @@ class TestListDocuments:
         def _fake_monotonic() -> float:
             return fake_now[0]
 
-        monkeypatch.setattr(_helpers_mod.time, "monotonic", _fake_monotonic)
+        monkeypatch.setattr(_cache_mod, "_now", _fake_monotonic)
 
         await list_documents(mock_ctx, project_id="proj1", page_size=100, page_number=1)
         first_calls = mock_client.get.call_count
 
         # Advance time past the TTL.
-        fake_now[0] += _helpers_mod._CACHE_TTL_SECONDS + 1.0
+        fake_now[0] += _cache_mod._DOCUMENT_LIST_TTL_SECONDS + 1.0
 
         await list_documents(mock_ctx, project_id="proj1", page_size=100, page_number=1)
         assert mock_client.get.call_count > first_calls
@@ -4209,9 +4209,9 @@ class TestReadPathEncoding:
 
     @pytest.fixture(autouse=True)
     def _clear_doc_cache(self) -> Iterator[None]:
-        _helpers_mod._documents_cache.clear()
+        _cache_mod._document_list_cache.clear()
         yield
-        _helpers_mod._documents_cache.clear()
+        _cache_mod._document_list_cache.clear()
 
     async def test_list_documents_encodes_project_id(
         self, mock_ctx: MagicMock, mock_client: AsyncMock

--- a/tests/tools/test_write.py
+++ b/tests/tools/test_write.py
@@ -37,8 +37,8 @@ from mcp_server_polarion.models import (
     WorkItemUpdateResult,
 )
 from mcp_server_polarion.server import mcp
+from mcp_server_polarion.tools import _cache as _cache_mod
 from mcp_server_polarion.tools import _enum_guard as _enum_guard_mod
-from mcp_server_polarion.tools import _helpers as _helpers_mod
 from mcp_server_polarion.tools import write as _write_mod
 
 # ``@mcp.tool`` returns the original function unchanged (not a FunctionTool
@@ -3244,7 +3244,7 @@ class TestCreateDocumentHappyPath:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         """``create_document`` drops the project's docs cache entry on 201."""
-        _helpers_mod.store_cached_documents("MyProj", [("_default", "OldDoc")])
+        _cache_mod.store_cached_documents("MyProj", [("_default", "OldDoc")])
         mock_client.post.return_value = {
             "data": [{"type": "documents", "id": "MyProj/_default/MySpec"}]
         }
@@ -3262,13 +3262,13 @@ class TestCreateDocumentHappyPath:
             dry_run=False,
         )
 
-        assert _helpers_mod.get_cached_documents("MyProj") is None
+        assert _cache_mod.get_cached_documents("MyProj") is None
 
     async def test_does_not_invalidate_cache_on_failure(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         """Cache is preserved when the POST raises — no half-state change."""
-        _helpers_mod.store_cached_documents("MyProj", [("_default", "OldDoc")])
+        _cache_mod.store_cached_documents("MyProj", [("_default", "OldDoc")])
         mock_client.post.side_effect = PolarionError("boom", status_code=500)
 
         with pytest.raises(RuntimeError):
@@ -3285,9 +3285,9 @@ class TestCreateDocumentHappyPath:
                 dry_run=False,
             )
 
-        cached = _helpers_mod.get_cached_documents("MyProj")
+        cached = _cache_mod.get_cached_documents("MyProj")
         assert cached == [("_default", "OldDoc")]
-        _helpers_mod.invalidate_documents_cache("MyProj")
+        _cache_mod.invalidate_documents_cache("MyProj")
 
 
 class TestCreateDocumentErrorMapping:


### PR DESCRIPTION
## Summary

Pulls the in-process caching out of `_helpers.py` into a dedicated
`tools/_cache.py` built on one generic `TTLCache[K, V]` primitive. `_helpers`
goes back to being request-shaping and JSON:API extraction only; the cache
module becomes the single owner of cache state (lifetime, key shape) behind
typed get / store / record wrappers. This is the foundation the guard-hardening
PR builds on.

> Stacked on #67 — review/merge that first.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

---

## Changes

- Add `tools/_cache.py`: generic `TTLCache[K, V]` (lazy expiry, monotonic clock seam) plus get/store/record wrappers for the document-discovery, enum-option, and custom-field-key caches.
- Remove the ad-hoc document cache from `_helpers.py`; redirect `read.py` / `write.py` imports to `_cache`.
- Add `tests/tools/test_cache.py` covering the primitive and every wrapper.

---

## Testing

- [x] Unit tests added / updated (`tests/`)
- [x] `uv run pytest` passes locally
- [x] `uv run mypy src/` passes with no errors
- [x] `uv run ruff check src tests` passes with no warnings

```bash
uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
