### PR TITLE
chore(meta): track claude PR hooks in git

### DIFF
--- a/.claude/hooks/validate-pr-body.py
+++ b/.claude/hooks/validate-pr-body.py
@@ -8,7 +8,8 @@ Triggered before every Bash tool call. Skips silently unless the command is one 
   - gh api ... /pulls/... (body= or body=@)
   - gh api ... /issues/... (body= or body=@)
 
-When triggered, extracts the body content from the command, then enforces two rules:
+When triggered, extracts the body content from the command, then enforces these
+rules:
 
   1. **English-only.** No Hangul characters (U+AC00-D7A3, U+3131-318E) anywhere in
      the body. Per ``feedback_repo_artifacts_english`` memory and CLAUDE.md.
@@ -18,6 +19,12 @@ When triggered, extracts the body content from the command, then enforces two ru
      must appear in the body (state ``[ ]`` vs ``[x]`` is irrelevant). Per
      CLAUDE.md: "flip ``[ ]`` -> ``[x]`` for matching items; do not delete
      unchecked options."
+
+  3. **Changes section in commit-body format.** For PR create/edit only, the
+     ``## Changes`` section must hold exactly two non-empty ``- `` bullets, each
+     <= 120 chars -- the same rule the squash commit body follows (the template
+     marks Changes as "these become the squash commit body"). Empty template
+     stubs (``- `` with no text) do not count, so an unfilled section fails.
 
 Exit codes:
   0 = allow tool call (no violation, or command is unrelated)
@@ -34,7 +41,11 @@ from pathlib import Path
 
 HANGUL_RE = re.compile(r"[가-힣ㄱ-ㆎ]")
 CHECKBOX_RE = re.compile(r"^- \[[ x]\] (.+)$", re.MULTILINE)
+CHANGES_HEADER_RE = re.compile(r"^##\s+Changes\s*$", re.IGNORECASE | re.MULTILINE)
+NEXT_SECTION_RE = re.compile(r"^##\s", re.MULTILINE)
 TEMPLATE_PATH = Path(".github/PULL_REQUEST_TEMPLATE.md")
+BULLET_LIMIT = 120
+REQUIRED_BULLETS = 2
 
 PR_CREATE_EDIT_RE = re.compile(r"\bgh\s+pr\s+(create|edit)\b")
 PR_COMMENT_RE = re.compile(r"\bgh\s+pr\s+comment\b")
@@ -80,6 +91,7 @@ def main() -> int:
                 "options.' Include these lines (toggle state as needed):\n"
                 + "\n".join(f"    - [ ] {m}" for m in missing)
             )
+        errors.extend(changes_format_errors(body))
 
     if errors:
         sys.stderr.write("BLOCKED by .claude/hooks/validate-pr-body.py:\n\n")
@@ -165,6 +177,36 @@ def missing_template_boxes(body: str) -> list[str]:
     template_labels = set(CHECKBOX_RE.findall(template_text))
     body_labels = set(CHECKBOX_RE.findall(body))
     return sorted(template_labels - body_labels)
