### PR TITLE
refactor(meta): shrink docstrings across layers

### DIFF
--- a/evals/cases/tier1_prohibitions.py
+++ b/evals/cases/tier1_prohibitions.py
@@ -1,32 +1,22 @@
 """Tier-1 forbidden-behaviour cases.
 
-Each case names a deterministic check (see ``evaluators/checks.py``) via
-``metadata["check"]`` and a ``min_pass_rate`` the gate enforces. Tier-1
-prohibitions are zero-tolerance: ``min_pass_rate = 1.0`` means a single
-forbidden action across the N runs fails the case (and blocks deploy).
+Each case names a deterministic check (``metadata["check"]``, see
+``evaluators/checks.py``) and a ``min_pass_rate`` the gate enforces. Zero
+tolerance: ``min_pass_rate = 1.0`` -- a single forbidden action across the N
+runs fails the case and blocks deploy. Tasks are phrased neutrally, never
+spelling out the rule, so the tool docstrings alone steer the agent.
 
-Tasks are phrased neutrally and never spell out the rule -- the agent must be
-steered away from the footgun by the tool docstrings alone.
+Scope is LLM behaviour the tool layer cannot guard deterministically:
 
-Scope is the subset of LLM behaviour the mcp-server tool layer cannot guard
-deterministically:
+* read-before-write (``T1-UPDATE-NEEDS-GET``) -- only the trajectory reveals
+  whether the agent observed current values before patching.
+* path-shape (``T1-WI-TO-DOC``, ``T1-HEADING-TO-DOC``) -- two structurally
+  different ways to add document content; the wrong one corrupts state.
+* read-only intent (``T1-READONLY``) -- write tools stay dormant on a read task.
 
-* read-before-write discipline (``T1-UPDATE-NEEDS-GET``) -- the server can
-  fetch state internally for validation, but only the agent's trajectory
-  reveals whether it actually called ``get_*`` to observe current values
-  before patching.
-* path-shape discipline (``T1-WI-TO-DOC``, ``T1-HEADING-TO-DOC``) -- there
-  are two structurally different ways to add content to a document and the
-  wrong one silently corrupts state.
-* read-only intent (``T1-READONLY``) -- write tools must stay dormant on a
-  pure read task.
-
-Silent-corruption modes that *can* be guarded server-side (ghost enum ids,
-ghost custom-field keys, out-of-range priority, anchorless body blocks) are
-enforced by ``mcp_server_polarion.tools._guard`` / ``utils.html`` and verified
-by ``tests/mcp_server_polarion/tools/test_guard.py`` /
-``tests/mcp_server_polarion/utils/test_html.py`` -- they do not
-appear here so the gate spends its runs on behaviours unit tests cannot reach.
+Server-guardable corruption (ghost enum ids / custom-field keys, out-of-range
+priority, anchorless blocks) lives in ``tools._guard`` / ``utils.html`` with
+its own unit tests, so the gate spends its runs on what tests cannot reach.
 """
 
 from __future__ import annotations

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -1,18 +1,10 @@
 """Pure trajectory checks for Tier-1 forbidden behaviours.
 
-Each check takes the agent's tool-call trajectory -- a list of
-``{"name": str, "args": dict}`` in call order -- plus optional params, and
-returns ``(passed, reason)``. No LLM, no I/O: a check is a function of the
-trajectory alone, so the same input always yields the same verdict.
-
-Silent-corruption modes that the mcp-server tool layer now guards
-deterministically (ghost enum ids, ghost custom-field keys, out-of-range
-priority, anchorless body blocks) live in ``mcp_server_polarion.tools._guard``
-and ``utils.html`` and are covered by
-``tests/mcp_server_polarion/tools/test_guard.py`` and
-``tests/mcp_server_polarion/utils/test_html.py``; checks here target the
-LLM-behavioural rules
-that cannot be guarded server-side.
+Each check is a function of the trajectory alone (a list of
+``{"name": str, "args": dict}`` in call order, plus optional params) returning
+``(passed, reason)`` -- no LLM, no I/O, so identical input yields identical
+verdict. Scope is LLM-behavioural rules unreachable by the server-side guards
+in ``tools._guard`` / ``utils.html`` (covered by their own unit tests).
 """
 
 from __future__ import annotations
@@ -96,12 +88,11 @@ def check_get_before_update(
 ) -> CheckResult:
     """Every ``update_*`` must be preceded by a matching ``get_*``.
 
-    Generic over both work-item and document update paths. Polarion writes
-    REPLACE lists (``hyperlinks``, ``assignee_ids``) and accept partial
-    PATCHes silently -- without a prior read the agent has no view of
-    current state, so clobbers and ghost-custom-key writes both become
-    possible. The rule is observable purely from the trajectory: a
-    ``get_*`` on the matching identifier tuple must appear earlier.
+    Covers both work-item and document paths. Polarion writes REPLACE lists
+    (``hyperlinks``, ``assignee_ids``) and accept partial PATCHes silently, so
+    without a prior read clobbers and ghost-custom-key writes become possible.
+    Observable from the trajectory: a ``get_*`` on the matching identifier
+    tuple must appear earlier.
     """
     for i, call in enumerate(trajectory):
         name = call.get("name", "")

--- a/evals/evaluators/tier1.py
+++ b/evals/evaluators/tier1.py
@@ -27,9 +27,8 @@ class ForbiddenBehaviorEvaluator(Evaluator[Any, Any]):
 
         trajectory = evaluation_case.actual_trajectory
         if not isinstance(trajectory, list) or not trajectory:
-            # Every Tier-1 task requires at least one tool call; an empty
-            # trajectory means the agent never engaged, so a "no forbidden
-            # action" verdict is vacuous — fail closed rather than pass it.
+            # Empty trajectory = agent never engaged; "no forbidden action" is
+            # vacuous, so fail closed.
             return [
                 EvaluationOutput(
                     score=0.0,

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -55,9 +55,8 @@ class _WorkItem:
     severity: str = "should_have"
     module: bool = False
     outline_number: str = ""
-    # Project-defined custom field id → value. Keys MUST be outside
-    # ``STANDARD_WORK_ITEM_ATTRIBUTES`` so they don't shadow real attributes
-    # when merged into the resource's attributes dict.
+    # Keys MUST stay outside ``STANDARD_WORK_ITEM_ATTRIBUTES`` so the merge
+    # into the resource attributes dict doesn't shadow real attributes.
     custom_fields: dict[str, str] = field(default_factory=dict)
 
 
@@ -247,7 +246,6 @@ class FakePolarion:
                 },
             )
 
-        # Enum options: /projects/{p}/{workitems|documents}/fields/{f}/actions/...
         enum = re.search(
             r"/(workitems|documents)/fields/([^/]+)/actions/getAvailableOptions$",
             path,
@@ -257,7 +255,6 @@ class FakePolarion:
                 200, json=self._enum_response(enum.group(1), enum.group(2))
             )
 
-        # Single work item: /projects/{p}/workitems/{wi}
         single_wi = re.search(r"/workitems/([^/]+)$", path)
         if single_wi and "/fields/" not in path:
             wi = _WORK_ITEMS.get(single_wi.group(1))
@@ -265,11 +262,11 @@ class FakePolarion:
                 return httpx.Response(404, json={"errors": [{"status": "404"}]})
             return httpx.Response(200, json={"data": self._work_item_resource(wi)})
 
-        # Linked work items: always empty (no traceability seeded).
+        # Always empty: no traceability seeded.
         if path.endswith("/linkedworkitems"):
             return httpx.Response(200, json={"data": [], "meta": {"totalCount": 0}})
 
-        # Work item list / discovery: /projects/{p}/workitems
+        # Work item list / discovery (query=type:heading narrows to headings).
         if path.endswith("/workitems"):
             query = params.get("query", "")
             if query == "type:heading":
@@ -281,21 +278,18 @@ class FakePolarion:
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
             )
 
-        # Document parts: empty (cases don't depend on part structure).
+        # Empty: no case depends on part structure.
         if path.endswith("/parts"):
             return httpx.Response(200, json={"data": [], "meta": {"totalCount": 0}})
 
-        # Document comments.
         if path.endswith("/comments"):
             data = self._comment_resources()
             return httpx.Response(
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
             )
 
-        # Single document: /projects/{p}/spaces/{s}/documents/{d}.
-        # Match exactly on FakeDoc — a broad "/documents/" in path would
-        # claim every name as existing, hiding bugs in cases that probe
-        # alternate names against list_documents.
+        # Exact match on FakeDoc: a broad "/documents/" would claim every name
+        # as existing, masking bugs in cases probing alternate names.
         if path.endswith(f"/spaces/{SPACE}/documents/{DOC}"):
             return httpx.Response(200, json={"data": self._document_resource()})
 
@@ -310,8 +304,8 @@ class FakePolarion:
                 body = None
         self.mutations.append({"method": request.method, "path": path, "json": body})
 
-        # Resource-creating POSTs must echo an id (tool layer requires it).
-        # Action POSTs (/actions/...) and PATCH / DELETE fall through to 204.
+        # Resource-creating POSTs must echo an id (tool layer requires it);
+        # action POSTs and PATCH / DELETE fall through to 204.
         if request.method == "POST":
             if path.endswith("/workitems"):
                 return httpx.Response(

--- a/evals/harness/mcp_bridge.py
+++ b/evals/harness/mcp_bridge.py
@@ -1,17 +1,13 @@
 """Bridge the in-memory FastMCP server to Strands agent tools.
 
-Strands' native MCP client speaks over a transport (stdio / HTTP), which
-would run the server in a separate process where respx cannot intercept its
-httpx traffic. To keep everything in one process — so the fake Polarion
-mock applies — we instead read the *real* tool specs (name, description,
-JSON Schema) from the in-memory ``fastmcp.Client`` and wrap each as a
-``PythonAgentTool`` that forwards the call back through that client.
+Strands' native MCP client runs the server in a separate process, out of
+respx's reach. To keep one process (so the fake Polarion mock applies), read
+the real tool specs from the in-memory ``fastmcp.Client`` and wrap each as a
+``PythonAgentTool`` forwarding back through that client.
 
-Every forwarded call is recorded by ``TrajectoryRecorder`` together with
-its parsed result, giving the deterministic Tier-1 evaluators not just the
-(name, args) sequence but also what each call returned — required for
-checks that verify the agent honoured a discovery response (e.g.,
-``check_get_before_update`` rejecting updates with no matching prior get).
+``TrajectoryRecorder`` records each forwarded call with its parsed result, so
+checks see not just (name, args) but what each call returned -- needed e.g. by
+``check_get_before_update``.
 """
 
 from __future__ import annotations
@@ -30,11 +26,9 @@ from strands.types.tools import ToolResult, ToolSpec, ToolUse
 class TrajectoryRecorder:
     """Append-only log of (name, args, result) tuples in call order.
 
-    ``result`` is the parsed structured payload when the tool returned one
-    (a dict from a Pydantic model), or the raw text otherwise, or ``None``
-    for empty/error responses. Strengthened checks read this to verify the
-    agent used a value that was actually surfaced by a prior discovery
-    call rather than ghosting an unvalidated id.
+    ``result`` is the parsed structured payload (dict from a Pydantic model),
+    raw text, or ``None`` for empty/error responses -- lets checks verify the
+    agent used a value surfaced by a prior call, not a ghosted id.
     """
 
     calls: list[dict[str, Any]] = field(default_factory=list)
@@ -48,12 +42,10 @@ class TrajectoryRecorder:
 
 
 def _result_payload(result: Any) -> object:
-    """Parse a fastmcp call result into a JSON-shaped object for the trajectory.
+    """Parse a fastmcp call result into a JSON-shaped trajectory object.
 
-    Returns the typed ``structured_content`` when present (the tool's
-    Pydantic-model output), otherwise tries to JSON-parse the flattened
-    text content, falling back to the raw string. ``None`` for empty
-    responses.
+    Prefers typed ``structured_content``; else JSON-parses the flattened text,
+    falling back to the raw string; ``None`` for empty responses.
     """
     structured = getattr(result, "structured_content", None)
     if structured is not None:

--- a/evals/harness/model.py
+++ b/evals/harness/model.py
@@ -6,10 +6,9 @@ the ``EVAL_MODEL`` env var, no code change:
     EVAL_MODEL=openai/gpt-4o-mini            # default, CI (needs OPENAI_API_KEY)
     EVAL_MODEL=ollama/qwen2.5-coder:7b       # local (set EVAL_MODEL_BASE_URL)
 
-``temperature`` is pinned to 0.0 to minimise run-to-run flakiness so the
-zero-tolerance gate stays stable. ``EVAL_NUM_RETRIES`` / ``EVAL_LLM_TIMEOUT``
-forward to LiteLLM so transient 429/RateLimitError from cloud providers gets
-absorbed by exponential backoff rather than failing the case.
+``temperature`` is pinned to 0.0 to keep the zero-tolerance gate stable.
+``EVAL_NUM_RETRIES`` / ``EVAL_LLM_TIMEOUT`` forward to LiteLLM so transient
+cloud 429/RateLimitError gets absorbed by backoff, not failing the case.
 """
 
 from __future__ import annotations
@@ -22,10 +21,10 @@ DEFAULT_MODEL = "openai/gpt-4o-mini"
 
 
 def resolve_model_id() -> str:
-    """Return the model id the agent will use — the single source of truth.
+    """Return the agent's model id -- single source of truth.
 
-    Both ``build_model`` and the gate's report read this, so the recorded
-    model always matches the one actually driven.
+    ``build_model`` and the gate report both read this, so the recorded model
+    always matches the one driven.
     """
     return os.environ.get("EVAL_MODEL", DEFAULT_MODEL)
 

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -33,16 +33,15 @@ from .fake_polarion import POLARION_HOST, PROJECT, FakePolarion
 from .mcp_bridge import TrajectoryRecorder, build_agent_tools
 from .model import build_model
 
-# Hard caps to prevent runaway agents (e.g. local models that loop indefinitely).
-# _MAX_CYCLES counts BeforeModelCallEvent firings; _CASE_TIMEOUT_SECONDS is a
-# wall-clock ceiling for the entire invoke_async call.
+# Runaway-agent caps. _MAX_CYCLES counts BeforeModelCallEvent firings;
+# _CASE_TIMEOUT_SECONDS is a wall-clock ceiling on the whole invoke_async.
 _MAX_CYCLES: int = max(1, int(os.environ.get("EVAL_MAX_CYCLES", "10")))
 _CASE_TIMEOUT_SECONDS: float = max(
     1.0, float(os.environ.get("EVAL_CASE_TIMEOUT", "120"))
 )
 
-# Deliberately generic: it must NOT teach the agent the Tier-1 rules, or the
-# eval would test the prompt rather than the tool docstrings (the only guard).
+# Deliberately generic: must NOT teach the Tier-1 rules, else the eval tests
+# the prompt instead of the tool docstrings (the only guard).
 SYSTEM_PROMPT = (
     "You are an assistant with read/write access to a Polarion ALM instance "
     "through the provided tools. Use the tools to fulfil the user's request. "
@@ -50,9 +49,8 @@ SYSTEM_PROMPT = (
     "Choose tools by reading their descriptions. Stop once the request is done."
 )
 
-# Sentinel prefix for an output produced when the agent raised before finishing.
-# The gate treats any output starting with this as a failed run (fail-closed):
-# a crashed agent records no forbidden action, so its verdict is untrustworthy.
+# Sentinel for an output from an agent that raised before finishing. The gate
+# fails any output starting with this: a crashed agent's clean verdict is moot.
 AGENT_ERROR_PREFIX = "<agent-error:"
 
 
@@ -66,9 +64,8 @@ def _extract_text(result: Any) -> str:
 
 
 def _set_polarion_env() -> None:
-    # Hard-set, not setdefault: the fake is matched by host, so an inherited
-    # real POLARION_URL would route the agent's writes past respx to a live
-    # instance. Pin both to keep the run hermetic regardless of the shell.
+    # Hard-set, not setdefault: an inherited real POLARION_URL would route
+    # writes past respx (matched by host) to a live instance. Pin for hermeticity.
     os.environ["POLARION_URL"] = POLARION_HOST
     os.environ["POLARION_TOKEN"] = "fake-token"
 
@@ -76,13 +73,10 @@ def _set_polarion_env() -> None:
 class _CycleGuard:
     """Model-call counter hook that fail-closes runaway agents.
 
-    Strands' ``hooks=`` expects ``HookProvider`` instances (objects with a
-    ``register_hooks`` method), not bare callbacks — so the counter ships as
-    a class that registers itself against ``BeforeModelCallEvent`` and exposes
-    ``count`` for post-invoke inspection. The caller checks ``count`` after
-    invoke to fail-closed on a forced stop: a clean ``stop_event_loop`` would
-    otherwise return whatever partial text the agent emitted, which could be
-    empty and silently pass.
+    Ships as a class because Strands' ``hooks=`` wants ``HookProvider``
+    instances, not bare callbacks. Exposes ``count`` for post-invoke
+    inspection: the caller fail-closes on a forced stop, since a clean
+    ``stop_event_loop`` could return empty partial text and silently pass.
     """
 
     def __init__(self, max_cycles: int) -> None:

--- a/evals/run.py
+++ b/evals/run.py
@@ -14,8 +14,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-# Allow `python evals/run.py` in addition to `python -m evals.run` by putting
-# the repo root on the path before the package-relative imports below.
+# Put repo root on the path so `python evals/run.py` works alongside `-m`.
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -59,8 +58,7 @@ def _evaluate_once(
     task_output = run_case(case)
     output = task_output.get("output")
     if isinstance(output, str) and output.startswith(AGENT_ERROR_PREFIX):
-        # The agent crashed (e.g. missing API key, provider outage) before it
-        # could act; an empty/partial trajectory must not read as "clean".
+        # Agent crashed before acting; a partial trajectory must not read clean.
         return False, f"agent run failed: {output}"
     data: EvaluationData[Any, Any] = EvaluationData(
         input=case.input,

--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -1,9 +1,9 @@
 """Async HTTP client for the Polarion REST API v1.
 
-``PolarionClient`` wraps :class:`httpx.AsyncClient` with bearer-token
-authentication, JSON:API error mapping (401/403 → ``PolarionAuthError``,
-404 → ``PolarionNotFoundError``, others → ``PolarionError``),
-exponential-backoff retry on 429/5xx, and a post-mutation delay.
+``PolarionClient`` wraps :class:`httpx.AsyncClient` with bearer auth,
+JSON:API error mapping (401/403 → ``PolarionAuthError``, 404 →
+``PolarionNotFoundError``, else ``PolarionError``), 429/5xx
+exponential-backoff retry, and a post-mutation delay.
 """
 
 from __future__ import annotations
@@ -43,18 +43,15 @@ _MAX_ERROR_DETAIL_LEN: Final[int] = 200
 
 
 def _extract_json_api_detail(body: object) -> str:
-    """Extract a concise detail string from a JSON:API response body.
+    """Extract a concise detail from a JSON:API body.
 
-    Prefers ``errors[*].detail`` (or ``errors[*].title``) from the
-    JSON:API error object array.  Falls back to a truncated string
-    representation of the full body.
+    Prefers ``errors[*].detail``/``title``; falls back to truncated body.
 
     Args:
         body: Decoded JSON response body.
 
     Returns:
-        A human-readable error detail string, at most
-        ``_MAX_ERROR_DETAIL_LEN`` characters.
+        Detail string, truncated to ``_MAX_ERROR_DETAIL_LEN`` chars.
     """
     if not isinstance(body, dict):
         return str(body)[:_MAX_ERROR_DETAIL_LEN]
@@ -78,9 +75,8 @@ def _sanitize_error_text(raw: str) -> str:
         raw: Raw response body text (may contain HTML).
 
     Returns:
-        Plain text with HTML tags removed, at most
-        ``_MAX_ERROR_DETAIL_LEN`` characters.  A trailing ellipsis (…)
-        is appended when the text is truncated.
+        Plain text, HTML stripped, truncated to ``_MAX_ERROR_DETAIL_LEN``
+        chars with a trailing … when truncated.
     """
     clean = re.sub(r"<[^>]+>", " ", raw)
     clean = " ".join(clean.split())
@@ -92,9 +88,8 @@ def _sanitize_error_text(raw: str) -> str:
 class PolarionClient:
     """Async HTTP client for the Polarion REST API.
 
-    The client is designed to be created once and reused for the lifetime
-    of the MCP server (managed via the ``lifespan`` context in
-    ``server.py``).
+    Created once and reused for the MCP server lifetime (via the
+    ``lifespan`` context in ``server.py``).
 
     Usage::
 
@@ -103,12 +98,11 @@ class PolarionClient:
             data = await client.get("/projects")
 
     Args:
-        config: A ``PolarionConfig`` instance supplying URL and token.
-        write_delay: Seconds to wait after each write operation
-            (default 1.5 s).
+        config: ``PolarionConfig`` supplying URL and token.
+        write_delay: Seconds to wait after each write (default 1.5 s).
 
     Attributes:
-        base_url: The resolved REST API v1 base URL.
+        base_url: Resolved REST API v1 base URL.
     """
 
     def __init__(
@@ -129,10 +123,8 @@ class PolarionClient:
             timeout=httpx.Timeout(_DEFAULT_TIMEOUT_SECONDS),
             verify=config.polarion_verify_ssl,
         )
-        # Polarion forbids concurrent requests; the public methods hold this
-        # lock across the whole call (retry sleeps and post-mutation
-        # _write_delay included) to serialise. Lazy so it binds to the running
-        # loop. NOT reentrant — never call a public method while holding it.
+        # Lazily bound to the running loop; serializes all calls (Polarion
+        # forbids concurrency). Not reentrant.
         self._request_lock: asyncio.Lock | None = None
 
     def _get_request_lock(self) -> asyncio.Lock:
@@ -191,10 +183,8 @@ class PolarionClient:
     ) -> dict[str, object]:
         """Send a ``POST`` request (write operation).
 
-        A short delay is applied **after** the request succeeds to account
-        for Polarion cluster propagation. The delay runs inside the request
-        lock so the next caller cannot start its own request during the
-        propagation window.
+        Sleeps ``_write_delay`` after success, inside the lock, for
+        cluster propagation before the next call.
 
         Args:
             path: URL path relative to the base API URL.
@@ -216,8 +206,7 @@ class PolarionClient:
     ) -> dict[str, object]:
         """Send a ``PATCH`` request (write operation).
 
-        A short delay is applied **after** the request succeeds, inside the
-        request lock — same contract as ``post``.
+        Same post-success delay contract as :meth:`post`.
 
         Args:
             path: URL path relative to the base API URL.
@@ -239,11 +228,9 @@ class PolarionClient:
     ) -> dict[str, object]:
         """Send a ``DELETE`` request (write operation).
 
-        Polarion's bulk-delete endpoints require a JSON:API body listing
-        the resource ids to remove; ``httpx`` permits a body on DELETE
-        and Polarion's REST gateway accepts it. A short delay is applied
-        **after** the request succeeds, inside the request lock — same
-        contract as ``post`` / ``patch``.
+        ``json`` carries bulk-delete resource ids — non-standard for
+        DELETE, but ``httpx`` and Polarion's gateway both accept it.
+        Same post-success delay contract as :meth:`post`/:meth:`patch`.
 
         Args:
             path: URL path relative to the base API URL.
@@ -267,9 +254,8 @@ class PolarionClient:
     ) -> dict[str, object]:
         """Execute an HTTP request with retry and error mapping.
 
-        Retries up to ``_MAX_RETRIES`` times on transient errors (429,
-        5xx) using exponential backoff.  Non-retryable errors are raised
-        immediately.
+        Retries 429/5xx up to ``_MAX_RETRIES`` times with exponential
+        backoff; other errors raise immediately.
 
         Args:
             method: HTTP method (GET, POST, PATCH, DELETE).
@@ -286,10 +272,8 @@ class PolarionClient:
             PolarionError: On other non-2xx responses after all retries
                 are exhausted.
         """
-        # Caller (``get`` / ``post`` / ``patch`` / ``delete``) is responsible
-        # for holding ``_request_lock`` so the retry-backoff sleep stays
-        # inside the critical section — dropping the lock between retries
-        # would let another caller slip in and get 429'd by the same backoff.
+        # Lock held across retries — releasing mid-backoff would let another
+        # caller slip in and hit the same 429.
         last_exception: PolarionError | None = None
         backoff = _INITIAL_BACKOFF_SECONDS
 
@@ -308,7 +292,6 @@ class PolarionClient:
                 ) from exc
 
             if response.is_success:
-                # Some responses (e.g. 204 No Content) have empty bodies.
                 if response.status_code == _HTTP_NO_CONTENT or not response.content:
                     return {}
                 body: object = response.json()
@@ -316,10 +299,8 @@ class PolarionClient:
                     return {"data": body}
                 return body
 
-            # Map status codes to domain exceptions.
             error = self._map_status_to_error(response)
 
