### PR TITLE
ci(meta): auto-publish github release

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy
-description: Deploy (release/version bump/tag) automation for mcp-server-polarion. Bumps version in pyproject.toml + uv.lock, commits with conventional message, creates structured annotated tag, and pushes to trigger PyPI publish workflow. Triggers on "/deploy", or any release/version bump/tag request.
+description: Deploy (release/version bump/tag) automation for mcp-server-polarion. Bumps version in pyproject.toml + uv.lock, commits with conventional message, creates a date-only annotated tag, and pushes it to trigger the PyPI publish workflow, which then auto-publishes a categorized GitHub Release. Triggers on "/deploy", or any release/version bump/tag request.
 ---
 
 # Deploy Skill
@@ -99,46 +99,21 @@ git push origin main
 
 No auto-retry on failure — surface error and let the user decide.
 
-## Step 6 — Draft tag annotation (interactive)
+## Step 6 — Create date-only tag locally
 
-Categorize each commit since `$PREV_TAG`:
-- `breaking` or `!:` in subject → **Breaking**
-- `feat(tool):` prefix → **New tools** (extract tool name and PR # from subject)
-- other `feat:` → **New**
-- `chore:` / `docs:` / `ci:` / `refactor:` / `test:` / `fix:` → **Misc**
-
-Write the draft to `/tmp/tag-msg-v${NEW_VERSION}.txt` using the Write tool. A temp file is required: `git tag -a -m` repeated flattens to paragraphs and breaks the labeled-section layout; `-F` preserves exact whitespace and newlines.
-
-Format:
-
-```
-<one-line headline, ≤72 chars, derived from highest-impact change>
-
-Breaking:
-- ...
-
-New tools:
-- tool_name (#PR) — short description
-
-New:
-- feature description
-
-Misc:
-- mechanical change
-```
-
-Omit empty sections entirely. Show file contents to the user via AskUserQuestion (`approve` / `edit` / `cancel`); on `edit`, rewrite the temp file with the user's replacement text.
-
-## Step 7 — Create tag locally
+The tag annotation carries only the release date; all the human-readable detail lives in the GitHub Release (Step 8). Keeping the tag minimal means the published-version marker never drifts from the curated release notes.
 
 ```bash
-git tag -a "v${NEW_VERSION}" -F "/tmp/tag-msg-v${NEW_VERSION}.txt"
-git show "v${NEW_VERSION}" --no-patch  # verify annotation rendered correctly
+RELEASE_DATE=$(date +%F)  # UTC release date, YYYY-MM-DD
+git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION} (${RELEASE_DATE})"
+git show "v${NEW_VERSION}" --no-patch  # verify the one-line annotation
 ```
 
-## Step 8 — Push tag (confirm #2, with irreversibility warning)
+No temp file, no interactive draft — the message is a single deterministic line.
 
-AskUserQuestion with this exact warning text: **"Pushing tag v${NEW_VERSION} triggers `.github/workflows/publish.yml` → TestPyPI → PyPI. IRREVERSIBLE (PyPI blocks re-uploading the same version). Continue?"** Options: `push` / `cancel`.
+## Step 7 — Push tag (confirm #2, with irreversibility warning)
+
+AskUserQuestion with this exact warning text: **"Pushing tag v${NEW_VERSION} triggers `.github/workflows/publish.yml` → evals → TestPyPI → PyPI → GitHub Release. IRREVERSIBLE (PyPI blocks re-uploading the same version). Continue?"** Options: `push` / `cancel`.
 
 ```bash
 git push origin "v${NEW_VERSION}"
@@ -146,11 +121,14 @@ git push origin "v${NEW_VERSION}"
 
 On failure: local tag still exists; user can retry with `git push origin v${NEW_VERSION}` or delete locally via `git tag -d v${NEW_VERSION}`.
 
-## Step 9 — Post-push summary
+The GitHub Release is created automatically by the `release` job in `publish.yml` after PyPI succeeds — `gh release create --generate-notes` builds categorized notes from the PRs merged since the previous tag, grouped per `.github/release.yml`. Do NOT create a release by hand here; a manual `gh release create` would collide with the workflow (`release already exists`). Categorization quality depends on each merged PR carrying the right label, which `.github/workflows/label-pr.yml` stamps from the PR's conventional-commit title.
+
+## Step 8 — Post-push summary
 
 ```bash
 OWNER_REPO=$(git remote get-url origin | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+).*#\1#')
 echo "Released v${NEW_VERSION}"
+echo "Release notes (auto-published after PyPI): https://github.com/${OWNER_REPO}/releases/tag/v${NEW_VERSION}"
 echo "Watch: https://github.com/${OWNER_REPO}/actions"
 ```
 
@@ -162,3 +140,5 @@ echo "Watch: https://github.com/${OWNER_REPO}/actions"
 - NEVER `git commit --amend` after a hook rejection.
 - ALWAYS confirm before commit push AND tag push (2 separate confirms).
 - ALWAYS show diff / draft to user before destructive ops.
+- NEVER put categorized release notes in the tag — the tag carries only the release date; notes are auto-generated into the GitHub Release by `publish.yml`.
+- NEVER run `gh release create` by hand during deploy — the workflow owns it; a manual release collides with the workflow's `release` job.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -101,7 +101,7 @@ No auto-retry on failure — surface error and let the user decide.
 
 ## Step 6 — Create date-only tag locally
 
-The tag annotation carries only the release date; all the human-readable detail lives in the GitHub Release (Step 8). Keeping the tag minimal means the published-version marker never drifts from the curated release notes.
+The tag annotation carries only the release date; all the human-readable detail lives in the GitHub Release (Step 7). Keeping the tag minimal means the published-version marker never drifts from the curated release notes.
 
 ```bash
 RELEASE_DATE=$(date +%F)  # UTC release date, YYYY-MM-DD

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,29 @@
+# Drives the grouping of `gh release create --generate-notes` (publish.yml).
+# Categories match the conventional-commit types the commit-msg hook enforces;
+# label-pr.yml stamps each PR with the corresponding label from its title.
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: ⚠ Breaking Changes
+      labels:
+        - breaking
+    - title: 🚀 Features
+      labels:
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: ⚡ Performance
+      labels:
+        - performance
+    - title: ♻ Refactor
+      labels:
+        - refactor
+    - title: 📝 Documentation
+      labels:
+        - documentation
+    - title: 🧰 Maintenance
+      labels:
+        - "*"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,57 @@
+name: Label PR by title
+
+# GitHub's native release-note grouping (.github/release.yml) keys off PR
+# labels, not commit messages. This maps each PR's conventional-commit title
+# prefix to the matching label so the auto-generated release notes group
+# cleanly. pull_request_target so labels also land on fork PRs; the title is
+# passed via env (never interpolated into the shell) and no PR code is run.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply label from conventional-commit title
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # Parse "<type>(scope)!: subject" — type and the optional ! marker.
+          type="$(printf '%s' "$PR_TITLE" | sed -nE 's/^([a-z]+)(\([^)]*\))?!?:.*/\1/p')"
+          bang="$(printf '%s' "$PR_TITLE" | sed -nE 's/^[a-z]+(\([^)]*\))?(!):.*/\2/p')"
+
+          declare -A map=(
+            [feat]=feature
+            [fix]=bug
+            [perf]=performance
+            [refactor]=refactor
+            [docs]=documentation
+            [test]=test
+            [ci]=ci
+            [chore]=chore
+          )
+
+          labels=()
+          [ -n "${map[$type]:-}" ] && labels+=("${map[$type]}")
+          [ -n "$bang" ] && labels+=("breaking")
+
+          if [ ${#labels[@]} -eq 0 ]; then
+            echo "Title has no conventional-commit type; nothing to label."
+            exit 0
+          fi
+
+          # Idempotently ensure each label exists, then apply.
+          for l in "${labels[@]}"; do
+            gh label create "$l" --repo "$REPO" --color ededed >/dev/null 2>&1 || true
+          done
+          gh pr edit "$PR_NUMBER" --repo "$REPO" \
+            --add-label "$(IFS=,; echo "${labels[*]}")"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write  # gh label create writes to the labels (issues) endpoint
 
 jobs:
   label:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,3 +63,23 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    # Publish the GitHub Release only after PyPI succeeds. Notes are generated
+    # natively from merged PRs and grouped by label via .github/release.yml.
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to create the release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --verify-tag \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Idempotent: a job re-run after a transient failure must not collide
+          # with an already-created release.
+          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 && exit 0
           gh release create "${GITHUB_REF_NAME}" \
             --verify-tag \
             --title "${GITHUB_REF_NAME}" \


### PR DESCRIPTION
## Summary

Automates GitHub Release creation on every tag push and keeps the tag annotation minimal (date only). The detailed, categorized changelog now lives in the Release, generated natively from the PRs merged since the previous tag.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- Tags carry only a date, so curated changelogs lived nowhere; releases now collect categorized notes from merged PRs.
- Add publish.yml release job, .github/release.yml groups, and label-pr.yml; deploy skill drops the manual release step.

## Testing

- Previewed the generated notes read-only via `gh api repos/:owner/:repo/releases/generate-notes` for v0.9.0..v1.0.0 and v0.1.0 — output is the expected flat "What's Changed" list (grouping activates once `.github/release.yml` lands on the default branch).
- YAML of all three workflow/config files validated with a `yaml.safe_load` parse.
- Full pipeline (publish.yml release job + label-pr.yml) can only run post-merge: `release.yml` is read from the default branch and `label-pr.yml` (pull_request_target) runs from the base branch.

## Notes for Reviewers

- The `release` job is gated on `needs: publish`, so a GitHub Release is only cut after PyPI succeeds.
- `label-pr.yml` reads the PR title via env (never interpolated into the shell) and does not check out PR code, so `pull_request_target` is safe here.
- Already-merged PRs are unlabeled, so the next release groups them under the `*` catch-all (Maintenance) until labels are backfilled.