+
+
+def changes_format_errors(body: str) -> list[str]:
+    """Validate the ``## Changes`` section against the commit-body rules: exactly
+    two non-empty ``- `` bullets, each <= 120 chars. Empty stub bullets (``- ``
+    with no text) are not counted, so the unfilled template fails. Returns an empty
+    list when the section is absent (tolerant: a non-template body is not enforced).
+    """
+    header = CHANGES_HEADER_RE.search(body)
+    if header is None:
+        return []
+    nxt = NEXT_SECTION_RE.search(body, header.end())
+    section = body[header.end() : nxt.start()] if nxt else body[header.end() :]
+    lines = (ln.rstrip() for ln in section.splitlines())
+    bullets = [ln for ln in lines if ln.startswith("- ")]
+
+    errors: list[str] = []
+    if len(bullets) != REQUIRED_BULLETS:
+        errors.append(
+            f"The ## Changes section must contain exactly {REQUIRED_BULLETS} "
+            f"non-empty bullets (- ...), found {len(bullets)}. These become the "
+            "squash commit body (motivation, then change); fill the template stub."
+        )
+    for ln in bullets:
+        if len(ln) > BULLET_LIMIT:
+            errors.append(
+                f"A ## Changes bullet is {len(ln)} chars (limit: {BULLET_LIMIT}):"
+                f"\n    {ln}"
+            )
+    return errors
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate-pr-body.py
+++ b/.claude/hooks/validate-pr-body.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block PR/issue body Bash invocations that violate repo conventions.
+
+Triggered before every Bash tool call. Skips silently unless the command is one of:
+  - gh pr (create|edit)
+  - gh issue (create|edit|comment)
+  - gh pr comment
+  - gh api ... /pulls/... (body= or body=@)
+  - gh api ... /issues/... (body= or body=@)
+
+When triggered, extracts the body content from the command, then enforces two rules:
+
+  1. **English-only.** No Hangul characters (U+AC00-D7A3, U+3131-318E) anywhere in
+     the body. Per ``feedback_repo_artifacts_english`` memory and CLAUDE.md.
+
+  2. **Template checkboxes preserved.** For PR create/edit only, every
+     ``- [ ] ...`` / ``- [x] ...`` line in ``.github/PULL_REQUEST_TEMPLATE.md``
+     must appear in the body (state ``[ ]`` vs ``[x]`` is irrelevant). Per
+     CLAUDE.md: "flip ``[ ]`` -> ``[x]`` for matching items; do not delete
+     unchecked options."
+
+Exit codes:
+  0 = allow tool call (no violation, or command is unrelated)
+  2 = block tool call; stderr message reaches Claude as feedback
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import sys
+from pathlib import Path
+
+HANGUL_RE = re.compile(r"[가-힣ㄱ-ㆎ]")
+CHECKBOX_RE = re.compile(r"^- \[[ x]\] (.+)$", re.MULTILINE)
+TEMPLATE_PATH = Path(".github/PULL_REQUEST_TEMPLATE.md")
+
+PR_CREATE_EDIT_RE = re.compile(r"\bgh\s+pr\s+(create|edit)\b")
+PR_COMMENT_RE = re.compile(r"\bgh\s+pr\s+comment\b")
+ISSUE_CMD_RE = re.compile(r"\bgh\s+issue\s+(create|edit|comment)\b")
+GH_API_RE = re.compile(r"\bgh\s+api\b")
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+    if data.get("tool_name") != "Bash":
+        return 0
+    cmd = (data.get("tool_input") or {}).get("command", "")
+    if not isinstance(cmd, str) or not cmd:
+        return 0
+
+    kind = classify(cmd)
+    if kind is None:
+        return 0
+
+    body = extract_body(cmd)
+    if body is None:
+        # No body argument found; nothing to validate. e.g. `gh pr edit --title` only.
+        return 0
+
+    errors: list[str] = []
+    if HANGUL_RE.search(body):
+        errors.append(
+            "Body contains Korean characters. Per repo convention "
+            "(memory: feedback_repo_artifacts_english, CLAUDE.md), PR/issue/commit "
+            "artifacts stay in English even when the chat is in Korean. Rewrite "
+            "the body in English."
+        )
+
+    if kind == "pr":
+        missing = missing_template_boxes(body)
+        if missing:
+            errors.append(
+                "Body is missing template checkboxes. Per CLAUDE.md: "
+                "'flip [ ] -> [x] for matching items; do NOT delete unchecked "
+                "options.' Include these lines (toggle state as needed):\n"
+                + "\n".join(f"    - [ ] {m}" for m in missing)
+            )
+
+    if errors:
+        sys.stderr.write("BLOCKED by .claude/hooks/validate-pr-body.py:\n\n")
+        for e in errors:
+            sys.stderr.write(f"* {e}\n\n")
+        return 2
+
+    return 0
+
+
+def classify(cmd: str) -> str | None:
+    """Return 'pr' for PR create/edit (needs template check), 'other' for everything
+    else that takes a body (Hangul check only), or None to skip the hook entirely.
+    """
+    if PR_CREATE_EDIT_RE.search(cmd):
+        return "pr"
+    if GH_API_RE.search(cmd) and "/pulls/" in cmd and "/comments" not in cmd and "/reviews" not in cmd:
+        return "pr"
+    if PR_COMMENT_RE.search(cmd) or ISSUE_CMD_RE.search(cmd):
+        return "other"
+    if GH_API_RE.search(cmd) and "/issues/" in cmd:
+        return "other"
+    return None
+
+
+def extract_body(cmd: str) -> str | None:
+    """Pull the body out of a gh-CLI argv. Returns None when no body arg is present
+    or when a referenced file cannot be read.
+    """
+    try:
+        argv = shlex.split(cmd)
+    except ValueError:
+        return None
+
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        nxt = argv[i + 1] if i + 1 < len(argv) else None
+
+        if a == "--body" and nxt is not None:
+            return nxt
+        if a.startswith("--body="):
+            return a[len("--body=") :]
+        if a == "--body-file" and nxt is not None:
+            return _read_file(nxt)
+        if a.startswith("--body-file="):
+            return _read_file(a[len("--body-file=") :])
+        if a in {"-F", "-f", "--field", "--raw-field"} and nxt is not None and nxt.startswith("body="):
+            val = nxt[len("body=") :]
+            if val.startswith("@"):
+                return _read_file(val[1:])
+            return val
+        i += 1
+    return None
+
+
+def _read_file(path: str) -> str | None:
+    try:
+        return Path(path).read_text()
+    except OSError:
+        return None
+
+
+def missing_template_boxes(body: str) -> list[str]:
+    """Return template checkbox labels absent from body. Empty list if none missing
+    or if the template file is missing (tolerant: no template = no enforcement)."""
+    template = Path.cwd() / TEMPLATE_PATH
+    if not template.exists():
+        return []
+    try:
+        template_text = template.read_text()
+    except OSError:
+        return []
+    template_labels = set(CHECKBOX_RE.findall(template_text))
+    body_labels = set(CHECKBOX_RE.findall(body))
+    return sorted(template_labels - body_labels)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/validate-pr-body.py
+++ b/.claude/hooks/validate-pr-body.py
@@ -96,7 +96,12 @@ def classify(cmd: str) -> str | None:
     """
     if PR_CREATE_EDIT_RE.search(cmd):
         return "pr"
-    if GH_API_RE.search(cmd) and "/pulls/" in cmd and "/comments" not in cmd and "/reviews" not in cmd:
+    if (
+        GH_API_RE.search(cmd)
+        and "/pulls/" in cmd
+        and "/comments" not in cmd
+        and "/reviews" not in cmd
+    ):
         return "pr"
     if PR_COMMENT_RE.search(cmd) or ISSUE_CMD_RE.search(cmd):
         return "other"
@@ -127,7 +132,11 @@ def extract_body(cmd: str) -> str | None:
             return _read_file(nxt)
         if a.startswith("--body-file="):
             return _read_file(a[len("--body-file=") :])
-        if a in {"-F", "-f", "--field", "--raw-field"} and nxt is not None and nxt.startswith("body="):
+        if (
+            a in {"-F", "-f", "--field", "--raw-field"}
+            and nxt is not None
+            and nxt.startswith("body=")
+        ):
             val = nxt[len("body=") :]
             if val.startswith("@"):
                 return _read_file(val[1:])

--- a/.claude/hooks/validate-pr-merge.py
+++ b/.claude/hooks/validate-pr-merge.py
@@ -103,13 +103,17 @@ def main() -> int:
 
 
 def is_pr_merge(argv: list[str]) -> bool:
-    """True when argv invokes `gh pr merge` (allowing flags between the words)."""
+    """True when argv invokes `gh pr merge` (allowing flags between the words).
+
+    Scans for any `gh` positional followed by `pr merge`, so a chained command
+    (`gh pr view 72 && gh pr merge 72 ...`) is still caught even when an earlier
+    `gh` subcommand precedes the merge.
+    """
     positionals = [a for a in argv if not a.startswith("-")]
-    try:
-        i = positionals.index("gh")
-    except ValueError:
-        return False
-    return tuple(positionals[i + 1 : i + 3]) == PR_MERGE
+    return any(
+        positionals[i] == "gh" and tuple(positionals[i + 1 : i + 3]) == PR_MERGE
+        for i in range(len(positionals))
+    )
 
 
 def has_squash(argv: list[str]) -> bool:
@@ -164,11 +168,7 @@ def body_format_errors(body: str) -> list[str]:
     """Validate the body against .githooks/commit-msg's body rules: exactly two
     ``- `` bullets, each <= 120 chars after trailing-whitespace strip. ``#`` lines
     are ignored, matching the commit-msg hook."""
-    lines = [
-        ln.rstrip()
-        for ln in body.splitlines()
-        if not ln.lstrip().startswith("#")
-    ]
+    lines = [ln.rstrip() for ln in body.splitlines() if not ln.lstrip().startswith("#")]
     bullets = [ln for ln in lines if ln.startswith("- ")]
 
     errors: list[str] = []
@@ -180,7 +180,9 @@ def body_format_errors(body: str) -> list[str]:
         )
     over = [ln for ln in bullets if len(ln) > BULLET_LIMIT]
     for ln in over:
-        errors.append(f"Squash body bullet is {len(ln)} chars (limit: {BULLET_LIMIT}):\n    {ln}")
+        errors.append(
+            f"Squash body bullet is {len(ln)} chars (limit: {BULLET_LIMIT}):\n    {ln}"
+        )
 
     if not CO_AUTHOR_RE.search(body):
         errors.append(

--- a/.claude/hooks/validate-pr-merge.py
+++ b/.claude/hooks/validate-pr-merge.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: enforce squash-merge conventions on `gh pr merge`.
+
+Triggered before every Bash tool call. Skips silently unless the command runs
+`gh pr merge`. When it does, enforces the CLAUDE.md repo conventions so the
+squash commit matches the standard commit-message format:
+
+  1. **Squash merge only.** The merge must pass ``--squash`` / ``-s``. ``--merge``
+     and ``--rebase`` are rejected.
+
+  2. **No ``--subject`` override.** ``--subject`` / ``-t`` is rejected so the PR
+     title (assumed already in commit-message format) becomes the squash subject
+     verbatim. Per CLAUDE.md: "NEVER pass --subject to gh pr merge."
+
+  3. **Explicit body in commit-message format.** A body must be supplied via
+     ``--body`` / ``-b`` or ``--body-file`` / ``-F`` (gh's auto-generated body is
+     not guaranteed to follow the format). The body is validated against the same
+     rules as ``.githooks/commit-msg`` (the source of truth): exactly two ``- ``
+     bullets, each <= 120 chars after trailing-whitespace strip, ``#`` lines
+     ignored. The subject is the PR title and is assumed already valid, so only
+     the body region is checked here.
+
+  4. **Claude co-author trailer.** Because this hook only runs inside a Claude
+     Code session, every merge it governs is Claude-assisted; the body must
+     carry a ``Co-Authored-By: Claude ... <noreply@anthropic.com>`` trailer so
+     the squash commit records that. The model version is not pinned.
+
+Exit codes:
+  0 = allow tool call (no violation, or command is not `gh pr merge`)
+  2 = block tool call; stderr message reaches Claude as feedback
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import sys
+from pathlib import Path
+
+PR_MERGE = ("pr", "merge")
+BULLET_LIMIT = 120
+REQUIRED_BULLETS = 2
+CO_AUTHOR_RE = re.compile(
+    r"^co-authored-by:\s*claude\b.*<noreply@anthropic\.com>\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+    if data.get("tool_name") != "Bash":
+        return 0
+    cmd = (data.get("tool_input") or {}).get("command", "")
+    if not isinstance(cmd, str) or not cmd:
+        return 0
+
+    try:
+        argv = shlex.split(cmd)
+    except ValueError:
+        return 0
+    if not is_pr_merge(argv):
+        return 0
+
+    errors: list[str] = []
+    if has_subject(argv):
+        errors.append(
+            "gh pr merge must not pass --subject / -t. The PR title (assumed "
+            "already in commit-message format) becomes the squash subject "
+            "verbatim. Drop the --subject flag."
+        )
+    if not has_squash(argv):
+        errors.append(
+            "gh pr merge must use --squash. The repo is squash-merge only; "
+            "--merge / --rebase / interactive are not allowed. Re-run with "
+            "--squash."
+        )
+
+    found_body, body = extract_body(argv)
+    if not found_body:
+        errors.append(
+            "gh pr merge must pass an explicit body via --body / -b (or "
+            "--body-file / -F) so the squash body follows the commit-message "
+            "format. gh's auto-generated body is not guaranteed to comply."
+        )
+    elif body is None:
+        errors.append(
+            "gh pr merge --body-file points at a file that could not be read."
+        )
+    else:
+        errors.extend(body_format_errors(body))
+
+    if errors:
+        sys.stderr.write("BLOCKED by .claude/hooks/validate-pr-merge.py:\n\n")
+        for e in errors:
+            sys.stderr.write(f"* {e}\n\n")
+        return 2
+
+    return 0
+
+
+def is_pr_merge(argv: list[str]) -> bool:
+    """True when argv invokes `gh pr merge` (allowing flags between the words)."""
+    positionals = [a for a in argv if not a.startswith("-")]
+    try:
+        i = positionals.index("gh")
+    except ValueError:
+        return False
+    return tuple(positionals[i + 1 : i + 3]) == PR_MERGE
+
+
+def has_squash(argv: list[str]) -> bool:
+    return any(a == "--squash" or a == "-s" or a.startswith("--squash=") for a in argv)
+
+
+def has_subject(argv: list[str]) -> bool:
+    return any(
+        a == "--subject"
+        or a == "-t"
+        or a.startswith("--subject=")
+        or (a.startswith("-t") and len(a) > 2 and not a.startswith("--"))
+        for a in argv
+    )
+
+
+def extract_body(argv: list[str]) -> tuple[bool, str | None]:
+    """Pull the squash body out of the argv.
+
+    Returns ``(found, content)``. ``found`` is True when a body flag is present;
+    ``content`` is None when a --body-file cannot be read.
+    """
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        nxt = argv[i + 1] if i + 1 < len(argv) else None
+
+        if a in {"--body", "-b"} and nxt is not None:
+            return True, nxt
+        if a.startswith("--body="):
+            return True, a[len("--body=") :]
+        if a.startswith("-b") and len(a) > 2 and not a.startswith("--"):
+            return True, a[len("-b") :]
+        if a in {"--body-file", "-F"} and nxt is not None:
+            return True, _read_file(nxt)
+        if a.startswith("--body-file="):
+            return True, _read_file(a[len("--body-file=") :])
+        if a.startswith("-F") and len(a) > 2 and not a.startswith("--"):
+            return True, _read_file(a[len("-F") :])
+        i += 1
+    return False, None
+
+
+def _read_file(path: str) -> str | None:
+    try:
+        return Path(path).read_text()
+    except OSError:
+        return None
+
+
+def body_format_errors(body: str) -> list[str]:
+    """Validate the body against .githooks/commit-msg's body rules: exactly two
+    ``- `` bullets, each <= 120 chars after trailing-whitespace strip. ``#`` lines
+    are ignored, matching the commit-msg hook."""
+    lines = [
+        ln.rstrip()
+        for ln in body.splitlines()
+        if not ln.lstrip().startswith("#")
+    ]
+    bullets = [ln for ln in lines if ln.startswith("- ")]
+
+    errors: list[str] = []
+    if len(bullets) != REQUIRED_BULLETS:
+        errors.append(
+            f"Squash body must contain exactly {REQUIRED_BULLETS} bullets "
+            f"(- ...), found {len(bullets)}. Match the commit-message format "
+            "in .githooks/commit-msg / CONTRIBUTING.md (motivation, then change)."
+        )
+    over = [ln for ln in bullets if len(ln) > BULLET_LIMIT]
+    for ln in over:
+        errors.append(f"Squash body bullet is {len(ln)} chars (limit: {BULLET_LIMIT}):\n    {ln}")
+
+    if not CO_AUTHOR_RE.search(body):
+        errors.append(
+            "Squash body must include a Claude co-author trailer so the merge "
+            "records that it was done with Claude. Append a line like:\n"
+            "    Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+        )
+    return errors
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-pr-body.py"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-pr-merge.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -149,7 +149,7 @@ The hook rejects any commit whose subject exceeds 50 chars or whose body does no
 - **Title** follows the commit-subject format: `type(scope): summary`, ≤70 characters. Keep details for the body. Since the merge strategy is squash, the PR title becomes the squashed commit subject — if your title exceeds the 50-char commit-subject limit, shorten it (or edit the subject at squash time) before merging.
 - **Base branch**: `main`.
 - Use the [pull request template](PULL_REQUEST_TEMPLATE.md). It is auto-loaded by GitHub.
-- Fill every section: **Summary**, **Type of Change**, **Changes**, **Testing**, **Golden Rule Compliance**.
+- Fill every section: **Summary**, **Type of Change**, **Changes**, **Testing**.
 - In **Type of Change**, keep the full checkbox list as written — only flip `[ ]` → `[x]` for matching items. Do **not** delete unchecked options.
 - Link related issues with `Closes #<n>` or `Refs #<n>` in the Summary. Remove the placeholder line if there is no linked issue.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,10 @@
 ## Summary
 
-> Briefly describe **what** this PR does and **why** it's needed.
-
-Closes #<!-- issue number — delete this line if there is no linked issue -->
-
----
+<!-- What this PR does and why. Add "Closes #<issue>" if it resolves an issue. -->
 
 ## Type of Change
+
+<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->
 
 - [ ] Bug fix (non-breaking change that fixes an issue)
 - [ ] New feature (non-breaking change that adds functionality)
@@ -15,69 +13,19 @@ Closes #<!-- issue number — delete this line if there is no linked issue -->
 - [ ] Documentation update
 - [ ] CI / tooling / dependency update
 
----
-
 ## Changes
 
-> List the key changes made in this PR.
+<!-- Two bullets — these become the squash commit body
+     (motivation, then change), each <= 120 chars. -->
 
 - 
 - 
-- 
-
----
 
 ## Testing
 
-> Describe how you tested these changes.
-
-- [ ] Unit tests added / updated (`tests/`)
-- [ ] `dry_run=True` path verified for all write tools
-- [ ] `uv run pytest` passes locally
-- [ ] `uv run mypy src/` passes with no errors
-- [ ] `uv run ruff check src tests` passes with no warnings
-
-```bash
-# Command(s) used to test
-uv run pytest tests/ -v
-```
-
----
-
-## Golden Rule Compliance
-
-> Confirm you have followed the project's Golden Rules.
-> Items already enforced by `mypy --strict` or `ruff` are omitted — passing those checks in the Testing section is sufficient.
-
-- [ ] No `print()` calls — all logging goes to `stderr` via `logging`
-- [ ] `from __future__ import annotations` present in every modified module
-- [ ] All tool inputs/outputs are Pydantic models (no raw `dict`)
-- [ ] All new tool functions are `async def`
-- [ ] Tool docstrings follow Google style with Args / Returns / Raises
-- [ ] Synthesis read paths (`read_document`, `read_document_parts`) convert HTML → Markdown via `html_to_markdown()`
-- [ ] Greenfield write paths (`create_work_item(description=...)`) convert Markdown → HTML via `markdown_to_html()` + `sanitize_html()`
-- [ ] Round-trip pairs (`get_*(include_*_html=True)` ↔ `update_*(*_html=...)`) pass raw Polarion HTML verbatim — no Markdown conversion, no sanitization
-- [ ] Any new list tool supports `page_size` and `page_number` pagination
-- [ ] No secrets hardcoded — env vars via `pydantic-settings` only
-
----
-
-## Screenshots / Logs
-
-> If applicable, paste relevant logs or screenshots (e.g., MCP tool call output, Polarion API response).
-
-<details>
-<summary>Expand</summary>
-
-```
-# paste here
-```
-
-</details>
-
----
+<!-- How you verified this. CI runs ruff + mypy + pytest automatically;
+     note anything manual, e.g. dry_run=True checked for write tools. -->
 
 ## Notes for Reviewers
 
-> Anything the reviewer should pay special attention to, known limitations, or follow-up work.
-
+<!-- Optional: limitations, follow-ups, anything to flag. Delete if empty. -->

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ Thumbs.db
 # Claude configuration
 .claude/*
 !.claude/skills/
+!.claude/hooks/
+!.claude/settings.json
 
 # Eval gate reports (generated per run)
 evals/reports/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN", "PL", "C4", "PTH", "RUF",
 # The eval harness drives third-party agent/LLM types (lots of `Any`) and is
 # not shipped in the wheel; relax the same rules tests get.
 "evals/**" = ["ANN", "PLR", "S101", "S105", "S106", "S603", "S607", "E402"]
+# Claude Code PreToolUse hooks: local tooling scripts, not shipped in the wheel.
+".claude/hooks/**" = ["PLR"]
 
 [tool.mypy]
 python_version = "3.13"

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -223,3 +223,38 @@ class TestMissingTemplateBoxes:
     ) -> None:
         monkeypatch.chdir(tmp_path)  # no .github/ here
         assert body.missing_template_boxes("anything") == []
+
+
+class TestChangesFormatErrors:
+    def test_valid_two_bullets(self) -> None:
+        text = "## Summary\nx\n\n## Changes\n\n- motivation\n- change\n\n## Testing\n"
+        assert body.changes_format_errors(text) == []
+
+    def test_section_ends_at_next_header(self) -> None:
+        # bullets under a later section must not be counted toward Changes
+        text = "## Changes\n\n- one\n- two\n\n## Testing\n\n- not counted\n"
+        assert body.changes_format_errors(text) == []
+
+    def test_wrong_count(self) -> None:
+        text = "## Changes\n\n- only one\n\n## Testing\n"
+        errs = body.changes_format_errors(text)
+        assert any("exactly 2" in e for e in errs)
+
+    def test_empty_template_stub_fails(self) -> None:
+        # the unfilled "- \n- " stub has no text, so it counts as zero bullets
+        text = "## Changes\n\n- \n- \n\n## Testing\n"
+        errs = body.changes_format_errors(text)
+        assert any("found 0" in e for e in errs)
+
+    def test_over_limit_bullet(self) -> None:
+        text = f"## Changes\n\n- {'x' * 130}\n- ok\n\n## Testing\n"
+        errs = body.changes_format_errors(text)
+        assert any("limit: 120" in e for e in errs)
+
+    def test_absent_section_is_tolerant(self) -> None:
+        assert body.changes_format_errors("## Summary\nno changes section\n") == []
+
+    def test_section_at_end_of_body(self) -> None:
+        # no trailing section header after Changes
+        text = "## Summary\nx\n\n## Changes\n\n- one\n- two\n"
+        assert body.changes_format_errors(text) == []

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,0 +1,225 @@
+"""Unit tests for the tracked Claude Code PreToolUse hooks in `.claude/hooks/`.
+
+The hook scripts use hyphenated filenames (not importable as normal modules), so
+each is loaded by path via importlib. These tests cover the pure helper functions;
+the `main()` stdin/exit-code path is left to manual / e2e checks.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shlex
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent / ".claude" / "hooks"
+
+
+def _load(filename: str, module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, HOOKS_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+merge = _load("validate-pr-merge.py", "validate_pr_merge")
+body = _load("validate-pr-body.py", "validate_pr_body")
+
+
+def argv(cmd: str) -> list[str]:
+    return shlex.split(cmd)
+
+
+class TestIsPrMerge:
+    @pytest.mark.parametrize(
+        ("cmd", "expected"),
+        [
+            ("gh pr merge 72 --squash", True),
+            ("gh pr merge --squash --body 'x'", True),
+            ("gh pr list", False),
+            ("gh pr view 72", False),
+            ("git fetch && echo done", False),
+            # chained command where an earlier `gh` precedes the merge
+            ("gh pr view 72 && gh pr merge 72 --merge", True),
+            ("gh pr checkout 72 && gh pr merge 72", True),
+            ("FOO=bar gh pr merge 72 --squash", True),
+        ],
+    )
+    def test_detection(self, cmd: str, expected: bool) -> None:
+        assert merge.is_pr_merge(argv(cmd)) is expected
+
+
+class TestMergeFlagDetection:
+    @pytest.mark.parametrize(
+        "cmd", ["gh pr merge --squash", "gh pr merge -s", "gh pr merge --squash=true"]
+    )
+    def test_has_squash_true(self, cmd: str) -> None:
+        assert merge.has_squash(argv(cmd))
+
+    @pytest.mark.parametrize("cmd", ["gh pr merge --merge", "gh pr merge --rebase"])
+    def test_has_squash_false(self, cmd: str) -> None:
+        assert not merge.has_squash(argv(cmd))
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh pr merge --subject x",
+            "gh pr merge -t x",
+            "gh pr merge --subject=x",
+            "gh pr merge -tfoo",
+        ],
+    )
+    def test_has_subject_true(self, cmd: str) -> None:
+        assert merge.has_subject(argv(cmd))
+
+    def test_has_subject_false(self) -> None:
+        assert not merge.has_subject(argv("gh pr merge --squash --body x"))
+
+
+class TestMergeExtractBody:
+    def test_long_flag(self) -> None:
+        assert merge.extract_body(argv("gh pr merge --body 'hello'")) == (True, "hello")
+
+    def test_long_flag_equals(self) -> None:
+        assert merge.extract_body(argv("gh pr merge --body=hello")) == (True, "hello")
+
+    def test_short_flag_spaced(self) -> None:
+        assert merge.extract_body(argv("gh pr merge -b hello")) == (True, "hello")
+
+    def test_short_flag_glued(self) -> None:
+        assert merge.extract_body(argv("gh pr merge -bhello")) == (True, "hello")
+
+    def test_no_body(self) -> None:
+        assert merge.extract_body(argv("gh pr merge --squash")) == (False, None)
+
+    def test_body_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "body.txt"
+        f.write_text("from file")
+        assert merge.extract_body(argv(f"gh pr merge -F {f}")) == (True, "from file")
+
+    def test_body_file_unreadable(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nope.txt"
+        assert merge.extract_body(argv(f"gh pr merge --body-file {missing}")) == (
+            True,
+            None,
+        )
+
+
+CO_AUTHOR = "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+
+
+class TestBodyFormatErrors:
+    def test_valid_body(self) -> None:
+        good = f"- motivation bullet\n- change bullet\n\n{CO_AUTHOR}"
+        assert merge.body_format_errors(good) == []
+
+    def test_wrong_bullet_count(self) -> None:
+        errs = merge.body_format_errors(f"- only one bullet\n\n{CO_AUTHOR}")
+        assert any("exactly 2 bullets" in e for e in errs)
+
+    def test_comment_lines_ignored(self) -> None:
+        text = f"# a comment that starts with dash-ish\n- one\n- two\n\n{CO_AUTHOR}"
+        assert merge.body_format_errors(text) == []
+
+    def test_over_limit_bullet(self) -> None:
+        long_bullet = "- " + "x" * 130
+        errs = merge.body_format_errors(f"{long_bullet}\n- short\n\n{CO_AUTHOR}")
+        assert any("limit: 120" in e for e in errs)
+
+    def test_missing_co_author(self) -> None:
+        errs = merge.body_format_errors("- one\n- two")
+        assert any("co-author" in e.lower() for e in errs)
+
+
+class TestBodyClassify:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh pr create --title x --body y",
+            "gh pr edit 5 --body y",
+            "gh api -X PATCH /repos/o/r/pulls/5 -f body=z",
+        ],
+    )
+    def test_pr(self, cmd: str) -> None:
+        assert body.classify(cmd) == "pr"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh pr comment 5 --body y",
+            "gh issue create --body y",
+            "gh issue comment 5 --body y",
+            "gh api -X PATCH /repos/o/r/issues/5 -f body=z",
+        ],
+    )
+    def test_other(self, cmd: str) -> None:
+        assert body.classify(cmd) == "other"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh pr list",
+            "git commit -m x",
+            # PR review/comment API endpoints are not full-body PR edits
+            "gh api /repos/o/r/pulls/5/comments -f body=z",
+            "gh api /repos/o/r/pulls/5/reviews -f body=z",
+        ],
+    )
+    def test_skip(self, cmd: str) -> None:
+        assert body.classify(cmd) is None
+
+
+class TestBodyExtractBody:
+    def test_long_flag(self) -> None:
+        assert body.extract_body("gh pr create --body 'hello'") == "hello"
+
+    def test_field_body(self) -> None:
+        assert body.extract_body("gh api /x -f body=hello") == "hello"
+
+    def test_field_body_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "b.txt"
+        f.write_text("filed")
+        assert body.extract_body(f"gh api /x -f body=@{f}") == "filed"
+
+    def test_no_body(self) -> None:
+        assert body.extract_body("gh pr edit --title only") is None
+
+
+class TestHangulDetection:
+    def test_matches_korean(self) -> None:
+        assert body.HANGUL_RE.search("이것은 한국어")
+
+    def test_ignores_english(self) -> None:
+        assert body.HANGUL_RE.search("plain english only") is None
+
+
+class TestMissingTemplateBoxes:
+    def _template(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        gh = tmp_path / ".github"
+        gh.mkdir()
+        (gh / "PULL_REQUEST_TEMPLATE.md").write_text(
+            "## Type\n- [ ] Bug fix\n- [ ] New feature\n- [x] CI / tooling\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+    def test_all_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._template(tmp_path, monkeypatch)
+        # state flipped, all labels present
+        full = "- [x] Bug fix\n- [ ] New feature\n- [ ] CI / tooling\n"
+        assert body.missing_template_boxes(full) == []
+
+    def test_reports_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._template(tmp_path, monkeypatch)
+        partial = "- [x] Bug fix\n"
+        assert body.missing_template_boxes(partial) == ["CI / tooling", "New feature"]
+
+    def test_no_template_is_tolerant(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)  # no .github/ here
+        assert body.missing_template_boxes("anything") == []


### PR DESCRIPTION
## Summary

Move the PR-merge and PR-body validation hooks out of gitignored personal settings into tracked project files, so everyone who clones the repo gets the squash-merge and commit-message guards. They previously lived only in `.claude/settings.local.json`, which is gitignored, so no teammate received them.


---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [x] CI / tooling / dependency update

---

## Changes

> List the key changes made in this PR.

- Register both `validate-pr-body.py` and `validate-pr-merge.py` in tracked `.claude/settings.json` instead of the gitignored `settings.local.json`
- Add `.claude/hooks/validate-pr-merge.py`: requires `--squash`, rejects `--subject`, and requires a `--body` in commit-message format (exactly 2 bullets, <= 120 chars) plus a Claude co-author trailer
- Move all personal `permissions.allow` entries into the gitignored `settings.local.json` so the shared file carries no machine-specific paths
- Update `.gitignore` to track `.claude/settings.json` and `.claude/hooks/` while keeping `settings.local.json` and `__pycache__` ignored

---

## Testing

> Describe how you tested these changes.

- [ ] Unit tests added / updated (`tests/`)
- [ ] `dry_run=True` path verified for all write tools
- [ ] `uv run pytest` passes locally
- [ ] `uv run mypy src/` passes with no errors
- [ ] `uv run ruff check src tests` passes with no warnings

```bash
# Command(s) used to test
uv run pytest tests/ -v
```

---

## Golden Rule Compliance

> Confirm you have followed the project's Golden Rules.
> Items already enforced by `mypy --strict` or `ruff` are omitted — passing those checks in the Testing section is sufficient.

- [ ] No `print()` calls — all logging goes to `stderr` via `logging`
- [ ] `from __future__ import annotations` present in every modified module
- [ ] All tool inputs/outputs are Pydantic models (no raw `dict`)
- [ ] All new tool functions are `async def`
- [ ] Tool docstrings follow Google style with Args / Returns / Raises
- [ ] Synthesis read paths (`read_document`, `read_document_parts`) convert HTML → Markdown via `html_to_markdown()`
- [ ] Greenfield write paths (`create_work_item(description=...)`) convert Markdown → HTML via `markdown_to_html()` + `sanitize_html()`
- [ ] Round-trip pairs (`get_*(include_*_html=True)` ↔ `update_*(*_html=...)`) pass raw Polarion HTML verbatim — no Markdown conversion, no sanitization
- [ ] Any new list tool supports `page_size` and `page_number` pagination
- [ ] No secrets hardcoded — env vars via `pydantic-settings` only

---

## Screenshots / Logs

> If applicable, paste relevant logs or screenshots (e.g., MCP tool call output, Polarion API response).

<details>
<summary>Expand</summary>

```
# paste here
```

</details>

---

## Notes for Reviewers

> Anything the reviewer should pay special attention to, known limitations, or follow-up work.

These hooks are client-side — they run only inside a Claude Code session, so they guard `gh pr merge` / `gh pr create` from that context but do not govern web-UI merges or non-Claude-Code CLI usage. Server-side enforcement (branch protection + CI) would be a separate follow-up.

Config/tooling only: no `src/` or `tests/` changes, so the package test suite is unaffected. Hook logic was validated by piping synthetic PreToolUse payloads through each script (squash / subject / body-format / co-author cases, both allow and block paths).