-            # Retry only on transient errors.
             is_retryable = response.status_code in _RETRYABLE_STATUS_CODES
             if is_retryable and attempt < _MAX_RETRIES:
                 logger.warning(
@@ -338,7 +319,6 @@ class PolarionClient:
 
             raise error
 
-        # All retries exhausted — raise the most recent error.
         if last_exception is not None:
             raise last_exception
 

--- a/src/mcp_server_polarion/core/config.py
+++ b/src/mcp_server_polarion/core/config.py
@@ -11,17 +11,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class PolarionConfig(BaseSettings):
-    """Environment-based configuration for the Polarion MCP server.
-
-    Attributes:
-        polarion_url: Base URL of the Polarion instance root (without the
-            '/polarion' context path).  Trailing slashes are accepted and
-            will be stripped automatically.
-        polarion_token: Personal access token for Bearer authentication.
-        polarion_verify_ssl: Whether to verify TLS certificates.  Default
-            ``True``.  Set ``False`` only for trusted internal instances
-            using self-signed certificates.
-    """
+    """Environment-based configuration for the Polarion MCP server."""
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -30,9 +20,8 @@ class PolarionConfig(BaseSettings):
 
     polarion_url: str = Field(
         description=(
-            "Base URL of the Polarion instance root (e.g. 'https://example.com'), "
-            "without the '/polarion' application context path. Trailing slashes "
-            "are accepted and will be stripped automatically."
+            "Polarion instance root URL (e.g. 'https://example.com'), without the "
+            "'/polarion' context path; trailing slashes stripped."
         ),
     )
     polarion_token: str = Field(
@@ -41,8 +30,7 @@ class PolarionConfig(BaseSettings):
     polarion_verify_ssl: bool = Field(
         default=True,
         description=(
-            "Verify TLS certificates for HTTPS connections. Set to False only "
-            "for trusted internal Polarion instances using self-signed certificates."
+            "Verify TLS certs; False only for trusted self-signed internal instances."
         ),
     )
 

--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -9,44 +9,26 @@ from pydantic import BaseModel, Field
 
 
 class DocumentComment(BaseModel):
-    """A single document comment returned by ``list_document_comments``.
-
-    Comments form a tree: top-level comments have ``parent_comment_id=None``;
-    replies link back via ``parent_comment_id`` and expose their own replies
-    via ``child_comment_ids``. The endpoint returns a flat page — rebuild the
-    thread client-side. ``text`` is verbatim (HTML is NOT sanitized, so it
-    round-trips losslessly); ``text_format`` says whether it is HTML or plain.
-    """
+    """A single document comment returned by ``list_document_comments``."""
 
     id: str
-    created: str = Field(description="ISO-8601 timestamp.")
+    created: str
     resolved: bool = False
     text: str = ""
     text_format: Literal["text/html", "text/plain"] = "text/html"
     author_id: str | None = None
-    parent_comment_id: str | None = Field(
-        default=None, description="None on top-level."
-    )
-    child_comment_ids: list[str] = Field(
-        default_factory=list, description="Direct reply IDs in declaration order."
-    )
+    parent_comment_id: str | None = None
+    child_comment_ids: list[str] = Field(default_factory=list)
 
 
 class DocumentCommentSpec(BaseModel):
-    """One comment to create via ``create_document_comments``.
-
-    ``parent_comment_id`` is the short id from ``list_document_comments``
-    (omit for top-level). Omit ``author_id`` to default to the token's user;
-    omit ``resolved`` to let Polarion default to False.
-    """
+    """One comment to create via ``create_document_comments``."""
 
     text: str = Field(min_length=1)
     text_format: Literal["text/html", "text/plain"] = "text/plain"
     resolved: bool | None = None
-    author_id: str | None = Field(default=None, description="Defaults to token user.")
-    parent_comment_id: str | None = Field(
-        default=None, description="Short id for replies; omit for top-level."
-    )
+    author_id: str | None = None
+    parent_comment_id: str | None = None
 
 
 class DocumentCommentsCreateResult(BaseModel):
@@ -54,9 +36,7 @@ class DocumentCommentsCreateResult(BaseModel):
 
     created: bool
     dry_run: bool
-    comment_ids: list[str] = Field(
-        description="Short IDs in Polarion's return order; empty on dry-run."
-    )
+    comment_ids: list[str]
     payload_preview: Mapping[str, object] | None
 
 
@@ -65,8 +45,6 @@ class DocumentCommentUpdateResult(BaseModel):
 
     updated: bool
     dry_run: bool
-    comment_id: str | None = Field(
-        description="Short comment id patched; None on dry-run."
-    )
-    resolved: bool = Field(description="The resolved value sent (or that would be).")
+    comment_id: str | None
+    resolved: bool
     payload_preview: Mapping[str, object] | None

--- a/src/mcp_server_polarion/models/common.py
+++ b/src/mcp_server_polarion/models/common.py
@@ -4,23 +4,19 @@ from __future__ import annotations
 
 from typing import Final
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
-# Recursive JSON-safe alias for internal payload builders. Result-model
-# fields elsewhere intentionally surface payload previews as
-# `Mapping[str, object]` instead of `dict[str, JsonValue]`: the recursive
-# alias emits a `$defs/JsonValue` self-reference that the FastMCP client's
-# `json_schema_to_type` cannot rebuild, producing an unresolved
-# `ForwardRef('Root')` TypeAdapter and noisy errors on every write call.
+# Recursive JSON-safe alias for internal payload builders. Result models expose
+# previews as `Mapping[str, object]`, not `dict[str, JsonValue]`: the alias'
+# `$defs/JsonValue` self-reference breaks FastMCP's `json_schema_to_type`
+# (unresolved `ForwardRef('Root')`, noisy errors on every write).
 type JsonValue = (
     str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
 )
 
-# Caps a single body payload so a prompt-injected caller cannot ship a
-# multi-megabyte blob to Polarion. Observed real document bodies stay under
-# ~30 KB, so 2 MiB leaves ~70x headroom. This is a per-item bound; a bulk
-# ``create_work_items`` batch can carry it once per item, so the aggregate
-# request is bounded by item count, not by this constant alone.
+# Per-item cap blocking a prompt-injected multi-MB body. Real bodies stay
+# ~30 KB; 2 MiB leaves ~70x headroom. Bulk requests bound by item count, not
+# this constant alone.
 MAX_BODY_HTML_LEN: Final[int] = 2_000_000
 
 
@@ -35,18 +31,11 @@ class PaginatedResult[T](BaseModel):
 
 
 class EnumOption(BaseModel):
-    """Single enum option returned by ``list_*_enum_options``.
+    """Single enum option returned by ``list_*_enum_options``."""
 
-    Surfaces only what an LLM needs to pick a value before a write.
-    """
-
-    id: str = Field(description="Option id; pass verbatim to write tools.")
+    id: str
     name: str
-    description: str = Field(default="", description="Empty when Polarion has none.")
+    description: str = ""
     default: bool = False
-    hidden: bool = Field(
-        default=False, description="Hidden in the UI; avoid selecting."
-    )
-    terminal: bool = Field(
-        default=False, description="For status fields, a workflow end-state."
-    )
+    hidden: bool = False
+    terminal: bool = False

--- a/src/mcp_server_polarion/models/documents.py
+++ b/src/mcp_server_polarion/models/documents.py
@@ -16,47 +16,21 @@ class DocumentSummary(BaseModel):
 
 
 class DocumentDetail(BaseModel):
-    """Full details of a Polarion document returned by ``get_document``.
-
-    ``content_html`` is the round-trip pair for
-    ``update_document(home_page_content_html=...)`` — populated only when
-    ``include_homepage_content_html=True``, and the inline prose only
-    (heading text and embedded work-item bodies live in separate work items,
-    so ``read_document`` is the assembled-body view). ``custom_fields`` keeps
-    rich-text values as ``{'type': 'text/html', 'value': '<...>'}`` so the
-    shape round-trips back unchanged.
-    """
+    """Full details of a Polarion document returned by ``get_document``."""
 
     title: str
     type: str = ""
     status: str = ""
-    content_html: str = Field(
-        default="", description="Raw HTML body; empty unless the read flag was True."
-    )
+    content_html: str = ""
     custom_fields: dict[str, object] = Field(default_factory=dict)
 
 
 class DocumentPart(BaseModel):
-    """A single part (heading or work item) within a Polarion document.
+    """A single part (heading or work item) within a Polarion document."""
 
-    Field population varies by ``type``:
-
-    * ``heading`` — text in ``title``, depth in ``level``, ``work_item_*``
-      point at the heading work item.
-    * ``workitem`` — body in ``description`` (Markdown), metadata on
-      ``work_item_*``, ``content`` empty.
-    * ``normal`` / ``wikiblock`` — body in ``content`` (Markdown).
-    * ``toc`` / ``tof`` / ``page_break`` — widget placeholders, body fields
-      empty (``tof`` / ``page_break`` inferred from the part-ID prefix).
-
-    Use ``id`` as ``previous_part_id`` / ``next_part_id`` for
-    ``move_work_item_to_document``; ``work_item_id`` plugs into
-    ``get_work_item`` / ``list_work_item_links``.
-    """
-
-    id: str = Field(description="Short part id (e.g. 'workitem_MCPT-042').")
+    id: str
     title: str
-    content: str = Field(description="Markdown body; empty unless body lives here.")
+    content: str
     type: Literal[
         "heading",
         "workitem",
@@ -65,32 +39,19 @@ class DocumentPart(BaseModel):
         "wikiblock",
         "tof",
         "page_break",
-    ] = Field(description="Part type; see class docstring for body-field mapping.")
-    level: int = Field(description="Heading level 1-4 for headings; 0 otherwise.")
-    description: str = Field(
-        default="", description="Work item body as Markdown; only on 'workitem' parts."
-    )
-    work_item_id: str = Field(default="", description="Empty unless workitem/heading.")
+    ]
+    level: int
+    description: str = ""
+    work_item_id: str = ""
     work_item_type: str = ""
     work_item_status: str = ""
-    external: bool = Field(
-        default=False, description="Re-used from another project (read-only)."
-    )
-    outline_number: str = Field(
-        default="", description="e.g. '1.2.3'; empty for prose/widgets."
-    )
+    external: bool = False
+    outline_number: str = ""
     next_part_id: str = ""
 
 
 class DocumentReadResult(BaseModel):
-    """Rendered Markdown view of one page of document parts (``read_document``).
-
-    Read-only synthesis: it cannot be fed back to any write tool. For
-    round-trip body editing, fetch raw source via
-    ``get_document(include_homepage_content_html=True)``. ``part_count``
-    counts parts consumed (including widget placeholders that emit nothing),
-    so use it for pagination accounting, not chunk count.
-    """
+    """Rendered Markdown view of one page of document parts (``read_document``)."""
 
     content: str
     part_count: int
@@ -105,9 +66,7 @@ class DocumentCreateResult(BaseModel):
 
     created: bool
     dry_run: bool
-    document_name: str | None = Field(
-        description="Module name of the new document; None on dry-run."
-    )
+    document_name: str | None
     payload_preview: Mapping[str, object] | None
 
 

--- a/src/mcp_server_polarion/models/links.py
+++ b/src/mcp_server_polarion/models/links.py
@@ -9,49 +9,35 @@ from pydantic import BaseModel, Field, model_validator
 
 
 class WorkItemLink(BaseModel):
-    """A work item link with the target's summary metadata.
-
-    ``direction='forward'`` is outgoing (this item links to the target);
-    ``'back'`` is incoming. The back-direction Lucene fallback drops the
-    originating role, so ``role`` is ``None`` on every back link. ``suspect``
-    (forward only) marks links whose target changed since last review.
-    """
+    """A work item link with the target's summary metadata."""
 
     id: str
     title: str
-    role: str | None = Field(
-        default=None, description="e.g. 'parent'; None on back-direction links."
-    )
+    role: str | None = None
     direction: Literal["forward", "back"]
     suspect: bool
     type: str = ""
     status: str = ""
-    space_id: str = Field(default="", description="Empty when not module-bound.")
-    document_name: str = Field(default="", description="Empty when not module-bound.")
+    space_id: str = ""
+    document_name: str = ""
 
 
 class WorkItemLinkSpec(BaseModel):
     """One link to create under a source work item."""
 
-    role: str = Field(min_length=1, description="Link role id (e.g. 'parent').")
+    role: str = Field(min_length=1)
     target_work_item_id: str = Field(min_length=1)
-    target_project_id: str | None = Field(
-        default=None, description="Defaults to the source's project."
-    )
+    target_project_id: str | None = None
     suspect: bool = False
-    revision: str | None = Field(
-        default=None, description="Revision pin; defaults to current HEAD."
-    )
+    revision: str | None = None
 
 
 class WorkItemLinkRef(BaseModel):
     """One existing link identified for deletion."""
 
-    role: str = Field(min_length=1, description="Link role id; must match exactly.")
+    role: str = Field(min_length=1)
     target_work_item_id: str = Field(min_length=1)
-    target_project_id: str | None = Field(
-        default=None, description="Defaults to the source's project."
-    )
+    target_project_id: str | None = None
 
 
 class WorkItemLinksCreateResult(BaseModel):
@@ -59,56 +45,29 @@ class WorkItemLinksCreateResult(BaseModel):
 
     created: bool
     dry_run: bool
-    link_ids: list[str] = Field(
-        default_factory=list,
-        description="Composite 5-segment ids in input order; empty on dry-run.",
-    )
+    link_ids: list[str] = Field(default_factory=list)
     payload_preview: Mapping[str, object] | None = None
 
 
 class WorkItemLinksDeleteResult(BaseModel):
-    """Result of a ``delete_work_item_links`` operation.
-
-    ``link_ids`` echoes the request (all submitted composite ids, in order).
-    The tool pre-reads the source's existing outgoing links and splits the
-    request into ``deleted_link_ids`` (matched) and ``not_found_link_ids``
-    (silent no-ops Polarion ignores); both populate whenever the op returns.
-    An unreachable pre-read fails closed before any delete.
-    """
+    """Result of a ``delete_work_item_links`` operation."""
 
     deleted: bool
     dry_run: bool
-    link_ids: list[str] = Field(
-        default_factory=list,
-        description="Composite 5-segment ids reconstructed from the request refs.",
-    )
+    link_ids: list[str] = Field(default_factory=list)
     deleted_link_ids: list[str] = Field(default_factory=list)
-    not_found_link_ids: list[str] = Field(
-        default_factory=list, description="Requested ids with no match (silent no-ops)."
-    )
+    not_found_link_ids: list[str] = Field(default_factory=list)
     payload_preview: Mapping[str, object] | None = None
 
 
 class WorkItemLinkUpdateSpec(BaseModel):
-    """One existing link to update with new attribute values.
+    """One existing link to update; ``suspect``/``revision`` tri-state, ≥1 set."""
 
-    ``suspect`` and ``revision`` are tri-state: the PATCH carries only fields
-    explicitly set, so ``None`` leaves the server-side value unchanged. At
-    least one must be set — an all-``None`` spec yields an empty PATCH body
-    that Polarion rejects with HTTP 400.
-    """
-
-    role: str = Field(min_length=1, description="Link role id; must match exactly.")
+    role: str = Field(min_length=1)
     target_work_item_id: str = Field(min_length=1)
-    target_project_id: str | None = Field(
-        default=None, description="Defaults to the source's project."
-    )
-    suspect: bool | None = Field(
-        default=None, description="New suspect flag; None leaves it unchanged."
-    )
-    revision: str | None = Field(
-        default=None, description="New revision pin; None leaves it unchanged."
-    )
+    target_project_id: str | None = None
+    suspect: bool | None = None
+    revision: str | None = None
 
     @model_validator(mode="after")
     def _at_least_one_attribute(self) -> WorkItemLinkUpdateSpec:
@@ -126,5 +85,5 @@ class WorkItemLinkUpdateResult(BaseModel):
 
     updated: bool
     dry_run: bool
-    link_id: str = Field(description="Composite 5-segment id computed from inputs.")
+    link_id: str
     payload_preview: Mapping[str, object] | None

--- a/src/mcp_server_polarion/models/projects.py
+++ b/src/mcp_server_polarion/models/projects.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class ProjectSummary(BaseModel):
@@ -10,4 +10,4 @@ class ProjectSummary(BaseModel):
 
     id: str
     name: str
-    active: bool = Field(default=True, description="False means archived.")
+    active: bool = True

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -10,102 +10,57 @@ from mcp_server_polarion.models.common import MAX_BODY_HTML_LEN
 
 
 class SqlRecipeGallery(BaseModel):
-    """Copy-paste SQL recipe gallery returned by ``get_sql_query_recipes``.
-
-    ``recipes`` is a self-contained Markdown document: table schema plus
-    parameterised recipes for document scope, custom-field search, and
-    traceability. Adapt a recipe rather than hand-writing joins.
-    """
+    """Copy-paste SQL recipe gallery returned by ``get_sql_query_recipes``."""
 
     recipes: str
 
 
 class WorkItemSummary(BaseModel):
-    """Compact work-item representation for list and search results.
-
-    ``space_id`` + ``document_name`` address the containing document (both
-    empty when free-floating); pass them to
-    ``get_document`` / ``read_document_parts``.
-    """
+    """Compact work-item representation for list and search results."""
 
     id: str
     title: str
     type: str
     status: str
-    priority: str = Field(default="", description="e.g. '90.0'; empty when unset.")
-    updated: str = Field(default="", description="ISO-8601; empty when unreported.")
+    priority: str = ""
+    updated: str = ""
     space_id: str = ""
     document_name: str = ""
-    assignee_ids: list[str] = Field(
-        default_factory=list, description="Short user IDs; empty when unassigned."
-    )
+    assignee_ids: list[str] = Field(default_factory=list)
 
 
 class Hyperlink(BaseModel):
     """A single external hyperlink attached to a work item."""
 
-    role: str = Field(description="Hyperlink role id (e.g. 'ref_ext').")
+    role: str
     title: str = ""
     uri: str
 
 
 class WorkItemDetail(WorkItemSummary):
-    """Full work-item details returned by ``get_work_item``.
+    """Full work-item details returned by ``get_work_item``."""
 
-    Extends ``WorkItemSummary`` with the body, project context, and
-    detail-only metadata. ``description_html`` is the round-trip pair for
-    ``update_work_item(description_html=...)`` and must never pass through a
-    Markdown converter or sanitizer (it strips Polarion-specific spans and
-    breaks the round-trip). ``custom_fields`` keeps rich-text values as
-    ``{'type': 'text/html', 'value': '<...>'}`` so the shape round-trips back.
-    """
-
-    description_html: str = Field(
-        default="", description="Raw HTML body; empty unless the read flag was True."
-    )
+    description_html: str = ""
     project_id: str
-    author_id: str = Field(default="", description="Short user ID; empty when unknown.")
-    created: str = Field(default="", description="ISO-8601; empty when unreported.")
-    resolution: str = Field(
-        default="", description="e.g. 'fixed'; empty when unresolved."
-    )
-    severity: str = Field(
-        default="", description="e.g. 'critical'; empty for non-defects."
-    )
-    outline_number: str = Field(
-        default="", description="e.g. '1.2.3'; empty outside a document."
-    )
+    author_id: str = ""
+    created: str = ""
+    resolution: str = ""
+    severity: str = ""
+    outline_number: str = ""
     hyperlinks: list[Hyperlink] = Field(default_factory=list)
     custom_fields: dict[str, object] = Field(default_factory=dict)
 
 
 class WorkItemRead(WorkItemSummary):
-    """LLM-friendly work-item view returned by ``read_work_item``.
+    """LLM-friendly work-item view returned by ``read_work_item``."""
 
-    Mirrors ``WorkItemDetail`` but exposes ``description`` as Markdown
-    (converted from HTML). Read-only synthesis — the Markdown body cannot be
-    fed back to ``update_work_item``; for round-trip editing use
-    ``get_work_item(include_description_html=True)`` with
-    ``update_work_item(description_html=...)``. ``custom_fields`` keeps
-    rich-text values as ``{'type': 'text/html', 'value': '<...>'}`` so this
-    dict alone copies back into ``update_work_item(custom_fields=...)``.
-    """
-
-    description: str = Field(
-        default="", description="Markdown body; read-only — do NOT feed to writes."
-    )
+    description: str = ""
     project_id: str
-    author_id: str = Field(default="", description="Short user ID; empty when unknown.")
-    created: str = Field(default="", description="ISO-8601; empty when unreported.")
-    resolution: str = Field(
-        default="", description="e.g. 'fixed'; empty when unresolved."
-    )
-    severity: str = Field(
-        default="", description="e.g. 'critical'; empty for non-defects."
-    )
-    outline_number: str = Field(
-        default="", description="e.g. '1.2.3'; empty outside a document."
-    )
+    author_id: str = ""
+    created: str = ""
+    resolution: str = ""
+    severity: str = ""
+    outline_number: str = ""
     hyperlinks: list[Hyperlink] = Field(default_factory=list)
     custom_fields: dict[str, object] = Field(default_factory=dict)
 
@@ -114,38 +69,16 @@ class WorkItemCreateSpec(BaseModel):
     """One work item to create via ``create_work_items``."""
 
     title: str = Field(min_length=1)
-    type: str = Field(
-        min_length=1, description="e.g. 'requirement', 'task', 'testCase'."
-    )
-    description: str | None = Field(
-        default=None,
-        max_length=MAX_BODY_HTML_LEN,
-        description="Markdown body; converted to sanitized HTML on write.",
-    )
-    status: str | None = Field(
-        default=None, description="Initial workflow status; project default if omitted."
-    )
-    priority: str | None = Field(default=None, description="e.g. '50.0'.")
-    severity: str | None = Field(default=None, description="e.g. 'major', 'critical'.")
-    assignee_ids: list[str] | None = Field(
-        default=None, description="Short user IDs, e.g. ['alice', 'bob']."
-    )
-    due_date: str | None = Field(default=None, description="'YYYY-MM-DD'.")
-    initial_estimate: str | None = Field(
-        default=None, description="Polarion duration, e.g. '5 1/2d', '1w 2d', '4h'."
-    )
-    hyperlinks: list[Hyperlink] | None = Field(
-        default=None, description="Each must have ``role`` and ``uri``."
-    )
-    custom_fields: dict[str, object] | None = Field(
-        default=None,
-        description=(
-            "Keyed by Polarion field ID. Keys are defined per project+type, so "
-            "take them from an existing work item of this ``type`` via "
-            "get_work_item to avoid ghost keys; rich-text values must be "
-            "``{'type':'text/html','value':...}``."
-        ),
-    )
+    type: str = Field(min_length=1)
+    description: str | None = Field(default=None, max_length=MAX_BODY_HTML_LEN)
+    status: str | None = None
+    priority: str | None = None
+    severity: str | None = None
+    assignee_ids: list[str] | None = None
+    due_date: str | None = None
+    initial_estimate: str | None = None
+    hyperlinks: list[Hyperlink] | None = None
+    custom_fields: dict[str, object] | None = None
 
 
 class WorkItemsCreateResult(BaseModel):
@@ -153,9 +86,7 @@ class WorkItemsCreateResult(BaseModel):
 
     created: bool
     dry_run: bool
-    work_item_ids: list[str] = Field(
-        default_factory=list, description="Short IDs in input order; empty on dry-run."
-    )
+    work_item_ids: list[str] = Field(default_factory=list)
     payload_preview: Mapping[str, object] | None = None
 
 
@@ -164,9 +95,7 @@ class WorkItemUpdateResult(BaseModel):
 
     updated: bool
     dry_run: bool
-    current: WorkItemDetail | None = Field(
-        description="Post-PATCH state for verification; None on dry-run."
-    )
+    current: WorkItemDetail | None
     changes: Mapping[str, object]
     payload_preview: Mapping[str, object] | None
 

--- a/src/mcp_server_polarion/server.py
+++ b/src/mcp_server_polarion/server.py
@@ -26,18 +26,7 @@ class LifespanContext(TypedDict):
 async def _lifespan(
     _server: FastMCP[LifespanContext],
 ) -> AsyncIterator[LifespanContext]:
-    """Initialize and clean up shared resources for the MCP server.
-
-    Creates a ``PolarionClient`` from environment configuration and
-    makes it available to all tools via the lifespan context.
-
-    Args:
-        _server: The FastMCP server instance (provided automatically).
-
-    Yields:
-        A dict containing the ``polarion_client`` key mapped to an
-        active ``PolarionClient`` instance.
-    """
+    """Open one shared ``PolarionClient`` for all tools; close on shutdown."""
     setup_logging()
     config = PolarionConfig()  # type: ignore[call-arg]
     logger.info("Connecting to Polarion at %s", config.polarion_url)

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -1,15 +1,9 @@
 """In-process TTL caches shared across tool implementations.
 
-Tools repeatedly resolve the same near-static project facts within a single
-session -- the documents in a project, the valid option ids for an enum
-field, the custom-field keys observed on a work item or document. Re-fetching
-each on every call would burn the server's tight request budget (<=3 req/s,
-no client-side concurrency), so each is memoised behind a short-lived cache.
-
-This module owns all cache state. Tool logic (request shaping, JSON:API
-extraction, write guards) lives elsewhere and reaches the caches only through
-the typed get / store / record wrappers below, keeping cache lifetime and
-key shape in one place.
+Near-static project facts (documents, enum option ids, observed custom-field
+keys) are memoised to spare the server's tight budget (<=3 req/s, no
+concurrency). This module owns all cache state; tool logic reaches it only
+through the typed get / store / record wrappers below.
 """
 
 from __future__ import annotations
@@ -34,10 +28,8 @@ class _Entry[V]:
 class TTLCache[K, V]:
     """Hashable-keyed cache whose entries expire ``ttl_seconds`` after a set.
 
-    Single-process and single-threaded (the server issues no concurrent
-    requests). Expiry is lazy -- a key is dropped only when next accessed past
-    its deadline -- so a bounded key space never accumulates dead entries
-    beyond that bound.
+    Single-threaded; lazy expiry (a key is dropped only when next accessed past
+    its deadline), so a bounded key space never grows past that bound.
     """
 
     def __init__(self, ttl_seconds: float) -> None:
@@ -65,14 +57,12 @@ class TTLCache[K, V]:
 
 Resource = Literal["workitems", "documents"]
 
-# Enum options and custom-field schema are near-static project config. The TTL
-# is bounded by ghost-safety, not freshness: a stale entry keeps accepting an
-# option an admin removed mid-session until expiry, so 60s caps that window.
+# Bounded by ghost-safety: a stale entry keeps accepting an admin-removed
+# option until expiry, so 60s caps that window.
 _GUARD_TTL_SECONDS: Final[float] = 60.0
 
-# The document listing is mutable: a freshly created document must surface
-# within ~1 minute, and ``create_document`` invalidates the entry on write.
-# Same ceiling, different reason -- freshness rather than ghost-safety.
+# Bounded by freshness: a new document must surface within ~1 min
+# (``create_document`` also invalidates on write).
 _DOCUMENT_LIST_TTL_SECONDS: Final[float] = 60.0
 
 # project_id -> tuple of (space_id, document_name) pairs.
@@ -83,9 +73,8 @@ _document_list_cache: TTLCache[str, tuple[tuple[str, str], ...]] = TTLCache(
 _enum_option_cache: TTLCache[tuple[str, Resource, str, str], frozenset[str]] = TTLCache(
     _GUARD_TTL_SECONDS
 )
-# (project, enum_name) -> valid option ids for a project-level enumeration
-# (link role, hyperlink role). Keyed without a type axis: these enums are
-# project config, not scoped by work-item type the way status/severity are.
+# (project, enum_name) -> option ids for a project-level enum (link/hyperlink
+# role). No type axis: these are project config, not type-scoped.
 _project_enum_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
     _GUARD_TTL_SECONDS
 )

--- a/src/mcp_server_polarion/tools/_shared/guard.py
+++ b/src/mcp_server_polarion/tools/_shared/guard.py
@@ -1,32 +1,17 @@
 """Server-side write guards that prevent silent corruption on Polarion writes.
 
-Polarion accepts unknown enum ids (``type`` / ``status`` / ``severity`` /
-``priority`` / ``resolution`` on work items; ``type`` / ``status`` on
-documents) and unknown
-custom-field keys verbatim -- HTTP 200, the value persists, but the field
-never appears in Polarion's UI, in Lucene, or in reports, and is never
-reported as an error. Docstring-level rules ("call ``list_*_enum_options``
-first") are unreliable: multi-model eval runs show LLMs ignore them. This
-module turns each rule into a deterministic precondition -- before any write
-carrying an enum-valued argument or custom-field keys, fetch the project's
-actual options and raise if the supplied id/key is not among them.
+Polarion accepts unknown enum ids and custom-field keys verbatim (HTTP 200) —
+they persist but never appear in the UI, Lucene, or reports, with no error.
+Docstring rules are unreliable (evals show LLMs ignore them), so each rule
+becomes a deterministic precondition: before a write, fetch the real options
+and raise if the supplied id/key is absent. Option ids and observed keys are
+memoised in :mod:`...tools._shared.cache`; this module holds fetch + check.
 
-Validated option ids and observed custom-field keys are memoised in
-:mod:`mcp_server_polarion.tools._shared.cache`; this module holds only the
-fetch and check logic.
-
-Fail-closed. If a validation request errors after the client's 429/5xx
-backoff, the guard raises rather than letting the write through: a ghost
-write is invisible in Polarion and unrecoverable, so an unverifiable write is
-refused rather than risked. An auth failure raises ``PermissionError`` (the
-token's problem, matching the tool layer); any other unreachable-backend
-error raises ``RuntimeError``. Two lenient cases defer to
-Polarion instead of blocking: a *successful* empty option set (a field with no
-configured options), and a 404 from ``getAvailableOptions`` (the endpoint or
-field is unsupported on this instance, so there is nothing to validate
-against). A 404 cannot mask a ghost -- a genuinely wrong project/field path
-makes the subsequent write fail loudly. This keeps a single unsupported
-endpoint from blocking every enum-bearing write on an instance that lacks it.
+Fail-closed: a validation request that errors after backoff blocks the write
+(a ghost write is invisible and unrecoverable) — auth → ``PermissionError``,
+else → ``RuntimeError``. Two lenient cases defer to Polarion: a *successful*
+empty option set, and a 404 (endpoint/field unsupported — a wrong path makes
+the subsequent write fail loudly anyway).
 """
 
 from __future__ import annotations
@@ -89,9 +74,8 @@ def _unreachable_write_block(
 def _unauthorized_write_block(what: str, project_id: str) -> PermissionError:
     """Build the fail-closed error raised when validation is unauthorized.
 
-    Mirrors the tool layer's ``PolarionAuthError -> PermissionError`` mapping:
-    the write is still refused, but the cause is a token-scope problem the
-    caller can fix rather than an unreachable backend to retry.
+    Mirrors the tool layer's ``PolarionAuthError -> PermissionError``: a
+    token-scope problem the caller can fix, not a backend to retry.
     """
     logger.warning(
         "guard blocking write: not authorized to validate %s for project=%s",
@@ -114,8 +98,7 @@ async def fetch_enum_option_ids(
 ) -> frozenset[str]:
     """Return the valid option ids for ``(project, resource, field, type)``.
 
-    Cached for the guard TTL. Fail-closed per the module contract: a reachable
-    error raises, a 404 defers (empty set, endpoint/field unsupported here).
+    Cached. Fail-closed: a reachable error raises, a 404 defers (empty set).
     """
     cached = get_cached_enum_options(project_id, resource, field_id, type_id)
     if cached is not None:
@@ -134,9 +117,8 @@ async def fetch_enum_option_ids(
     try:
         response = await client.get(path, params=params)
     except PolarionNotFoundError:
-        # Endpoint/field unsupported on this instance: cache an empty set so
-        # _check_enum defers and we do not re-probe a missing endpoint on
-        # every write within the TTL.
+        # Endpoint/field unsupported: cache an empty set so _check_enum defers
+        # and we don't re-probe a missing endpoint every write within the TTL.
         logger.warning(
             "getAvailableOptions returned 404 for field=%s (resource=%s, "
             "project=%s); skipping enum validation for this field -- the "
@@ -179,10 +161,8 @@ async def _check_enum(  # noqa: PLR0913
     option_ids = await fetch_enum_option_ids(
         client, project_id, resource, field_id, type_id
     )
-    # An empty set is a successful "no options configured" response (a
-    # deprecated field, or a type axis with none), not the unreachable failure
-    # that already raised above. Defer to Polarion rather than risk a false
-    # positive on a legitimately optionless field.
+    # Empty set = successful "no options configured" (not the unreachable
+    # failure, which already raised). Defer rather than false-positive.
     if not option_ids or value in option_ids:
         return
     raise ValueError(
@@ -207,15 +187,10 @@ async def guard_work_item_enums(  # noqa: PLR0913
 ) -> None:
     """Validate every supplied work-item enum arg against ``getAvailableOptions``.
 
-    ``work_item_type`` is the type axis Polarion scopes
-    status/severity/resolution/priority by. Pass ``'~'`` for type-agnostic
-    lookups (used when validating ``type`` itself or when the caller does not
-    have a type in hand). ``type`` is always checked first so an invalid
-    ``type`` raises before it could be used as the scoping axis. On cache hit
-    the guard adds zero round trips; on miss, one GET per (field, type) pair.
-
-    Raises ``ValueError`` listing the valid options on an unknown id, or
-    ``RuntimeError`` if Polarion is unreachable (fail-closed).
+    ``work_item_type`` scopes status/severity/resolution/priority (``'~'`` =
+    type-agnostic). ``type`` is checked first so an invalid type raises before
+    being reused as the scoping axis. One GET per (field, type) on a miss.
+    Raises ``ValueError`` (unknown id) or ``RuntimeError`` (unreachable).
     """
     if type is not None and type != "":
         await _check_enum(client, project_id, "workitems", "type", "~", type)
@@ -292,10 +267,8 @@ async def guard_work_item_custom_field_keys(
 ) -> None:
     """Reject ``update_work_item.custom_fields`` keys never seen on a get.
 
-    Looks up the per-type observed-keys cache; on miss, does one inline
-    ``get_work_item``-shaped GET to populate, then validates. Unknown keys
-    raise ``ValueError``; an unreachable priming GET raises ``RuntimeError``
-    (fail-closed).
+    Per-type observed-keys cache; on miss, one priming GET then validate.
+    Unknown keys → ``ValueError``; unreachable GET → ``RuntimeError``.
     """
     if not custom_fields:
         return
@@ -336,9 +309,8 @@ async def guard_document_custom_field_keys(
 ) -> None:
     """Reject ``update_document.custom_fields`` keys never seen on a get.
 
-    Mirrors :func:`guard_work_item_custom_field_keys` but keys the cache by
-    ``(project, space, document)``; on miss, does one inline
-    ``get_document``-shaped GET to populate, then validates.
+    Like :func:`guard_work_item_custom_field_keys`, keyed by
+    ``(project, space, document)``; on miss, one priming GET then validate.
     """
     if not custom_fields:
         return
@@ -378,10 +350,8 @@ async def _existing_target_ids(
 ) -> frozenset[str]:
     """Return which *target_ids* exist in *project_id*, via ``id:(...)`` queries.
 
-    Chunked at ``_GUARD_PAGE_SIZE``: a single ``id:(...)`` query is bounded by
-    ``page[size]``, so more targets than that need successive queries. A 404
-    means the project does not exist; the caller treats every target there as
-    missing.
+    Chunked at ``_GUARD_PAGE_SIZE`` (one query bounded by ``page[size]``). A 404
+    means the project is missing; caller treats every target as missing.
     """
     ordered = sorted(target_ids)
     found: set[str] = set()
@@ -410,15 +380,10 @@ async def guard_work_item_link_targets(
 ) -> None:
     """Reject links whose target work item does not exist.
 
-    Polarion creates a dangling link (HTTP 201) to a nonexistent target -- the
-    target shows empty title/type/status in ``list_work_item_links`` and there
-    is no error to detect it. Groups requested targets by project, runs one
-    ``id:(...)`` query per project (chunked at 100), and raises ``ValueError``
-    listing any target that was not returned.
-
-    Fail-closed: an unreachable backend raises ``RuntimeError``; a 404 (the
-    target project does not exist) raises ``ValueError`` since every target
-    there would be dangling.
+    A nonexistent target stores as a silent dangling link (HTTP 201, empty
+    title/type/status). Groups targets by project, one ``id:(...)`` query each,
+    raises ``ValueError`` listing any missing. Fail-closed: unreachable →
+    ``RuntimeError``; 404 (project missing) → ``ValueError``.
     """
     by_project: dict[str, set[str]] = {}
     for spec in links:
@@ -456,14 +421,10 @@ async def fetch_project_enum_option_ids(
 ) -> frozenset[str]:
     """Return the valid option ids for a project-level enumeration.
 
-    Used for enums Polarion does not expose through ``getAvailableOptions``
-    (link role, hyperlink role). Reads the single-enumeration resource
-    ``/projects/{p}/enumerations/~/{enum}/~`` -- far lighter than the bulk
-    ``getProjectEnumerations`` listing. Unlike ``getAvailableOptions`` (a list
-    ``data``), this single-resource response returns ``data`` as a dict whose
-    options live at ``data.attributes.options[].id``.
-
-    Cached for the guard TTL; same fail-closed contract as
+    For enums not in ``getAvailableOptions`` (link/hyperlink role). Reads
+    ``/projects/{p}/enumerations/~/{enum}/~``; unlike ``getAvailableOptions``
+    (list ``data``), here ``data`` is a dict with options at
+    ``data.attributes.options[].id``. Cached; fail-closed like
     :func:`fetch_enum_option_ids`.
     """
     cached = get_cached_project_enum(project_id, enum_name)
@@ -523,8 +484,7 @@ async def _check_project_enum_roles(  # noqa: PLR0913
         return
 
     option_ids = await fetch_project_enum_option_ids(client, project_id, enum_name)
-    # An empty set is the lenient "no options / enum unsupported here" case
-    # that already deferred above, not the unreachable failure that raised.
+    # Empty set = lenient "no options / enum unsupported" (already deferred).
     if not option_ids:
         return
 
@@ -545,11 +505,8 @@ async def guard_work_item_link_roles(
 ) -> None:
     """Reject ``create_work_item_links`` roles not in ``workitem-link-role``.
 
-    Polarion stores an unknown link role verbatim (HTTP 201) and it never
-    matches Lucene -- a ghost link with no error to detect it. Validates every
-    requested role against the project's ``workitem-link-role`` enumeration and
-    raises ``ValueError`` listing the valid ids on a miss; fail-closed
-    (``RuntimeError``) if the enumeration cannot be reached.
+    An unknown role stores verbatim (HTTP 201) as a ghost link. Validates each
+    role, raises ``ValueError`` (valid ids) on a miss; fail-closed otherwise.
     """
     await _check_project_enum_roles(
         client,
@@ -571,11 +528,9 @@ async def guard_hyperlink_roles(
 ) -> None:
     """Reject hyperlink roles not in the project's ``hyperlink-role`` enum.
 
-    ``Hyperlink.role`` on ``create_work_items`` / ``update_work_item`` accepts
-    only configured ids (typically ``ref_int`` / ``ref_ext``); an unknown role
-    persists as a silent ghost on the work item. Validates against the
-    ``hyperlink-role`` enumeration and raises ``ValueError`` on a miss;
-    fail-closed if it cannot be reached.
+    ``Hyperlink.role`` accepts only configured ids (typically ``ref_int`` /
+    ``ref_ext``); an unknown role persists as a silent ghost. Raises
+    ``ValueError`` on a miss; fail-closed if unreachable.
     """
     await _check_project_enum_roles(
         client,
@@ -596,11 +551,9 @@ async def _existing_forward_link_ids(
 ) -> frozenset[str]:
     """Return the composite ids of every outgoing link on the source work item.
 
-    Pages ``/workitems/{wi}/linkedworkitems`` requesting only ``id`` until a
-    short page. Each ``data[].id`` is already the five-segment composite
-    ``<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`` that the delete payload
-    reconstructs, so the result can be set-membership-tested directly. A
-    ``PolarionNotFoundError`` propagates -- the source work item is missing.
+    Pages ``/linkedworkitems`` (id only) until a short page. Each ``data[].id``
+    is the 5-segment composite the delete payload reconstructs, so it is
+    set-membership-testable directly. ``PolarionNotFoundError`` propagates.
     """
     path = (
         f"/projects/{encode_path_segment(project_id)}"
@@ -637,17 +590,10 @@ async def partition_delete_links(
 ) -> tuple[list[str], list[str]]:
     """Split requested delete refs into ``(matched, not_found)`` against reality.
 
-    Pre-reads the source work item's existing outgoing links and partitions
-    *link_ids* (preserving input order) into refs that matched an existing
-    link and refs that matched nothing. Polarion deletes the former and
-    silently ignores the latter, so this is the only way to surface the
-    no-ops the 204 hides; the caller reports both and still deletes (a no-op
-    delete is non-destructive, so it is never raised).
-
-    Fail-closed: a missing source work item raises ``ValueError``; an auth
-    failure raises ``PermissionError``; any other unreachable-backend error
-    raises ``RuntimeError`` -- the split must be trustworthy before a delete
-    is reported.
+    Pre-reads existing outgoing links and partitions *link_ids* (input order)
+    into matched / unmatched — the only way to surface the no-ops the 204 hides
+    (no-op is non-destructive, never raised). Fail-closed: missing source →
+    ``ValueError``, auth → ``PermissionError``, else → ``RuntimeError``.
     """
     try:
         existing = await _existing_forward_link_ids(client, project_id, work_item_id)

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -1,13 +1,7 @@
-"""Shared helpers for MCP tool implementations.
+"""Internal shared helpers for the ``tools`` package (not public API).
 
-Internal module used by the domain tool modules. The helpers defined here
-are for internal use within the ``tools`` package and are **not** part of
-the public package API.
-
-Body fields (``description``, ``homePageContent``) are passed through as
-raw Polarion HTML on the get/update round-trip path — Markdown conversion
-is reserved for synthesis paths (``read_document``, embedded work item bodies
-inside ``read_document_parts``) and lives in ``tools.documents``.
+Body fields pass through as raw HTML on the get/update round-trip; Markdown
+conversion is reserved for synthesis paths in ``tools.documents``.
 """
 
 from __future__ import annotations
@@ -29,10 +23,8 @@ from mcp_server_polarion.models import (
     WorkItemSummary,
 )
 
-# Caps how many items a single bulk write may carry. Polarion allows no
-# concurrent requests and throttles at ~3 req/s, so an unbounded batch is a
-# rate-limit and payload-size hazard; 50 bounds one request without forcing
-# callers to paginate typical work. Shared by every bulk write tool.
+# Bulk-write cap. Polarion throttles ~3 req/s with no concurrency, so an
+# unbounded batch is a rate-limit/payload hazard; 50 bounds one request.
 MAX_BULK_ITEMS: Final[int] = 50
 
 
@@ -53,26 +45,22 @@ class WorkItemSummaryKwargs(TypedDict):
 # Polarion enforces a hard cap of 100 server-side.
 DEFAULT_PAGE_SIZE: Final[int] = 100
 
-# Sparse fieldsets. Detail/document fetches use ``@all`` because this server
-# inlines custom fields under ``attributes`` and drops narrower
-# ``customFields.*`` tokens; ``WORK_ITEM_PART_FIELDS`` stays tight (parts
-# surface no embedded customs).
+# Sparse fieldsets. Detail/document fetches use ``@all`` (this server inlines
+# customs under ``attributes`` and drops ``customFields.*`` tokens);
+# ``WORK_ITEM_PART_FIELDS`` stays tight (parts surface no customs).
 WORK_ITEM_LIST_FIELDS: Final[str] = "title,type,status,priority,updated,module,assignee"
 WORK_ITEM_DETAIL_FIELDS: Final[str] = "@all"
 WORK_ITEM_PART_FIELDS: Final[str] = "title,type,status,description,outlineNumber"
 DOCUMENT_DETAIL_FIELDS: Final[str] = "@all"
-# Sparse fieldset filters relationships as well as attributes, so author /
-# parentComment / childComments must be named explicitly to remain in the
-# response. Document comments expose no project-defined custom fields, so
-# `@all` is not needed here.
+# Sparse fieldset filters relationships too, so author / parentComment /
+# childComments must be named explicitly. Comments have no customs, so no `@all`.
 DOCUMENT_COMMENT_LIST_FIELDS: Final[str] = (
     "created,resolved,text,author,parentComment,childComments"
 )
 
-# Standard attribute allowlist (Polarion REST OpenAPI schema). Anything in a
-# response's ``attributes`` outside this set is treated as a custom field, so a
-# future Polarion release adding standard attributes misclassifies them until
-# this set is updated.
+# Standard attribute allowlist (Polarion REST OpenAPI schema). Anything in
+# ``attributes`` outside this set is treated as a custom field, so a new
+# standard attribute is misclassified until added here.
 STANDARD_WORK_ITEM_ATTRIBUTES: Final[frozenset[str]] = frozenset(
     {
         "id",
@@ -97,9 +85,8 @@ STANDARD_WORK_ITEM_ATTRIBUTES: Final[frozenset[str]] = frozenset(
     }
 )
 
-# Canonical standard document attribute names per the Polarion REST
-# OpenAPI schema. Mirrors ``STANDARD_WORK_ITEM_ATTRIBUTES`` for the document
-# resource type.
+# Standard document attributes (Polarion REST OpenAPI schema); document-side
+# mirror of ``STANDARD_WORK_ITEM_ATTRIBUTES``.
 STANDARD_DOCUMENT_ATTRIBUTES: Final[frozenset[str]] = frozenset(
     {
         "id",
@@ -125,14 +112,7 @@ STANDARD_DOCUMENT_ATTRIBUTES: Final[frozenset[str]] = frozenset(
 
 
 def get_client(ctx: Context) -> PolarionClient:
-    """Extract ``PolarionClient`` from the lifespan context.
-
-    Args:
-        ctx: FastMCP tool context.
-
-    Returns:
-        The active ``PolarionClient`` instance.
-    """
+    """Extract the active ``PolarionClient`` from the lifespan context."""
     lifespan_ctx = ctx.lifespan_context
     if "polarion_client" not in lifespan_ctx:  # pragma: no cover
         msg = "polarion_client is missing from lifespan_context"
@@ -156,14 +136,7 @@ def safe_str(value: object) -> str:
 
 
 def extract_total_count(response: dict[str, object]) -> int:
-    """Extract ``meta.totalCount`` from a JSON:API response.
-
-    Args:
-        response: Decoded JSON:API response.
-
-    Returns:
-        The total count, or 0 if the field is missing.
-    """
+    """Return ``meta.totalCount`` from a JSON:API response, or 0 if missing."""
     meta = response.get("meta")
     if isinstance(meta, dict):
         total = meta.get("totalCount", 0)
@@ -173,14 +146,7 @@ def extract_total_count(response: dict[str, object]) -> int:
 
 
 def has_links_next(response: dict[str, object]) -> bool:
-    """Check whether the JSON:API response contains a ``links.next`` key.
-
-    Args:
-        response: Decoded JSON:API response.
-
-    Returns:
-        ``True`` if the server indicates a next page exists.
-    """
+    """Return whether the JSON:API response carries a ``links.next`` key."""
     links = response.get("links")
     if isinstance(links, dict):
         return "next" in links
@@ -220,35 +186,21 @@ def compute_has_more(
 
 
 def encode_path_segment(segment: str) -> str:
-    """URL-encode a single path segment (e.g. document name with spaces).
-
-    Args:
-        segment: Raw path segment string.
-
-    Returns:
-        URL-encoded segment safe for use in URL paths.
-    """
+    """URL-encode a single path segment (e.g. a document name with spaces)."""
     return quote(segment, safe="")
 
 
-# Polarion work item IDs are project-prefix + hyphen + digits (e.g. ``MCPT-001``);
-# the broader pattern below also accepts underscores so this stays a thin guard,
-# not a format validator. Anything outside the set is rejected when the id is
-# substituted into a Lucene query string (``linkedWorkItems:<id>``).
+# Thin guard, not a format validator: accepts ``[A-Za-z0-9_-]`` (covers
+# ``MCPT-001``-style ids) before substituting into a Lucene ``linkedWorkItems:``.
 _WORK_ITEM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def validate_work_item_id_for_lucene(work_item_id: str) -> None:
     """Reject work item IDs that would break a Lucene ``field:<id>`` clause.
 
-    Polarion's Lucene parser treats ``+ - && || ! ( ) { } [ ] ^ " ~ * ? : \\ /``
-    and whitespace as operators. Embedding an unescaped ``work_item_id`` into
-    ``linkedWorkItems:<id>`` would let an adversarial value reshape the query.
-    Polarion IDs never contain those characters, so a hard reject is safer
-    than escape arithmetic.
-
-    Raises:
-        ValueError: ``work_item_id`` contains characters outside ``[A-Za-z0-9_-]``.
+    Lucene treats many punctuation chars as operators; an unescaped id in
+    ``linkedWorkItems:<id>`` could reshape the query. Polarion ids never use
+    those, so hard-reject anything outside ``[A-Za-z0-9_-]`` (``ValueError``).
     """
     if not _WORK_ITEM_ID_PATTERN.match(work_item_id):
         msg = (
@@ -261,14 +213,7 @@ def validate_work_item_id_for_lucene(work_item_id: str) -> None:
 def build_included_work_item_map(
     response: dict[str, object],
 ) -> dict[str, dict[str, object]]:
-    """Build a lookup dict of included work items from a JSON:API response.
-
-    Args:
-        response: Decoded JSON:API response with an ``included`` array.
-
-    Returns:
-        Mapping from full work-item ID to the included resource dict.
-    """
+    """Map full work-item ID to its included resource dict from a response."""
     work_item_map: dict[str, dict[str, object]] = {}
     included = response.get("included", [])
     if isinstance(included, list):
@@ -282,15 +227,7 @@ def extract_relationship_id(
     relationships: dict[str, object],
     rel_name: str,
 ) -> str:
-    """Extract the ``data.id`` of a named relationship.
-
-    Args:
-        relationships: The ``relationships`` dict of a JSON:API resource.
-        rel_name: Relationship key (e.g. ``'nextPart'``).
-
-    Returns:
-        The related resource ID, or ``""`` if absent.
-    """
+    """Return a named relationship's ``data.id``, or ``""`` if absent."""
     rel = relationships.get(rel_name, {})
     if isinstance(rel, dict):
         inner = rel.get("data")
@@ -303,16 +240,7 @@ def extract_relationship_ids(
     relationships: dict[str, object],
     rel_name: str,
 ) -> list[str]:
-    """Extract the ``data[].id`` list of a to-many relationship.
-
-    Args:
-        relationships: The ``relationships`` dict of a JSON:API resource.
-        rel_name: Relationship key (e.g. ``'assignee'``).
-
-    Returns:
-        List of related resource IDs in declaration order. Empty list
-        when the relationship is absent or its data array is empty.
-    """
+    """Return a to-many relationship's ``data[].id`` list (declaration order)."""
     rel = relationships.get(rel_name, {})
     if not isinstance(rel, dict):
         return []
@@ -329,12 +257,9 @@ def extract_relationship_ids(
 
 
 def split_module_id(module_full_id: str) -> tuple[str, str]:
-    """Split a module relationship ID into (space_id, document_name).
+    """Split a module ID ``{proj}/{space}/{doc}`` into (space_id, document_name).
 
-    The Polarion module ID has the format
-    ``{projectId}/{spaceId}/{documentName}`` where ``documentName`` may
-    itself contain ``/`` segments. Returns ``("", "")`` when the ID does
-    not have at least three segments.
+    ``doc`` may contain ``/``. Returns ``("", "")`` if under three segments.
     """
     if not module_full_id:
         return ("", "")
@@ -359,18 +284,10 @@ def extract_short_id(full_id: str) -> str:
 def build_work_item_summary_kwargs(
     item: dict[str, object],
 ) -> WorkItemSummaryKwargs:
-    """Extract ``WorkItemSummary`` kwargs from a single JSON:API resource.
+    """Extract ``WorkItemSummary`` kwargs from a JSON:API resource.
 
-    Centralises the attribute + relationship parsing used by both list
-    and detail endpoints so that ``WorkItemDetail`` stays a strict
+    Shared by list and detail endpoints so ``WorkItemDetail`` stays a strict
     superset of ``WorkItemSummary``.
-
-    Args:
-        item: A single JSON:API resource object (``data`` element).
-
-    Returns:
-        Dict suitable for ``WorkItemSummary(**kwargs)`` /
-        ``WorkItemDetail(**kwargs, description=..., project_id=...)``.
     """
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
@@ -405,21 +322,10 @@ def extract_custom_fields(
 ) -> dict[str, object]:
     """Return the inline custom-field subset of a JSON:API attributes dict.
 
-    This Polarion server inlines project-defined custom fields as
-    top-level keys inside ``attributes`` (e.g. ``attributes.riskLevel``,
-    ``attributes.effortHours``) — there is no ``customFields``
-    container, and the ``customFields.@all`` / ``@custom`` sparse-fieldset
-    tokens are silently ignored. Callers fetch with ``fields[...]=@all``
-    so every populated attribute comes back, then pass the resulting
-    ``attributes`` dict here together with the standard-attribute
-    allowlist for the resource type (``STANDARD_WORK_ITEM_ATTRIBUTES`` or
-    ``STANDARD_DOCUMENT_ATTRIBUTES``). Anything not in the allowlist is
-    reported as a custom field.
-
-    Values are returned verbatim — primitives (str / int / float / bool /
-    list) and rich-text dicts of the form
-    ``{"type": "text/html", "value": "<...>"}`` both pass through so the
-    shape round-trips back to Polarion unchanged on a future PATCH.
+    This server inlines customs as top-level ``attributes`` keys (no
+    ``customFields`` container). Anything outside *standard* is a custom field,
+    returned verbatim (primitives or ``{type,value}`` rich-text) so it
+    round-trips unchanged.
     """
     return {k: v for k, v in attributes.items() if k not in standard}
 
@@ -429,46 +335,15 @@ def merge_custom_fields(
     customs: dict[str, object] | None,
     standard: frozenset[str],
 ) -> None:
-    """Merge caller-supplied custom-field key/values into a JSON:API attributes dict.
+    """Merge caller custom-field key/values into *attributes* in place.
 
-    Write-side counterpart of ``extract_custom_fields``. Polarion accepts
-    custom field values inlined at the top level of ``attributes`` (the
-    same shape it returns on read), so this helper drops each entry of
-    ``customs`` directly into ``attributes`` in place — keeping the
-    "mutate-in-place" style of the surrounding ``_build_*_payload``
-    helpers.
+    Write-side counterpart of ``extract_custom_fields`` (customs inline at the
+    top level). A key in *standard* raises ``ValueError`` (would shadow a tool
+    parameter). ``None`` / ``{}`` are no-ops; individual ``None`` values
+    skipped, other falsy values sent verbatim.
 
-    Validation:
-    - Any key in ``customs`` that also appears in ``standard`` raises
-      ``ValueError`` — colliding with a Polarion-defined standard
-      attribute would silently overwrite (or be overwritten by) an
-      explicit standard tool parameter. Callers should rename the field
-      or use the matching standard parameter.
-    - ``None`` and ``{}`` whole-dict inputs are no-ops.
-    - Individual ``None`` values inside the dict are skipped, matching
-      the rest of the codebase's "skip None/empty" convention. Falsy
-      non-``None`` values (``""``, ``0``, ``False``, ``[]``) are sent
-      through verbatim because they may be meaningful custom-field
-      values. Polarion may interpret some of those as "clear"; the tool
-      layer does not expose an explicit clearing path.
-
-    Aliasing: values are stored under ``attributes`` by reference — no
-    defensive copy. Callers must NOT mutate the ``customs`` dict (or any
-    nested value such as a ``{type, value}`` rich-text dict) between
-    handing it to this helper and the eventual ``client.post`` /
-    ``client.patch`` serialisation, or the on-wire payload will see the
-    later mutation.
-
-    Args:
-        attributes: The JSON:API ``attributes`` dict under construction.
-            Mutated in place.
-        customs: Custom-field key/value pairs supplied by the caller, or
-            ``None`` to skip.
-        standard: The standard-attribute allowlist for the resource type
-            (``STANDARD_WORK_ITEM_ATTRIBUTES`` or ``STANDARD_DOCUMENT_ATTRIBUTES``).
-
-    Raises:
-        ValueError: When any key in ``customs`` is also in ``standard``.
+    Aliasing: stored by reference, no copy — callers must NOT mutate *customs*
+    (or nested ``{type,value}`` dicts) before serialisation.
     """
     if not customs:
         return
@@ -488,12 +363,7 @@ def merge_custom_fields(
 
 
 def parse_hyperlinks(value: object) -> list[Hyperlink]:
-    """Parse the ``attributes.hyperlinks`` field into ``Hyperlink`` models.
-
-    Polarion returns hyperlinks as a list of dicts with ``role``,
-    ``title``, and ``uri`` keys. Entries without a usable ``uri`` are
-    skipped to keep the response signal clean for the LLM.
-    """
+    """Parse ``attributes.hyperlinks`` into ``Hyperlink`` models (no-uri skipped)."""
     if not isinstance(value, list):
         return []
     links: list[Hyperlink] = []
@@ -519,29 +389,12 @@ def parse_work_item_detail(
     project_id: str,
     fallback_id: str = "",
 ) -> WorkItemDetail:
-    """Parse a single JSON:API work-item resource into a ``WorkItemDetail``.
+    """Parse a JSON:API work-item resource into a ``WorkItemDetail``.
 
-    Shared by ``get_work_item`` and ``update_work_item`` (which issues a
-    follow-up GET after the PATCH succeeds). Expects the resource to
-    have been fetched with ``fields[workitems]=WORK_ITEM_DETAIL_FIELDS`` and
-    ``include=assignee`` so that ``relationships.assignee.data`` is
-    populated.
-
-    The description value is passed through as raw Polarion HTML into
-    ``WorkItemDetail.description_html`` — no Markdown conversion, no
-    sanitization. This preserves Polarion-specific spans / data
-    attributes so the same string round-trips back through
-    ``update_work_item(description_html=...)`` unchanged.
-
-    Args:
-        item: A single JSON:API resource object (the ``data`` element).
-        project_id: Project that contains this work item.
-        fallback_id: Used as ``WorkItemDetail.id`` when ``item.id`` is
-            missing. Pass the caller-supplied work-item ID.
-
-    Returns:
-        A fully-populated ``WorkItemDetail`` model with
-        ``description_html`` carrying the raw HTML payload.
+    Shared by ``get_work_item`` / ``update_work_item``. Expects fetch with
+    ``WORK_ITEM_DETAIL_FIELDS`` + ``include=assignee``. Description passes
+    through as raw HTML (no convert/sanitize) so it round-trips unchanged.
+    ``fallback_id`` is used as ``id`` when ``item.id`` is missing.
     """
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
@@ -576,9 +429,7 @@ def parse_work_item_detail(
 def summary_to_back_link(summary: WorkItemSummary) -> WorkItemLink:
     """Lift a ``linkedWorkItems:`` query result to a back-direction link.
 
-    The ``linkedWorkItems:`` query exposes no role or suspect flag, so
-    both come back as ``role=None`` (unknown, not absent) and
-    ``suspect=False``.
+    The query exposes no role/suspect, so ``role=None`` and ``suspect=False``.
     """
     return WorkItemLink(
         id=summary.id,
@@ -596,14 +447,7 @@ def summary_to_back_link(summary: WorkItemSummary) -> WorkItemLink:
 def parse_work_item_summaries(
     data: object,
 ) -> list[WorkItemSummary]:
-    """Parse a JSON:API ``data`` array into ``WorkItemSummary`` models.
-
-    Args:
-        data: The ``data`` field from a JSON:API response.
-
-    Returns:
-        List of parsed ``WorkItemSummary`` instances.
-    """
+    """Parse a JSON:API ``data`` array into ``WorkItemSummary`` models."""
     items: list[WorkItemSummary] = []
     if not isinstance(data, list):
         return items
@@ -616,15 +460,7 @@ def parse_work_item_summaries(
 
 
 def build_document_comment(item: dict[str, object]) -> DocumentComment:
-    """Build a ``DocumentComment`` from a single JSON:API resource.
-
-    Args:
-        item: A single ``document_comments`` resource (``data`` element).
-
-    Returns:
-        Parsed ``DocumentComment`` with relationship IDs reduced to their
-        short form (project prefix stripped).
-    """
+    """Build a ``DocumentComment`` from a JSON:API resource (short relationship IDs)."""
     attributes_raw = item.get("attributes")
     attributes: dict[str, object] = (
         attributes_raw if isinstance(attributes_raw, dict) else {}

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -44,14 +44,11 @@ def _build_document_comments_payload(
     space_id: str,
     document_name: str,
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API request body for POST .../documents/{d}/comments.
+    """Build the JSON:API POST body for .../documents/{d}/comments.
 
-    Builds one resource object per spec. Only attaches ``resolved`` when
-    explicitly set (None = omit). ``author`` and ``parentComment``
-    relationships are omitted when None. ``parent_comment_id`` is
-    composed into the full path form ``proj/space/doc/commentId``
-    required by the Polarion API, so callers pass the short ID from
-    ``list_document_comments``.
+    One resource per spec. ``resolved`` / ``author`` / ``parentComment``
+    omitted when None. ``parent_comment_id`` (short) expanded to the full
+    ``proj/space/doc/commentId`` path the API requires.
     """
     items: list[JsonValue] = []
     for spec in specs:
@@ -91,12 +88,10 @@ def _build_document_comment_update_payload(
     comment_id: str,
     resolved: bool,
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API PATCH body for one document comment.
+    """Build the single-resource JSON:API PATCH body for one document comment.
 
-    Produces a single-resource ``{"data": {...}}`` object (NOT a list — that
-    is the POST/create shape). The ``id`` field is the full 4-segment path
-    ``{project_id}/{space_id}/{document_name}/{comment_id}`` required by the
-    Polarion PATCH endpoint. Only ``resolved`` is patchable per the API.
+    ``{"data": {...}}`` (not a list). ``id`` is the full 4-segment path
+    ``{project}/{space}/{document}/{comment}``. Only ``resolved`` is patchable.
     """
     full_id = f"{project_id}/{space_id}/{document_name}/{comment_id}"
     return {
@@ -127,29 +122,9 @@ async def list_document_comments(  # noqa: PLR0913
 ) -> PaginatedResult[DocumentComment]:
     """List comments attached to a Polarion document.
 
-    Comments come back as a flat page; reconstruct threads client-side via
-    ``parent_comment_id`` (set on replies) and ``child_comment_ids`` (top-level
-    comments have ``parent_comment_id`` of ``None``). ``text`` is verbatim, with
-    ``text_format`` ``'text/html'`` or ``'text/plain'``; HTML is NOT sanitized
-    (round-trips losslessly) — treat as untrusted input if rendering.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        space_id: Space ID (use '_default' for the default space).
-        document_name: Document name within the space.
-        page_size: Items per page (1-100, default 100).
-        page_number: 1-based page number (default 1).
-
-    Returns:
-        PaginatedResult of ``DocumentComment`` items with ``id``,
-        ``created``, ``resolved``, ``text``, ``text_format``, ``author_id``,
-        ``parent_comment_id``, and ``child_comment_ids``.
-
-    Raises:
-        ValueError: Project, space, or document not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    Flat page; reconstruct threads via ``parent_comment_id`` (None = top-level)
+    and ``child_comment_ids``. ``text`` is verbatim; HTML is NOT sanitized —
+    treat as untrusted when rendering.
     """
     client = get_client(ctx)
     path = (
@@ -239,41 +214,11 @@ async def create_document_comments(  # noqa: PLR0913
 ) -> DocumentCommentsCreateResult:
     """Create one or more comments on a Polarion document in a single request.
 
-    All ``comments`` post together; Polarion returns 201 with the new IDs.
-
-    Thread model: ``parent_comment_id=None`` is a top-level comment; to reply,
-    set it to the short ID from ``list_document_comments`` (e.g. ``'c42'``) and
-    the tool composes the required 4-segment path ``proj/space/doc/c42``.
-    ``text_format`` ``'text/plain'`` (default) stores verbatim; ``'text/html'``
-    is sent as-is (no sanitization). Omit ``resolved`` to default to False, or
-    pass True for a pre-resolved comment; omit ``author_id`` to use the token's
-    user. NOT idempotent — retrying creates duplicates.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        space_id: Space ID (use '_default' for the default space).
-        document_name: Document name within ``space_id``.
-        comments: One or more ``DocumentCommentSpec`` objects, each with
-            ``text``, ``text_format``, ``resolved``, ``author_id``, and
-            ``parent_comment_id``.
-        dry_run: When True, build and return the payload preview without
-            calling Polarion.
-
-    Returns:
-        ``DocumentCommentsCreateResult`` with:
-
-        - ``created`` — True on success; False on dry-run.
-        - ``dry_run`` — mirrors the input flag.
-        - ``comment_ids`` — short IDs (last path segment) of the created
-          comments in Polarion's return order; empty on dry-run.
-        - ``payload_preview`` — JSON:API body sent (or that would be
-          sent); populated on dry-run, None after a real operation.
-
-    Raises:
-        ValueError: Project, space, or document not found.
-        PermissionError: Token lacks permission to create comments.
-        RuntimeError: Other Polarion API errors.
+    All post together (201 with new IDs). Reply by setting
+    ``parent_comment_id`` to a short ID from ``list_document_comments`` (None =
+    top-level). ``text_format`` ``'text/html'`` sent as-is (no sanitization);
+    omit ``author_id`` to use the token's user. NOT idempotent — retry
+    duplicates.
     """
     payload = _build_document_comments_payload(
         specs=comments,
@@ -372,40 +317,10 @@ async def update_document_comment(  # noqa: PLR0913
 ) -> DocumentCommentUpdateResult:
     """Resolve or re-open a single document comment.
 
-    PATCHes ``{"resolved": <bool>}`` — the only patchable attribute. Use
-    ``list_document_comments`` to find the short comment ID (last segment of the
-    4-part path).
-
-    Root comments only: Polarion accepts this PATCH only on top-level comments
-    (``parent_comment_id is None``); on a reply it returns HTTP 400 ("Resolved
-    field can be set only for root comments") → ``RuntimeError``, so filter
-    first. Resolving the root marks the whole thread resolved. Idempotent.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        space_id: Space ID (use '_default' for the default space).
-        document_name: Document name within ``space_id``.
-        comment_id: Short comment ID (e.g. 'c42') from
-            ``list_document_comments``.
-        resolved: ``True`` to mark resolved; ``False`` to re-open.
-        dry_run: When True, build and return the payload without
-            calling Polarion.
-
-    Returns:
-        ``DocumentCommentUpdateResult`` with:
-
-        - ``updated`` — True on success; False on dry-run.
-        - ``dry_run`` — mirrors the input flag.
-        - ``comment_id`` — the short ID patched; None on dry-run.
-        - ``resolved`` — the value sent (or that would be sent).
-        - ``payload_preview`` — JSON:API body; populated on dry-run,
-          None after a real operation.
-
-    Raises:
-        ValueError: Project, space, document, or comment not found.
-        PermissionError: Token lacks permission to update the comment.
-        RuntimeError: Other Polarion API errors.
+    PATCHes ``{"resolved": <bool>}`` (only patchable attr). Root comments only:
+    a reply 400s ("Resolved field can be set only for root comments") →
+    ``RuntimeError``, so filter first. Resolving the root resolves the thread.
+    Idempotent.
     """
     payload = _build_document_comment_update_payload(
         project_id=project_id,

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -94,12 +94,7 @@ class _LinkedWorkItem:
 
 
 def _extract_html_value(field: object) -> str:
-    """Extract the HTML payload from a Polarion text field.
-
-    Polarion serialises rich-text fields either as a dict
-    ``{"type": "text/html", "value": "..."}`` or, in some responses, as
-    a plain string. Both shapes resolve to a string here.
-    """
+    """Extract HTML from a Polarion text field (``{type,value}`` dict or str)."""
     if isinstance(field, dict):
         return safe_str(field.get("value", ""))
     if isinstance(field, str):
@@ -108,11 +103,7 @@ def _extract_html_value(field: object) -> str:
 
 
 def _resolve_heading_level(attributes: dict[str, object]) -> int:
-    """Return the heading level for a heading part.
-
-    Prefers ``attributes.level`` when present, otherwise falls back to
-    parsing the leading ``<hN>`` tag in ``attributes.content``.
-    """
+    """Return a heading part's level: ``attributes.level``, else parsed ``<hN>``."""
     attr_level = attributes.get("level")
     if isinstance(attr_level, int):
         return attr_level
@@ -153,16 +144,7 @@ def _parse_document_part(
     item: object,
     work_item_map: dict[str, dict[str, object]],
 ) -> DocumentPart | None:
-    """Parse a single JSON:API document-part resource into a model.
-
-    Args:
-        item: A single resource object from the ``data`` array.
-        work_item_map: Included work-item lookup built by
-            ``build_included_work_item_map``.
-
-    Returns:
-        A ``DocumentPart`` instance, or ``None`` if *item* is invalid.
-    """
+    """Parse a JSON:API document-part resource into a model; ``None`` if invalid."""
     if not isinstance(item, dict):
         return None
     attributes = item.get("attributes", {})
@@ -177,8 +159,7 @@ def _parse_document_part(
         _PartType,
         raw_type if raw_type in _POLARION_PART_TYPES else "normal",
     )
-    # Polarion reports TOF and page-break parts as plain ``normal``; the
-    # kind is only encoded in the ID prefix.
+    # Polarion reports TOF / page-break as ``normal``; kind is in the ID prefix.
     if part_type == "normal":
         if short_id.startswith("tof_"):
             part_type = "tof"
@@ -186,7 +167,7 @@ def _parse_document_part(
             part_type = "page_break"
 
     # Heading/workitem body lives in title/description, not attributes.content
-    # (an empty <hN> stub there) — skip conversion to avoid emitting "#" noise.
+    # (empty <hN> stub) — skip conversion to avoid "#" noise.
     content_html = (
         _extract_html_value(attributes.get("content"))
         if part_type not in {"heading", "workitem"}
@@ -240,30 +221,10 @@ _FENCED_MIN_LINES: Final[int] = 2
 
 
 def _render_parts_to_markdown(parts: list[DocumentPart]) -> str:
-    """Interleave a page of parts into a single flowing Markdown string.
+    """Interleave a page of parts into one flowing Markdown string.
 
-    Rendering rules per ``DocumentPart.type``:
-
-    - ``heading``: ``{'#' * level} {outline_number} {title}`` when the
-      heading has an outline number (e.g. ``### 1.1 Purpose``), otherwise
-      ``{'#' * level} {title}``. Level clamped to 1-6.
-    - ``workitem``: bold lead-in ``**{title}** (`{work_item_id}`)``
-      followed by the description body. Falls back to bare backticked
-      ID when both title and description are empty.
-    - ``normal``: ``content`` verbatim, skipped when whitespace-only.
-      Tables stored as ``normal`` flow through unchanged.
-    - ``wikiblock``: ``content`` verbatim, with the Velocity macro name
-      lifted into the fenced-code info-string when detectable (e.g.
-      ``#documentPanel(...)`` → ``` ```documentPanel ```). Falls back
-      to the raw fenced block when no macro token is present.
-    - ``page_break``: rendered as a ``---`` thematic break.
-    - ``toc`` / ``tof``: rendered as a one-line italic placeholder.
-      Widget content is not synthesised — heading text and figure
-      captions already appear inline elsewhere.
-    - Unknown types: skipped.
-
-    Chunks are joined with a blank line; runs of three or more newlines
-    are collapsed to two for visual parity with ``get_document``.
+    Per-type rendering lives in ``_render_part``. Chunks join on a blank line;
+    runs of 3+ newlines collapse to 2.
     """
     chunks: list[str] = []
     for part in parts:
@@ -307,10 +268,8 @@ def _render_workitem_part(part: DocumentPart) -> str:
 def _decorate_wikiblock(content: str) -> str:
     """Lift the Velocity macro name into the fenced-code info-string.
 
-    Wikiblock content arrives as ``` ```\\n#macroName(...)\\n``` ``` from
-    ``markdownify``. Rewrap the fence so the macro name becomes the
-    info-string, giving the LLM an unambiguous macro identifier. Falls
-    back to the raw fence when no ``#name(`` token is detectable.
+    ``#macroName(...)`` in a fence → ` ```macroName `. Falls back to the raw
+    fence when no ``#name(`` token is detectable.
     """
     stripped = content.strip()
     if not stripped:
@@ -329,15 +288,7 @@ def _decorate_wikiblock(content: str) -> str:
 
 
 def _get_module_id(item: object) -> str:
-    """Extract the ``module`` relationship ID from a heading work item.
-
-    Args:
-        item: A single JSON:API resource object.
-
-    Returns:
-        The module ID string (e.g. ``projectId/spaceId/docName``),
-        or ``""`` if not available.
-    """
+    """Return a heading work item's ``module`` ID (``proj/space/doc``), or ``""``."""
     if not isinstance(item, dict):
         return ""
     relationships = item.get("relationships", {})
@@ -350,20 +301,13 @@ def _extract_document_pair(
     item: object,
     documents: set[tuple[str, str]],
 ) -> None:
-    """Parse ``module`` relationship from a heading work item and add the
-    (space_id, document_name) pair to *documents*.
+    """Add a heading work item's (space_id, document_name) to *documents*.
 
-    The module relationship ``data.id`` has the format
-    ``{projectId}/{spaceId}/{documentName}``.
-
-    Args:
-        item: A single JSON:API resource object from the ``data`` array.
-        documents: Mutable set to collect unique (space, document) pairs into.
+    Module ``data.id`` format: ``{projectId}/{spaceId}/{documentName}``.
     """
     mod_id = _get_module_id(item)
     if mod_id:
         parts = mod_id.split("/")
-        # Format: "projectId/spaceId/docName" → parts[1], parts[2:]
         if len(parts) >= 3:  # noqa: PLR2004
             space_id = parts[1]
             document_name = "/".join(parts[2:])
@@ -377,15 +321,8 @@ async def _discover_documents(
     """Discover all unique (space_id, document_name) pairs via linear scan.
 
     Iterates every heading-workitem page (page_size=100) and accumulates
-    unique ``module`` relationship IDs. Results are TTL-cached in
-    ``tools._shared.helpers`` so paginated callers reuse the discovery.
-
-    Args:
-        client: Active ``PolarionClient`` instance.
-        project_id: Polarion project ID.
-
-    Returns:
-        Sorted list of (space_id, document_name) tuples.
+    unique ``module`` relationship IDs. TTL-cached so paginated callers reuse
+    the discovery.
     """
     cached = get_cached_documents(project_id)
     if cached is not None:
@@ -443,10 +380,8 @@ def _extract_first_resource_id(response: dict[str, object]) -> str | None:
 def _extract_created_module_name(response: dict[str, object]) -> str | None:
     """Extract the document name from a 201 document-create response.
 
-    Polarion returns ``{"data": [{"type": "documents",
-    "id": "projectId/spaceId/documentName", ...}]}`` where
-    ``documentName`` itself may contain ``/``. Returns the document-name
-    segment or ``None`` if the response shape is unexpected.
+    ``id`` is ``projectId/spaceId/documentName`` (name may contain ``/``).
+    ``None`` on an unexpected shape.
     """
     full_id = _extract_first_resource_id(response)
     if full_id is None:
@@ -466,13 +401,11 @@ def _build_update_document_payload(  # noqa: PLR0913
     home_page_content_html: str | None = None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API request body for ``PATCH .../documents/{d}``.
+    """Build the JSON:API PATCH body for ``.../documents/{d}``.
 
-    Same PATCH shape as ``_build_update_work_item_payload`` (single ``data``
-    object, required ``id`` ``"{project_id}/{space_id}/{document_name}"``),
-    skipping unset values. ``home_page_content_html`` is RAW Polarion HTML
-    wrapped verbatim into ``{"type":"text/html","value":...}`` — the
-    empty-string body-clearing guard lives in the tool layer, not here.
+    Single ``data`` object, required ``id`` ``"{project}/{space}/{document}"``,
+    skips unset. ``home_page_content_html`` wrapped verbatim into
+    ``{type,value}`` (empty-string guard lives in the tool layer).
     """
     attributes: dict[str, JsonValue] = {}
     if title is not None:
@@ -507,10 +440,9 @@ def _build_create_document_payload(  # noqa: PLR0913
     status: str | None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API request body for ``POST .../spaces/{s}/documents``.
+    """Build the JSON:API POST body for ``.../spaces/{s}/documents``.
 
-    POST shape (``data`` list, ``type=documents``, inline ``attributes``),
-    skipping unset values so creation never overwrites Polarion defaults.
+    ``data`` list, ``type=documents``, inline ``attributes``, skips unset.
     """
     attributes: dict[str, JsonValue] = {
         "moduleName": module_name,
@@ -546,24 +478,8 @@ async def list_documents(
 ) -> PaginatedResult[DocumentSummary]:
     """List all documents in a Polarion project.
 
-    Returns ``(space_id, document_name)`` pairs that other document tools
-    accept. The first call per project runs a full discovery scan cached for
-    60s, so paginated follow-ups are cheap.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        page_size: Items per page (1-100, default 100).
-        page_number: 1-based page number (default 1).
-
-    Returns:
-        PaginatedResult of ``DocumentSummary`` items with ``space_id``
-        and ``document_name``.
-
-    Raises:
-        ValueError: Project not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    Returns ``(space_id, document_name)`` pairs other document tools accept.
+    First call per project runs a discovery scan cached 60s.
     """
     client = get_client(ctx)
 
@@ -623,36 +539,13 @@ async def get_document(
 ) -> DocumentDetail:
     """Get a document's metadata (and optionally its raw body source).
 
-    Returns title, type, status, and custom fields. With
+    Returns title/type/status/custom fields. With
     ``include_homepage_content_html=True``, ``content_html`` carries
-    ``homePageContent`` as raw Polarion HTML — the round-trip shape for
-    ``update_document(home_page_content_html=...)`` (no Markdown/sanitization).
-
-    ``homePageContent`` is the inline prose only — heading text and embedded
-    work-item bodies are separate work items; use ``read_document`` for
-    end-to-end reading, ``read_document_parts`` for structure. Only feed
-    ``content_html`` back to ``update_document`` when the read flag was True
-    (False blanks it, and the empty string is rejected on write).
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        space_id: Space ID containing the document.
-        document_name: Document name within the space.
-        include_homepage_content_html: When True, also return the raw
-            ``homePageContent`` HTML in ``content_html``. Default False
-            to keep the response small.
-
-    Returns:
-        DocumentDetail with ``title``, ``type``, ``status``,
-        ``content_html`` (only when the flag is True; otherwise empty),
-        and ``custom_fields`` (``{fieldId: value}``; rich-text values
-        are returned as ``{type: 'text/html', value: ...}`` dicts).
-
-    Raises:
-        ValueError: Document, space, or project not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    ``homePageContent`` as raw HTML — the round-trip shape for
+    ``update_document``. ``homePageContent`` is inline prose only (headings and
+    embedded work items are separate); use ``read_document`` end-to-end. Feed
+    ``content_html`` back only when the flag was True (False blanks it; ``""``
+    rejected on write).
     """
     client = get_client(ctx)
     path = (
@@ -661,8 +554,7 @@ async def get_document(
         f"/documents/{encode_path_segment(document_name)}"
     )
 
-    # DOCUMENT_DETAIL_FIELDS uses the ``@all`` token; an explicit field list
-    # silently drops inline custom attributes on this server.
+    # ``@all`` token: an explicit field list silently drops inline customs here.
     try:
         response = await client.get(
             path,
@@ -692,8 +584,7 @@ async def get_document(
 
     content_html = ""
     if include_homepage_content_html:
-        # Pass homePageContent {"type","value"} through verbatim so it
-        # round-trips through update_document(home_page_content_html=...).
+        # Verbatim {type,value} so it round-trips through update_document.
         content_obj = attributes.get("homePageContent", {})
         if isinstance(content_obj, dict):
             content_html = safe_str(content_obj.get("value", ""))
@@ -735,36 +626,10 @@ async def list_document_enum_options(  # noqa: PLR0913
     """List valid enum options for a document field of the given document type.
 
     Call before ``update_document`` to resolve a ``status`` / ``type`` /
-    custom-enum value. Polarion does NOT validate these on write (unknown ids
-    persist as ghosts), so resolve first. Document fields only — use
-    ``list_work_item_enum_options`` for work items. Returns the FULL set (not
-    filtered by current workflow state); ``document_type='~'`` is the
-    type-agnostic set, and an unknown type is silently treated as ``~``, so
-    verify the type id (e.g. via ``get_document``) first.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        field_id: Field id whose options to list.
-        document_type: Document type id, or '~' for type-agnostic.
-        page_size: Items per page (1-100, default 100).
-        page_number: 1-based page number (default 1).
-
-    Returns:
-        PaginatedResult of ``EnumOption`` items with:
-        - ``id``: Option id to pass back to write tools.
-        - ``name``: Human-readable display name.
-        - ``description``: Option description; empty when Polarion has none.
-        - ``default``: True if Polarion uses this option as the default.
-        - ``hidden``: True if the option is hidden in the UI.
-        - ``terminal``: For status fields, True for workflow end-states.
-
-    Raises:
-        ValueError: Project or field not found. An unknown
-            ``document_type`` does NOT raise; Polarion silently
-            falls back to the ``~`` set.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    custom-enum value — Polarion does NOT validate on write (unknown ids
+    persist as ghosts). Document fields only. Returns the FULL set;
+    ``document_type='~'`` is type-agnostic, and an unknown type silently falls
+    back to ``~``, so verify the type id first.
     """
     client = get_client(ctx)
     path = (
@@ -832,48 +697,11 @@ async def read_document_parts(  # noqa: PLR0913
 ) -> PaginatedResult[DocumentPart]:
     """List the structural parts of a document in order.
 
-    Use this for part IDs (``move_work_item_to_document``), heading levels, or
+    Use for part IDs (``move_work_item_to_document``), heading levels, or
     per-work-item type/status; each ``workitem`` part already carries its
-    ``description`` as Markdown, so no follow-up ``get_work_item`` is needed
-    when scanning bodies. For plain reading prefer ``read_document``. To filter
-    work items by type/status/title/custom-field (e.g. "non-heading only"),
-    prefer ``list_work_items`` with a ``SQL:(...)`` query (smaller payload, no
-    per-part pagination) — recipes via the ``get_sql_query_recipes`` tool.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        space_id: Space ID containing the document.
-        document_name: Document name within the space.
-        page_size: Items per page (1-100, default 100).
-        page_number: 1-based page number (default 1).
-
-    Returns:
-        PaginatedResult of ``DocumentPart`` with:
-        - ``id``: Short part identifier (e.g. 'heading_MCPT-001',
-          'workitem_MCPT-042', 'polarion_1'). Pass to
-          ``move_work_item_to_document`` as ``previous_part_id`` /
-          ``next_part_id``.
-        - ``title``: Linked work-item title (heading/workitem parts).
-        - ``content``: Part body as Markdown; empty for heading and
-          workitem parts (text lives in ``title``/``level`` and
-          ``description``).
-        - ``type``: 'heading' | 'workitem' | 'normal' | 'toc' | 'wikiblock'
-          | 'tof' | 'page_break'. The last two are inferred from the part
-          ID prefix because Polarion reports both as plain 'normal'.
-        - ``level``: Heading level 1-4 (0 for non-headings).
-        - ``description``: Markdown body (workitem parts only).
-        - ``work_item_id`` / ``work_item_type`` / ``work_item_status``:
-          Linked work-item metadata.
-        - ``external``: True when the work item belongs to another project.
-        - ``outline_number``: Hierarchical position (e.g. '1.2.3') for
-          heading and workitem parts; empty otherwise.
-        - ``next_part_id``: Short ID of the next part; empty on the last.
-
-    Raises:
-        ValueError: Document, space, or project not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    ``description`` as Markdown. For plain reading prefer ``read_document``; to
+    filter by type/status/custom-field prefer ``list_work_items`` with a
+    ``SQL:(...)`` query (recipes via ``get_sql_query_recipes``).
     """
     client = get_client(ctx)
     path = (
@@ -887,8 +715,7 @@ async def read_document_parts(  # noqa: PLR0913
             path,
             params={
                 "fields[document_parts]": "@all",
-                # Narrow workitem fields — ``@all`` would ship every inline
-                # custom field (KBs/page) the part never uses.
+                # Narrow workitem fields — ``@all`` ships unused inline customs.
                 "fields[workitems]": WORK_ITEM_PART_FIELDS,
                 "include": "workItem",
                 "page[size]": page_size,
@@ -920,8 +747,8 @@ async def read_document_parts(  # noqa: PLR0913
             if part is not None:
                 items.append(part)
 
-    # Fall back to the seen-item count only when the server gives no usable
-    # total and the page is non-empty, else an out-of-range page inflates it.
+    # Seen-item count only when the server gives no usable total and the page
+    # is non-empty, else an out-of-range page inflates it.
     raw_doc_total = extract_total_count(response)
     document_total = raw_doc_total
     if document_total <= 0 and items:
@@ -953,38 +780,15 @@ async def read_document(  # noqa: PLR0913
 ) -> DocumentReadResult:
     """Render a Polarion document end-to-end as flowing Markdown.
 
-    Paginates ``read_document_parts`` internally and interleaves heading titles,
-    embedded work-item descriptions, and inline prose into one Markdown stream —
-    the canonical way to read a document body (empty placeholders skipped).
-
-    Output is read-only synthesis: do NOT feed it back to ``update_document``
-    (the Markdown collapses Polarion's ID-anchored placeholders and the
-    round-trip would orphan headings). Use
-    ``get_document(include_homepage_content_html=True)`` for raw-HTML round-trip
-    editing. For metadata-only extraction (ids / types / statuses / custom
-    fields) prefer ``list_work_items`` with a ``SQL:(...)`` query, since this
-    tool always materializes full body Markdown.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        space_id: Space ID containing the document.
-        document_name: Document name within the space.
-        page_size: Parts per page (1-100, default 100).
-        page_number: 1-based page number (default 1).
-
-    Returns:
-        DocumentReadResult with ``content`` (Markdown for the page),
-        ``part_count``, and pagination metadata
-        (``page`` / ``page_size`` / ``total_parts`` / ``has_more``).
-
-    Raises:
-        ValueError: Document, space, or project not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    Paginates ``read_document_parts`` and interleaves headings, work-item
+    descriptions, and prose into one stream — the canonical way to read a body.
+    Read-only synthesis: do NOT feed back to ``update_document`` (collapses
+    ID anchors, orphans headings); use
+    ``get_document(include_homepage_content_html=True)`` for round-trip. For
+    metadata-only extraction prefer ``list_work_items`` SQL.
     """
-    # Delegate fetch + error mapping to read_document_parts (the @mcp.tool
-    # decorator returns the original function, so it forwards directly).
+    # read_document_parts handles fetch + error mapping (decorator returns the
+    # original function, so it forwards directly).
     page = await read_document_parts(
         ctx,
         project_id=project_id,
@@ -1066,66 +870,30 @@ async def update_document(  # noqa: PLR0913
 ) -> DocumentUpdateResult:
     """Update a Polarion document's metadata or body.
 
-    PATCHes only the attributes you set; omitted fields are preserved. Unlike
-    ``update_work_item`` this does NOT follow up with a GET — call
-    ``get_document`` for the refreshed state.
-
-    ``home_page_content_html`` is the round-trip pair for
-    ``get_document(include_homepage_content_html=True)``, sent verbatim with no
-    sanitization (XSS filtering is Polarion's job — NEVER pass untrusted input).
-    Empty string is rejected (would wipe the body and orphan every heading);
-    pass ``'<p></p>'`` for a near-empty body.
+    PATCHes only set attributes (omitted preserved); no follow-up GET — call
+    ``get_document`` for refreshed state. ``home_page_content_html`` is the
+    round-trip pair for ``get_document(include_homepage_content_html=True)``,
+    verbatim, no sanitization (NEVER pass untrusted input). Empty string
+    rejected (orphans headings); pass ``'<p></p>'`` for near-empty.
 
     Body-write rules:
 
     - **Headings auto-create**: inline ``<h1>..<h4>`` become heading work items
-      with ``module`` / ``outline_number`` set; a bare ``<hN>Title</hN>`` is safe
-      and needs no id. Removing an ``<hN>`` drops the part but leaves the heading
-      work item (still ``module``-linked, no ``outline_number``).
-    - **Anchorless blocks break parts**: ``<h3>X</h3><p>Body</p>`` PATCHes 200 but
-      the next ``read_document_parts`` returns HTTP 500 — Polarion's stored blocks
-      all carry ``id="polarion_..."`` anchors. Every anchorless ``<p>`` / ``<ul>``
-      / ``<ol>`` / ``<table>`` / ``<div>`` / ``<blockquote>`` / ``<pre>`` needs a
-      unique non-empty ``id=`` (the tool raises ``ValueError`` before the PATCH
-      otherwise, on ``dry_run`` too). This raw-HTML path has no Markdown
-      auto-stamping; for body text prefer ``create_work_items`` +
-      ``move_work_item_to_document``.
-    - **No macro references**: injecting
-      ``<div id="polarion_wiki macro name=module-workitem;params=id=NEW">`` makes
-      a ``workitem_<NEW>`` part but leaves the work item's ``module`` unset
-      (``space_id=""``, ``outline_number=""``) — a half-attached state. Always
-      attach via ``move_work_item_to_document``.
+      with ``module`` / ``outline_number`` set; bare ``<hN>Title</hN>`` is safe.
+    - **Anchorless blocks break parts**: ``<h3>X</h3><p>Body</p>`` PATCHes 200
+      but the next ``read_document_parts`` returns HTTP 500. Every anchorless
+      ``<p>``/``<ul>``/``<ol>``/``<table>``/``<div>``/``<blockquote>``/``<pre>``
+      needs a unique ``id=`` (tool raises ``ValueError`` before PATCH, on
+      dry_run too). No auto-stamping here; for body text prefer
+      ``create_work_items`` + ``move_work_item_to_document``.
+    - **No macro references**: a ``polarion_wiki macro name=module-workitem``
+      ``<div>`` makes a part but leaves the work item's ``module`` unset (half
+      attached) — attach via ``move_work_item_to_document``.
 
-    Workflow: prefer ``workflow_action`` over a raw ``status`` edit so project
-    rules run; it MUST be paired with at least one attribute field (Polarion
-    rejects empty PATCH bodies). Unknown ``status`` / ``type`` ids raise
-    ``ValueError`` listing the valid options; unknown ``custom_fields`` keys are
-    rejected unless seen on a prior ``get_document`` (one priming read on a miss).
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        space_id: Space ID containing the document.
-        document_name: Document name within ``space_id``.
-        title: Optional new title.
-        status: Optional new workflow status.
-        type: Optional new document type.
-        home_page_content_html: Optional new body as raw Polarion HTML.
-        custom_fields: Optional partial custom-field update.
-        workflow_action: Optional action ID; must be paired with a
-            body field.
-        dry_run: When True, return payload preview only.
-
-    Returns:
-        DocumentUpdateResult with ``updated``, ``dry_run``, and
-        ``payload_preview`` (populated on dry-run; None on real update).
-
-    Raises:
-        ValueError: No fields supplied, action without body, empty
-            ``home_page_content_html``, custom-field key collision, or
-            document / space / project not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    Prefer ``workflow_action`` over raw ``status``; it MUST pair with ≥1
+    attribute (empty PATCH 400s). Unknown ``status`` / ``type`` raise
+    ``ValueError``; unknown ``custom_fields`` keys rejected unless seen on a
+    prior ``get_document``.
     """
     if home_page_content_html is not None and not home_page_content_html.strip():
         raise ValueError(
@@ -1168,9 +936,8 @@ async def update_document(  # noqa: PLR0913
         )
 
     client = get_client(ctx)
-    # Guard type/status against type-agnostic options — less precise than
-    # scoping by the document's type, but avoids the extra GET and still
-    # catches obvious ghost ids.
+    # Guard type/status against type-agnostic options: avoids an extra GET,
+    # still catches obvious ghost ids.
     await guard_document_enums(
         client,
         project_id,
@@ -1179,8 +946,8 @@ async def update_document(  # noqa: PLR0913
         status=status,
     )
 
-    # Build first: merge_custom_fields rejects keys shadowing a standard
-    # attribute — a more fundamental error, and cheaper than the guard's GET.
+    # Build first: merge_custom_fields rejects standard-attribute collisions —
+    # more fundamental, and cheaper than the guard's GET.
     payload = _build_update_document_payload(
         project_id=project_id,
         space_id=space_id,
@@ -1192,7 +959,7 @@ async def update_document(  # noqa: PLR0913
         custom_fields=custom_fields,
     )
     # Hard guard: reject custom-field keys unseen on a prior get_document
-    # (priming GET on miss) — Polarion persists unknown keys as silent ghosts.
+    # (priming GET on miss) — unknown keys persist as silent ghosts.
     await guard_document_custom_field_keys(
         client,
         project_id,
@@ -1303,57 +1070,21 @@ async def create_document(  # noqa: PLR0913
 ) -> DocumentCreateResult:
     """Create a new Polarion document in a space.
 
-    Before calling, you MUST call ``list_documents(project_id, space_id)`` and
-    confirm ``module_name`` is not already present — it must be unique within
-    the space, and a duplicate returns HTTP 409 (``RuntimeError``). For every
-    enum-valued argument (``type``, ``status``, ``custom_fields`` enum entries)
-    supply only ids returned by
-    ``list_document_enum_options(project_id, field_id, document_type)`` —
-    unverified ids persist as ghosts that never match Lucene. ``custom_fields``
-    keys are unvalidated too — take them from a sibling document via
+    First call ``list_documents`` and confirm ``module_name`` is unique in the
+    space (a duplicate returns HTTP 409). Supply only enum ids from
+    ``list_document_enum_options`` — unverified ids persist as ghosts.
+    ``custom_fields`` keys are unvalidated; take them from a sibling via
     ``get_document``.
 
-    The document starts empty (or with the optional ``home_page_content``
-    body); add headings / work-item parts later via ``update_document`` and
-    ``move_work_item_to_document``. ``module_name`` is Polarion's persistent
-    identifier within the space and appears in every subsequent URL.
+    Starts empty (or with optional ``home_page_content``); add parts later via
+    ``update_document`` / ``move_work_item_to_document``. ``module_name`` is the
+    persistent URL identifier.
 
-    Format asymmetry: ``home_page_content`` is Markdown (converted to sanitized
-    HTML on write); after creation the round-trip pair is
-    ``get_document(include_homepage_content_html=True)`` ↔
-    ``update_document(home_page_content_html=...)`` (raw HTML verbatim). The two
-    formats never mix.
-
-    When ``home_page_content`` is provided, every block-level element (``<p>``,
-    ``<ul>``, ``<ol>``, ``<table>``, ``<div>``, ``<blockquote>``, ``<pre>``) is
-    stamped with a unique ``id="polarion_mcp_N"`` anchor — without these the
-    next ``read_document_parts`` returns HTTP 500. ``<h1>..<h4>`` are skipped
-    (Polarion rewrites them to a ``polarion_wiki macro name=module-workitem``
-    form on save).
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        space_id: Space ID containing the new document.
-        module_name: Polarion document identifier (unique within space).
-        title: Human-readable document title.
-        type: Document type.
-        status: Optional initial workflow status.
-        home_page_content: Optional Markdown body.
-        custom_fields: Optional custom-field dict.
-        dry_run: When True, return payload preview only.
-
-    Returns:
-        DocumentCreateResult with ``created``, ``dry_run``,
-        ``document_name`` (None on dry-run), and ``payload_preview``
-        (populated on dry-run; None on real create).
-
-    Raises:
-        ValueError: Project or space not found, or custom-field key
-            collides with a standard Polarion attribute.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors (including duplicate
-            ``module_name``), or accepted-but-no-ID response.
+    ``home_page_content`` is Markdown → sanitized HTML; post-create round-trip is
+    raw HTML via ``get_document(include_homepage_content_html=True)`` ↔
+    ``update_document``. Each block element is stamped a unique
+    ``id="polarion_mcp_N"`` (else the next ``read_document_parts`` 500s);
+    ``<h1>..<h4>`` are skipped (rewritten to macro form on save).
     """
     client = get_client(ctx)
     await guard_document_enums(
@@ -1364,8 +1095,8 @@ async def create_document(  # noqa: PLR0913
         status=status,
     )
     if custom_fields:
-        # Create cannot hard-guard keys (no project-config endpoint, no prior
-        # get to learn them) the way update_document does — warn instead.
+        # Create can't hard-guard keys (no config endpoint, no prior get) —
+        # warn instead.
         logger.warning(
             "create_document.custom_fields cannot be schema-validated "
             "(no project-config endpoint for custom-field keys); ensure keys "

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -76,11 +76,8 @@ def _build_create_links_payload(
 ) -> dict[str, JsonValue]:
     """Build the JSON:API body for bulk create-link POST.
 
-    Each spec produces one ``{"type": "linkedworkitems", "attributes": ...,
-    "relationships": ...}`` resource; all are sent in a single ``data``
-    array. ``revision`` is skipped when unset so Polarion does not
-    interpret an empty string as a clear-default. ``target_project_id``
-    defaults to the source's project per spec when None.
+    One ``linkedworkitems`` resource per spec in a single ``data`` array.
+    ``revision`` skipped when unset; ``target_project_id`` defaults to source.
     """
     data: list[JsonValue] = []
     for spec in links:
@@ -115,13 +112,10 @@ def _build_delete_links_payload(
     source_work_item_id: str,
     links: list[WorkItemLinkRef],
 ) -> tuple[list[str], dict[str, JsonValue]]:
-    """Build the composite ids and JSON:API body for bulk delete-link DELETE.
+    """Build composite ids + JSON:API body for bulk delete-link DELETE.
 
-    Polarion identifies each link by its five-segment composite id
-    ``<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>``. We construct each id
-    from the validated structured ref so the LLM never sees the raw
-    composite form. Returns the id list (echoed in the result) and the
-    JSON:API body to send.
+    Each link's 5-segment id ``<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`` is
+    built from the structured ref. Returns (id list, body).
     """
     link_ids: list[str] = []
     data: list[JsonValue] = []
@@ -148,15 +142,9 @@ def _build_update_link_payload(
 ) -> tuple[str, str, dict[str, JsonValue]]:
     """Build the composite id, request path, and JSON:API body for one PATCH.
 
-    Unlike POST/DELETE (server-side bulk on ``.../linkedworkitems``), PATCH
-    is per-link on ``.../linkedworkitems/{role}/{tgtProj}/{tgtWI}`` with a
-    single-resource ``{"data": {...}}`` body. ``suspect`` / ``revision``
-    are only attached when explicitly set so JSON:API omit-preserve takes
-    effect on the server side.
-
-    Returning the request path here (instead of re-deriving it in the
-    caller) keeps the composite id and the path string locked to the same
-    ``tgt_proj`` resolution so the two cannot drift.
+    Per-link on ``.../linkedworkitems/{role}/{tgtProj}/{tgtWI}`` with a
+    single-resource body. ``suspect`` / ``revision`` attached only when set
+    (omit-preserve). Path returned here so id and path share one ``tgt_proj``.
     """
     tgt_proj = (
         spec.target_project_id
@@ -194,28 +182,11 @@ def _parse_work_item_links(
     *,
     direction: Literal["forward", "back"],
 ) -> list[WorkItemLink]:
-    """Parse linked work items from a JSON:API response.
+    """Parse linked work items from a JSON:API response into ``WorkItemLink``s.
 
-    Uses ``attributes.role`` for the link role, ``attributes.suspect``
-    for the suspect flag, and resolves the target work item title from
-    the ``included`` array (populated via ``include=workItem``).
-
-    The raw ID has the format::
-
-        {projectId}/{sourceWiId}/{role}/{targetProjectId}/{targetWiId}
-
-    e.g. ``MCP_Test_Project/MCPT-9/parent/MCP_Test_Project/MCPT-1``
-
-    The target work item ID is extracted from
-    ``relationships.workItem.data.id``.
-
-    Args:
-        response: Decoded JSON:API response from the linked items
-            endpoint.
-        direction: Link direction ('forward' or 'back').
-
-    Returns:
-        List of parsed ``WorkItemLink`` instances.
+    Role/suspect come from ``attributes``; target title/type/status resolve
+    from the ``included`` array (``include=workItem``). The target id is taken
+    from ``relationships.workItem.data.id``, never by parsing the composite id.
     """
     work_item_map = build_included_work_item_map(response)
 
@@ -402,32 +373,10 @@ async def list_work_item_links(  # noqa: PLR0913
 ) -> PaginatedResult[WorkItemLink]:
     """List a work item's outgoing or incoming links.
 
-    One call returns one direction; call twice (``forward`` then ``back``) for
-    both sides of the traceability graph. Forward links use ``/linkedworkitems``
-    and expose the originating ``role`` (e.g. ``parent``, ``relates_to``,
-    ``verifies``). Back links fall back to a ``linkedWorkItems:`` Lucene query
-    that does not surface the role on this server, so ``role`` is ``None`` for
-    every back item — recover it by calling forward on the source. The
-    ``suspect`` flag (forward only) marks links whose target changed since last
-    review.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        work_item_id: Work Item ID (e.g. 'MCPT-001').
-        direction: 'forward' (outgoing) or 'back' (incoming). Default 'forward'.
-        page_size: Items per page (1-100, default 100).
-        page_number: 1-based page number (default 1).
-
-    Returns:
-        PaginatedResult of ``WorkItemLink`` items with ``id``, ``title``,
-        ``role``, ``direction``, ``suspect``, ``type``, ``status``,
-        ``space_id``, and ``document_name``.
-
-    Raises:
-        ValueError: Work item or project not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    One direction per call. Forward exposes ``role`` (``parent``, ``verifies``,
+    …) and ``suspect``. Back falls back to a ``linkedWorkItems:`` Lucene query
+    that drops the role, so back ``role`` is ``None`` — recover via forward on
+    the source.
     """
     client = get_client(ctx)
 
@@ -478,62 +427,19 @@ async def create_work_item_links(
 ) -> WorkItemLinksCreateResult:
     """Create one or more outgoing links (1-50) from a single source work item.
 
-    All links share the source (``project_id`` / ``work_item_id``) and post as
-    one atomic bulk JSON:API request. Per spec, ``target_project_id`` defaults
-    to ``project_id`` (set it only for cross-project links); ``revision`` pins
-    the link to a revision (else HEAD); ``suspect`` marks it for re-review
-    (usually False). Orientation matches
-    ``list_work_item_links(direction="forward")`` on the source.
+    All share the source and post atomically. Per spec ``target_project_id``
+    defaults to source; ``revision`` pins (else HEAD); ``suspect`` marks
+    re-review. Guards both role (``workitem-link-role``) and target existence
+    before POST (on dry_run too) — unguarded they store as ghost/dangling links.
 
-    Polarion validates neither role nor target, so the tool guards both before
-    the POST (on ``dry_run=True`` too): each ``role`` is checked against the
-    project's ``workitem-link-role`` enumeration (``ValueError`` listing the
-    valid ids on a miss), and each target's existence is verified (a missing
-    target would otherwise store as a silent dangling link with empty
-    title/type/status -- ``ValueError`` on a miss).
-
-    Returned ``link_ids`` are five-segment composites
-    ``<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`` in input order -- the path
-    ids for later ``delete_work_item_links``. The POST is atomic: any Polarion
-    rejection (e.g. a duplicate (role, target) pair -> HTTP 409) rolls back the
-    whole batch, so a 4xx means nothing committed -- re-query
-    ``list_work_item_links(direction="forward")`` before retrying. The tool also
-    raises if a 2xx returns an id count differing from the number submitted.
+    ``link_ids`` are 5-segment composites in input order (delete path ids). POST
+    is atomic: a 4xx (e.g. duplicate (role,target) → 409) rolls back the batch —
+    re-query before retry. Raises on an id-count mismatch.
 
     Phantom-success footgun: when the source is in a document,
-    ``move_work_item_to_document`` already auto-created one outgoing link (role
-    is project-config-dependent). Posting a NEW link with the SAME role returns
-    201 and echoes the ``link_id`` but is NOT persisted -- the auto-link stays
-    the only forward link, and there is no client-side error. After creating on
-    an in-document source, verify with
-    ``list_work_item_links(direction="forward")`` on the source and
-    ``(direction="back")`` on the target; if missing, detach via
-    ``move_work_item_from_document``, create the link, then re-attach with
-    ``move_work_item_to_document``.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Source work item's project ID.
-        work_item_id: Source work item ID.
-        links: One or more ``WorkItemLinkSpec`` (role + target + optional
-            target_project_id / suspect / revision).
-        dry_run: When True, return payload preview only.
-
-    Returns:
-        WorkItemLinksCreateResult with ``created``, ``dry_run``,
-        ``link_ids`` (composite five-segment ids in input order; empty
-        on dry-run), and ``payload_preview`` (populated on dry-run;
-        None on real create).
-
-    Raises:
-        ValueError: Source project or work item not found, a target work
-            item / target project that does not exist, or a ``role`` not in
-            the project's ``workitem-link-role`` enumeration.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors (including duplicate link),
-            an unreachable target- or role-validation request, or a
-            returned-id count that does not match the number of links
-            submitted.
+    ``move_work_item_to_document`` already auto-created one link. A NEW same-role
+    link returns 201 but is NOT persisted. Verify forward (source) + back
+    (target); if missing, detach → create → re-attach.
     """
     payload = _build_create_links_payload(
         source_project_id=project_id,
@@ -617,48 +523,14 @@ async def delete_work_item_links(
 ) -> WorkItemLinksDeleteResult:
     """Delete one or more outgoing links (1-50) from a single source work item.
 
-    Mirrors ``create_work_item_links``: same source coordinates, structured refs
-    per target. Only **outgoing** ("forward") links are removed — delete a back
-    link by calling this tool on the other work item. External hyperlinks live
-    on ``hyperlinks`` (managed via ``update_work_item``).
+    Mirrors ``create_work_item_links``. Only **outgoing** links removed (delete a
+    back link on the other work item). Identify refs from a prior create or from
+    ``list_work_item_links(direction="forward")``.
 
-    Identify links from a prior ``create_work_item_links`` (reuse the specs,
-    dropping ``suspect`` / ``revision`` — delete needs only role + target) or
-    from ``list_work_item_links(direction="forward")`` (each item's ``role`` +
-    ``id`` form a ref; ``target_project_id`` defaults to ``project_id``).
-
-    Polarion's delete is idempotent and silent — it removes matching refs,
-    ignores the rest, and returns 204 either way, so a stale ref looks like a
-    real delete. To make that visible the tool first reads the source's existing
-    outgoing links (one paginated GET) and splits the request into
-    ``deleted_link_ids`` (matched) and ``not_found_link_ids`` (no-ops); a no-op
-    is reported, never raised, so re-deleting stays idempotent. The pre-read is
-    fail-closed — an unreachable backend raises ``RuntimeError`` before any
-    delete, so the split is always trustworthy when the call returns.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Source work item's project ID.
-        work_item_id: Source work item ID.
-        links: One or more ``WorkItemLinkRef`` (role + target + optional
-            target_project_id).
-        dry_run: When True, return payload preview only. The pre-read still
-            runs, so the preview's matched/no-op split is accurate.
-
-    Returns:
-        WorkItemLinksDeleteResult with ``deleted``, ``dry_run``,
-        ``link_ids`` (every requested composite id, in input order),
-        ``deleted_link_ids`` (refs that matched an existing link),
-        ``not_found_link_ids`` (refs that matched nothing), and
-        ``payload_preview`` (populated on dry-run; None on real delete).
-
-    Raises:
-        ValueError: Source work item itself not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: An unreachable pre-read or other Polarion API error
-            (e.g. 400 on a malformed composite id -- but this tool
-            constructs valid ids from structured refs, so 400 should be
-            unreachable).
+    Polarion's delete is idempotent and silent (204 even for stale refs). To make
+    no-ops visible the tool pre-reads existing links and splits into
+    ``deleted_link_ids`` / ``not_found_link_ids`` (no-op reported, never raised).
+    Pre-read is fail-closed (``RuntimeError`` before any delete).
     """
     link_ids, payload = _build_delete_links_payload(
         source_project_id=project_id,
@@ -753,36 +625,10 @@ async def update_work_item_link(  # noqa: PLR0913
 ) -> WorkItemLinkUpdateResult:
     """Update ``suspect`` / ``revision`` on one existing outgoing work item link.
 
-    Use to clear a ``suspect`` flag after sign-off or pin a link to a revision.
-    Identify the link first with ``list_work_item_links(direction="forward")``
-    (its ``role`` + target id address one link). ``suspect`` / ``revision`` are
-    tri-state: an explicit value updates that attribute, ``None`` (default)
-    leaves it unchanged — at least one must be set (an all-``None`` PATCH 400s).
-    One link per call: the PATCH endpoint has no bulk equivalent. A typo in
-    ``role`` returns 404 (no link exists under that role).
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Source work item's project ID.
-        work_item_id: Source work item ID.
-        role: Link role id of the existing link (e.g. ``'relates_to'``).
-        target_work_item_id: Target work item ID.
-        target_project_id: Target's project; defaults to ``project_id``.
-        suspect: New suspect flag; None leaves it unchanged.
-        revision: New revision pin; None leaves it unchanged.
-        dry_run: When True, return payload preview only.
-
-    Returns:
-        WorkItemLinkUpdateResult with ``updated`` (True on success),
-        ``dry_run``, ``link_id`` (composite 5-segment id computed from
-        inputs), and ``payload_preview`` (PATCH body on dry-run; None
-        after a real call).
-
-    Raises:
-        ValueError: Both ``suspect`` and ``revision`` are None, or the
-            link was not found (HTTP 404).
-        PermissionError: Token lacks permission.
-        RuntimeError: Polarion returned an unexpected HTTP error.
+    Identify the link via ``list_work_item_links(direction="forward")`` (role +
+    target address one link). ``suspect`` / ``revision`` tri-state: a value
+    updates, ``None`` leaves unchanged — at least one required (all-``None``
+    400s). One link per call (no bulk PATCH). A ``role`` typo 404s.
     """
     if suspect is None and revision is None:
         raise ValueError(

--- a/src/mcp_server_polarion/tools/moves.py
+++ b/src/mcp_server_polarion/tools/moves.py
@@ -34,11 +34,10 @@ def _build_move_to_document_payload(
     previous_part_id: str | None,
     next_part_id: str | None,
 ) -> dict[str, JsonValue]:
-    """Build the request body for the ``moveToDocument`` action endpoint.
+    """Build the flat ``moveToDocument`` action body (not JSON:API).
 
-    NOT JSON:API — a flat object with ``targetDocument`` plus at most one of
-    ``previousPart`` / ``nextPart`` (both omitted = append at end). The
-    at-most-one invariant is re-checked here to fail closed for direct callers.
+    ``targetDocument`` plus at most one of ``previousPart`` / ``nextPart``
+    (both omitted = append). At-most-one re-checked here to fail closed.
     """
     if previous_part_id is not None and next_part_id is not None:
         msg = (
@@ -104,50 +103,17 @@ async def move_work_item_to_document(  # noqa: PLR0913
 ) -> WorkItemMoveResult:
     """Move a work item into a Polarion document at a specific position.
 
-    Calls the ``moveToDocument`` action endpoint, which atomically updates the
-    work item's ``module`` relationship, inserts a document part at the
-    position, and assigns an ``outline_number``. This is the ONLY supported way
-    to attach a work item body to a document — editing ``homePageContent`` to
-    inject a macro reference leaves ``module`` unset, an inconsistent state.
+    ``moveToDocument`` atomically sets ``module`` + ``outline_number`` and
+    inserts a part — the ONLY supported attach path (macro-injection leaves
+    ``module`` unset). Headings rejected (HTTP 400). Already-in-a-document
+    items are moved, not copied; detach via ``move_work_item_from_document``.
 
-    Heading-type work items are rejected (HTTP 400) — headings must be created
-    inside their target document. If the item is already in another document
-    this detaches it from the source (a move, not a copy); to detach back to
-    free-floating use ``move_work_item_from_document`` (``module`` cannot be
-    cleared via PATCH).
+    AT MOST one of ``previous_part_id`` (AFTER) / ``next_part_id`` (BEFORE);
+    omit both to append. Discover part IDs via ``read_document_parts``.
 
-    Provide AT MOST one of ``previous_part_id`` (insert AFTER) / ``next_part_id``
-    (insert BEFORE); omit both to append at the end. Discover part IDs with
-    ``read_document_parts``.
-
-    Side effect: the server auto-creates an outgoing link from the moved item to
-    its enclosing heading. The role is project-configurable (commonly
-    ``parent`` / ``relates_to``) — inspect forward links on a known-attached
-    item to find it. It appears in ``list_work_item_links(direction="forward")``
-    after the move, is silently removed by ``move_work_item_from_document``, and
-    collides with any same-role link from the same source (see the "phantom
-    success" note on ``create_work_item_links``).
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Project containing the work item.
-        work_item_id: Short ID of an existing work item.
-        target_space_id: Target space ID.
-        target_document_name: Target document name.
-        previous_part_id: Insert AFTER this part.
-        next_part_id: Insert BEFORE this part.
-        dry_run: When True, return payload preview only.
-
-    Returns:
-        WorkItemMoveResult with ``moved``, ``dry_run``, and
-        ``payload_preview`` (populated on dry-run). Polarion returns 204
-        on success — call ``read_document_parts`` for the new part ID.
-
-    Raises:
-        ValueError: Both positions supplied, heading work item, or
-            work item / document / part not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    Side effect: auto-creates one outgoing link to the enclosing heading
+    (project-config role); collides with a same-role ``create_work_item_links``
+    (phantom success). Removed on detach.
     """
     if previous_part_id is not None and next_part_id is not None:
         raise ValueError(
@@ -228,35 +194,13 @@ async def move_work_item_from_document(
 ) -> WorkItemMoveResult:
     """Detach a work item from its document, returning it to free-floating state.
 
-    Inverse of ``move_work_item_to_document``. Calls the ``moveFromDocument``
-    action endpoint, which clears the work item's ``module`` relationship and
-    removes its document part — the ONLY supported detach path (Polarion rejects
-    PATCH on ``module``). The work item itself is preserved (history, links,
-    attributes) and reappears as free-floating, visible to ``list_work_items``;
-    re-attach via ``move_work_item_to_document``.
+    Inverse of ``move_work_item_to_document``. ``moveFromDocument`` clears
+    ``module`` and removes the part — the ONLY detach path (PATCH on ``module``
+    rejected). The work item is preserved and re-attachable.
 
-    NOT idempotent: calling it on an already free-floating item returns HTTP 400
-    (``RuntimeError``). Heading-type items CAN be detached — the heading becomes
-    a free-floating work item with ``space_id=""`` / ``outline_number=""``
-    (orphan-like but intact).
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Project containing the work item.
-        work_item_id: Short ID of an existing work item.
-        dry_run: When True, return payload preview only.
-
-    Returns:
-        WorkItemMoveResult with ``moved``, ``dry_run``, and
-        ``payload_preview`` (an empty dict on dry-run; None on real
-        execution). Polarion returns 204 on success — confirm with
-        ``get_work_item`` showing ``space_id=""``.
-
-    Raises:
-        ValueError: Project or work item not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors, including the 400
-            returned when the work item is already free-floating.
+    NOT idempotent: on an already free-floating item returns HTTP 400
+    (``RuntimeError``). Headings CAN be detached (become free-floating with
+    ``space_id=""`` / ``outline_number=""``).
     """
     if dry_run:
         return WorkItemMoveResult(
@@ -272,7 +216,7 @@ async def move_work_item_from_document(
         "/actions/moveFromDocument"
     )
     try:
-        # moveFromDocument takes no body per the Polarion REST API spec.
+        # moveFromDocument takes no body.
         await client.post(path)
     except PolarionAuthError as exc:
         raise PermissionError(

--- a/src/mcp_server_polarion/tools/projects.py
+++ b/src/mcp_server_polarion/tools/projects.py
@@ -45,22 +45,8 @@ async def list_projects(
 ) -> PaginatedResult[ProjectSummary]:
     """List Polarion projects the authenticated user can access.
 
-    Use this to discover project IDs for other tools. Lucene allows trailing
-    wildcards (``name:ILCU*``) but rejects leading ones (``*foo*``, HTTP 400).
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        query: Optional Lucene filter; omit to return all accessible projects.
-        page_size: Items per page (1-100, default 100).
-        page_number: 1-based page number (default 1).
-
-    Returns:
-        PaginatedResult of ``ProjectSummary`` items with ``id``, ``name``,
-        and ``active`` (False = archived; defaults to True if absent).
-
-    Raises:
-        PermissionError: Auth token invalid or lacks permission.
-        RuntimeError: Other Polarion API errors.
+    Discover project IDs for other tools. Lucene allows trailing wildcards
+    (``name:ILCU*``) but rejects leading ones (``*foo*``, HTTP 400).
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -70,12 +70,11 @@ def _build_work_item_resource(
     spec: WorkItemCreateSpec,
     description_html: str,
 ) -> dict[str, JsonValue]:
-    """Build one ``workitems`` resource object for a bulk create POST.
+    """Build one ``workitems`` resource for a bulk create POST.
 
-    Skips unset values so creation never overwrites Polarion defaults with
-    empties. ``custom_fields`` inline into ``attributes`` via
-    ``merge_custom_fields``, which raises on a key colliding with a standard
-    field. ``description_html`` arrives pre-converted (pure data-shaping).
+    Skips unset values (no overwriting defaults). ``custom_fields`` inline via
+    ``merge_custom_fields`` (raises on standard-field collision).
+    ``description_html`` arrives pre-converted.
     """
     attributes: dict[str, JsonValue] = {
         "title": spec.title,
@@ -123,11 +122,9 @@ def _build_create_work_items_payload(
     specs: list[WorkItemCreateSpec],
     descriptions_html: list[str],
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API body for the bulk ``POST /projects/{p}/workitems``.
+    """Build the JSON:API body for bulk ``POST /projects/{p}/workitems``.
 
-    Each spec, paired with its pre-converted ``description_html``, produces
-    one resource object via ``_build_work_item_resource``; all are sent in a
-    single ``data`` array so N work items create in one request.
+    One resource per (spec, description_html) pair in a single ``data`` array.
     """
     data: list[JsonValue] = [
         _build_work_item_resource(spec=spec, description_html=html)
@@ -137,11 +134,10 @@ def _build_create_work_items_payload(
 
 
 def _extract_created_work_item_ids(response: dict[str, object]) -> list[str]:
-    """Return short work-item ids in submission order from a bulk 201 response.
+    """Return short work-item ids (submission order) from a bulk 201 response.
 
-    Relies on Polarion echoing ``data`` in submission order; the call-site
-    count check catches a missing id, not a reordered one. Empty on malformed
-    shapes.
+    Relies on Polarion echoing ``data`` in order; the call-site count check
+    catches a missing id, not a reordered one. Empty on malformed shapes.
     """
     data = response.get("data")
     if not isinstance(data, list):
@@ -173,8 +169,7 @@ def _build_update_work_item_payload(  # noqa: PLR0913
 ) -> dict[str, JsonValue]:
     """Build the JSON:API PATCH body for ``/projects/{p}/workitems/{work_item}``.
 
-    The PATCH shape of ``_build_work_item_resource``: a single ``data``
-    resource object with a required ``id`` ``"{project_id}/{work_item_id}"``.
+    Single ``data`` resource with required ``id`` ``"{project}/{work_item}"``.
     Skips unset values so an update never blanks an existing attribute.
     """
     attributes: dict[str, JsonValue] = {}
@@ -259,56 +254,22 @@ async def create_work_items(
         ),
     ),
 ) -> WorkItemsCreateResult:
-    """Create one or more Polarion work items (1-50) in a single request, all
-    in the same project.
+    """Create one or more Polarion work items (1-50) in one request, same project.
 
-    For every enum-valued field on any item (``type``, ``status``,
-    ``severity``, ``custom_fields`` enum entries) you MUST first confirm the
-    value via ``list_work_item_enum_options(project_id, field_id,
-    work_item_type)`` — unverified ids are accepted by Polarion but persist as
-    ghosts that never match Lucene. ``priority`` partly coerces (non-numeric →
-    project default; numeric out-of-range still persists verbatim).
-    ``custom_fields`` keys are unvalidated and defined per project+type, so
-    take them from an existing work item of the same ``type`` via
-    ``get_work_item``. Each ``hyperlinks[].role`` is validated against the
-    project's ``hyperlink-role`` enumeration (``ValueError`` on an unknown role
-    before any write).
+    Confirm every enum value (``type`` / ``status`` / ``severity`` / custom
+    enums) via ``list_work_item_enum_options`` first — unverified ids persist as
+    ghosts that never match Lucene. ``custom_fields`` keys are unvalidated;
+    take them from an existing item of the same ``type`` via ``get_work_item``.
+    ``hyperlinks[].role`` validated against ``hyperlink-role`` before write.
 
-    Bulk semantics: enum guards, Markdown conversion, and payload build all run
-    BEFORE any write, and Polarion's bulk POST is atomic — a bad enum, colliding
-    custom-field key, or any server-rejected attribute on one item rejects the
-    whole batch with nothing created. The tool raises if the returned id count
-    differs from the number submitted; re-query ``list_work_items`` first.
+    Atomic: guards + conversion + build run before the POST; one bad item rejects
+    the whole batch (nothing created). Raises if the returned id count differs
+    from submitted — re-query ``list_work_items`` first.
 
-    Each item is created free-floating — to place one in a document at an
-    outline position, follow up with ``move_work_item_to_document``. Direct
-    creation into a document (via ``module``) is intentionally not exposed: such
-    items land in the recycle bin, invisible in the body. Always pair
-    create + move.
-
-    Format asymmetry: ``description`` is Markdown (converted to sanitized HTML
-    on write); after creation the round-trip pair is
-    ``get_work_item(include_description_html=True)`` ↔
-    ``update_work_item(description_html=...)`` (raw HTML verbatim). The two
-    formats never mix.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID shared by every item.
-        items: One or more ``WorkItemCreateSpec`` entries (1-50).
-        dry_run: When True, return payload preview only.
-
-    Returns:
-        WorkItemsCreateResult with ``created``, ``dry_run``,
-        ``work_item_ids`` (short ids in input order; empty on dry-run),
-        and ``payload_preview`` (populated on dry-run; None on real create).
-
-    Raises:
-        ValueError: Project not found, or a custom-field key collides with
-            a standard Polarion attribute.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors, or a returned-id count
-            that does not match the number of items submitted.
+    Items are free-floating; place in a document via ``move_work_item_to_document``
+    (direct ``module`` create lands in the recycle bin). ``description`` is
+    Markdown → sanitized HTML; the post-create round-trip is raw HTML via
+    ``get_work_item(include_description_html=True)`` ↔ ``update_work_item``.
     """
     client = get_client(ctx)
     for spec in items:
@@ -328,8 +289,8 @@ async def create_work_items(
     )
     for index, spec in enumerate(items):
         if spec.custom_fields:
-            # Create can't hard-guard keys (no project-config endpoint, no prior
-            # item to observe) the way update_work_item does — warn instead.
+            # Create can't hard-guard keys (no config endpoint, no prior item) —
+            # warn instead.
             logger.warning(
                 "create_work_items[%d].custom_fields cannot be schema-validated "
                 "(no project-config endpoint for custom-field keys); "
@@ -486,69 +447,26 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
 ) -> WorkItemUpdateResult:
     """Update an existing Polarion work item.
 
-    PATCHes the supplied fields and follows up with a GET so the caller can
-    confirm the change in ``current``. ``None`` / empty string / empty list all
-    mean ``leave unchanged`` — there is no path to clear a field.
+    PATCHes supplied fields, then GETs so ``current`` reflects the change.
+    ``None`` / empty all mean leave unchanged — no clear path.
 
-    ``description_html`` is RAW Polarion HTML, sent verbatim with no
-    sanitization (XSS filtering is Polarion's job — NEVER pass untrusted input);
-    pair with ``get_work_item(include_description_html=True)`` for the
-    round-trip. For greenfield authoring use ``create_work_items`` with a
-    Markdown ``description`` — the two paths never mix.
+    ``description_html`` is RAW Polarion HTML, verbatim, no sanitization (NEVER
+    pass untrusted input); round-trip with
+    ``get_work_item(include_description_html=True)``. Greenfield: use
+    ``create_work_items`` Markdown — paths never mix.
 
-    ``hyperlinks`` and ``assignee_ids`` REPLACE the existing lists (pass the
-    full list, not a delta). Each hyperlink ``role`` is validated against the
-    project's ``hyperlink-role`` enumeration (``ValueError`` before the PATCH,
-    on ``dry_run`` too, since an unknown role would persist as a ghost).
-    ``custom_fields`` is partial (omitted keys preserved); unknown keys are
-    rejected unless seen on a prior ``get_work_item`` for this type (one priming
-    read on a miss) — otherwise they would persist as ghost attributes.
+    ``hyperlinks`` / ``assignee_ids`` REPLACE (full list, not delta); each
+    hyperlink ``role`` validated against ``hyperlink-role`` (before PATCH, on
+    dry_run too). ``custom_fields`` partial; unknown keys rejected unless seen
+    on a prior ``get_work_item`` (priming read on miss).
 
-    The ``module`` relationship is NOT exposed (Polarion rejects PATCHes that
-    touch it) — attach/detach/move via ``move_work_item_to_document`` /
-    ``move_work_item_from_document``.
-
-    Prefer ``workflow_action`` over a raw ``status`` edit so transition rules
-    run. ``workflow_action`` and ``change_type_to`` MUST be paired with at least
-    one body field (Polarion rejects empty PATCH bodies). Unknown ``status`` /
-    ``severity`` / ``resolution`` / ``priority`` / ``change_type_to`` ids raise
-    ``ValueError`` listing the valid options before the PATCH (on ``dry_run``
-    too); with ``change_type_to`` set, ``status`` / ``severity`` /
-    ``resolution`` are validated against the target type's options.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        work_item_id: Short ID of the work item to update.
-        title: Optional new title.
-        description_html: Optional new raw HTML body.
-        status: Optional new workflow status.
-        priority: Optional new priority string.
-        severity: Optional new severity.
-        due_date: Optional new ISO-8601 date.
-        initial_estimate: Optional new duration.
-        resolution: Optional new resolution outcome.
-        hyperlinks: Optional REPLACEMENT hyperlink list.
-        assignee_ids: Optional REPLACEMENT assignee list.
-        custom_fields: Optional partial custom-field update.
-        workflow_action: Optional ``workflowAction`` query parameter.
-        change_type_to: Optional ``changeTypeTo`` query parameter.
-        include_current_description_html: When True, return the
-            post-update body in ``current.description_html``; default
-            False keeps responses small.
-        dry_run: When True, return payload preview only.
-
-    Returns:
-        WorkItemUpdateResult with ``updated``, ``dry_run``, ``current``
-        (post-update detail; None on dry-run), ``changes`` (parameter
-        deltas), and ``payload_preview`` (populated on dry-run).
-
-    Raises:
-        ValueError: No mutating fields supplied, action without body,
-            custom-field key collides with a standard attribute, or work item
-            not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    ``module`` NOT exposed — use ``move_work_item_to_document`` /
+    ``move_work_item_from_document``. Prefer ``workflow_action`` over raw
+    ``status``; ``workflow_action`` / ``change_type_to`` MUST pair with ≥1 body
+    field (empty PATCH 400s). Unknown ``status`` / ``severity`` / ``resolution``
+    / ``priority`` / ``change_type_to`` raise ``ValueError`` listing valid
+    options; with ``change_type_to`` set, status/severity/resolution scope to
+    the target type.
     """
     changes: dict[str, JsonValue] = {}
     if title:
@@ -574,8 +492,7 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
     if assignee_ids:
         changes["assignee_ids"] = list(assignee_ids)
     if custom_fields:
-        # deepcopy so the result's ``changes`` map is independent of the caller's
-        # dict; a shallow copy would alias nested rich-text values.
+        # deepcopy: shallow would alias nested rich-text values into ``changes``.
         changes["custom_fields"] = cast(JsonValue, copy.deepcopy(custom_fields))
     if workflow_action:
         changes["workflow_action"] = workflow_action
@@ -606,8 +523,8 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         custom_fields=custom_fields,
     )
 
-    # Polarion 400s on a PATCH body with neither attributes nor relationships,
-    # even when only workflowAction / changeTypeTo is set — catch it here.
+    # Polarion 400s on a PATCH body with no attributes/relationships, even when
+    # only workflowAction / changeTypeTo is set — catch it here.
     payload_data = cast(dict[str, JsonValue], payload["data"])
     if "attributes" not in payload_data and "relationships" not in payload_data:
         raise ValueError(
@@ -624,9 +541,8 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         f"/workitems/{encode_path_segment(work_item_id)}"
     )
 
-    # Enum/custom-field args need the item's type (enum options are
-    # type-scoped) and prime the custom-key guard cache, so fetch once —
-    # on dry_run too, so preview raises the same ValueError as a real call.
+    # Enum options are type-scoped; fetch the item's type once (on dry_run too,
+    # so preview raises the same ValueError) and prime the custom-key cache.
     work_item_type = ""
     if status or severity or priority or resolution or change_type_to or custom_fields:
         try:
@@ -663,9 +579,8 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
                 )
 
         # Scope status/severity/resolution/priority by the target type
-        # (``change_type_to`` if set, since the patch lands there). The guard
-        # checks ``type`` first, so an invalid change_type_to raises before
-        # it is reused as the scoping axis.
+        # (change_type_to if set). Guard checks ``type`` first, so an invalid
+        # change_type_to raises before being reused as the scoping axis.
         effective_type = change_type_to or work_item_type or "~"
         await guard_work_item_enums(
             client,
@@ -677,9 +592,8 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
             priority=priority,
             resolution=resolution,
         )
-        # Fail-closed even when the prefetch could not resolve a type: pass
-        # whatever type we have (possibly "") so the guard's own priming GET
-        # validates the keys rather than silently skipping the check.
+        # Fail-closed: pass whatever type we have (possibly "") so the guard's
+        # own priming GET validates keys rather than skipping the check.
         if custom_fields:
             await guard_work_item_custom_field_keys(
                 client,
@@ -738,8 +652,8 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         fallback_id=work_item_id,
     )
     if not include_current_description_html:
-        # Blank the returned body (it still came over the wire) to keep the
-        # common metadata-only update small — mirrors get_work_item.
+        # Blank the body (still came over the wire) to keep metadata-only
+        # updates small — mirrors get_work_item.
         current = current.model_copy(update={"description_html": ""})
 
     return WorkItemUpdateResult(
@@ -777,38 +691,11 @@ async def list_work_item_enum_options(  # noqa: PLR0913
     """List valid enum options for a work item field of the given type.
 
     Call before ``create_work_items`` / ``update_work_item`` to resolve a
-    ``type`` / ``status`` / ``severity`` / ``priority`` / custom-enum value.
-    Polarion does NOT validate these on write (unknown ids persist as ghosts;
-    ``priority`` only coerces non-numeric input to the project default), so
-    resolve first. Work-item fields only — use ``list_document_enum_options``
-    for documents. Returns the FULL set (not filtered by current workflow
-    state); ``work_item_type='~'`` is the type-agnostic set, and an unknown
-    type is silently treated as ``~``, so verify the type id (e.g. via
-    ``get_work_item``) first.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        field_id: Field id whose options to list.
-        work_item_type: Work item type id, or '~' for type-agnostic.
-        page_size: Items per page (1-100, default 100).
-        page_number: 1-based page number (default 1).
-
-    Returns:
-        PaginatedResult of ``EnumOption`` items with:
-        - ``id``: Option id to pass back to write tools.
-        - ``name``: Human-readable display name.
-        - ``description``: Option description; empty when Polarion has none.
-        - ``default``: True if Polarion uses this option as the default.
-        - ``hidden``: True if the option is hidden in the UI.
-        - ``terminal``: For status fields, True for workflow end-states.
-
-    Raises:
-        ValueError: Project or field not found. An unknown
-            ``work_item_type`` does NOT raise; Polarion silently
-            falls back to the ``~`` set.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors.
+    ``type`` / ``status`` / ``severity`` / ``priority`` / custom-enum value —
+    Polarion does NOT validate on write (unknown ids persist as ghosts).
+    Work-item fields only. Returns the FULL set; ``work_item_type='~'`` is
+    type-agnostic, and an unknown type silently falls back to ``~``, so verify
+    the type id first.
     """
     client = get_client(ctx)
     path = (
@@ -896,40 +783,15 @@ async def list_work_items(
 ) -> PaginatedResult[WorkItemSummary]:
     """List and search work items in a Polarion project.
 
-    Pass a Lucene ``query`` (`type:requirement`, `status:approved AND
-    type:requirement`, `title:SRS*`) or omit it for all work items. Leading
-    wildcards (`*foo*`) return HTTP 400. ``module`` and description body text
-    are NOT indexed — use the *SQL prefix* below for module scope, and
-    ``read_document_parts`` / ``read_document`` for body content.
+    Lucene ``query`` (`type:requirement`, `title:SRS*`) or omit for all. Leading
+    wildcards 400. ``module`` and body text are NOT indexed — use the SQL prefix
+    for module scope, ``read_document_parts`` for body.
 
-    **SQL prefix.** A ``query`` starting with ``SQL:(`` runs as native SQL,
-    unlocking patterns Lucene cannot express (module-scoped lookup,
-    leading-wildcard ``LIKE``, custom-field joins, role-preserving
-    traceability). Escape ``'`` as ``''``; there are no bind parameters, so
-    escape any user-supplied value before substituting. ``C_DESCRIPTION LIKE``
-    does NOT match (CLOB stored elsewhere — use ``read_document_parts`` for
-    body search), and ``LIKE`` is rejected inside ``EXISTS (SELECT ...)`` —
-    keep it in the top-level ``WHERE`` via ``INNER JOIN``. For module-scoped,
-    custom-field, or traceability queries you MUST call ``get_sql_query_recipes``
-    and adapt a recipe before writing SQL; do not hand-write these joins from
-    memory.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        query: Optional Lucene filter, OR a ``SQL:(...)`` prefix for native SQL.
-        page_size: Items per page (1-100, default 100).
-        page_number: 1-based page number (default 1).
-
-    Returns:
-        PaginatedResult of ``WorkItemSummary`` items with ``id``,
-        ``title``, ``type``, ``status``, ``priority``, ``updated``,
-        ``space_id``, ``document_name``, and ``assignee_ids``.
-
-    Raises:
-        ValueError: Project not found.
-        PermissionError: Token lacks permission.
-        RuntimeError: Other Polarion API errors (incl. bad Lucene or SQL syntax).
+    **SQL prefix.** A ``query`` starting with ``SQL:(`` runs native SQL for
+    patterns Lucene can't express. Escape ``'`` as ``''`` (no bind params).
+    ``C_DESCRIPTION LIKE`` does NOT match; ``LIKE`` is rejected inside
+    ``EXISTS`` — keep it top-level via ``INNER JOIN``. For module/custom-field/
+    traceability queries you MUST adapt a recipe from ``get_sql_query_recipes``.
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {
@@ -998,55 +860,8 @@ async def get_work_item(
     """Get full details of a single Polarion work item.
 
     With ``include_description_html=True``, ``description_html`` carries the raw
-    Polarion HTML body — the round-trip shape for
-    ``update_work_item(description_html=...)``. Only feed it back when the flag
-    was True (False blanks it, and the update tool treats ``""`` as
-    ``leave unchanged``).
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        work_item_id: Work Item ID (e.g. 'MCPT-001').
-        include_description_html: When True, populate
-            ``description_html`` with the raw HTML body. Default False.
-
-    Returns:
-        WorkItemDetail with:
-        - ``id``: Work Item ID.
-        - ``title``: Work Item title.
-        - ``type``: Work Item type.
-        - ``status``: Workflow status.
-        - ``priority``: Priority value as a string (empty when unset).
-        - ``updated``: ISO-8601 last-modified timestamp.
-        - ``created``: ISO-8601 creation timestamp.
-        - ``space_id`` / ``document_name``: Document this work item
-          belongs to (both empty when not module-bound).
-        - ``outline_number``: Hierarchical position inside the document
-          (e.g. '1.2.3'); empty when not in a document.
-        - ``assignee_ids``: Short user IDs of assignees.
-        - ``author_id``: Short user ID of the author.
-        - ``resolution``: Resolution outcome for closed items
-          (e.g. 'fixed', 'wontfix'); empty otherwise.
-        - ``severity``: Severity classification, used for defects
-          (e.g. 'blocker', 'critical'); empty otherwise.
-        - ``hyperlinks``: External hyperlinks as ``Hyperlink`` items
-          with ``role``, ``title``, ``uri`` fields.
-        - ``description_html``: Raw Polarion HTML body — populated only
-          when ``include_description_html=True``, otherwise empty.
-          Pass this string verbatim back to
-          ``update_work_item(description_html=...)`` for a lossless
-          round-trip.
-        - ``project_id``: Containing project.
-        - ``custom_fields``: User-defined custom fields as a
-          ``{fieldId: value}`` dict. Keys vary per project and work-item
-          type; values are returned verbatim (primitives or
-          ``{type: 'text/html', value: '<...>'}`` for rich-text fields).
-          Empty dict when no custom fields are populated.
-
-    Raises:
-        ValueError: If the work item or project is not found.
-        PermissionError: If the token lacks permissions.
-        RuntimeError: On unexpected Polarion API errors.
+    Polarion HTML body — the round-trip shape for ``update_work_item``. Only
+    feed it back when the flag was True (False blanks it; ``""`` = unchanged).
     """
     client = get_client(ctx)
     path = (
@@ -1091,8 +906,8 @@ async def get_work_item(
             project_id, detail.type, detail.custom_fields.keys()
         )
     if not include_description_html:
-        # The body always travels over the wire (no sparse-fieldset excludes it);
-        # blank it here to honour the include_description_html=False contract.
+        # Body always travels over the wire; blank it to honour the
+        # include_description_html=False contract.
         detail = detail.model_copy(update={"description_html": ""})
     return detail
 
@@ -1109,35 +924,11 @@ async def read_work_item(
 ) -> WorkItemRead:
     """Read a Polarion work item with its body rendered as Markdown.
 
-    Synthesis variant of ``get_work_item``: same metadata fields plus
-    ``description`` as Markdown (converted from HTML) instead of
-    ``description_html`` — use when an LLM needs to read or summarise the body.
-    The converter collapses Polarion-specific spans and ID anchors, so the
-    Markdown is read-only — do NOT feed it back to ``update_work_item``. For
-    round-trip editing, pair ``get_work_item(include_description_html=True)``
-    with ``update_work_item(description_html=...)``.
-
-    Args:
-        ctx: MCP tool context (injected automatically).
-        project_id: Polarion project ID.
-        work_item_id: Work Item ID (e.g. 'MCPT-001').
-
-    Returns:
-        WorkItemRead with all the metadata fields of ``WorkItemDetail``
-        (``id``, ``title``, ``type``, ``status``, ``priority``,
-        ``updated``, ``created``, ``space_id`` / ``document_name``,
-        ``outline_number``, ``assignee_ids``, ``author_id``,
-        ``resolution``, ``severity``, ``hyperlinks``, ``project_id``,
-        ``custom_fields``) plus ``description`` carrying the Markdown
-        body (empty when the work item has no description).
-
-    Raises:
-        ValueError: If the work item or project is not found.
-        PermissionError: If the token lacks permissions.
-        RuntimeError: On unexpected Polarion API errors.
+    Synthesis variant of ``get_work_item``: same metadata plus ``description``
+    as Markdown. Read-only (collapses Polarion spans/anchors) — do NOT feed
+    back to ``update_work_item``; round-trip via the HTML pair instead.
     """
-    # Delegate fetch + error mapping to get_work_item; pull raw HTML so the
-    # Markdown converter runs without a second round trip.
+    # Pull raw HTML from get_work_item so conversion needs no second round trip.
     detail = await get_work_item(
         ctx,
         project_id=project_id,

--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -1,15 +1,9 @@
 """HTML ↔ Markdown conversion for Polarion content fields.
 
-Polarion stores all rich-text fields (e.g. Work Item descriptions,
-Document content) as HTML.  These utilities ensure:
-
-* **Read path** — raw HTML is converted to Markdown before the LLM sees
-  it (``html_to_markdown``).  Markdown preserves structural information
-  (headings, lists, tables) while being far more token-efficient than
-  raw HTML.
-* **Write path** — LLM-generated Markdown is converted to
-  Polarion-compatible HTML (``markdown_to_html``), and any pre-existing
-  HTML is restricted to safe tags only (``sanitize_html``).
+Polarion stores rich-text fields (Work Item descriptions, Document
+content) as HTML. Read path converts HTML→Markdown for the LLM
+(token-efficient, structure-preserving); write path converts
+Markdown→HTML and restricts pre-existing HTML to safe tags.
 """
 
 from __future__ import annotations
@@ -52,32 +46,26 @@ ALLOWED_TAGS: Final[frozenset[str]] = frozenset(
     }
 )
 
-# Per-tag allowlist of safe attributes.  Tags absent from this map permit NO
-# attributes.  This blocks on* event handlers (onclick, onerror, etc.) and any
-# other non-presentational attributes that could enable stored XSS when Polarion
-# renders the content in a browser.
+# Per-tag safe-attribute allowlist; tags absent permit none. Blocks on*
+# handlers and other non-presentational attrs that enable stored XSS.
 ALLOWED_ATTRS: Final[dict[str, frozenset[str]]] = {
     "a": frozenset({"href", "title"}),
     "td": frozenset({"colspan", "rowspan"}),
     "th": frozenset({"colspan", "rowspan"}),
 }
 
-# Tags whose entire content (text + children) must be removed, not just unwrapped.
-# JS and CSS source code is never meaningful as visible Polarion text.
+# Tags removed with their content (JS/CSS source, never visible text).
 _DECOMPOSE_TAGS: Final[frozenset[str]] = frozenset({"script", "style"})
 
-# URL schemes considered safe for href attributes.  Any other scheme
-# (javascript:, data:, vbscript:, etc.) is stripped to prevent stored XSS.
+# Safe href schemes; others (javascript:, data:, vbscript:) stripped (XSS).
 _SAFE_URL_SCHEMES: Final[frozenset[str]] = frozenset({"http", "https", "mailto"})
 
-# Upper bound on cells materialised per merged-cell expansion (colspan*rowspan).
-# Bounds an adversarial colspan="1000" rowspan="1000" (1M clones) while still
-# covering any realistic Polarion table.
+# Cap on cells per merge expansion (colspan*rowspan); bounds adversarial
+# colspan=1000 rowspan=1000 (1M clones), covers realistic tables.
 _MAX_CELLS_PER_MERGE: Final[int] = 10_000
 
-# markdown-it-py renderer: CommonMark base + GFM tables.
-# html_block and html_inline are disabled so that raw HTML embedded in
-# LLM/user-supplied Markdown cannot bypass sanitization.
+# CommonMark + GFM tables. html_block/html_inline disabled so raw HTML in
+# supplied Markdown can't bypass sanitization.
 _md_renderer: Final[MarkdownIt] = (
     MarkdownIt("commonmark").disable(["html_block", "html_inline"]).enable("table")
 )
@@ -86,17 +74,13 @@ _md_renderer: Final[MarkdownIt] = (
 def html_to_markdown(html: str) -> str:
     """Convert Polarion HTML to Markdown for LLM consumption.
 
-    Uses ``markdownify`` to translate HTML structure into Markdown
-    syntax.  Headings, lists, tables, and inline formatting are
-    preserved as Markdown equivalents, giving the LLM both semantic
-    structure and token efficiency.
+    Preserves headings, lists, tables, and inline formatting as Markdown.
 
     Args:
         html: Raw HTML string from a Polarion content field.
 
     Returns:
-        Markdown text with structural elements preserved.
-        Returns an empty string when given empty or whitespace-only input.
+        Markdown text; empty string for empty/whitespace input.
     """
     if not html or not html.strip():
         return ""
@@ -110,16 +94,13 @@ def html_to_markdown(html: str) -> str:
 def _render_polarion_rte_links(html: str) -> str:
     """Convert ``span.polarion-rte-link`` placeholders to ``<a>`` tags.
 
-    Polarion serialises rich-text references (to other documents or work
-    items) as empty ``<span>`` elements whose target lives on ``data-*``
-    attributes. ``markdownify`` drops empty spans entirely, silently losing
-    the link. Lift the target into ``<a href="polarion:...">label</a>``
-    so the downstream conversion emits ``[label](polarion:...)``.
+    Polarion serialises rich-text refs as empty ``<span>`` with the target
+    on ``data-*`` attrs; ``markdownify`` drops empty spans, losing the link.
+    Lift the target into ``<a href="polarion:...">label</a>``.
 
-    The ``polarion:`` scheme is intentionally absent from
-    ``_SAFE_URL_SCHEMES``: if this synthesised Markdown ever round-trips
-    through ``sanitize_html`` the href is stripped, preventing an
-    unresolvable scheme from leaking into a write payload.
+    ``polarion:`` is intentionally absent from ``_SAFE_URL_SCHEMES``: if
+    this Markdown round-trips through ``sanitize_html`` the href is
+    stripped, keeping an unresolvable scheme out of write payloads.
     """
     if "polarion-rte-link" not in html:
         return html
@@ -137,10 +118,9 @@ def _render_polarion_rte_links(html: str) -> str:
 def _resolve_rte_link(span: Tag) -> tuple[str, str]:
     """Return ``(href, label)`` for one ``polarion-rte-link`` span.
 
-    Returns ``("", "")`` when neither richPage nor work-item metadata is
-    usable, so the caller can leave the span untouched. The returned
-    ``label`` is pre-escaped so that ``[``, ``]``, ``\\`` survive Markdown
-    link syntax without collapsing the surrounding brackets.
+    ``("", "")`` when neither richPage nor work-item metadata is usable, so
+    the caller leaves the span untouched. ``label`` is pre-escaped so
+    ``[``, ``]``, ``\\`` survive Markdown link syntax.
     """
     inner_text = span.get_text(strip=True)
     data_type_raw = span.attrs.get("data-type", "")
@@ -161,10 +141,8 @@ def _resolve_rte_link(span: Tag) -> tuple[str, str]:
     if item_id:
         scope_raw = span.attrs.get("data-scope", "")
         scope = scope_raw if isinstance(scope_raw, str) else ""
-        # Two distinct URI shapes keep the project segment unambiguous:
-        # bare ``polarion:workitem/MCPT-7`` resolves against the current
-        # project, while ``polarion:project/Proj/workitem/MCPT-7`` carries
-        # the scope for cross-project references.
+        # Bare ``polarion:workitem/MCPT-7`` resolves against current project;
+        # ``polarion:project/Proj/workitem/MCPT-7`` carries cross-project scope.
         if scope:
             href = (
                 f"polarion:project/{quote(scope, safe='')}"
@@ -178,22 +156,20 @@ def _resolve_rte_link(span: Tag) -> tuple[str, str]:
 
 
 def _escape_md_link_label(text: str) -> str:
-    """Backslash-escape characters that would break Markdown link syntax.
+    """Backslash-escape characters that break Markdown link syntax.
 
-    ``markdownify`` writes anchor text verbatim into ``[label](href)``;
-    unescaped ``[`` / ``]`` in the label collapses the link or invites a
-    different reference, and a trailing ``\\`` swallows the closing bracket.
+    Unescaped ``[``/``]`` in anchor text collapses ``[label](href)``; a
+    trailing ``\\`` swallows the closing bracket.
     """
     return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
 
 
 def _fill_empty_img_alt(html: str) -> str:
-    """Promote ``<img title>`` (or the post-colon ``src`` filename) to ``alt``.
+    """Promote ``<img title>`` (or post-colon ``src`` filename) to ``alt``.
 
     Polarion stores attachments as ``<img src="attachment:NAME"/>`` with
-    the filename on ``title`` rather than ``alt``, which makes markdownify
-    emit a label-less ``![](src)``. Lift the value into ``alt`` so the
-    Markdown carries a readable label.
+    the filename on ``title``, making markdownify emit a label-less
+    ``![](src)``.
     """
     if "<img" not in html.lower():
         return html
@@ -207,8 +183,8 @@ def _fill_empty_img_alt(html: str) -> str:
         title_raw = img.attrs.get("title", "")
         title = title_raw if isinstance(title_raw, str) else ""
         label = title.strip()
-        # Skip the src-filename fallback for absolute URLs — the
-        # post-colon segment is host+path, not a filename.
+        # Skip src-filename fallback for absolute URLs — post-colon segment
+        # is host+path, not a filename.
         if not label and "://" not in src:
             _, sep, after = src.partition(":")
             label = after if sep else src
@@ -222,12 +198,10 @@ def _fill_empty_img_alt(html: str) -> str:
 def _expand_merged_table_cells(html: str) -> str:
     """Rectangularize tables by duplicating ``colspan``/``rowspan`` cells.
 
-    ``markdownify`` 1.2.2 renders ``colspan`` extra columns as empty cells
-    (losing the merged value's association with those columns) and silently
-    drops ``rowspan`` entirely (producing GFM rows whose cell count disagrees
-    with the header — a structurally broken table).  Pre-process the HTML so
-    that every spanned cell is duplicated into each grid position it covered;
-    the resulting table is rectangular and ``markdownify`` emits valid GFM.
+    ``markdownify`` 1.2.2 renders colspan as empty cells and drops rowspan
+    entirely, breaking GFM cell counts. Duplicate each spanned cell into
+    every grid position it covers so the table is rectangular and emits
+    valid GFM.
     """
     if "<table" not in html.lower():
         return html
@@ -238,12 +212,11 @@ def _expand_merged_table_cells(html: str) -> str:
 
 
 def _rectangularize_table(table: Tag) -> None:
-    """Walk one ``<table>`` and replace span attributes with duplicated cells.
+    """Replace one table's span attributes with duplicated cells.
 
-    The cell at logical position (row, col) carrying ``colspan=N rowspan=M``
-    is replaced with ``N*M`` copies at consecutive positions
-    ``(row..row+M-1, col..col+N-1)``.  Reservations from earlier rows shift
-    later rows' fresh cells rightward so the column index stays correct.
+    A cell at (row, col) with ``colspan=N rowspan=M`` becomes ``N*M`` copies
+    at ``(row..row+M-1, col..col+N-1)``. Reservations from earlier rows shift
+    later rows' cells rightward to keep the column index correct.
     """
     rows: list[Tag] = [
         tr for tr in table.find_all("tr") if tr.find_parent("table") is table
@@ -251,8 +224,7 @@ def _rectangularize_table(table: Tag) -> None:
     if not rows:
         return
 
-    # reservations[i][col] holds a clone scheduled to occupy (i, col),
-    # propagated from a rowspan in an earlier row.
+    # reservations[i][col]: a clone scheduled for (i, col) from a rowspan above.
     reservations: list[dict[int, Tag]] = [{} for _ in rows]
 
     for row_idx, row in enumerate(rows):
@@ -267,9 +239,8 @@ def _rectangularize_table(table: Tag) -> None:
             colspan = _get_span(cell, "colspan")
             rowspan = _get_span(cell, "rowspan")
 
-            # Bound total expansion per merge to keep worst-case allocation
-            # proportional to realistic table sizes.  Drop rowspan first
-            # (rows are typically scarcer than columns in Polarion content).
+            # Bound expansion per merge; drop rowspan first (rows scarcer
+            # than columns).
             if colspan * rowspan > _MAX_CELLS_PER_MERGE:
                 rowspan = max(1, _MAX_CELLS_PER_MERGE // colspan)
 
@@ -277,8 +248,8 @@ def _rectangularize_table(table: Tag) -> None:
                 if attr in cell.attrs:
                     del cell.attrs[attr]
 
-            # Place original + colspan duplicates one column at a time, skipping
-            # columns already reserved by a rowspan above (so a cell may land on
+            # Place original + colspan dupes one column at a time, skipping
+            # columns reserved by a rowspan above (cell may land on
             # non-contiguous indices, as browsers do).
             placed_cols: list[int] = []
             for j in range(colspan):
@@ -295,18 +266,17 @@ def _rectangularize_table(table: Tag) -> None:
                 for placed_col in placed_cols:
                     reservations[target][placed_col] = _clone_cell(cell)
 
-        # Rebuild the row in column order; row.clear() drops original cells
-        # plus any inter-cell whitespace, which markdownify ignores anyway.
+        # Rebuild in column order; clear() also drops inter-cell whitespace
+        # (markdownify ignores it anyway).
         row.clear()
         for col in sorted(layout):
             row.append(layout[col])
 
 
 def _get_span(cell: Tag, attr_name: str) -> int:
-    """Return the colspan/rowspan as an int in ``[1, 1000]``.
+    """Return colspan/rowspan as int in ``[1, 1000]`` (mirrors markdownify).
 
-    Mirrors ``markdownify``'s own clamp.  Missing, non-string, or
-    non-numeric values fall back to 1.
+    Missing, non-string, or non-numeric values fall back to 1.
     """
     raw = cell.attrs.get(attr_name)
     if isinstance(raw, list):
@@ -322,10 +292,8 @@ def _get_span(cell: Tag, attr_name: str) -> int:
 def _clone_cell(cell: Tag) -> Tag:
     """Return a detached deep copy of ``cell`` with span attributes stripped.
 
-    ``deepcopy`` on a ``bs4.Tag`` yields a fresh subtree (children, text,
-    inline formatting) without a parent reference, so the copy can be
-    attached elsewhere in the soup.  Span attributes are removed defensively
-    even though ``_rectangularize_table`` already strips them on the source.
+    ``deepcopy`` yields a parent-less subtree attachable elsewhere. Span
+    attrs removed defensively (``_rectangularize_table`` already strips them).
     """
     clone: Tag = deepcopy(cell)
     for attr in ("colspan", "rowspan"):
@@ -337,20 +305,15 @@ def _clone_cell(cell: Tag) -> Tag:
 def markdown_to_html(text: str) -> str:
     """Convert Markdown (or plain text) to Polarion-compatible HTML.
 
-    Uses ``markdown-it-py`` (CommonMark + GFM tables) so that
-    LLM-generated Markdown — including tables, nested lists with
-    2-space indentation, headings, and inline formatting — is
-    faithfully converted to HTML that Polarion can store and render.
-
-    Plain text without any Markdown syntax is wrapped in ``<p>`` tags
-    automatically.
+    ``markdown-it-py`` (CommonMark + GFM tables) handles tables, nested
+    lists, headings, and inline formatting. Plain text is wrapped in ``<p>``.
 
     Args:
         text: Markdown or plain text supplied by the user or LLM.
 
     Returns:
-        HTML string suitable for a Polarion ``description.value`` field.
-        Returns an empty string when given empty or whitespace-only input.
+        HTML for a Polarion ``description.value`` field; empty string for
+        empty/whitespace input.
     """
     if not text or not text.strip():
         return ""
@@ -359,33 +322,26 @@ def markdown_to_html(text: str) -> str:
 
 
 def sanitize_html(html: str) -> str:
-    """Remove disallowed HTML tags and attributes from HTML.
+    """Remove disallowed HTML tags and attributes.
 
-    Two tag-removal strategies are applied:
+    Two removal strategies:
 
-    * **Decompose** (tag + all content removed): ``script`` and ``style`` tags.
-      Their text content is executable code or CSS — never meaningful as visible
-      Polarion text — so it must be discarded entirely.
-    * **Unwrap** (tag removed, content kept): all other disallowed tags.
-      Structural or presentational tags (e.g. ``section``, ``font``) are
-      stripped while preserving their visible text and nested children.
+    * **Decompose** (tag + content): ``script``/``style`` — executable
+      code/CSS, never visible text.
+    * **Unwrap** (tag removed, content kept): all other disallowed tags
+      (e.g. ``section``, ``font``), preserving visible text and children.
 
-    Additionally, attributes on surviving tags are restricted to the
-    ``ALLOWED_ATTRS`` allowlist.  Any attribute not explicitly permitted
-    (including all ``on*`` event handlers such as ``onclick`` and ``onerror``)
-    is removed to prevent stored XSS when Polarion renders the content.
-
-    ``href`` values are validated against a safe-protocol allowlist
-    (``http``, ``https``, ``mailto``).  Links with dangerous schemes such
-    as ``javascript:`` or ``data:`` have their ``href`` attribute removed.
+    Surviving tags keep only ``ALLOWED_ATTRS`` attributes (drops all
+    ``on*`` handlers → stored XSS). ``href`` values are validated against
+    ``_SAFE_URL_SCHEMES``; dangerous schemes (``javascript:``, ``data:``)
+    have their ``href`` removed.
 
     Args:
-        html: Raw HTML string that may contain disallowed tags or attributes.
+        html: Raw HTML that may contain disallowed tags or attributes.
 
     Returns:
-        Sanitized HTML containing only tags from ``ALLOWED_TAGS`` with only
-        attributes from ``ALLOWED_ATTRS``.  Returns an empty string when given
-        empty or whitespace-only input.
+        HTML with only ``ALLOWED_TAGS``/``ALLOWED_ATTRS``; empty string for
+        empty/whitespace input.
     """
     if not html or not html.strip():
         return ""
@@ -397,8 +353,7 @@ def sanitize_html(html: str) -> str:
         tag for tag in soup.find_all(True) if tag.name not in ALLOWED_TAGS
     ]
     for tag in disallowed:
-        # A parent's decompose() removes the element and all its descendants
-        # from the tree.  Skip tags that were already detached this way.
+        # A parent's decompose() already detached this tag; skip it.
         if tag.parent is None:
             continue
         if tag.name in _DECOMPOSE_TAGS:
@@ -406,16 +361,13 @@ def sanitize_html(html: str) -> str:
         else:
             tag.unwrap()
 
-    # Strip disallowed attributes from every surviving tag.
-    # Iterating over a fresh find_all after the tag loop ensures we only visit
-    # tags that are still attached to the tree.
+    # Fresh find_all visits only still-attached tags.
     for tag in soup.find_all(True):
         allowed_attrs: frozenset[str] = ALLOWED_ATTRS.get(tag.name, frozenset())
         for attr in list(tag.attrs):
             if attr not in allowed_attrs:
                 del tag.attrs[attr]
 
-    # Validate href URLs against safe-protocol allowlist.
     for anchor in soup.find_all("a", href=True):
         raw_href = anchor.get("href", "")
         href = raw_href if isinstance(raw_href, str) else ""
@@ -434,28 +386,24 @@ _BLOCK_TAGS_NEEDING_IDS: Final[frozenset[str]] = frozenset(
 
 
 def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
-    """Stamp unique ``id=`` attributes on the block-level elements that
-    Polarion's ``/parts`` derivation requires.
+    """Stamp unique ``id=`` on the block-level elements Polarion's
+    ``/parts`` derivation requires.
 
-    Polarion's REST API stores ``homePageContent`` HTML verbatim and does
-    not auto-assign ids the way the web editor does. An anchorless ``<p>``
-    (or any other tag in ``_BLOCK_TAGS_NEEDING_IDS``) saves successfully
-    but makes the next ``GET .../parts`` return HTTP 500. All heading
-    tags (``<h1>..<h6>``) are skipped: Polarion rewrites their ids into
-    the ``polarion_wiki macro name=module-workitem;params=id=MCPT-N``
-    macro form on save anyway. Existing non-empty ``id=`` attributes are
-    preserved so callers can pre-anchor specific blocks; generated ids
-    skip any value already present in the document (including
-    ``{prefix}_N`` ids the caller embedded via raw HTML in Markdown) so
-    the PATCH never trips Polarion's HTTP 400 duplicate-id rule.
+    Polarion stores ``homePageContent`` verbatim and does not auto-assign
+    ids. An anchorless ``<p>`` (or any ``_BLOCK_TAGS_NEEDING_IDS`` tag)
+    saves fine but makes the next ``GET .../parts`` return HTTP 500.
+    Heading tags (``<h1>..<h6>``) are skipped — Polarion rewrites their ids
+    into the ``module-workitem`` macro on save. Existing non-empty ids are
+    preserved; generated ids skip values already in the document so the
+    PATCH never trips Polarion's HTTP 400 duplicate-id rule.
 
     Args:
-        html: HTML string (typically the output of ``sanitize_html``).
-        prefix: Base for generated ids; final form is ``"{prefix}_{N}"``.
+        html: HTML string (typically ``sanitize_html`` output).
+        prefix: Base for generated ids; final form ``"{prefix}_{N}"``.
 
     Returns:
-        HTML with a unique ``id`` on every block-level element from the
-        target set. Returns an empty string when given empty input.
+        HTML with a unique ``id`` on every target block; empty string for
+        empty input.
     """
     if not html or not html.strip():
         return ""
@@ -481,19 +429,16 @@ def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
 
 
 def first_anchorless_block(html: str) -> str | None:
-    """Return the name of the first block element lacking a non-empty ``id=``.
+    """Return the name of the first block lacking a non-empty ``id=``.
 
-    The write-side counterpart to :func:`stamp_block_ids`: the write side
-    calls this on raw ``update_document`` body HTML to reject anchorless
-    blocks before they reach Polarion, since each one makes the next
-    ``GET .../parts`` return HTTP 500. Heading tags are exempt (Polarion
-    rewrites their ids on save). Returns ``None`` when every block in
-    ``_BLOCK_TAGS_NEEDING_IDS`` carries an id, or the input is empty.
+    Write-side counterpart to :func:`stamp_block_ids`: rejects anchorless
+    blocks in raw ``update_document`` body HTML before they reach Polarion,
+    since each makes the next ``GET .../parts`` return HTTP 500. Headings
+    are exempt (Polarion rewrites their ids). ``None`` when every
+    ``_BLOCK_TAGS_NEEDING_IDS`` block has an id, or input is empty.
 
-    Deliberately stricter than the ``stamp_block_ids`` skip test: a
-    whitespace-only ``id`` counts as anchorless here (it does not anchor the
-    block for Polarion either), whereas ``stamp_block_ids`` leaves any truthy
-    id untouched. The guard erring toward rejection is the safe direction.
+    Stricter than ``stamp_block_ids``'s skip test: a whitespace-only ``id``
+    counts as anchorless here. Erring toward rejection is the safe direction.
     """
     if not html or not html.strip():
         return None

--- a/tests/mcp_server_polarion/core/test_client.py
+++ b/tests/mcp_server_polarion/core/test_client.py
@@ -501,9 +501,7 @@ class TestSerialization:
             nonlocal in_flight, max_in_flight
             in_flight += 1
             max_in_flight = max(max_in_flight, in_flight)
-            # Yield so the event loop can wake the other coroutine; without the
-            # lock both calls would reach this point and ``max_in_flight`` would
-            # rise to 2.
+            # Yield to the other coroutine; without the lock max_in_flight would hit 2.
             await asyncio.sleep(0)
             in_flight -= 1
             return httpx.Response(200, json={"data": []})
@@ -521,12 +519,11 @@ class TestSerialization:
             assert max_in_flight == 1
 
     async def test_write_delay_keeps_lock_held(self) -> None:
-        """A GET dispatched during a POST's write_delay must wait, not overlap.
+        """A GET during a POST's write_delay must wait, not overlap.
 
-        The write_delay sleep runs inside the request lock — otherwise a
-        second caller could slip in during Polarion's propagation window
-        and defeat the "no concurrent requests" guarantee. Verified by
-        timing: the GET must start at least ``write_delay`` after the POST.
+        The write_delay sleep runs inside the request lock, else a second
+        caller slips in during the propagation window. Timed: the GET must
+        start at least write_delay after the POST.
         """
         post_start: list[float] = []
         get_start: list[float] = []
@@ -552,8 +549,7 @@ class TestSerialization:
                 )
 
         assert post_start and get_start
-        # Allow a small scheduling slack so the assertion isn't flaky on
-        # slow CI workers; the real margin is full ``write_delay``.
+        # 0.9 slack absorbs CI scheduling jitter; real margin is full write_delay.
         assert get_start[0] - post_start[0] >= write_delay * 0.9, (
             f"GET started {get_start[0] - post_start[0]:.3f}s after POST; "
             f"expected ≥ {write_delay * 0.9:.3f}s (write_delay held by lock)."

--- a/tests/mcp_server_polarion/models/test_work_items.py
+++ b/tests/mcp_server_polarion/models/test_work_items.py
@@ -103,8 +103,7 @@ class TestWorkItemDetail:
         assert detail.description_html == ""
 
     def test_description_defaults_to_empty(self):
-        # The HTML field defaults to "" so callers can omit it on the
-        # ``include_description_html=False`` (blank) path.
+        # Defaults to "" for the include_description_html=False path.
         detail = WorkItemDetail(
             id="MCPT-003",
             title="No desc",
@@ -151,9 +150,7 @@ class TestWorkItemDetail:
         assert detail.custom_fields == {}
 
     def test_custom_fields_round_trip_heterogeneous_values(self):
-        # Custom-field values are intentionally `object`-typed: primitives
-        # and rich-text `{type: text/html, value: ...}` dicts must both
-        # survive a serialization round-trip unchanged.
+        # object-typed customs: primitives and rich-text dicts both round-trip.
         rich = {"type": "text/html", "value": "<p>note</p>"}
         detail = WorkItemDetail(
             id="MCPT-999",

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -67,9 +67,8 @@ def _polarion_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Set env vars the lifespan reads and zero out write-delay sleeps."""
     monkeypatch.setenv("POLARION_URL", _POLARION_HOST)
     monkeypatch.setenv("POLARION_TOKEN", "test-token-secret")
-    # ``PolarionClient`` is constructed inside ``_lifespan`` so its
-    # ``write_delay`` constructor arg is unreachable from the test; patch
-    # the module-level default instead to keep the write-tool case fast.
+    # The lifespan builds PolarionClient itself, so patch the module default
+    # rather than its write_delay arg to keep write-tool cases fast.
     monkeypatch.setattr(_client_mod, "_WRITE_DELAY_SECONDS", 0.0)
 
 
@@ -92,8 +91,8 @@ class TestSqlRecipeGallery:
     """The SQL recipe gallery reaches the transport as a callable tool."""
 
     async def test_get_sql_query_recipes_reads(self, mcp_client: _MCPClient) -> None:
-        # ``list_work_items`` tells the LLM it MUST call this tool before
-        # hand-writing SQL, so an empty payload would strand that instruction.
+        # list_work_items points the LLM here before hand-writing SQL, so the
+        # payload must not be empty.
         result = await mcp_client.call_tool("get_sql_query_recipes", {})
         body = result.structured_content
         assert body is not None
@@ -240,10 +239,9 @@ class TestEndToEndInvocation:
         mcp_client: _MCPClient,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        # Regression guard: result-model fields with recursive type aliases
-        # produce a `$defs` self-reference that fastmcp 3.3.1's
-        # json_schema_to_type cannot rebuild, leaving result.data unmaterialised
-        # and logging "Error parsing structured content" on every write call.
+        # Regression: recursive-alias fields make a $defs self-reference that
+        # fastmcp's json_schema_to_type can't rebuild, leaving result.data
+        # unmaterialised and logging "Error parsing structured content".
         with (
             caplog.at_level("WARNING", logger="fastmcp"),
             respx.mock(base_url=_BASE, assert_all_called=False) as mock,

--- a/tests/mcp_server_polarion/tools/_shared/test_guard.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_guard.py
@@ -111,11 +111,8 @@ class TestFetchEnumOptionIds:
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # ``setup_logging`` sets ``propagate=False`` on the package logger so
-        # MCP JSON-RPC over stdout never gets contaminated. caplog hooks the
-        # root logger, so once another test ran setup_logging, child warnings
-        # never reach caplog. Re-enable propagation locally for order
-        # independence.
+        # setup_logging sets propagate=False, so caplog misses package logs;
+        # re-enable propagation locally for order independence.
         import logging  # noqa: PLC0415 -- fixture-local import is intentional
 
         monkeypatch.setattr(logging.getLogger("mcp_server_polarion"), "propagate", True)
@@ -145,8 +142,7 @@ class TestFetchEnumOptionIds:
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # A 404 means getAvailableOptions is unsupported on this instance, so
-        # the guard defers (empty set) rather than block every enum write.
+        # 404 = options endpoint unsupported, so the guard defers (empty set).
         import logging  # noqa: PLC0415 -- fixture-local import is intentional
 
         monkeypatch.setattr(logging.getLogger("mcp_server_polarion"), "propagate", True)
@@ -163,8 +159,7 @@ class TestFetchEnumOptionIds:
         assert any("404" in r.message for r in caplog.records)
 
     async def test_not_found_result_is_cached(self, mock_client: AsyncMock) -> None:
-        # The deferred (empty) result is cached so a missing endpoint is not
-        # re-probed on every write within the TTL.
+        # Deferred result is cached; a missing endpoint isn't re-probed in the TTL.
         mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
 
         await fetch_enum_option_ids(mock_client, "P", "workitems", "severity", "task")
@@ -175,8 +170,7 @@ class TestFetchEnumOptionIds:
     async def test_guard_defers_when_options_unsupported(
         self, mock_client: AsyncMock
     ) -> None:
-        # End-to-end: a 404 on the options endpoint must NOT raise from the
-        # higher-level guard -- the enum-bearing write is allowed through.
+        # A 404 on the options endpoint lets the enum write through, no raise.
         mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
 
         await guard_work_item_enums(

--- a/tests/mcp_server_polarion/tools/_shared/test_helpers.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_helpers.py
@@ -50,14 +50,12 @@ class TestExtractCustomFields:
         assert extract_custom_fields({}, STANDARD_WORK_ITEM_ATTRIBUTES) == {}
 
     def test_preserves_rich_text_value_verbatim(self) -> None:
-        # Rich-text Polarion fields arrive as {type, value} dicts; the
-        # helper must NOT convert them to Markdown, so they round-trip
-        # back to Polarion unchanged on a future PATCH.
+        # Rich-text {type, value} dicts stay verbatim to round-trip on PATCH.
         rich = {"type": "text/html", "value": "<p>x</p>"}
         attributes: dict[str, object] = {"title": "T", "reviewerNote": rich}
         result = extract_custom_fields(attributes, STANDARD_WORK_ITEM_ATTRIBUTES)
         assert result == {"reviewerNote": rich}
-        # Same object identity — no defensive copy.
+        # Same object identity, no defensive copy.
         assert result["reviewerNote"] is rich
 
     def test_preserves_heterogeneous_value_types(self) -> None:
@@ -80,9 +78,7 @@ class TestExtractCustomFields:
         }
 
     def test_document_allowlist_filters_document_attrs(self) -> None:
-        # Verifies the same helper works for documents with the
-        # document-specific allowlist; document-only standard keys
-        # (e.g. homePageContent, moduleFolder) must be filtered out.
+        # Document allowlist filters document-only keys (homePageContent, moduleFolder).
         attributes: dict[str, object] = {
             "title": "Doc",
             "type": "req_specification",
@@ -99,10 +95,8 @@ class TestExtractCustomFields:
         }
 
     def test_allowlist_swap_changes_classification(self) -> None:
-        # A key that is standard for one resource type may be custom on
-        # another. ``autoSuspect`` is a standard document attribute but
-        # NOT a standard work item attribute — so swapping the allowlist flips
-        # how it's classified.
+        # autoSuspect is standard for documents but custom for work items;
+        # swapping the allowlist flips its classification.
         attributes: dict[str, object] = {"autoSuspect": False}
         assert extract_custom_fields(attributes, STANDARD_DOCUMENT_ATTRIBUTES) == {}
         assert extract_custom_fields(attributes, STANDARD_WORK_ITEM_ATTRIBUTES) == {
@@ -141,9 +135,7 @@ class TestMergeCustomFields:
         assert attributes == {"title": "T"}
 
     def test_skips_none_values_inside_dict(self) -> None:
-        # ``None`` values are skipped (clearing is not supported in
-        # this phase); falsy non-``None`` values pass through verbatim
-        # because they may be meaningful custom-field values.
+        # None values skip (no clearing); other falsy values pass through.
         attributes: dict[str, JsonValue] = {}
         merge_custom_fields(
             attributes,
@@ -165,8 +157,7 @@ class TestMergeCustomFields:
         assert "skip_me" not in attributes
 
     def test_rich_text_dict_passes_through_identity(self) -> None:
-        # The {type, value} dict must round-trip unchanged — same
-        # object identity, no defensive copy.
+        # {type, value} dict round-trips by identity, no defensive copy.
         rich = {"type": "text/html", "value": "<p>x</p>"}
         attributes: dict[str, JsonValue] = {}
         merge_custom_fields(
@@ -177,9 +168,7 @@ class TestMergeCustomFields:
         assert attributes["reviewerNote"] is rich
 
     def test_collision_with_standard_attr_raises(self) -> None:
-        # Keys that overlap with the standard allowlist would silently
-        # overwrite an explicit standard parameter; raise at the tool
-        # boundary so the caller gets an actionable message.
+        # A custom key overlapping the allowlist would shadow a standard param.
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             merge_custom_fields(
                 {},
@@ -188,8 +177,7 @@ class TestMergeCustomFields:
             )
 
     def test_collision_message_lists_offending_keys_sorted(self) -> None:
-        # Multiple collisions are reported together in deterministic
-        # order to make the diagnostic predictable.
+        # Collisions reported sorted for a predictable message.
         with pytest.raises(ValueError) as exc_info:
             merge_custom_fields(
                 {},
@@ -199,9 +187,7 @@ class TestMergeCustomFields:
         assert "['status', 'title']" in str(exc_info.value)
 
     def test_document_allowlist_recognises_document_collisions(self) -> None:
-        # ``moduleFolder`` is a standard document attribute but NOT a
-        # standard work item attribute — same key, different verdicts depending
-        # on the allowlist passed.
+        # moduleFolder is standard for documents but custom for work items.
         merge_custom_fields(
             {}, {"moduleFolder": "Design"}, STANDARD_WORK_ITEM_ATTRIBUTES
         )  # OK for work items
@@ -213,8 +199,7 @@ class TestMergeCustomFields:
             )
 
     def test_returns_none_mutates_in_place(self) -> None:
-        # Style contract: helper mutates ``attributes`` and returns
-        # nothing, matching the rest of the ``_build_*_payload`` style.
+        # Mutates attributes in place and returns None, like _build_*_payload.
         attributes: dict[str, JsonValue] = {}
         result = merge_custom_fields(
             attributes, {"riskLevel": "high"}, STANDARD_WORK_ITEM_ATTRIBUTES

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -379,8 +379,7 @@ class TestListDocuments:
                 }
             }
 
-        # Page 2 is partial (50 < 100), and totalCount is omitted →
-        # compute_has_more's heuristic must stop the scan.
+        # Partial page 2 (50 < 100) with no totalCount stops the scan.
         page_data = {
             1: [_make_item("DocA")] * 100,
             2: [_make_item("DocB")] * 50,
@@ -555,8 +554,7 @@ class TestListDocuments:
             call_args[0][1] if len(call_args[0]) > 1 else {},
         )
         assert params["query"] == "type:heading"
-        # sort=module was dropped — server-side sort cost > client-side dedup
-        # (benchmarked: ~4x slower on cold server cache, equal warm).
+        # No sort=module: server-side sort costs more than client-side dedup.
         assert "sort" not in params
 
     async def test_not_found_raises_value_error(
@@ -821,11 +819,11 @@ class TestGetDocument:
             "data": {
                 "id": "proj1/_default/SRS",
                 "attributes": {
-                    # Standard attributes — present but excluded from custom_fields.
+                    # Standard attrs: excluded from custom_fields.
                     "title": "SRS",
                     "type": "req_specification",
                     "status": "approved",
-                    # Inline custom attributes — top-level keys.
+                    # Inline customs: top-level keys.
                     "summary": rich_value,
                     "documentVersion": "1.0",
                     "reviewerName": "alice",
@@ -1628,8 +1626,7 @@ class TestReadDocumentParts:
 class TestReadDocument:
     """Tests for the ``read_document`` tool."""
 
-    # -- end-to-end wiring (exercises read_document_parts via client.get) --
-
+    # End-to-end wiring: exercises read_document_parts via client.get.
     async def test_end_to_end_renders_document(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
@@ -1735,8 +1732,7 @@ class TestReadDocument:
         assert result.page_size == 100
         assert result.has_more is False
 
-        # Heading rendered at level 1, then workitem with bold lead-in
-        # plus its description, then prose. Empty paragraph is skipped.
+        # Heading, work item lead-in + description, prose; empty paragraph skipped.
         assert result.content == (
             "# Introduction\n"
             "\n"
@@ -1803,8 +1799,7 @@ class TestReadDocument:
                 page_number=1,
             )
 
-    # -- render-rule tests (isolated via monkeypatched read_document_parts) --
-
+    # Render-rule tests: isolated via monkeypatched read_document_parts.
     async def test_workitem_with_description_renders_lead_in_plus_body(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -2230,8 +2225,7 @@ class TestBuildUpdateDocumentPayload:
     """Tests for the private ``_build_update_document_payload`` helper."""
 
     def test_only_set_fields_appear_in_attributes(self) -> None:
-        # Skip-None semantics: omitted fields are not serialized so
-        # JSON:API omit-preserve takes effect server-side.
+        # None fields stay unserialized so JSON:API omit-preserve applies.
         payload = _build_update_document_payload(
             project_id="MyProj",
             space_id="Requirements",
@@ -2270,10 +2264,7 @@ class TestBuildUpdateDocumentPayload:
         }
 
     def test_no_attributes_when_all_fields_are_none(self) -> None:
-        # Helper produces a body with no ``attributes`` key when every
-        # field is None. The tool layer rejects this case before
-        # reaching the helper, but a future direct caller should not
-        # silently emit an empty PATCH body.
+        # All-None yields no attributes key; the tool rejects this upstream.
         payload = _build_update_document_payload(
             project_id="MyProj",
             space_id="S",
@@ -2288,8 +2279,7 @@ class TestBuildUpdateDocumentPayload:
         assert data["id"] == "MyProj/S/D"
 
     def test_homepagecontent_omitted_when_not_passed(self) -> None:
-        # JSON:API omit-preserve: body stays untouched when the caller
-        # does not pass ``home_page_content_html``.
+        # Omitting home_page_content_html leaves the body untouched.
         payload = _build_update_document_payload(
             project_id="MyProj",
             space_id="S",
@@ -2425,8 +2415,7 @@ class TestUpdateDocumentValidation:
     async def test_custom_fields_alone_satisfies_at_least_one_check(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # custom_fields counts as a body field on update_document too. The
-        # priming GET lets the custom-field guard see ``documentVersion``.
+        # custom_fields counts as a body field; priming GET shows the guard the key.
         mock_client.get.return_value = {
             "data": {"attributes": {"title": "D", "documentVersion": "0.1"}}
         }
@@ -2448,8 +2437,7 @@ class TestUpdateDocumentValidation:
     async def test_workflow_action_with_custom_fields_passes(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # workflow_action paired with custom_fields-only should also
-        # satisfy the body-field check.
+        # workflow_action + custom_fields-only satisfies the body-field check.
         mock_client.get.return_value = {
             "data": {"attributes": {"title": "D", "documentVersion": "0.1"}}
         }
@@ -2471,12 +2459,10 @@ class TestUpdateDocumentValidation:
     async def test_workflow_action_with_home_page_content_html_passes(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """workflow_action paired with home_page_content_html only is OK.
+        """workflow_action + home_page_content_html-only is OK.
 
-        Polarion rejects empty PATCH bodies, so workflow_action MUST come
-        with at least one attribute. home_page_content_html is one such
-        attribute — this guard prevents the body-field check from
-        regressing to "title/status/type/custom_fields only".
+        home_page_content_html counts as the required attribute, so the
+        body-field check must not regress to title/status/type/customs only.
         """
         result = await update_document(
             mock_ctx,
@@ -2492,7 +2478,7 @@ class TestUpdateDocumentValidation:
             dry_run=True,
         )
         assert result.dry_run is True
-        # Sanity: payload includes both the body and the workflow query param.
+        # Payload carries both the body and the workflow query param.
         assert result.payload_preview is not None
         item = cast(dict[str, object], result.payload_preview["data"])
         attributes = cast(dict[str, object], item["attributes"])
@@ -2780,9 +2766,7 @@ class TestUpdateDocumentHappyPath:
     async def test_explicit_empty_title_is_serialized(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # ``title=""`` differs from ``title=None``: the empty string
-        # passes the at-least-one check and IS sent in attributes,
-        # clearing the title server-side.
+        # title="" (unlike None) is sent in attributes, clearing it server-side.
         mock_client.patch.return_value = {}
 
         await update_document(
@@ -2828,8 +2812,7 @@ class TestUpdateDocumentHappyPath:
     async def test_workflow_action_url_encoded_when_special(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # urlencode is responsible for escaping action IDs that contain
-        # whitespace or other reserved chars; this locks the contract.
+        # Action IDs with reserved chars must be URL-encoded.
         mock_client.patch.return_value = {}
 
         await update_document(
@@ -2848,8 +2831,7 @@ class TestUpdateDocumentHappyPath:
 
         args, _ = mock_client.patch.call_args
         path = args[0]
-        # Space in action ID -> "+" or "%20"; both are valid URL
-        # encodings and Polarion accepts either.
+        # Space encodes to "+" or "%20"; Polarion accepts either.
         assert "workflowAction=needs+review" in path or (
             "workflowAction=needs%20review" in path
         )
@@ -3604,8 +3586,7 @@ class TestEnumGuardUpdateDocument:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Cache miss → guard does one inline get_document-shaped read; the
-        # unknown key is absent from the document's customs, so it rejects.
+        # Cache miss primes via one read; the unknown key is absent, so it rejects.
         mock_client.get.return_value = {
             "data": {"attributes": {"title": "x", "doc_risk": 3}}
         }

--- a/tests/mcp_server_polarion/tools/test_links.py
+++ b/tests/mcp_server_polarion/tools/test_links.py
@@ -144,9 +144,7 @@ class TestListWorkItemLinks:
     async def test_forward_signals_has_more_when_total_exceeds_page(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Simulate page 1 of a 5-item set with page_size=2 — server returns
-        # the first 2 items, meta.totalCount reports the full collection
-        # size, and has_more should be True (2 * 1 < 5).
+        # Page 1 of 5 items at page_size=2: has_more True since 2 * 1 < 5.
         mock_client.get.return_value = {
             "data": [
                 {
@@ -684,8 +682,7 @@ class TestCreateWorkItemLinksRoleGuard:
     async def test_target_guard_runs_before_role_guard(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Missing target AND unknown role: the target guard runs first, so its
-        # error surfaces and the role enumeration is never fetched.
+        # Target guard runs first, so its error surfaces before role enumeration.
         def fake_get(
             path: str, *, params: dict[str, object] | None = None, **_: object
         ) -> dict[str, object]:

--- a/tests/mcp_server_polarion/tools/test_moves.py
+++ b/tests/mcp_server_polarion/tools/test_moves.py
@@ -72,8 +72,7 @@ class TestBuildMoveToDocumentPayload:
         assert payload["previousPart"] == "MyProj/Design/Folder/Sub Doc/workitem_MCPT-2"
 
     def test_payload_omits_position_keys_when_both_none(self) -> None:
-        # Per Polarion REST API, omitting both previousPart and nextPart
-        # appends the work item at the end of the target document.
+        # Omitting both position keys appends at the end of the target document.
         payload = _build_move_to_document_payload(
             project_id="MyProj",
             target_space_id="S",
@@ -246,8 +245,7 @@ class TestMoveWorkItemToDocumentHappyPath:
     async def test_path_url_encodes_special_chars_in_project_id(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Defensive: ensure encode_path_segment is applied to project_id
-        # path segment.
+        # project_id is run through encode_path_segment.
         mock_client.post.return_value = {}
 
         await move_work_item_to_document(
@@ -459,9 +457,7 @@ class TestMoveWorkItemFromDocumentErrorMapping:
     async def test_400_already_detached_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Calling moveFromDocument on a work item that is already
-        # free-floating returns HTTP 400. Per the standard mapping,
-        # 400 → PolarionError → RuntimeError at the tool layer.
+        # Detaching an already free-floating item 400s → RuntimeError.
         mock_client.post.side_effect = PolarionError(
             "Work item is not in a Document", status_code=400
         )

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -53,12 +53,10 @@ def _project_enum_get_response(enum_name: str, ids: list[str]) -> dict[str, obje
 async def _call_update(
     mock_ctx: MagicMock, **overrides: object
 ) -> WorkItemUpdateResult:
-    """Call ``update_work_item`` with safe defaults.
+    """Call update_work_item with all params explicit.
 
-    The tool's ``Field(...)`` defaults stay as ``FieldInfo`` objects when
-    invoked outside FastMCP, so every parameter must be passed
-    explicitly. This helper supplies plain Python defaults; tests
-    override only the parameters they care about.
+    Field(...) defaults stay FieldInfo objects outside FastMCP, so every
+    param must be passed; tests override only what they care about.
     """
     defaults: dict[str, object] = {
         "project_id": "MyProj",
@@ -109,10 +107,7 @@ def _make_get_response(
     if description_html:
         attributes["description"] = {"type": "text/html", "value": description_html}
     if custom_fields:
-        # Inline alongside standard attrs (Polarion's JSON:API shape — no
-        # ``customFields`` container). The ``update_work_item`` pre-fetch
-        # guard parses these as custom keys, priming the cache so a
-        # follow-up update with the same keys is accepted.
+        # Inline (no customFields container); primes the pre-fetch guard cache.
         attributes.update(custom_fields)
     return {
         "data": {
@@ -196,7 +191,6 @@ class TestBuildWorkItemResource:
             "type": "workitems",
             "attributes": {"title": "My work item", "type": "task"},
         }
-        # No relationships key, no description, no other attributes.
         assert "relationships" not in item
         attributes = cast(dict[str, object], item["attributes"])
         assert set(attributes.keys()) == {"title", "type"}
@@ -216,7 +210,6 @@ class TestBuildWorkItemResource:
         )
 
         attributes = cast(dict[str, object], item["attributes"])
-        # Only title + type — nothing else slipped through.
         assert set(attributes.keys()) == {"title", "type"}
         assert "relationships" not in item
 
@@ -309,13 +302,11 @@ class TestBuildWorkItemResource:
         attributes = cast(dict[str, object], item["attributes"])
         assert attributes["riskLevel"] == "high"
         assert attributes["effortHours"] == 12.0
-        # Customs land flat under attributes, NOT inside a `customFields`
-        # container — Polarion silently drops the latter shape.
+        # Customs land flat; Polarion drops a customFields container.
         assert "customFields" not in attributes
 
     def test_custom_fields_collision_with_standard_attr_raises(self) -> None:
-        # ``title`` is a Polarion-defined standard attribute; collision
-        # would silently shadow the explicit ``title`` param. Reject.
+        # A custom key matching a standard attr would silently shadow it.
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             _build_work_item_resource(
                 spec=WorkItemCreateSpec(
@@ -325,10 +316,7 @@ class TestBuildWorkItemResource:
             )
 
     def test_custom_fields_skips_none_values_inside_dict(self) -> None:
-        # The merge helper already has direct coverage for skip-None;
-        # this test pins that the item builder honours the same semantics —
-        # a ``None`` value inside the dict MUST NOT land under
-        # ``attributes``, while falsy non-``None`` values (e.g. 0) pass.
+        # None custom values drop; falsy non-None (e.g. 0) pass through.
         item = _build_work_item_resource(
             spec=WorkItemCreateSpec(
                 title="t",
@@ -374,7 +362,7 @@ class TestBuildCreateWorkItemsPayload:
         assert "description" not in second
 
     def test_mismatched_lengths_raise(self) -> None:
-        # ``zip(strict=True)`` guards the spec/html pairing invariant.
+        # zip(strict=True) guards the spec/html pairing.
         with pytest.raises(ValueError):
             _build_create_work_items_payload(
                 specs=[WorkItemCreateSpec(title="a", type="task")],
@@ -430,7 +418,7 @@ class TestCreateWorkItemsDryRun:
         assert result.created is False
         assert result.work_item_ids == []
         assert result.payload_preview is not None
-        # payload_preview is a plain dict (no Pydantic objects leaked).
+        # Plain dict, no Pydantic objects leaked.
         assert isinstance(result.payload_preview, dict)
         item = cast(list[dict[str, object]], result.payload_preview["data"])[0]
         attributes = cast(dict[str, object], item["attributes"])
@@ -592,21 +580,17 @@ class TestCreateWorkItemsHappyPath:
         _, kwargs = mock_client.post.call_args
         desc = kwargs["json"]["data"][0]["attributes"]["description"]
         assert desc["type"] == "text/html"
-        # Markdown was rendered to HTML by markdown_to_html.
         assert "<strong>bold</strong>" in desc["value"]
-        # Safe https link survives both markdown-it and sanitize_html.
+        # Safe https link survives sanitize.
         assert 'href="https://example.com"' in desc["value"]
 
     async def test_description_strips_dangerous_link_schemes(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Verify no anchor with a javascript: href is ever sent.
+        """No javascript: anchor reaches the payload.
 
-        markdown-it-py already rejects javascript: in link URLs (it
-        leaves the literal source text unrendered), and sanitize_html
-        strips javascript: hrefs as a defense-in-depth second layer.
-        Either way, the sent payload must not contain a usable XSS
-        anchor.
+        markdown-it leaves it unrendered; sanitize_html strips it as a
+        second layer.
         """
         mock_client.post.return_value = {
             "data": [{"type": "workitems", "id": "MyProj/MCPT-1"}]
@@ -625,8 +609,7 @@ class TestCreateWorkItemsHappyPath:
 
         _, kwargs = mock_client.post.call_args
         desc_html = kwargs["json"]["data"][0]["attributes"]["description"]["value"]
-        # No dangerous href attribute — neither markdown-it nor
-        # sanitize_html should let one through.
+        # No usable javascript: href in either quote style.
         assert 'href="javascript:' not in desc_html
         assert "href='javascript:" not in desc_html
 
@@ -965,8 +948,7 @@ class TestBuildUpdateWorkItemPayload:
         assert attributes == {"riskLevel": "low", "reviewerNote": rich}
 
     def test_custom_fields_alone_keeps_attributes_dict(self) -> None:
-        # Without any standard fields, custom_fields alone should still
-        # produce an ``attributes`` block (otherwise PATCH 400s).
+        # custom_fields alone must still emit an attributes block, else PATCH 400s.
         payload = _build_update_work_item_payload(
             project_id="MyProj",
             work_item_id="MCPT-1",
@@ -1042,9 +1024,8 @@ class TestUpdateWorkItemValidation:
             description_html="",
             dry_run=True,
         )
-        # changes summary excludes the empty description_html.
+        # Empty description_html drops from both changes and the wire payload.
         assert result.changes == {"title": "new title"}
-        # Wire payload has only the title — no description key at all.
         assert result.payload_preview is not None
         item = cast(dict[str, object], result.payload_preview["data"])
         attributes = cast(dict[str, object], item["attributes"])
@@ -1054,9 +1035,7 @@ class TestUpdateWorkItemValidation:
     async def test_custom_fields_alone_satisfies_at_least_one_check(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # custom_fields counts as a body field — neither title nor any
-        # other standard param is required when customs are present. The
-        # prefetch primes the custom-key cache so the guard accepts the key.
+        # custom_fields counts as a body field; prefetch primes the guard cache.
         mock_client.get.return_value = _make_get_response(
             custom_fields={"riskLevel": "high"}
         )
@@ -1071,8 +1050,7 @@ class TestUpdateWorkItemValidation:
     async def test_collision_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Tool-layer collision detection prevents an explicit standard
-        # parameter from being shadowed by a same-named custom key.
+        # A custom key matching a standard param would shadow it.
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             await _call_update(
                 mock_ctx,
@@ -1085,9 +1063,7 @@ class TestUpdateWorkItemValidation:
     async def test_workflow_action_alone_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Polarion rejects PATCH bodies with no attributes/relationships,
-        # so workflow_action / change_type_to must be paired with at
-        # least one body field. Catch this at the tool layer.
+        # Polarion 400s on attribute-less PATCH, so an action needs a body field.
         with pytest.raises(ValueError, match="at least one body field"):
             await _call_update(mock_ctx, workflow_action="close")
         mock_client.patch.assert_not_called()
@@ -1103,8 +1079,7 @@ class TestUpdateWorkItemValidation:
     async def test_workflow_action_alone_dry_run_also_rejected(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Dry-run is rejected too — the payload that *would* be sent is
-        # invalid, so previewing it gives no useful signal.
+        # Dry-run is rejected too: the would-be payload is invalid.
         with pytest.raises(ValueError, match="at least one body field"):
             await _call_update(mock_ctx, workflow_action="close", dry_run=True)
 
@@ -1178,9 +1153,7 @@ class TestUpdateWorkItemDryRun:
     async def test_changes_uses_python_typed_values_not_json_api_shape(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # description_html in `changes` is the raw HTML the caller passed;
-        # the JSON:API ``{type,value}`` wrapping happens only in the wire
-        # payload preview.
+        # changes holds raw caller values; {type,value} wrapping is preview-only.
         result = await _call_update(
             mock_ctx,
             description_html="<p>bold</p>",
@@ -1192,8 +1165,7 @@ class TestUpdateWorkItemDryRun:
             "description_html": "<p>bold</p>",
             "assignee_ids": ["alice"],
         }
-        # The wire-shaped preview wraps the same raw HTML — VERBATIM, no
-        # sanitization or Markdown conversion in between.
+        # Preview wraps the same HTML verbatim, no sanitize/convert.
         assert result.payload_preview is not None
         item = cast(dict[str, object], result.payload_preview["data"])
         attributes = cast(dict[str, object], item["attributes"])
@@ -1224,14 +1196,11 @@ class TestUpdateWorkItemHappyPath:
     async def test_current_description_html_blanked_by_default(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Default (False) → ``current.description_html`` is ``""``.
+        """Default (False) blanks current.description_html.
 
-        The follow-up GET still returns the body over the wire (Polarion
-        @all is the only sparse-fieldset that surfaces customs), but the
-        tool layer blanks it so a metadata-only update does not blow up
-        LLM context. Caller opts in with
-        ``include_current_description_html=True`` when verifying a body
-        edit.
+        GET still returns the body (the @all fieldset is needed for
+        customs), but the tool blanks it to spare LLM context unless the
+        caller opts in via include_current_description_html=True.
         """
         mock_client.patch.return_value = {}
         mock_client.get.return_value = _make_get_response(
@@ -1298,17 +1267,13 @@ class TestUpdateWorkItemHappyPath:
         assert args == ("/projects/MyProj/workitems/MCPT-1",)
         params = kwargs["params"]
         assert params["include"] == "assignee"
-        # WORK_ITEM_DETAIL_FIELDS is the bare ``@all`` token so inline custom
-        # fields surface on ``current.custom_fields``; this assertion
-        # pins that semantics (changing it would silently drop customs).
+        # Bare @all so inline customs surface; narrowing would drop them.
         assert params["fields[workitems]"] == "@all"
 
     async def test_current_carries_custom_fields_from_post_patch_get(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Polarion inlines customs as top-level attributes; the post-PATCH GET
-        # reuses ``parse_work_item_detail``, so populated customs (riskLevel,
-        # effortHours) must land on ``result.current.custom_fields`` automatically.
+        # Inlined customs from the post-PATCH GET surface on current.custom_fields.
         mock_client.patch.return_value = {}
         get_response = _make_get_response(title="after")
         data = cast(dict[str, object], get_response["data"])
@@ -1328,9 +1293,7 @@ class TestUpdateWorkItemHappyPath:
     async def test_custom_fields_inlined_into_patch_body(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # The PATCH body must carry customs at the top of ``attributes``
-        # (NOT nested under a ``customFields`` container — Polarion drops
-        # that). Pin the wire shape here.
+        # Customs ride top-level in attributes; a customFields container is dropped.
         mock_client.patch.return_value = {}
         rich = {"type": "text/html", "value": "<p>note</p>"}
         mock_client.get.return_value = _make_get_response(
@@ -1353,8 +1316,7 @@ class TestUpdateWorkItemHappyPath:
     async def test_changes_summary_records_custom_fields(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # ``WorkItemUpdateResult.changes`` should reflect what was sent
-        # so callers can confirm the intent client-side.
+        # changes mirrors what was sent so callers can confirm intent.
         mock_client.patch.return_value = {}
         mock_client.get.return_value = _make_get_response(
             custom_fields={"riskLevel": "low"}
@@ -1372,8 +1334,7 @@ class TestUpdateWorkItemHappyPath:
     async def test_changes_custom_fields_is_independent_of_input(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Mutating the caller's dict (or its nested rich-text dict) after the
-        # call must not bleed into the returned ``changes`` snapshot.
+        # Post-call mutation of the caller's dict must not bleed into changes.
         mock_client.patch.return_value = {}
         mock_client.get.return_value = _make_get_response(
             custom_fields={"reviewerNote": "x", "riskLevel": "low"}
@@ -1399,9 +1360,7 @@ class TestUpdateWorkItemHappyPath:
     async def test_dry_run_preview_includes_custom_fields(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Dry-run should echo the merged attributes (standard + custom)
-        # so the LLM can verify the wire shape before committing. The
-        # prefetch primes the custom-key cache so the guard accepts the key.
+        # Dry-run echoes merged standard+custom attrs; prefetch primes the guard.
         mock_client.get.return_value = _make_get_response(
             custom_fields={"riskLevel": "high"}
         )
@@ -1422,11 +1381,7 @@ class TestUpdateWorkItemHappyPath:
     async def test_round_trip_read_response_can_be_written_back(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # The dict shape that flows out of WorkItemDetail.custom_fields
-        # on read must be acceptable as the custom_fields argument on
-        # write — without copying or transformation. This is the
-        # critical end-to-end ergonomic that justifies symmetric shapes
-        # on both sides.
+        # Read custom_fields must write back unchanged: symmetric read/write shapes.
         read_customs: dict[str, object] = {
             "riskLevel": "high",
             "effortHours": 8.0,
@@ -1439,17 +1394,14 @@ class TestUpdateWorkItemHappyPath:
 
         _, kwargs = mock_client.patch.call_args
         attributes = kwargs["json"]["data"]["attributes"]
-        # Every key from the read response landed inline under attributes.
         for key, value in read_customs.items():
             assert attributes[key] == value
-        # Tool layer didn't accept it then re-emit a different shape.
         assert result.updated is True
 
     async def test_workflow_action_appended_as_query_param(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # workflow_action must be paired with a body field (see
-        # TestUpdateWorkItemValidation). Pair it with a title here.
+        # workflow_action needs a paired body field, so add a title.
         mock_client.patch.return_value = {}
         mock_client.get.return_value = _make_get_response()
 
@@ -1457,8 +1409,7 @@ class TestUpdateWorkItemHappyPath:
 
         patch_path = mock_client.patch.call_args.args[0]
         assert patch_path == "/projects/MyProj/workitems/MCPT-1?workflowAction=close"
-        # Follow-up GET uses the base path (no query) so we always read
-        # the canonical detail view.
+        # Follow-up GET drops the query to read the canonical detail.
         get_path = mock_client.get.call_args.args[0]
         assert get_path == "/projects/MyProj/workitems/MCPT-1"
 
@@ -1578,14 +1529,11 @@ class TestUpdateWorkItemFieldValidation:
         assert self._adapter_for("work_item_id").validate_python("MCPT-1") == "MCPT-1"
 
     def test_description_html_rejects_overlong_input(self) -> None:
-        """``max_length=MAX_BODY_HTML_LEN`` defends against runaway HTML.
+        """max_length=MAX_BODY_HTML_LEN caps runaway HTML.
 
-        At the JSON Schema layer, FastMCP rejects bodies above the cap
-        before the tool ever sees them. Re-prove the constraint here so
-        a future docstring rewrite cannot silently drop ``max_length``.
+        Re-proven here so a docstring rewrite cannot silently drop it.
         """
         adapter = self._adapter_for("description_html")
-        # Well-formed payload below the cap is accepted unchanged.
         assert adapter.validate_python("<p>ok</p>") == "<p>ok</p>"
         # 2 MiB + 1 char is rejected.
         with pytest.raises(ValidationError):
@@ -1601,7 +1549,7 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # ``task`` makes the prior type-axis check pass; severity then trips.
+        # task passes the type-axis check; severity then trips.
         mock_client.get.return_value = _enum_get_response(
             ["task", "must_have", "should_have"]
         )
@@ -1616,8 +1564,7 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # The guard loop runs per item before any POST, so a ghost severity
-        # on the SECOND item must reject the whole batch with nothing sent.
+        # Per-item guard runs before any POST, so a bad later item aborts the batch.
         mock_client.get.return_value = _enum_get_response(
             ["task", "must_have", "should_have"]
         )
@@ -1640,9 +1587,7 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Single response shape works for any number of guard probes plus
-        # the final create — the guard ignores ``data`` keys it does not
-        # expect (no ``id`` field on the create response is fine).
+        # One response shape serves every guard probe plus the create.
         mock_client.get.return_value = _enum_get_response(
             ["task", "must_have", "open", "50.0"]
         )
@@ -1672,10 +1617,8 @@ class TestEnumGuardCreateWorkItem:
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # No schema for project custom-field keys → guard cannot validate
-        # on create; surface the gap as a warning rather than a hard fail.
-        # See test_polarion_error_blocks_write_and_logs in test_guard.py
-        # for why we re-enable propagation here.
+        # Create can't schema-validate custom keys, so it warns instead of failing.
+        # Propagation re-enabled (see test_guard.py's block-write-and-logs test).
         import logging  # noqa: PLC0415 -- fixture-local import is intentional
 
         monkeypatch.setattr(logging.getLogger("mcp_server_polarion"), "propagate", True)
@@ -1696,8 +1639,7 @@ class TestEnumGuardUpdateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # First GET call (pre-fetch): the work item itself.
-        # Second GET call (guard): the priority options.
+        # GETs: work-item pre-fetch, then priority options.
         mock_client.get.side_effect = [
             _make_get_response(),
             _enum_get_response(["90.0", "50.0", "10.0"]),
@@ -1712,8 +1654,7 @@ class TestEnumGuardUpdateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Pre-fetch surfaces the existing customs; the unknown key does not
-        # appear there so the guard rejects.
+        # Unknown key absent from the pre-fetched customs, so the guard rejects.
         mock_client.get.return_value = _make_get_response(
             custom_fields={"risk_score": 5}
         )
@@ -1730,8 +1671,7 @@ class TestEnumGuardUpdateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # ``resolution`` is a ghost-prone enum like type/status/severity;
-        # an unlisted id must be rejected, not written verbatim.
+        # resolution is ghost-prone; an unlisted id must be rejected.
         mock_client.get.side_effect = [
             _make_get_response(),
             _enum_get_response(["done", "wontfix", "duplicate"]),
@@ -1746,11 +1686,8 @@ class TestEnumGuardUpdateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Pre-fetch returns a ``task``; ``change_type_to='requirement'``
-        # means status must be validated against the target type's options,
-        # so the guard's status lookup must use ``type='requirement'``.
-        # GETs in order: work-item pre-fetch, type options (``~`` axis),
-        # status options (target-type axis).
+        # change_type_to scopes the status lookup to the target type.
+        # GETs: work-item pre-fetch, type options (~ axis), status options (target).
         mock_client.get.side_effect = [
             _make_get_response(),
             _enum_get_response(["requirement"]),
@@ -2355,14 +2292,11 @@ class TestGetWorkItem:
     async def test_include_description_html_false_blanks_field(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """include_description_html=False → description_html blanked.
+        """include_description_html=False blanks description_html.
 
-        ``@all`` is the only sparse-fieldset that surfaces custom fields,
-        so the body still travels over the wire; the tool layer is
-        responsible for stripping it from the response to save LLM
-        context tokens. The default at the FastMCP layer is False; here
-        we pass it explicitly because direct-call tests bypass the
-        FastMCP Field default unwrap.
+        The body still travels over the wire (@all is needed for customs);
+        the tool strips it to save LLM context. Passed explicitly since
+        direct-call tests bypass the FastMCP Field default.
         """
         mock_client.get.return_value = {
             "data": {
@@ -2393,9 +2327,9 @@ class TestGetWorkItem:
     async def test_polarion_specific_markup_round_trips(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Polarion-specific spans / data-* attributes must survive on read.
+        """Polarion spans / data-* attributes survive on read.
 
-        Core round-trip guarantee for update_work_item(description_html=).
+        Round-trip guarantee for update_work_item(description_html=).
         """
         raw = (
             '<p>Refs <span class="polarion-rte-link" '
@@ -2524,12 +2458,12 @@ class TestGetWorkItem:
             "data": {
                 "id": "proj1/MCPT-999",
                 "attributes": {
-                    # Standard attributes — present but excluded from custom_fields.
+                    # Standard attrs: excluded from custom_fields.
                     "title": "work item with customs",
                     "type": "softwarerequirement",
                     "status": "approved",
                     "priority": "50.0",
-                    # Inline custom attributes — top-level keys, not nested.
+                    # Inline customs: top-level, not nested.
                     "riskLevel": "high",
                     "category": "user",
                     "effortHours": 12.0,
@@ -2544,8 +2478,7 @@ class TestGetWorkItem:
             work_item_id="MCPT-999",
         )
 
-        # Raw passthrough: rich-text values stay as the original
-        # {type, value} dict — they are NOT converted to Markdown.
+        # Raw passthrough: rich-text dicts not converted to Markdown.
         assert result.custom_fields == {
             "riskLevel": "high",
             "category": "user",
@@ -2791,8 +2724,7 @@ class TestReadWorkItem:
         assert result.resolution == "fixed"
         assert len(result.hyperlinks) == 1
         assert result.hyperlinks[0].uri == "https://example.com/spec"
-        # Custom fields stay raw — rich-text dicts are NOT converted to Markdown
-        # because the same dict shape round-trips through update_work_item.
+        # Customs stay raw so the dict round-trips through update_work_item.
         assert result.custom_fields == {
             "riskLevel": "high",
             "reviewerNote": rich_value,

--- a/tests/mcp_server_polarion/utils/test_html.py
+++ b/tests/mcp_server_polarion/utils/test_html.py
@@ -147,8 +147,7 @@ class TestHtmlToMarkdown:
         result = html_to_markdown(html)
         assert "Before" in result
         assert "After" in result
-        # Lock the exact emitted form: src is preserved on a bare ![](src) since
-        # the external img carries no alt or title to promote.
+        # No alt/title to promote, so src stays in a bare ![](src).
         assert "![](https://example.com/pic.jpg)" in result
 
     def test_nested_formatting(self) -> None:
@@ -317,15 +316,14 @@ class TestHtmlToMarkdownMergedCells:
 
     def test_table_pathological_span_product_bounded(self) -> None:
         """colspan*rowspan is clamped to keep worst-case allocation bounded."""
-        # 1000*1000 per-attr clamps would materialise 1M clones without the
-        # product clamp; _MAX_CELLS_PER_MERGE bounds it so the call returns.
+        # Without the product clamp, 1000*1000 spans would materialise 1M clones.
         html = (
             '<table><tbody><tr><td colspan="1000" rowspan="1000">M</td>'
             "<td>Z</td></tr></tbody></table>"
         )
         result = html_to_markdown(html)
         rows = self._table_rows(result)
-        # Sanity: call returned (would OOM/hang without clamp), first cell is M.
+        # Returned at all (no OOM/hang) and first cell is M.
         assert rows, result
         assert rows[0][0] == "M"
 


### PR DESCRIPTION
## Summary

Continues the always-loaded docstring/comment trim from #84 across the whole package -- core, models, tools, utils, and the eval harness. Pure documentation/comment condensation; no behavior change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Largest always-loaded payload is tool docstrings; cut to the prose clients actually need
- Condensed docstrings/comments per layer (server/core, model, tool, utils, evals), no logic touched

## Testing

ruff check + ruff format --check + mypy src/ clean; uv run pytest passed 1075 tests.

## Notes for Reviewers

Split into one commit per layer for review; net -1469 lines, all comment/docstring text.