### PR TITLE
test(meta): add tier-2 evals, slim docstrings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,6 +17,7 @@ Format: `<type>/<short-kebab-summary>`
 | `feature/`  | New tool, capability, or user-visible behavior                 | `feature/read-fidelity`       |
 | `fix/`      | Bug fix on existing behavior                                   | `fix/utils-html-attachments`  |
 | `refactor/` | Internal restructuring with no functional change               | `refactor/tools`              |
+| `test/`     | Test-only changes (unit tests, eval cases, fixtures)           | `test/tier2-efficiency-evals` |
 | `docs/`     | Documentation-only changes                                     | `docs/contributing`           |
 | `chore/`    | Dependency bumps, build tooling, repository housekeeping       | `chore/bump-fastmcp`          |
 | `ci/`       | GitHub Actions / workflow / release-pipeline changes           | `ci/cache-uv-deps`            |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@
 - [ ] New feature (non-breaking change that adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Refactor (no functional changes, code quality improvement)
+- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
 - [ ] Documentation update
 - [ ] CI / tooling / dependency update
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Project Overview
-
-MCP server giving AI assistants read/write access to Polarion ALM via MCP. FastMCP 3.0, strict async, fully typed.
+MCP server: AI read/write access to Polarion ALM. FastMCP 3.0, strict async, fully typed.
 
 ## Commands
 
 ```bash
 uv sync --dev                                            # install deps
 uv run pytest                                            # all tests
-uv run pytest tests/mcp_server_polarion/tools/test_work_items.py::TestGetWorkItem  # single class
 uv run pytest -k test_page_size_rejects_above_max        # single test
 uv run ruff check . && uv run ruff format . && uv run mypy src/  # lint + format + types
 uv run mcp-server-polarion                               # run server (stdio)
@@ -21,89 +16,78 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 
 ## Architecture
 
-- **`core/`** — `client.py` (async httpx wrapper: 429/5xx backoff, post-mutation delay, maps to `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (Pydantic settings `POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only), `exceptions.py`. Every module: `logging.getLogger("mcp_server_polarion.<module>")`.
-- **`tools/`** — domain-grouped tool modules: `projects.py`, `work_items.py` (incl. SQL recipes), `documents.py`, `links.py`, `comments.py`, `moves.py` (each create/update tool has a `_build_*_payload` helper as the unit-test seam). Importing each in `tools/__init__.py` registers its `@mcp.tool`s. Shared layer under **`tools/_shared/`** — `helpers.py` (sparse-fieldset constants, JSON:API extractors, pagination, custom-field merge, `MAX_BULK_ITEMS`, `build_enum_option`), `cache.py` (generic `TTLCache[K, V]` + all cache state behind get/store/record wrappers), `guard.py` (enum / custom-field write guards; reads `cache.py`). `tools/guides/` holds on-demand data (`sql_query_recipes.md`).
-- **`utils/html.py`** — Markdown ↔ HTML (markdownify + BeautifulSoup4 sanitize), `stamp_block_ids` (write-side anchor injection), `first_anchorless_block` (reject anchorless body blocks).
-- **`models/`** — Pydantic v2, grouped by domain (`common`, `projects`, `documents`, `work_items`, `links`, `comments`) and re-exported from `models/__init__.py`. `PaginatedResult[T]` wraps all list responses.
-- **`server.py`** — FastMCP instance; lifespan opens/closes `PolarionClient`.
+- `core/` — `client.py` (async httpx: 429/5xx backoff, post-mutation delay, maps to `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only). Loggers: `logging.getLogger("mcp_server_polarion.<module>")`.
+- `tools/` — domain modules (`projects`, `work_items`, `documents`, `links`, `comments`, `moves`); each create/update tool has `_build_*_payload` helper = unit-test seam. Import in `tools/__init__.py` registers `@mcp.tool`s. `tools/_shared/`: `helpers.py` (JSON:API extractors, pagination, `MAX_BULK_ITEMS`), `cache.py` (`TTLCache`, all cache state behind wrappers), `guard.py` (write guards). `tools/guides/` = on-demand data (`sql_query_recipes.md`).
+- `utils/html.py` — Markdown ↔ HTML, `stamp_block_ids`, `first_anchorless_block`.
+- `models/` — Pydantic v2 by domain, re-exported from `models/__init__.py`. `PaginatedResult[T]` wraps all list responses.
+- `server.py` — FastMCP instance; lifespan owns `PolarionClient`.
 
 ## Non-Negotiable Rules
 
-- **NEVER `print()`** — stdout is MCP JSON-RPC; log to stderr.
-- **NEVER `typing.Any`** — concrete types or `object`.
-- All functions: full annotations + `from __future__ import annotations`. All tool functions: `async def` returning a Pydantic model.
-- **Body fields are asymmetric by tool purpose**:
-  - **Round-trip** (lossless): `get_*(include_*_html=True)` returns raw Polarion HTML; `update_*(*_html=...)` accepts it verbatim — no sanitize/convert. XSS is Polarion's renderer's job.
-  - **Greenfield create** (Markdown): `create_work_items(description=...)` and `create_document(home_page_content=...)` run `markdown_to_html` + `sanitize_html`. Post-create edits switch to raw-HTML round-trip; the formats never mix.
-  - **Synthesis** (Markdown, READ-ONLY): `read_document` / `read_document_parts` / `read_work_item` convert HTML→Markdown. Feeding output back to writes loses Polarion markup.
-- **Write payloads** skip `None`/empty (Polarion reads empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take a flat object.
-- Every list tool: `page_size` (max 100) + `page_number`; returns `PaginatedResult[T]` with `has_more`.
-- Every write tool: `dry_run: bool = False` — build & return the `_build_*_payload` JSON:API payload without hitting Polarion.
-- Tool docstrings are the LLM's manual — Google-style. **Only prose above `Args:` ships to clients** (FastMCP strips `Args:`/`Returns:`/`Raises:`); keep it tight (largest always-loaded payload). Keep return-field bullets in sync with the Pydantic model.
-- **Error mapping**: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`.
+- NEVER `print()` — stdout is MCP JSON-RPC; log to stderr.
+- NEVER `typing.Any` — concrete types or `object`.
+- All functions: full annotations + `from __future__ import annotations`. Tool functions: `async def` returning Pydantic model.
+- Body fields asymmetric by tool purpose:
+  - Round-trip: `get_*(include_*_html=True)` returns raw Polarion HTML; `update_*(*_html=...)` accepts verbatim — no sanitize/convert.
+  - Greenfield create (Markdown): `create_work_items(description=...)` + `create_document(home_page_content=...)` run `markdown_to_html` + `sanitize_html`. Post-create edits = raw-HTML round-trip; formats never mix.
+  - Synthesis (Markdown, READ-ONLY): `read_*` tools convert HTML→Markdown; feeding output back to writes loses Polarion markup.
+- Write payloads skip `None`/empty (Polarion reads empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
+- Every list tool: `page_size` (max 100) + `page_number` → `PaginatedResult[T]` with `has_more`.
+- Every write tool: `dry_run: bool = False` — return payload without hitting Polarion.
+- Tool docstrings = LLM's manual, Google-style. Only prose above `Args:` ships to clients (FastMCP strips the rest); keep tight. Return-field bullets in sync with Pydantic model.
+- Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`.
 
 ## Comment & Docstring Style
 
-Applies to ALL comments/docstrings (tools, helpers, inline, CLAUDE.md).
+Applies to ALL comments/docstrings incl. CLAUDE.md.
 
-- Field descriptions stay one line; skip when name + type say everything. Cross-model invariant: `tests/mcp_server_polarion/models/test_invariants.py::test_field_descriptions_are_non_empty_when_set`.
-- No `WARNING:` / `FOOTGUN:` / `NOTE:` prefix upgrades — state the fact plainly.
-- No dev-narrative ("verified via smoke test", "we tried X then switched to Y", "as of vN") — belongs in commit messages and PR descriptions.
-- No banner-divider comments (`# ---`, `# === Section ===`).
-- **CLAUDE.md is dev-only.** Other MCP hosts (Cursor / Copilot / generic FastMCP clients) never load it — anything an MCP-user LLM needs must live inside the `@mcp.tool` docstring, even if it duplicates content here.
-- Module docstrings explain *why* the module exists; specific timing / sizing / refactor history goes inline next to the thing it constrains.
+- Field descriptions one line; skip when name + type say all.
+- No `WARNING:`/`NOTE:` prefixes — state fact plainly. No dev-narrative ("we tried X then Y"). No banner-divider comments.
+- CLAUDE.md is dev-only — other MCP hosts never load it; anything an MCP-user LLM needs must live in the `@mcp.tool` docstring, even if duplicated here.
+- Module docstrings = why module exists; timing/sizing constraints go inline next to what they constrain.
 
 ## Polarion API & Gotchas
 
-- **Endpoints** (JSON:API v1): `/projects`, `/projects/{p}/workitems[?query=]`, `/projects/{p}/workitems/{wi}[/linkedworkitems]`, `/projects/{p}/spaces/{s}/documents/{d}[/parts]`. HTML stored as `{"type": "text/html", "value": "..."}`.
-- **ID shapes**: linked-work-item ids are 5 segments — derive targets via `relationships.workItem.data.id`, never parse. Module ids are 3 segments, document names may contain `/` — use `split_module_id`.
-- **Lucene**: trailing wildcards OK, leading 400. `module` / `description` not indexed — use `query="SQL:(...)"` for module/custom-field/traceability/body searches. SQL fundamentals (escaping, `C_DESCRIPTION` CLOB caveat, `LIKE` rejected inside `EXISTS`→use top-level `WHERE` + `INNER JOIN`) live in the `list_work_items` docstring; full recipe gallery via the `get_sql_query_recipes` tool (loads `tools/guides/sql_query_recipes.md` on demand — keeps the gallery out of always-loaded context while staying model-callable in every MCP host, unlike a resource).
-- **Server limits**: ≤3 req/s, no concurrency. `PolarionClient` retries 429/5xx but does NOT serialize client-side.
-
-### JSON:API quirks
-
-- **Sparse fieldset drops relationships too.** `fields[workitems]=title,type` silently drops the `relationships` block — list relationship names explicitly (`WORK_ITEM_LIST_FIELDS`), else derived fields (`space_id`/`document_name`/`assignee_ids`/`author_id`) empty out.
-- **To-many relationships need `include=`**; to-one (`module`, `author`, `project`) inline without it.
-- **Backlinks**: `/backlinkedworkitems` unsupported. `list_work_item_links` falls back to `query=linkedWorkItems:{wi}` for the back direction, so back results have `role=None`.
-- **Custom fields inline under `attributes`** (no `customFields` container; `@all` tokens dropped). Server fetches `fields[*]=@all` and splits via `STANDARD_*_ATTRIBUTES` allowlists. Polarion does NOT validate custom-field ids — unknown keys persist as silent ghosts; wrong-type values 400.
-  - Guarded writes: `guard_work_item_custom_field_keys` validates `create_work_items` + `update_work_item.custom_fields` against a `(project, type)` schema cached from a MIN-per-key SQL sample (`one_item_per_custom_field_sql`: `GROUP BY cf.c_name`, one item per distinct key, `@all`, paged 100). SQL rejection fails closed — no Lucene fallback (a partial sample false-rejects real keys); an empty schema (type populates no custom) also fails closed. A would-be-unknown key forces one fresh re-fetch (admin-added field) before rejecting. Window SQL (`MAX(COUNT(...)) OVER ()`) avoided — full-partition aggregation unsafe at ≤3 req/s; MIN groups on indexed `c_name`. **Documents** mirror this on the **document-type** axis (`guard_document_custom_field_keys`, `(project, document_type)` cache). The `module` table JOINs/filters in REST SQL but never returns as a resource (a workitem query yields work items; `SELECT` list ignored), so the sample is `one_heading_per_document_sql` (one heading per module) + `include=module&fields[documents]=@all` — each `module` lands in `included` with its type + inline customs, unioned per type. `GET /projects/{p}/documents` is absent on some builds (e.g. 2506); the heading + `include` path is not. Trade-off: a document with no heading is invisible. `update_document` resolves the doc's type via narrow GET (or the new `type` when changing it); `create_document` uses its `type` arg. Same fail-closed-on-empty + bypass-retry as work items.
-- **Enum validation is absent in Polarion**, enforced at the tool layer. Unknown `type`/`status`/`severity`/`priority`/`resolution` would persist and never match Lucene; `guard_work_item_enums` / `guard_document_enums` fetch `getAvailableOptions` and raise `ValueError` with the valid ids. `type` is checked first (an invalid `change_type_to` raises before being reused as the scoping axis; status/severity/resolution are scoped by target type).
-  - **Link / hyperlink roles** aren't in `getAvailableOptions`: `guard_work_item_link_roles` / `guard_hyperlink_roles` fetch `GET /projects/{p}/enumerations/~/{enumName}/~` (`workitem-link-role`/`hyperlink-role`) via `fetch_project_enum_option_ids`. That response's `data` is a **dict** (`data.attributes.options[].id`), unlike `getAvailableOptions`'s list.
-- **Guards are fail-closed.** A validation GET that errors after backoff blocks the write: auth failure → `PermissionError`, else → `RuntimeError` (a ghost write is invisible in the UI and unrecoverable). Lone lenient case: a *successful* empty option set defers to Polarion. TTL `_GUARD_TTL_SECONDS` = 60s; tests drive expiry by patching `tools._shared.cache._now`.
+- JSON:API v1. HTML stored as `{"type": "text/html", "value": "..."}`.
+- ID shapes: linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse. Module ids = 3 segments, document names may contain `/` — use `split_module_id`.
+- Lucene: trailing wildcards OK, leading 400. `module`/`description` not indexed — use `query="SQL:(...)"`. SQL fundamentals in `list_work_items` docstring; recipes via `get_sql_query_recipes` tool.
+- Server limits: ≤3 req/s, no concurrency. Client retries 429/5xx, does NOT serialize client-side.
+- Sparse fieldset drops `relationships` block too — list relationship names explicitly (`WORK_ITEM_LIST_FIELDS`). To-many relationships need `include=`; to-one inline without it.
+- `/backlinkedworkitems` unsupported — back direction via `query=linkedWorkItems:{wi}`, so back results have `role=None`.
+- Custom fields inline under `attributes` (no `customFields` container; `@all` tokens dropped). Polarion does NOT validate custom-field ids (unknown keys persist as silent ghosts; wrong-type values 400) — `guard_work_item_custom_field_keys` / `guard_document_custom_field_keys` validate against `(project, type)` schema cached from SQL sample. Fail closed on SQL error AND empty schema; would-be-unknown key forces one fresh re-fetch before rejecting. Document axis = document-type, sampled via headings + `include=module` (`GET /projects/{p}/documents` absent on some builds).
+- Enum validation absent in Polarion — `guard_work_item_enums` / `guard_document_enums` fetch `getAvailableOptions`, raise `ValueError` with valid ids. `type` checked first. Link/hyperlink roles not in `getAvailableOptions` — `fetch_project_enum_option_ids` hits `GET /projects/{p}/enumerations/~/{enumName}/~` (response `data` is dict, not list).
+- Guards fail-closed: validation GET error blocks write (auth → `PermissionError`, else `RuntimeError`). Lone lenient case: successful empty option set defers to Polarion. TTL `_GUARD_TTL_SECONDS` = 60s; tests drive expiry by patching `tools._shared.cache._now`.
 
 ### Document writes
 
-- **Body edits go through `homePageContent` PATCH, not `/parts`.** `update_document(home_page_content_html=...)` carries the full body. `/parts` POST and `actions/moveToDocument` are wrappers that reject heading-type items. Empty `home_page_content_html` is rejected (would orphan every heading).
-- **`<hN>` alone is safe; anchorless `<p>`/`<ul>`/`<ol>`/`<table>`/`<div>`/`<blockquote>`/`<pre>` are NOT** — PATCH 200, next `GET .../parts` 500. Each needs a unique non-empty `id=`. `create_document` runs `stamp_block_ids`; `update_document` is raw HTML, so the tool hard-rejects anchorless blocks via `first_anchorless_block` (`ValueError` before PATCH, on `dry_run` too). For body text, prefer `create_work_items` + `move_work_item_to_document`.
-- **`module` cannot be set via `PATCH /workitems/{wi}` nor by injecting `<div ...module-workitem...>`** (leaves a half-attached `space_id=""`/`outline_number=""` state). Use the action pair `moveToDocument` / `moveFromDocument` — only `move_work_item_to_document` sets `module` + `outline_number` + `homePageContent` atomically. `create_work_item` doesn't expose `module` (would land in recycle bin) — create free-floating then move. `moveFromDocument` isn't idempotent (400 if already detached). `moveToDocument` auto-creates one link to the enclosing heading (project-config role, removed on detach); a later same-role `create_work_item_links` 201s but isn't persisted (phantom success).
+- Body edits via `homePageContent` PATCH, not `/parts` (those wrappers reject heading-type items). Empty `home_page_content_html` rejected (would orphan headings).
+- Anchorless `<p>`/`<ul>`/`<ol>`/`<table>`/`<div>`/`<blockquote>`/`<pre>` break `/parts` (PATCH 200, next GET 500); each needs unique non-empty `id=`. `create_document` runs `stamp_block_ids`; `update_document` hard-rejects via `first_anchorless_block`. For body text, prefer `create_work_items` + `move_work_item_to_document`.
+- `module` cannot be set via PATCH or HTML injection — only `move_work_item_to_document` / `move_work_item_from_document` (atomic action pair). `create_work_item` doesn't expose `module` (would land in recycle bin) — create free-floating, then move. `moveFromDocument` not idempotent (400 if detached). `moveToDocument` auto-creates one link to enclosing heading; later same-role `create_work_item_links` 201s but isn't persisted (phantom success).
 
 ### Work item & comment quirks
 
-- **Link tools**: `create_work_item_links` (bulk), `update_work_item_link` (single), `delete_work_item_links` (idempotent 204). Composite ids `<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>` from `WorkItemLinkRef`. Bulk tools cap at `MAX_BULK_ITEMS` (50). Create POST is atomic — a 4xx (e.g. duplicate `(role,target)` 409) rolls back the batch, so re-query `list_work_item_links` before retry. Polarion validates neither target existence nor role, so the create path guards both (`guard_work_item_link_targets`, `guard_work_item_link_roles`); `update_work_item_link` is unguarded (an unknown role there 404s loudly). `delete_work_item_links` pre-reads outgoing links (`partition_delete_links`) → `deleted_link_ids` / `not_found_link_ids` (no-op reported, never raised); pre-read is fail-closed and runs on `dry_run`.
-- **`update_work_item_link.suspect`** is tri-state on update (`None`=unchanged) vs `WorkItemLinkSpec.suspect: bool = False` on create. At least one of `suspect`/`revision` required.
-- **`PATCH /workitems`** needs ≥1 `attributes`/`relationships` entry — 400s even when only `workflowAction`/`changeTypeTo` is set (tool validates). `changeTypeTo` resets `status` to the new type's initial state — re-apply in a follow-up if preservation matters.
-- **`update_document_comment`** PATCH takes only the full 4-segment id and only on root comments (replies 400 → `RuntimeError`); resolving a root marks the whole thread resolved.
+- Link ids composite `<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`. Bulk tools cap at `MAX_BULK_ITEMS` (50). Link-create POST atomic — 4xx rolls back batch; re-query `list_work_item_links` before retry. Polarion validates neither link target nor role — create path guards both; `update_work_item_link` unguarded (unknown role 404s loudly). `delete_work_item_links` pre-reads (fail-closed, runs on `dry_run`) → `deleted_link_ids`/`not_found_link_ids`, never raises on no-op.
+- `update_work_item_link.suspect` tri-state (`None`=unchanged) vs create default `False`. At least one of `suspect`/`revision` required.
+- `PATCH /workitems` needs ≥1 `attributes`/`relationships` entry (400 otherwise, tool validates). `changeTypeTo` resets `status` to new type's initial state.
+- `update_document_comment`: full 4-segment id, root comments only (replies 400 → `RuntimeError`); resolving root resolves whole thread.
 
 ## Testing
 
-`tests/` mirrors every source tree one-to-one — `tests/mcp_server_polarion/` (with `core/`, `tools/`, `utils/`) mirrors the package, `tests/evals/` mirrors `evals/` (`evaluators/`, `harness/`, `cases/`), and `tests/claude_hooks/` + `tests/github_scripts/` mirror the loose scripts under `.claude/hooks/` + `.github/scripts/`. One test module per source module; `conftest.py` stays at the `tests/` root so its shared fixtures reach the whole tree.
-
-`pytest-asyncio` in `mode=auto`. **Tool tests** (`tests/mcp_server_polarion/tools/`) call tool functions directly with an injected `mock_client` (FastMCP 3.0's `@mcp.tool` returns the original function). **Client tests** (`tests/mcp_server_polarion/core/test_client.py`) use `respx`. `mock_client` / `mock_ctx` + autouse guard-cache reset live in `tests/mcp_server_polarion/tools/conftest.py`; root `tests/conftest.py` holds `polarion_config` / `polarion_client` (pass `write_delay=0` for real `PolarionClient` instances). Pydantic `Field` constraints bypass FastMCP's JSON Schema on direct calls — verify via `TypeAdapter` reconstruction (see `TestCreateWorkItemFieldValidation`).
-
-**Transport tests** (`tests/mcp_server_polarion/test_mcp_transport.py`) drive the server through `fastmcp.Client(mcp)` in-memory transport so registration → JSON Schema → lifespan → `get_client(ctx)` → real `PolarionClient` → mocked HTTP runs end to end. Adding a new `@mcp.tool` requires updating `EXPECTED_TOOL_NAMES` — that is the forcing function. The fixture monkeypatches `_WRITE_DELAY_SECONDS` because the lifespan constructs `PolarionClient` itself.
-
-Tests for the eval harness (`tests/evals/`) import `strands` / `strands_evals`, only present in the `evals` dependency group, so they open with `pytest.importorskip` — they run in CI because `ci.yml` syncs `--group evals`, and skip (rather than error) on a bare `uv sync --dev`.
+- `tests/` mirrors every source tree one-to-one; `conftest.py` at `tests/` root for shared fixtures.
+- `pytest-asyncio` `mode=auto`. Tool tests call tool functions directly with injected `mock_client` (`@mcp.tool` returns original function); client tests use `respx`. `mock_client`/`mock_ctx` + autouse guard-cache reset in `tests/mcp_server_polarion/tools/conftest.py`. Pydantic `Field` constraints bypass JSON Schema on direct calls — verify via `TypeAdapter` reconstruction.
+- Transport tests (`test_mcp_transport.py`) drive server via `fastmcp.Client(mcp)` in-memory. New `@mcp.tool` requires updating `EXPECTED_TOOL_NAMES`.
+- `tests/evals/` opens with `pytest.importorskip` (`evals` dependency group; CI syncs `--group evals`).
 
 ## Evals — Tier-1 deploy gate
 
-`evals/` (separate group, not in the wheel) drives a real LLM agent through the in-memory server against a mocked Polarion and deterministically asserts no forbidden/footgun action — **no LLM judge**. Hard gate before the PyPI publish jobs in `.github/workflows/publish.yml`; each case passes at `min_pass_rate=1.0`. `EVAL_MODEL` switches model (CI `openai/gpt-4o-mini`). Adding a case: register a check in `evals/evaluators/checks.py::REGISTRY`, add a `Case` to `cases/tier1_prohibitions.py`, and **phrase the task neutrally** (stating the rule tests the prompt, not the docstrings). Detail in [evals/README.md](evals/README.md).
+`evals/` drives real LLM agent through in-memory server against mocked Polarion; deterministic checks, no LLM judge. Hard gate before PyPI publish (`min_pass_rate=1.0`). New case: register check in `evals/evaluators/checks.py::REGISTRY`, add `Case` to `cases/tier1_prohibitions.py`, phrase task neutrally (stating rule tests prompt, not docstrings). Detail: [evals/README.md](evals/README.md).
 
 ## Repo Conventions
 
-Full rules in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md); enforced by `.githooks/commit-msg` + the `.claude/hooks/` PR hooks (English-only bodies, template checkboxes, squash-only merges). Quick reference:
+Full rules in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md); enforced by `.githooks/commit-msg` + `.claude/hooks/`.
 
-- **Branches**: `<type>/<short-kebab-summary>` off `main`, one topic each. Types: `feature|fix|refactor|docs|chore|ci`.
-- **Commits**: `type(scope): summary` ≤50 chars, lowercase imperative, no period. Types: `feat|fix|docs|refactor|perf|test|ci|chore`. Scopes: `tool|server|transport|config|deps|utils|model|project|meta|git`. Body: blank line + exactly 2 bullets (motivation, then change), ≤120 chars each, no prefixes.
-- **PR template checklist**: flip `[ ]`→`[x]`; don't delete unchecked options.
-- **Squash merge only** — let the PR title become the subject; NEVER pass `--subject` to `gh pr merge`.
-- **Force push** feature branches only after explicit authorization; never `main`.
+- Branches: `<type>/<short-kebab-summary>` off `main`. Types: `feature|fix|refactor|docs|chore|ci`.
+- Commits: `type(scope): summary` ≤50 chars, lowercase imperative, no period. Types: `feat|fix|docs|refactor|perf|test|ci|chore`. Scopes: `tool|server|transport|config|deps|utils|model|project|meta|git`. Body: blank line + exactly 2 bullets (motivation, then change), ≤120 chars each.
+- PR template checklist: flip `[ ]`→`[x]`; don't delete unchecked options.
+- Squash merge only; NEVER pass `--subject` to `gh pr merge`.
+- Force push feature branches only after explicit authorization; never `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Applies to ALL comments/docstrings incl. CLAUDE.md.
 
 Full rules in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md); enforced by `.githooks/commit-msg` + `.claude/hooks/`.
 
-- Branches: `<type>/<short-kebab-summary>` off `main`. Types: `feature|fix|refactor|docs|chore|ci`.
+- Branches: `<type>/<short-kebab-summary>` off `main`. Types: `feature|fix|refactor|test|docs|chore|ci`.
 - Commits: `type(scope): summary` ≤50 chars, lowercase imperative, no period. Types: `feat|fix|docs|refactor|perf|test|ci|chore`. Scopes: `tool|server|transport|config|deps|utils|model|project|meta|git`. Body: blank line + exactly 2 bullets (motivation, then change), ≤120 chars each.
 - PR template checklist: flip `[ ]`→`[x]`; don't delete unchecked options.
 - Squash merge only; NEVER pass `--subject` to `gh pr merge`.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,13 +1,23 @@
-# Pre-deploy evaluation gate (Tier 1)
+# Pre-deploy evaluation gate
 
 Drives an LLM agent through the **real** in-memory MCP server against a
-**mocked** Polarion backend, then deterministically asserts the agent never
-took a destructive or footgun action. Runs as a hard gate ahead of the PyPI
-publish jobs in [`.github/workflows/publish.yml`](../.github/workflows/publish.yml) —
-a single forbidden action blocks the release.
+**mocked** Polarion backend, then deterministically asserts the agent's
+behaviour. Runs as a hard gate ahead of the PyPI publish jobs in
+[`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
 
-Tier 1 needs **no LLM judge**: every verdict is a pure function of the tool-call
-trajectory. The only model cost is the agent under test.
+Two tiers, same harness and evaluator, different tolerance:
+
+- **Tier 1 — prohibitions** ([`cases/tier1_prohibitions.py`](cases/tier1_prohibitions.py)):
+  destructive / corrupting / footgun actions. `min_pass_rate = 1.0` — a single
+  forbidden action across the N runs blocks the release.
+- **Tier 2 — efficiency** ([`cases/tier2_efficiency.py`](cases/tier2_efficiency.py)):
+  the agent succeeds, but must take the short, correct path (one bulk call,
+  direct get by known id, no redundant identical reads, right query
+  mechanism). `min_pass_rate = 0.8` — occasional wasteful runs tolerated,
+  systematic waste blocks.
+
+No tier needs an **LLM judge**: every verdict is a pure function of the
+tool-call trajectory. The only model cost is the agent under test.
 
 ## How it works
 
@@ -42,9 +52,9 @@ uv run python evals/run.py        # equivalent
 uv run python -m evals.run --case T1-READONLY --runs 1
 ```
 
-Each case runs N times; a Tier-1 case passes only at `min_pass_rate` (1.0 —
-zero tolerance). The gate fails (exit 1) if any case falls short. A JSON report
-is written to `evals/reports/tier1-<sha>.json` (gitignored).
+Each case runs N times and passes only at its `min_pass_rate` (Tier 1: 1.0,
+Tier 2: 0.8). The gate fails (exit 1) if any case falls short. A JSON report
+is written to `evals/reports/gate-<sha>-<model>.json` (gitignored).
 
 ## Choosing the model
 
@@ -59,7 +69,9 @@ EVAL_MODEL=ollama_chat/qwen3.5:9b-mlx uv run python -m evals.run
 # (set EVAL_MODEL_BASE_URL if Ollama is not on localhost:11434)
 ```
 
-`temperature` is pinned to 0 to keep the zero-tolerance gate stable.
+`temperature` is pinned to 0 and `parallel_tool_calls` off (gpt-4o-mini can
+emit the same tool call twice in one parallel block) to keep the
+zero-tolerance gate stable.
 
 ## Runaway protection
 
@@ -107,13 +119,17 @@ first tagged release.
 
 1. Add a pure check to `evaluators/checks.py` and register it in `REGISTRY`
    (or reuse an existing one). Keep it a function of the trajectory only.
-2. Add a `Case` to `cases/tier1_prohibitions.py` with
-   `metadata={"check": "<name>", "params": {...}, "min_pass_rate": 1.0}`.
+2. Add a `Case` to `cases/tier1_prohibitions.py` (prohibition,
+   `min_pass_rate: 1.0`) or `cases/tier2_efficiency.py` (efficiency,
+   `min_pass_rate: 0.8`); `run.py` loads both lists.
 3. Phrase the task neutrally — never state the rule, or you test the prompt
    instead of the tool docstrings (the only guard).
 
-Seed entities (project `MCP_Test_Project`, doc `FakeDoc`, free-floating
-`MCPT-200` task carrying `custom_fields={"acceptance_criteria_id": "AC-1"}`,
-`MCPT-201` heading, `MCPT-202` ghost-typed task, comment thread `1`→`2`)
-live in [`harness/fake_polarion.py`](harness/fake_polarion.py). Mirror the
-real server's *structure* there; keep all content synthetic.
+Seed entities (project `MCP_Test_Project`, doc `FakeDoc` with an anchored
+intro paragraph, free-floating `MCPT-200` task carrying
+`custom_fields={"acceptance_criteria_id": "AC-1"}` and one `ref_ext`
+hyperlink, `MCPT-201` heading, `MCPT-202` ghost-typed task, comment thread
+`1`→`2`, project enum `hyperlink-role`) live in
+[`harness/fake_polarion.py`](harness/fake_polarion.py). Mirror the real
+server's *structure* there; keep all content synthetic. Bulk POSTs echo one
+id per submitted entry, so bulk cases exercise the tools' count-match rule.

--- a/evals/cases/tier1_prohibitions.py
+++ b/evals/cases/tier1_prohibitions.py
@@ -13,6 +13,15 @@ Scope is LLM behaviour the tool layer cannot guard deterministically:
 * path-shape (``T1-WI-TO-DOC``, ``T1-HEADING-TO-DOC``) -- two structurally
   different ways to add document content; the wrong one corrupts state.
 * read-only intent (``T1-READONLY``) -- write tools stay dormant on a read task.
+* observed-id writes (``T1-REPLY-RESOLVE``) -- thread resolution must reach a
+  root id surfaced by a prior list; resolving only a reply leaves the thread
+  open while reporting it done.
+* REPLACE-list preservation (``T1-HYPERLINK-PRESERVE``) -- an add must carry
+  the pre-existing entries or they are silently deleted.
+* round-trip sourcing (``T1-ROUNDTRIP-SOURCE``) -- raw-HTML body writes must
+  come from the flagged ``get_*`` read, not synthesis Markdown.
+* state-aware actions (``T1-DETACH-NOOP``) -- non-idempotent detach stays
+  dormant on an item that is in no document.
 
 Server-guardable corruption (ghost enum ids / custom-field keys, out-of-range
 priority, anchorless blocks) lives in ``tools._guard`` / ``utils.html`` with
@@ -25,7 +34,9 @@ from strands_evals import Case
 
 from evals.harness.fake_polarion import (
     DOC,
+    FLOATING_TASK_HYPERLINK_URI,
     FLOATING_TASK_ID,
+    ROOT_COMMENT_ID,
     SPACE,
 )
 
@@ -61,5 +72,32 @@ CASES: list[Case] = [
         "T1-UPDATE-NEEDS-GET",
         f"Set the priority of {FLOATING_TASK_ID} to a lower level.",
         "get_before_update",
+    ),
+    _case(
+        "T1-REPLY-RESOLVE",
+        f"The feedback in the comment thread on document '{DOC}' in space "
+        f"'{SPACE}' has been addressed. Mark it as resolved.",
+        "resolve_root_comment",
+        root_ids=[ROOT_COMMENT_ID],
+    ),
+    _case(
+        "T1-HYPERLINK-PRESERVE",
+        f"Add a hyperlink to https://example.com/review-checklist on work "
+        f"item {FLOATING_TASK_ID}.",
+        "preserve_hyperlinks",
+        work_item_id=FLOATING_TASK_ID,
+        required_uris=[FLOATING_TASK_HYPERLINK_URI],
+    ),
+    _case(
+        "T1-ROUNDTRIP-SOURCE",
+        f"In the document '{DOC}' in space '{SPACE}', change the intro "
+        f"paragraph to read 'Fake intro paragraph, now reviewed.'",
+        "round_trip_source",
+    ),
+    _case(
+        "T1-DETACH-NOOP",
+        f"Make sure work item {FLOATING_TASK_ID} is not part of any document.",
+        "no_blind_detach",
+        floating_ids=[FLOATING_TASK_ID],
     ),
 ]

--- a/evals/cases/tier2_efficiency.py
+++ b/evals/cases/tier2_efficiency.py
@@ -1,0 +1,70 @@
+"""Tier-2 efficiency cases.
+
+Same harness and deterministic checks as Tier 1, but the rule is "took the
+short, correct path", not "never corrupted state", so ``min_pass_rate = 0.8``
+-- occasional wasteful runs are tolerated, systematic waste fails the gate.
+Tasks state the goal only; the efficient path must be discoverable from the
+tool docstrings alone.
+
+* single bulk call (``T2-BULK-CREATE``) -- N items go through one
+  ``create_work_items``, not N calls.
+* direct lookup (``T2-DIRECT-GET``) -- a known id is fetched, not scanned for.
+* no redundant reads (``T2-NO-DUP-READS``, ``T2-ENUM-ONCE``) -- identical
+  reads repeat only after a write could have changed the answer.
+* query mechanism (``T2-SQL-NOT-LUCENE``) -- document scoping uses the
+  ``SQL:(...)`` prefix or ``read_document_parts``, never a Lucene ``module``
+  term (not indexed).
+"""
+
+from __future__ import annotations
+
+from strands_evals import Case
+
+from evals.harness.fake_polarion import (
+    DOC,
+    FLOATING_TASK_ID,
+    SPACE,
+)
+
+MIN_PASS_RATE = 0.8
+
+
+def _case(name: str, prompt: str, check: str, **params: object) -> Case:
+    return Case(
+        name=name,
+        input=prompt,
+        metadata={"check": check, "params": params, "min_pass_rate": MIN_PASS_RATE},
+    )
+
+
+CASES: list[Case] = [
+    _case(
+        "T2-BULK-CREATE",
+        "Create three new tasks titled 'Fake alpha', 'Fake beta', and 'Fake gamma'.",
+        "single_bulk_create",
+    ),
+    _case(
+        "T2-DIRECT-GET",
+        f"What is the current status and severity of work item {FLOATING_TASK_ID}?",
+        "direct_read",
+        work_item_id=FLOATING_TASK_ID,
+    ),
+    _case(
+        "T2-NO-DUP-READS",
+        f"Summarize the document '{DOC}' in space '{SPACE}' and list any "
+        f"unresolved comment threads on it.",
+        "no_duplicate_reads",
+    ),
+    _case(
+        "T2-ENUM-ONCE",
+        "Create two tasks: 'Fake delta' with severity must_have and "
+        "'Fake epsilon' with severity nice_to_have.",
+        "no_duplicate_reads",
+    ),
+    _case(
+        "T2-SQL-NOT-LUCENE",
+        f"List the IDs of the work items contained in the document '{DOC}' "
+        f"in space '{SPACE}'.",
+        "scoped_query_uses_sql",
+    ),
+]

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -1,14 +1,16 @@
-"""Pure trajectory checks for Tier-1 forbidden behaviours.
+"""Pure trajectory checks for Tier-1 prohibitions and Tier-2 efficiency.
 
 Each check is a function of the trajectory alone (a list of
-``{"name": str, "args": dict}`` in call order, plus optional params) returning
-``(passed, reason)`` -- no LLM, no I/O, so identical input yields identical
-verdict. Scope is LLM-behavioural rules unreachable by the server-side guards
-in ``tools._guard`` / ``utils.html`` (covered by their own unit tests).
+``{"name": str, "args": dict, "result": ...}`` in call order, plus optional
+params) returning ``(passed, reason)`` -- no LLM, no I/O, so identical input
+yields identical verdict. Scope is LLM-behavioural rules unreachable by the
+server-side guards in ``tools._guard`` / ``utils.html`` (covered by their own
+unit tests).
 """
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from typing import Any
 
@@ -31,9 +33,50 @@ WRITE_TOOLS: frozenset[str] = frozenset(
     }
 )
 
+# Reads whose result can change after a write: a repeat is legitimate once any
+# write has run in between.
+STATE_READ_TOOLS: frozenset[str] = frozenset(
+    {
+        "get_work_item",
+        "read_work_item",
+        "list_work_items",
+        "get_document",
+        "read_document",
+        "read_document_parts",
+        "list_documents",
+        "list_document_comments",
+        "list_work_item_links",
+    }
+)
+
+# Reads invariant under the agent's own writes: an identical repeat is always
+# redundant.
+STABLE_READ_TOOLS: frozenset[str] = frozenset(
+    {
+        "list_projects",
+        "list_work_item_enum_options",
+        "list_document_enum_options",
+        "get_sql_query_recipes",
+    }
+)
+
 
 def _names(trajectory: Trajectory) -> list[str]:
     return [c.get("name", "") for c in trajectory]
+
+
+def _args(call: dict[str, Any]) -> dict[str, Any]:
+    return call.get("args", {}) or {}
+
+
+def _short_id(value: object) -> str:
+    """Trailing segment of a possibly project-qualified id ('P/X' -> 'X')."""
+    return str(value).rsplit("/", maxsplit=1)[-1]
+
+
+def _errored(call: dict[str, Any]) -> bool:
+    result = call.get("result")
+    return isinstance(result, dict) and "error" in result
 
 
 def check_readonly(trajectory: Trajectory, _params: dict[str, Any]) -> CheckResult:
@@ -116,9 +159,257 @@ def check_get_before_update(
     return True, "every update_* was preceded by a matching get_*"
 
 
+def check_resolve_root_comment(
+    trajectory: Trajectory, params: dict[str, Any]
+) -> CheckResult:
+    """Thread resolution must reach an observed root, not stop at a reply.
+
+    A resolve PATCH on a reply 400s loudly in real Polarion (server-guarded),
+    so a stray reply attempt alongside a root resolve is tolerated. The
+    silent failure the tool layer cannot catch: resolving ONLY a reply and
+    reporting the thread done, or PATCHing an id never observed via
+    ``list_document_comments``. Root ids come from ``params["root_ids"]``.
+    """
+    root_ids = {str(r) for r in params.get("root_ids", [])}
+    doc_keys = ("project_id", "space_id", "document_name")
+    resolved_root = False
+    resolved_non_root: str | None = None
+    for i, call in enumerate(trajectory):
+        if call.get("name") != "update_document_comment":
+            continue
+        target = _target_key(call, doc_keys)
+        listed = any(
+            earlier.get("name") == "list_document_comments"
+            and _target_key(earlier, doc_keys) == target
+            for earlier in trajectory[:i]
+        )
+        if not listed:
+            return False, (
+                "updated a comment without a prior list_document_comments on "
+                "the same document -- the comment id was guessed, not observed"
+            )
+        comment_id = _short_id(_args(call).get("comment_id", ""))
+        if comment_id in root_ids:
+            resolved_root = True
+        else:
+            resolved_non_root = comment_id
+    if resolved_non_root is not None and not resolved_root:
+        return False, (
+            f"resolved only comment '{resolved_non_root}', which is not a "
+            f"thread root (roots: {sorted(root_ids)}) -- the thread was never "
+            "actually resolved"
+        )
+    return True, "thread resolution reached an observed root comment"
+
+
+def check_preserve_hyperlinks(
+    trajectory: Trajectory, params: dict[str, Any]
+) -> CheckResult:
+    """A ``hyperlinks`` update must carry every pre-existing URI.
+
+    Polarion REPLACES the whole list, so an update omitting an existing URI
+    silently deletes it. ``params``: ``work_item_id`` (target item) and
+    ``required_uris`` (seeded URIs that must survive).
+    """
+    target = _short_id(params.get("work_item_id", ""))
+    required = [str(u) for u in params.get("required_uris", [])]
+    for call in trajectory:
+        if call.get("name") != "update_work_item":
+            continue
+        args = _args(call)
+        if _short_id(args.get("work_item_id", "")) != target:
+            continue
+        hyperlinks = args.get("hyperlinks")
+        if not hyperlinks:
+            continue
+        uris = {str(h.get("uri", "")) for h in hyperlinks if isinstance(h, dict)}
+        missing = [u for u in required if u not in uris]
+        if missing:
+            return False, (
+                f"update_work_item replaced hyperlinks on {target} without "
+                f"pre-existing URI(s) {missing} -- the full list must be passed"
+            )
+    return True, "no hyperlink update dropped a pre-existing URI"
+
+
+_BODY_WRITE_TO_SOURCE: dict[str, tuple[str, str, str, tuple[str, ...]]] = {
+    "update_document": (
+        "home_page_content_html",
+        "get_document",
+        "include_homepage_content_html",
+        ("project_id", "space_id", "document_name"),
+    ),
+    "update_work_item": (
+        "description_html",
+        "get_work_item",
+        "include_description_html",
+        ("project_id", "work_item_id"),
+    ),
+}
+
+
+def check_round_trip_source(
+    trajectory: Trajectory, _params: dict[str, Any]
+) -> CheckResult:
+    """Raw-HTML body writes must source from the flagged ``get_*`` read.
+
+    ``read_document`` / ``read_work_item`` emit synthesis Markdown that
+    collapses Polarion anchors; feeding it back corrupts the body. Only
+    ``get_*(include_*_html=True)`` yields the round-trip shape, so every body
+    write needs one earlier on the same target.
+    """
+    for i, call in enumerate(trajectory):
+        spec = _BODY_WRITE_TO_SOURCE.get(call.get("name", ""))
+        if spec is None:
+            continue
+        body_arg, get_name, flag_arg, id_keys = spec
+        if not _args(call).get(body_arg):
+            continue
+        target = _target_key(call, id_keys)
+        sourced = any(
+            earlier.get("name") == get_name
+            and _target_key(earlier, id_keys) == target
+            and bool(_args(earlier).get(flag_arg))
+            for earlier in trajectory[:i]
+        )
+        if not sourced:
+            return False, (
+                f"{call.get('name')}({target}) wrote {body_arg} without a prior "
+                f"{get_name}({flag_arg}=True) -- body was not round-trip sourced"
+            )
+    return True, "every body write was round-trip sourced"
+
+
+def check_no_blind_detach(
+    trajectory: Trajectory, params: dict[str, Any]
+) -> CheckResult:
+    """``move_work_item_from_document`` must not target a free-floating item.
+
+    The action is not idempotent: detaching an item that is in no document
+    returns HTTP 400. ``params["floating_ids"]`` lists the seeded
+    free-floating items.
+    """
+    floating = {_short_id(x) for x in params.get("floating_ids", [])}
+    for call in trajectory:
+        if call.get("name") != "move_work_item_from_document":
+            continue
+        work_item_id = _short_id(_args(call).get("work_item_id", ""))
+        if work_item_id in floating:
+            return False, (
+                f"called move_work_item_from_document on {work_item_id}, which "
+                "is not in any document -- the action 400s instead of no-opping"
+            )
+    return True, "no detach was issued against a free-floating item"
+
+
+def check_single_bulk_create(
+    trajectory: Trajectory, params: dict[str, Any]
+) -> CheckResult:
+    """Items creatable in one bulk call must not be split across calls.
+
+    Counts committed ``create_work_items`` calls (``dry_run`` previews and
+    guard-rejected calls excluded). ``params["max_calls"]`` defaults to 1.
+    """
+    max_calls = int(params.get("max_calls", 1))
+    committed = [
+        call
+        for call in trajectory
+        if call.get("name") == "create_work_items"
+        and not _args(call).get("dry_run")
+        and not _errored(call)
+    ]
+    if len(committed) > max_calls:
+        return False, (
+            f"split creation into {len(committed)} create_work_items calls "
+            f"(max {max_calls}) -- one bulk call accepts up to 50 items"
+        )
+    return True, "creation used a single bulk call"
+
+
+def check_direct_read(trajectory: Trajectory, params: dict[str, Any]) -> CheckResult:
+    """A known-id lookup must use ``get_*``/``read_*``, not a list scan."""
+    target = _short_id(params.get("work_item_id", ""))
+    if "list_work_items" in _names(trajectory):
+        return False, (
+            f"scanned with list_work_items although the id {target} was known "
+            "-- get_work_item/read_work_item resolves it directly"
+        )
+    direct = any(
+        call.get("name") in ("get_work_item", "read_work_item")
+        and _short_id(_args(call).get("work_item_id", "")) == target
+        for call in trajectory
+    )
+    if not direct:
+        return False, f"never read work item {target} directly"
+    return True, "resolved the known id with a direct read"
+
+
+def check_no_duplicate_reads(
+    trajectory: Trajectory, _params: dict[str, Any]
+) -> CheckResult:
+    """No read may repeat with identical args while nothing changed.
+
+    State reads (item/document/comment fetches) reset on any write -- a
+    re-read after a mutation is legitimate. Stable reads (enum options,
+    SQL recipes, project list) never change under the agent's writes, so an
+    identical repeat is always redundant.
+    """
+    seen_state: set[tuple[str, str]] = set()
+    seen_stable: set[tuple[str, str]] = set()
+    for call in trajectory:
+        name = call.get("name", "")
+        if name in WRITE_TOOLS:
+            seen_state.clear()
+            continue
+        key = (name, json.dumps(_args(call), sort_keys=True, default=str))
+        if name in STABLE_READ_TOOLS:
+            if key in seen_stable:
+                return False, (
+                    f"repeated identical {name} call -- its options never "
+                    "change within a task; reuse the first result"
+                )
+            seen_stable.add(key)
+        elif name in STATE_READ_TOOLS:
+            if key in seen_state:
+                return False, (
+                    f"repeated identical {name} call with no intervening "
+                    "write -- reuse the first result"
+                )
+            seen_state.add(key)
+    return True, "no redundant identical reads"
+
+
+def check_scoped_query_uses_sql(
+    trajectory: Trajectory, _params: dict[str, Any]
+) -> CheckResult:
+    """Module-scoped work item searches must not use a Lucene ``module`` term.
+
+    ``module`` is not Lucene-indexed -- only the ``SQL:(...)`` prefix (or
+    ``read_document_parts``) scopes by document.
+    """
+    for call in trajectory:
+        if call.get("name") != "list_work_items":
+            continue
+        query = str(_args(call).get("query") or "")
+        if "module" in query.lower() and not query.lstrip().lower().startswith("sql:"):
+            return False, (
+                f"list_work_items used Lucene query '{query}' -- module is not "
+                "indexed; use the SQL:(...) prefix or read_document_parts"
+            )
+    return True, "no Lucene module query issued"
+
+
 REGISTRY: dict[str, Callable[[Trajectory, dict[str, Any]], CheckResult]] = {
     "readonly": check_readonly,
     "no_update_document": check_no_update_document,
     "heading_to_doc": check_heading_to_doc,
     "get_before_update": check_get_before_update,
+    "resolve_root_comment": check_resolve_root_comment,
+    "preserve_hyperlinks": check_preserve_hyperlinks,
+    "round_trip_source": check_round_trip_source,
+    "no_blind_detach": check_no_blind_detach,
+    "single_bulk_create": check_single_bulk_create,
+    "direct_read": check_direct_read,
+    "no_duplicate_reads": check_no_duplicate_reads,
+    "scoped_query_uses_sql": check_scoped_query_uses_sql,
 }

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -11,6 +11,7 @@ unit tests).
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -122,8 +123,19 @@ _UPDATE_TO_GET: dict[str, tuple[str, tuple[str, ...]]] = {
 
 
 def _target_key(call: dict[str, Any], keys: tuple[str, ...]) -> tuple[object, ...]:
-    args = call.get("args", {}) or {}
-    return tuple(args.get(k) for k in keys)
+    """Identifier tuple for matching two calls on the same target.
+
+    ``work_item_id`` is normalized via ``_short_id`` so a project-qualified id
+    in one call still matches the short form in another. ``document_name`` is
+    left verbatim — document names may legitimately contain ``/``.
+    """
+    args = _args(call)
+    return tuple(
+        _short_id(args[k])
+        if k == "work_item_id" and args.get(k) is not None
+        else args.get(k)
+        for k in keys
+    )
 
 
 def check_get_before_update(
@@ -168,7 +180,8 @@ def check_resolve_root_comment(
     so a stray reply attempt alongside a root resolve is tolerated. The
     silent failure the tool layer cannot catch: resolving ONLY a reply and
     reporting the thread done, or PATCHing an id never observed via
-    ``list_document_comments``. Root ids come from ``params["root_ids"]``.
+    ``list_document_comments``. Only ``resolved=True`` on a root counts as a
+    resolution. Root ids come from ``params["root_ids"]``.
     """
     root_ids = {str(r) for r in params.get("root_ids", [])}
     doc_keys = ("project_id", "space_id", "document_name")
@@ -188,9 +201,11 @@ def check_resolve_root_comment(
                 "updated a comment without a prior list_document_comments on "
                 "the same document -- the comment id was guessed, not observed"
             )
-        comment_id = _short_id(_args(call).get("comment_id", ""))
+        args = _args(call)
+        comment_id = _short_id(args.get("comment_id", ""))
         if comment_id in root_ids:
-            resolved_root = True
+            if args.get("resolved") is True:
+                resolved_root = True
         else:
             resolved_non_root = comment_id
     if resolved_non_root is not None and not resolved_root:
@@ -385,13 +400,15 @@ def check_scoped_query_uses_sql(
     """Module-scoped work item searches must not use a Lucene ``module`` term.
 
     ``module`` is not Lucene-indexed -- only the ``SQL:(...)`` prefix (or
-    ``read_document_parts``) scopes by document.
+    ``read_document_parts``) scopes by document. Matches ``module`` only as a
+    Lucene field name (``module:`` / ``module.id:``), not as plain text.
     """
+    field_re = re.compile(r"\bmodule(?:\.\w+)?\s*:", re.IGNORECASE)
     for call in trajectory:
         if call.get("name") != "list_work_items":
             continue
         query = str(_args(call).get("query") or "")
-        if "module" in query.lower() and not query.lstrip().lower().startswith("sql:"):
+        if field_re.search(query) and not query.lstrip().lower().startswith("sql:"):
             return False, (
                 f"list_work_items used Lucene query '{query}' -- module is not "
                 "indexed; use the SQL:(...) prefix or read_document_parts"

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -42,6 +42,13 @@ FLOATING_GHOST_ID = "MCPT-202"
 ROOT_COMMENT_ID = "1"
 REPLY_COMMENT_ID = "2"
 
+# Pre-existing hyperlink on the floating task; T1-HYPERLINK-PRESERVE asserts
+# an update keeps it (Polarion REPLACES the whole list).
+FLOATING_TASK_HYPERLINK_URI = "https://specs.example.com/fake-spec"
+
+# Anchored intro paragraph in the doc body; T1-ROUNDTRIP-SOURCE edits it.
+DOC_INTRO_PARAGRAPH_ID = "p-1"
+
 _TS = "2026-01-01T00:00:00.000Z"
 
 
@@ -55,6 +62,7 @@ class _WorkItem:
     severity: str = "should_have"
     module: bool = False
     outline_number: str = ""
+    hyperlinks: list[dict[str, str]] = field(default_factory=list)
     # Keys MUST stay outside ``STANDARD_WORK_ITEM_ATTRIBUTES`` so the merge
     # into the resource attributes dict doesn't shadow real attributes.
     custom_fields: dict[str, str] = field(default_factory=dict)
@@ -69,6 +77,7 @@ _WORK_ITEMS: dict[str, _WorkItem] = {
         FLOATING_TASK_ID,
         "Floating task",
         "task",
+        hyperlinks=[{"role": "ref_ext", "uri": FLOATING_TASK_HYPERLINK_URI}],
         custom_fields={"acceptance_criteria_id": "AC-1"},
     ),
     FLOATING_HEADING_ID: _WorkItem(FLOATING_HEADING_ID, "Floating heading", "heading"),
@@ -119,6 +128,12 @@ _ENUMS: dict[tuple[str, str], list[tuple[str, bool]]] = {
     ],
 }
 
+# Project-level enums (``/enumerations/~/{name}/~``) -- dict-shaped ``data``
+# with ``attributes.options[].id``, unlike getAvailableOptions' list.
+_PROJECT_ENUMS: dict[str, list[str]] = {
+    "hyperlink-role": ["ref_int", "ref_ext"],
+}
+
 
 @dataclass
 class FakePolarion:
@@ -147,7 +162,7 @@ class FakePolarion:
                 "created": _TS,
                 "updated": _TS,
                 "description": {"type": "text/html", "value": ""},
-                "hyperlinks": [],
+                "hyperlinks": list(wi.hyperlinks),
                 **wi.custom_fields,
             },
             "relationships": relationships,
@@ -165,7 +180,10 @@ class FakePolarion:
                 "moduleFolder": SPACE,
                 "homePageContent": {
                     "type": "text/html",
-                    "value": '<h1 id="h-1">Fake Doc</h1>',
+                    "value": (
+                        '<h1 id="h-1">Fake Doc</h1>'
+                        f'<p id="{DOC_INTRO_PARAGRAPH_ID}">Fake intro paragraph.</p>'
+                    ),
                 },
             },
         }
@@ -255,6 +273,23 @@ class FakePolarion:
                 200, json=self._enum_response(enum.group(1), enum.group(2))
             )
 
+        project_enum = re.search(r"/enumerations/~/([^/]+)/~$", path)
+        if project_enum:
+            name = project_enum.group(1)
+            options = _PROJECT_ENUMS.get(name)
+            if options is None:
+                return httpx.Response(404, json={"errors": [{"status": "404"}]})
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "type": "enumerations",
+                        "id": f"~/{name}/~",
+                        "attributes": {"options": [{"id": o} for o in options]},
+                    }
+                },
+            )
+
         single_wi = re.search(r"/workitems/([^/]+)$", path)
         if single_wi and "/fields/" not in path:
             wi = _WORK_ITEMS.get(single_wi.group(1))
@@ -304,14 +339,23 @@ class FakePolarion:
                 body = None
         self.mutations.append({"method": request.method, "path": path, "json": body})
 
-        # Resource-creating POSTs must echo an id (tool layer requires it);
+        # Resource-creating POSTs must echo one id per submitted entry (the
+        # tool layer raises on a count mismatch, so bulk cases need N ids);
         # action POSTs and PATCH / DELETE fall through to 204.
+        submitted = 1
+        if isinstance(body, dict):
+            data = body.get("data")
+            if isinstance(data, list) and data:
+                submitted = len(data)
         if request.method == "POST":
             if path.endswith("/workitems"):
                 return httpx.Response(
                     201,
                     json={
-                        "data": [{"type": "workitems", "id": f"{PROJECT}/MCPT-9001"}]
+                        "data": [
+                            {"type": "workitems", "id": f"{PROJECT}/MCPT-{9001 + i}"}
+                            for i in range(submitted)
+                        ]
                     },
                 )
             if path.endswith("/documents"):
@@ -336,7 +380,11 @@ class FakePolarion:
                     201,
                     json={
                         "data": [
-                            {"type": "linkedworkitems", "id": f"{PROJECT}/MCPT-9001"}
+                            {
+                                "type": "linkedworkitems",
+                                "id": f"{PROJECT}/MCPT-{9001 + i}",
+                            }
+                            for i in range(submitted)
                         ]
                     },
                 )

--- a/evals/harness/model.py
+++ b/evals/harness/model.py
@@ -6,9 +6,10 @@ the ``EVAL_MODEL`` env var, no code change:
     EVAL_MODEL=openai/gpt-4o-mini            # default, CI (needs OPENAI_API_KEY)
     EVAL_MODEL=ollama/qwen2.5-coder:7b       # local (set EVAL_MODEL_BASE_URL)
 
-``temperature`` is pinned to 0.0 to keep the zero-tolerance gate stable.
-``EVAL_NUM_RETRIES`` / ``EVAL_LLM_TIMEOUT`` forward to LiteLLM so transient
-cloud 429/RateLimitError gets absorbed by backoff, not failing the case.
+``temperature`` is pinned to 0.0 and ``parallel_tool_calls`` to False to keep
+the zero-tolerance gate stable. ``EVAL_NUM_RETRIES`` / ``EVAL_LLM_TIMEOUT``
+forward to LiteLLM so transient cloud 429/RateLimitError gets absorbed by
+backoff, not failing the case.
 """
 
 from __future__ import annotations
@@ -44,6 +45,13 @@ def build_model() -> LiteLLMModel:
         model_id=model_id,
         params={
             "temperature": 0.0,
+            # gpt-4o-mini sometimes emits the SAME tool call twice in one
+            # parallel-tool-call block (observed duplicating a successful bulk
+            # create) -- provider nondeterminism no docstring can steer, so it
+            # is pinned off like temperature. drop_params lets backends that
+            # don't know the flag (e.g. Ollama) ignore it instead of erroring.
+            "parallel_tool_calls": False,
+            "drop_params": True,
             "num_retries": max(0, int(os.environ.get("EVAL_NUM_RETRIES", "10"))),
             "timeout": max(1.0, float(os.environ.get("EVAL_LLM_TIMEOUT", "60"))),
         },

--- a/evals/harness/model.py
+++ b/evals/harness/model.py
@@ -45,11 +45,10 @@ def build_model() -> LiteLLMModel:
         model_id=model_id,
         params={
             "temperature": 0.0,
-            # gpt-4o-mini sometimes emits the SAME tool call twice in one
-            # parallel-tool-call block (observed duplicating a successful bulk
-            # create) -- provider nondeterminism no docstring can steer, so it
-            # is pinned off like temperature. drop_params lets backends that
-            # don't know the flag (e.g. Ollama) ignore it instead of erroring.
+            # Some providers emit the same tool call twice in one parallel
+            # block -- nondeterminism no docstring can steer, pinned off like
+            # temperature. drop_params lets backends without the flag
+            # (e.g. Ollama) ignore it.
             "parallel_tool_calls": False,
             "drop_params": True,
             "num_retries": max(0, int(os.environ.get("EVAL_NUM_RETRIES", "10"))),

--- a/evals/run.py
+++ b/evals/run.py
@@ -1,9 +1,10 @@
-"""Tier-1 deploy gate entry point.
+"""Eval deploy gate entry point.
 
-Runs every Tier-1 case N times against the mocked-Polarion harness, applies
-the deterministic ``ForbiddenBehaviorEvaluator``, and exits non-zero if any
-case's pass rate falls below its ``min_pass_rate`` (1.0 for prohibitions).
-Wired into ``publish.yml`` ahead of the PyPI publish jobs.
+Runs every case (Tier-1 prohibitions + Tier-2 efficiency) N times against the
+mocked-Polarion harness, applies the deterministic
+``ForbiddenBehaviorEvaluator``, and exits non-zero if any case's pass rate
+falls below its ``min_pass_rate`` (1.0 for Tier-1, 0.8 for Tier-2). Wired into
+``publish.yml`` ahead of the PyPI publish jobs.
 
     uv run python -m evals.run                 # all cases, EVAL_RUNS (default 10)
     uv run python -m evals.run --case T1-READONLY --runs 1
@@ -28,12 +29,15 @@ from typing import Any
 from strands_evals import Case
 from strands_evals.types.evaluation import EvaluationData
 
-from evals.cases.tier1_prohibitions import CASES
+from evals.cases.tier1_prohibitions import CASES as TIER1_CASES
+from evals.cases.tier2_efficiency import CASES as TIER2_CASES
 from evals.evaluators.tier1 import ForbiddenBehaviorEvaluator
 from evals.harness.model import resolve_model_id
 from evals.harness.runner import AGENT_ERROR_PREFIX, run_case
 
 _REPORT_DIR = Path(__file__).parent / "reports"
+
+ALL_CASES = [*TIER1_CASES, *TIER2_CASES]
 
 
 def _git_sha() -> str:
@@ -97,7 +101,7 @@ def _run_case_n_times(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Tier-1 deploy gate")
+    parser = argparse.ArgumentParser(description="Eval deploy gate")
     parser.add_argument("--case", help="run only this case name (e.g. T1-READONLY)")
     parser.add_argument(
         "--runs",
@@ -107,16 +111,16 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    cases = CASES
+    cases = ALL_CASES
     if args.case:
-        cases = [c for c in CASES if c.name == args.case]
+        cases = [c for c in ALL_CASES if c.name == args.case]
         if not cases:
             print(f"no case named '{args.case}'", file=sys.stderr)
             return 2
 
     evaluator = ForbiddenBehaviorEvaluator()
     model = resolve_model_id()
-    print(f"Tier-1 gate · model={model} · runs={args.runs} · cases={len(cases)}\n")
+    print(f"Eval gate · model={model} · runs={args.runs} · cases={len(cases)}\n")
 
     results = [_run_case_n_times(c, args.runs, evaluator) for c in cases]
     gate_passed = all(r["passed"] for r in results)
@@ -130,10 +134,10 @@ def main() -> int:
     }
     _REPORT_DIR.mkdir(exist_ok=True)
     model_slug = re.sub(r"[^A-Za-z0-9]+", "-", model).strip("-")
-    report_path = _REPORT_DIR / f"tier1-{report['git_sha']}-{model_slug}.json"
+    report_path = _REPORT_DIR / f"gate-{report['git_sha']}-{model_slug}.json"
     report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
 
-    print("\n=== Tier-1 summary ===")
+    print("\n=== Gate summary ===")
     for r in results:
         status = "PASS" if r["passed"] else "FAIL"
         print(

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -113,18 +113,16 @@ def _build_document_comment_update_payload(
 async def list_document_comments(  # noqa: PLR0913
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
-    space_id: str = Field(
-        description="Space ID containing the document (e.g. '_default')."
-    ),
-    document_name: str = Field(description="Document name within the space."),
+    space_id: str = Field(description="Space ID ('_default' = default space)."),
+    document_name: str = Field(description="Document name within ``space_id``."),
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[DocumentComment]:
-    """List comments attached to a Polarion document.
+    """List a document's comments as a flat page.
 
-    Flat page; reconstruct threads via ``parent_comment_id`` (None = top-level)
-    and ``child_comment_ids``. ``text`` is verbatim; HTML is NOT sanitized —
-    treat as untrusted when rendering.
+    Threads reconstruct via ``parent_comment_id`` (``None`` = root) +
+    ``child_comment_ids``. ``text`` is verbatim, unsanitized — treat as
+    untrusted when rendering.
     """
     client = get_client(ctx)
     path = (
@@ -197,7 +195,7 @@ async def create_document_comments(  # noqa: PLR0913
     project_id: str = Field(min_length=1, description="Polarion project ID."),
     space_id: str = Field(
         min_length=1,
-        description="Space ID (use '_default' for the default space).",
+        description="Space ID ('_default' = default space).",
     ),
     document_name: str = Field(
         min_length=1,
@@ -205,20 +203,19 @@ async def create_document_comments(  # noqa: PLR0913
     ),
     comments: list[DocumentCommentSpec] = Field(  # noqa: B008
         min_length=1,
-        description="One or more comments to create in a single request.",
+        description="Comments to create in one request.",
     ),
     dry_run: bool = Field(
         default=False,
-        description="When True, return payload preview without calling Polarion.",
+        description="Preview payload without calling Polarion.",
     ),
 ) -> DocumentCommentsCreateResult:
-    """Create one or more comments on a Polarion document in a single request.
+    """Create one or more comments on a document in a single request.
 
-    All post together (201 with new IDs). Reply by setting
-    ``parent_comment_id`` to a short ID from ``list_document_comments`` (None =
-    top-level). ``text_format`` ``'text/html'`` sent as-is (no sanitization);
-    omit ``author_id`` to use the token's user. NOT idempotent — retry
-    duplicates.
+    Reply: set ``parent_comment_id`` to a short ID from
+    ``list_document_comments`` (``None`` = top-level). ``'text/html'`` text is
+    sent unsanitized; omit ``author_id`` for the token's user. NOT idempotent —
+    a retry duplicates.
     """
     payload = _build_document_comments_payload(
         specs=comments,
@@ -297,7 +294,7 @@ async def update_document_comment(  # noqa: PLR0913
     project_id: str = Field(min_length=1, description="Polarion project ID."),
     space_id: str = Field(
         min_length=1,
-        description="Space ID (use '_default' for the default space).",
+        description="Space ID ('_default' = default space).",
     ),
     document_name: str = Field(
         min_length=1,
@@ -305,22 +302,19 @@ async def update_document_comment(  # noqa: PLR0913
     ),
     comment_id: str = Field(
         min_length=1,
-        description=(
-            "Short comment ID to update (e.g. 'c42' from ``list_document_comments``)."
-        ),
+        description="Short comment ID (e.g. 'c42' from ``list_document_comments``).",
     ),
-    resolved: bool = Field(description="New resolved state for the comment."),
+    resolved: bool = Field(description="New resolved state."),
     dry_run: bool = Field(
         default=False,
-        description="When True, return payload preview without calling Polarion.",
+        description="Preview payload without calling Polarion.",
     ),
 ) -> DocumentCommentUpdateResult:
-    """Resolve or re-open a single document comment.
+    """Resolve or re-open one document comment thread.
 
-    PATCHes ``{"resolved": <bool>}`` (only patchable attr). Root comments only:
-    a reply 400s ("Resolved field can be set only for root comments") →
-    ``RuntimeError``, so filter first. Resolving the root resolves the thread.
-    Idempotent.
+    Root comments only (a reply 400s) — pick a root id
+    (``parent_comment_id=None``) from ``list_document_comments``; resolving
+    the root resolves the whole thread. Idempotent.
     """
     payload = _build_document_comment_update_payload(
         project_id=project_id,

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -618,10 +618,11 @@ async def list_document_enum_options(  # noqa: PLR0913
 ) -> PaginatedResult[EnumOption]:
     """List valid enum option ids for a document field of the given type.
 
-    Call before ``create_document`` / ``update_document`` — Polarion does NOT
-    validate enum values on write (unknown ids persist as ghosts). An unknown
-    ``document_type`` silently falls back to ``~``, so verify the type id
-    first.
+    Resolve enum ids here before ``create_document`` / ``update_document``.
+    Standard fields (``type``/``status``) are validated on write — invalid ids
+    raise with this set. Custom-field enum values are NOT — an unresolved id
+    persists as a ghost. An unknown ``document_type`` silently falls back to
+    ``~``, so verify the type id first.
     """
     client = get_client(ctx)
     path = (
@@ -901,16 +902,17 @@ async def update_document(  # noqa: PLR0913
     - Inline ``<h1>..<h4>`` auto-create heading work items — THE way to add a
       heading. For body text or work items use ``create_work_items`` +
       ``move_work_item_to_document``, NOT this tool.
-    - An anchorless ``<p>``/``<ul>``/``<ol>``/``<table>``/``<div>``/
-      ``<blockquote>``/``<pre>`` block PATCHes 200 but the next
-      ``read_document_parts`` returns HTTP 500 — every such block needs a
-      unique ``id=`` (tool rejects beforehand).
+    - Every anchorless ``<p>``/``<ul>``/``<ol>``/``<table>``/``<div>``/
+      ``<blockquote>``/``<pre>`` block is rejected before PATCH — give each a
+      unique ``id=``. (Unguarded, the PATCH would 200 and the next
+      ``read_document_parts`` would return HTTP 500.)
     - A ``polarion_wiki macro name=module-workitem`` ``<div>`` leaves the work
       item's ``module`` unset — attach via ``move_work_item_to_document``.
 
     ``workflow_action`` must pair with ≥1 attribute (400 otherwise). Unknown
     ``status`` / ``type`` raise ``ValueError``; ``custom_fields`` keys outside
-    the document type's schema are rejected.
+    the document type's schema are rejected, values are NOT validated —
+    resolve enum values via ``list_document_enum_options`` first.
     """
     if home_page_content_html is not None and not home_page_content_html.strip():
         raise ValueError(
@@ -1081,9 +1083,11 @@ async def create_document(  # noqa: PLR0913
     """Create a new Polarion document in a space.
 
     ``module_name`` must be unique in the space (duplicate → HTTP 409) — check
-    ``list_documents`` first. Enum ids (``type``/``status``) must come from
-    ``list_document_enum_options`` — unverified ids persist as ghosts.
-    ``custom_fields`` keys are validated against the document type's schema.
+    ``list_documents`` first. ``type``/``status`` are validated — unknown ids
+    raise ``ValueError`` with valid options. Custom-field enum values are
+    NOT — an unresolved id persists as a ghost; resolve via
+    ``list_document_enum_options`` first. ``custom_fields`` keys are validated
+    against the document type's schema.
 
     ``home_page_content`` is Markdown → sanitized HTML, blocks auto-stamped
     with unique ids. Post-create edits are raw-HTML round-trip via

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -478,11 +478,10 @@ async def list_documents(
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[DocumentSummary]:
-    """List all documents in a Polarion project.
+    """List a project's documents.
 
-    Returns ``space_id`` + ``document_name`` (other document tools accept these)
-    plus the document ``type``. First call per project runs a discovery scan
-    cached 60s.
+    Returns ``space_id`` + ``document_name`` (inputs to the other document
+    tools) plus ``type``. Discovery scan cached 60s.
     """
     client = get_client(ctx)
 
@@ -530,27 +529,23 @@ async def get_document(
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
     space_id: str = Field(
-        description="Space ID containing the document (e.g. '_default').",
+        description="Space ID ('_default' = default space).",
     ),
     document_name: str = Field(
-        description="Document name within the space (spaces handled automatically).",
+        description="Document name within ``space_id``.",
     ),
     include_homepage_content_html: bool = Field(
         default=False,
-        description=(
-            "When True, fill ``content_html`` with raw HTML for round-trip editing."
-        ),
+        description="Fill ``content_html`` with raw HTML for round-trip editing.",
     ),
 ) -> DocumentDetail:
-    """Get a document's metadata (and optionally its raw body source).
+    """Get a document's metadata: title/type/status/custom fields.
 
-    Returns title/type/status/custom fields. With
-    ``include_homepage_content_html=True``, ``content_html`` carries
-    ``homePageContent`` as raw HTML — the round-trip shape for
-    ``update_document``. ``homePageContent`` is inline prose only (headings and
-    embedded work items are separate); use ``read_document`` end-to-end. Feed
-    ``content_html`` back only when the flag was True (False blanks it; ``""``
-    rejected on write).
+    ``include_homepage_content_html=True`` fills ``content_html`` with raw
+    ``homePageContent`` HTML — the required source for
+    ``update_document(home_page_content_html=...)``. That body is inline prose
+    only (headings / embedded work items live elsewhere; ``read_document``
+    renders everything). Never feed back a blanked (flag=False) body.
     """
     client = get_client(ctx)
     path = (
@@ -613,24 +608,20 @@ async def list_document_enum_options(  # noqa: PLR0913
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
     field_id: str = Field(
-        description=("Field id (e.g. 'status', 'type', or a custom field id)."),
+        description="e.g. 'status', 'type', or a custom field id.",
     ),
     document_type: str = Field(
-        description=(
-            "Document type id (e.g. 'systemReqSpecification')."
-            " Pass '~' for type-agnostic options."
-        ),
+        description="e.g. 'systemReqSpecification'; '~' = type-agnostic.",
     ),
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[EnumOption]:
-    """List valid enum options for a document field of the given document type.
+    """List valid enum option ids for a document field of the given type.
 
-    Call before ``update_document`` to resolve a ``status`` / ``type`` /
-    custom-enum value — Polarion does NOT validate on write (unknown ids
-    persist as ghosts). Document fields only. Returns the FULL set;
-    ``document_type='~'`` is type-agnostic, and an unknown type silently falls
-    back to ``~``, so verify the type id first.
+    Call before ``create_document`` / ``update_document`` — Polarion does NOT
+    validate enum values on write (unknown ids persist as ghosts). An unknown
+    ``document_type`` silently falls back to ``~``, so verify the type id
+    first.
     """
     client = get_client(ctx)
     path = (
@@ -691,18 +682,17 @@ async def list_document_enum_options(  # noqa: PLR0913
 async def read_document_parts(  # noqa: PLR0913
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
-    space_id: str = Field(description="Space ID containing the document."),
-    document_name: str = Field(description="Document name within the space."),
+    space_id: str = Field(description="Space ID ('_default' = default space)."),
+    document_name: str = Field(description="Document name within ``space_id``."),
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[DocumentPart]:
-    """List the structural parts of a document in order.
+    """List a document's structural parts in order.
 
-    Use to map a document's structure — part IDs
-    (``move_work_item_to_document``), heading levels, body content; each
-    ``workitem`` part carries its ``description`` as Markdown. For plain
-    reading prefer ``read_document``. To list a document's work items use
-    ``list_work_items`` instead.
+    Use for structure: part IDs (positions for
+    ``move_work_item_to_document``), heading levels, per-part Markdown. Plain
+    reading → ``read_document``; listing a document's work items →
+    ``list_work_items``.
     """
     client = get_client(ctx)
     path = (
@@ -774,18 +764,16 @@ async def read_document_parts(  # noqa: PLR0913
 async def read_document(  # noqa: PLR0913
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
-    space_id: str = Field(description="Space ID containing the document."),
-    document_name: str = Field(description="Document name within the space."),
+    space_id: str = Field(description="Space ID ('_default' = default space)."),
+    document_name: str = Field(description="Document name within ``space_id``."),
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> DocumentReadResult:
-    """Render a Polarion document end-to-end as flowing Markdown.
+    """Render a document end-to-end as flowing Markdown — THE way to read a body.
 
-    Paginates ``read_document_parts`` and interleaves headings, work-item
-    descriptions, and prose into one stream — the canonical way to read a body.
-    Read-only synthesis: do NOT feed back to ``update_document`` (collapses
-    ID anchors, orphans headings); use
-    ``get_document(include_homepage_content_html=True)`` for round-trip. For
+    Interleaves headings, work-item descriptions, and prose. Synthesis output:
+    NEVER feed it to ``update_document`` (anchors collapse, headings orphan) —
+    round-trip via ``get_document(include_homepage_content_html=True)``. For
     metadata-only extraction prefer ``list_work_items`` SQL.
     """
     # read_document_parts handles fetch + error mapping (decorator returns the
@@ -863,7 +851,7 @@ async def update_document(  # noqa: PLR0913
     project_id: str = Field(description="Polarion project ID."),
     space_id: str = Field(
         min_length=1,
-        description="Space ID (use '_default' for the default space).",
+        description="Space ID ('_default' = default space).",
     ),
     document_name: str = Field(
         min_length=1,
@@ -872,9 +860,7 @@ async def update_document(  # noqa: PLR0913
     title: str | None = None,
     status: str | None = Field(
         default=None,
-        description=(
-            "New workflow status; prefer ``workflow_action`` for real transitions."
-        ),
+        description="New status; prefer ``workflow_action`` for real transitions.",
     ),
     type: str | None = Field(
         default=None, description="New document type (e.g. 'req_specification')."
@@ -883,58 +869,48 @@ async def update_document(  # noqa: PLR0913
         default=None,
         max_length=MAX_BODY_HTML_LEN,
         description=(
-            "New body as raw Polarion HTML (round-trip shape from get_document); "
-            "'' is rejected."
+            "New body as raw HTML from "
+            "``get_document(include_homepage_content_html=True)``; '' rejected."
         ),
     ),
     custom_fields: dict[str, object] | None = Field(  # noqa: B008
         default=None,
         description=(
-            "Partial custom-field update; "
-            "rich-text values must be ``{'type':'text/html','value':...}``."
+            "Partial update; rich-text values as ``{'type':'text/html','value':...}``."
         ),
     ),
     workflow_action: str | None = Field(
         default=None,
-        description=(
-            "Workflow action ID; must be paired with at least one attribute field."
-        ),
+        description="Workflow action ID.",
     ),
     dry_run: bool = Field(
         default=False,
-        description=(
-            "When True, return the payload preview without writing; "
-            "enum/custom-field guards still query Polarion, so the document "
-            "must be readable and the validation endpoint reachable."
-        ),
+        description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> DocumentUpdateResult:
     """Update a Polarion document's metadata or body.
 
-    PATCHes only set attributes (omitted preserved); no follow-up GET — call
-    ``get_document`` for refreshed state. ``home_page_content_html`` is the
-    round-trip pair for ``get_document(include_homepage_content_html=True)``,
-    verbatim, no sanitization (NEVER pass untrusted input). Empty string
-    rejected (orphans headings); pass ``'<p></p>'`` for near-empty.
+    PATCHes only the supplied attributes (omitted preserved); no follow-up GET.
+    Fetch via ``get_document`` BEFORE updating. ``home_page_content_html`` is
+    sent verbatim/unsanitized — source it from
+    ``get_document(include_homepage_content_html=True)``; empty string rejected
+    (orphans headings), pass ``'<p></p>'`` for near-empty.
 
-    Body-write rules:
+    Body rules:
 
-    - **Headings auto-create**: inline ``<h1>..<h4>`` become heading work items
-      with ``module`` / ``outline_number`` set; bare ``<hN>Title</hN>`` is safe.
-    - **Anchorless blocks break parts**: ``<h3>X</h3><p>Body</p>`` PATCHes 200
-      but the next ``read_document_parts`` returns HTTP 500. Every anchorless
-      ``<p>``/``<ul>``/``<ol>``/``<table>``/``<div>``/``<blockquote>``/``<pre>``
-      needs a unique ``id=`` (tool raises ``ValueError`` before PATCH, on
-      dry_run too). No auto-stamping here; for body text prefer
-      ``create_work_items`` + ``move_work_item_to_document``.
-    - **No macro references**: a ``polarion_wiki macro name=module-workitem``
-      ``<div>`` makes a part but leaves the work item's ``module`` unset (half
-      attached) — attach via ``move_work_item_to_document``.
+    - Inline ``<h1>..<h4>`` auto-create heading work items — THE way to add a
+      heading. For body text or work items use ``create_work_items`` +
+      ``move_work_item_to_document``, NOT this tool.
+    - An anchorless ``<p>``/``<ul>``/``<ol>``/``<table>``/``<div>``/
+      ``<blockquote>``/``<pre>`` block PATCHes 200 but the next
+      ``read_document_parts`` returns HTTP 500 — every such block needs a
+      unique ``id=`` (tool rejects beforehand).
+    - A ``polarion_wiki macro name=module-workitem`` ``<div>`` leaves the work
+      item's ``module`` unset — attach via ``move_work_item_to_document``.
 
-    Prefer ``workflow_action`` over raw ``status``; it MUST pair with ≥1
-    attribute (empty PATCH 400s). Unknown ``status`` / ``type`` raise
-    ``ValueError``; a ``custom_fields`` key absent from the document type's
-    sampled schema is rejected (a type with no populated customs blocks it).
+    ``workflow_action`` must pair with ≥1 attribute (400 otherwise). Unknown
+    ``status`` / ``type`` raise ``ValueError``; ``custom_fields`` keys outside
+    the document type's schema are rejected.
     """
     if home_page_content_html is not None and not home_page_content_html.strip():
         raise ValueError(
@@ -1064,18 +1040,18 @@ async def create_document(  # noqa: PLR0913
     project_id: str = Field(min_length=1, description="Polarion project ID."),
     space_id: str = Field(
         min_length=1,
-        description="Space ID (use '_default' for the default space).",
+        description="Space ID ('_default' = default space).",
     ),
     module_name: str = Field(
         min_length=1,
         description=(
-            "Polarion document identifier (e.g. 'MySpecV1'); "
-            "must be unique within ``space_id`` and appears in the document URL."
+            "Document identifier (e.g. 'MySpecV1'); unique within ``space_id``, "
+            "appears in the document URL."
         ),
     ),
     title: str = Field(
         min_length=1,
-        description="Human-readable document title (required, non-empty).",
+        description="Human-readable document title.",
     ),
     type: str = Field(
         min_length=1,
@@ -1083,49 +1059,36 @@ async def create_document(  # noqa: PLR0913
     ),
     status: str | None = Field(
         default=None,
-        description=(
-            "Optional initial workflow status (project default applies if omitted)."
-        ),
+        description="Initial workflow status (project default if omitted).",
     ),
     home_page_content: str | None = Field(
         default=None,
         max_length=MAX_BODY_HTML_LEN,
-        description="Optional Markdown body; converted to sanitized HTML on write.",
+        description="Markdown body; converted to sanitized HTML.",
     ),
     custom_fields: dict[str, object] | None = Field(  # noqa: B008
         default=None,
         description=(
-            "Optional custom fields keyed by Polarion field ID; take keys "
-            "from a sibling document via get_document to avoid ghost keys; "
-            "rich-text values must be ``{'type':'text/html','value':...}``."
+            "Keyed by Polarion field ID (copy keys from a sibling document); "
+            "rich-text values as ``{'type':'text/html','value':...}``."
         ),
     ),
     dry_run: bool = Field(
         default=False,
-        description=(
-            "When True, return the payload preview without writing; the enum "
-            "guard still calls Polarion's getAvailableOptions, so that "
-            "endpoint must be reachable."
-        ),
+        description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> DocumentCreateResult:
     """Create a new Polarion document in a space.
 
-    First call ``list_documents`` and confirm ``module_name`` is unique in the
-    space (a duplicate returns HTTP 409). Supply only enum ids from
+    ``module_name`` must be unique in the space (duplicate → HTTP 409) — check
+    ``list_documents`` first. Enum ids (``type``/``status``) must come from
     ``list_document_enum_options`` — unverified ids persist as ghosts.
-    ``custom_fields`` keys are validated against the document type's existing
-    schema; a key no document of that ``type`` uses is rejected.
+    ``custom_fields`` keys are validated against the document type's schema.
 
-    Starts empty (or with optional ``home_page_content``); add parts later via
-    ``update_document`` / ``move_work_item_to_document``. ``module_name`` is the
-    persistent URL identifier.
-
-    ``home_page_content`` is Markdown → sanitized HTML; post-create round-trip is
-    raw HTML via ``get_document(include_homepage_content_html=True)`` ↔
-    ``update_document``. Each block element is stamped a unique
-    ``id="polarion_mcp_N"`` (else the next ``read_document_parts`` 500s);
-    ``<h1>..<h4>`` are skipped (rewritten to macro form on save).
+    ``home_page_content`` is Markdown → sanitized HTML, blocks auto-stamped
+    with unique ids. Post-create edits are raw-HTML round-trip via
+    ``get_document(include_homepage_content_html=True)`` ↔ ``update_document``;
+    add work items via ``move_work_item_to_document``.
     """
     client = get_client(ctx)
     await guard_document_enums(

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -426,8 +426,8 @@ async def create_work_item_links(
 ) -> WorkItemLinksCreateResult:
     """Create 1-50 outgoing links from one source work item, atomically.
 
-    Role and target existence are validated before POST (Polarion itself
-    stores ghost roles / dangling targets silently). Per spec:
+    Role and target existence are validated before POST — invalid ones raise
+    ``ValueError``. Per spec:
     ``target_project_id`` defaults to source, ``revision`` pins (else HEAD),
     ``suspect`` flags re-review. A 4xx (e.g. duplicate role+target → 409)
     rolls back the whole batch — re-query ``list_work_item_links`` before

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -366,17 +366,16 @@ async def _get_back_link_page(
 async def list_work_item_links(  # noqa: PLR0913
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
-    work_item_id: str = Field(description="Work Item ID (e.g. 'MCPT-001')."),
+    work_item_id: str = Field(description="Work item ID (e.g. 'MCPT-001')."),
     direction: Literal["forward", "back"] = "forward",
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[WorkItemLink]:
-    """List a work item's outgoing or incoming links.
+    """List a work item's links, one direction per call.
 
-    One direction per call. Forward exposes ``role`` (``parent``, ``verifies``,
-    …) and ``suspect``. Back falls back to a ``linkedWorkItems:`` Lucene query
-    that drops the role, so back ``role`` is ``None`` — recover via forward on
-    the source.
+    Forward carries ``role`` (``parent``, ``verifies``, …) and ``suspect``;
+    back is a Lucene fallback that drops ``role`` (always ``None``) — recover
+    it via forward on the source.
     """
     client = get_client(ctx)
 
@@ -413,33 +412,31 @@ async def create_work_item_links(
     project_id: str = Field(min_length=1, description="Source work item's project ID."),
     work_item_id: str = Field(
         min_length=1,
-        description="Source work item ID (the links' outgoing endpoint).",
+        description="Source work item ID.",
     ),
     links: list[WorkItemLinkSpec] = Field(  # noqa: B008
         min_length=1,
         max_length=MAX_BULK_ITEMS,
-        description="One or more links to create under the source work item (1-50).",
+        description="Links to create under the source work item (1-50).",
     ),
     dry_run: bool = Field(
         default=False,
-        description="When True, return payload preview without calling Polarion.",
+        description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> WorkItemLinksCreateResult:
-    """Create one or more outgoing links (1-50) from a single source work item.
+    """Create 1-50 outgoing links from one source work item, atomically.
 
-    All share the source and post atomically. Per spec ``target_project_id``
-    defaults to source; ``revision`` pins (else HEAD); ``suspect`` marks
-    re-review. Guards both role (``workitem-link-role``) and target existence
-    before POST (on dry_run too) — unguarded they store as ghost/dangling links.
+    Role and target existence are validated before POST (Polarion itself
+    stores ghost roles / dangling targets silently). Per spec:
+    ``target_project_id`` defaults to source, ``revision`` pins (else HEAD),
+    ``suspect`` flags re-review. A 4xx (e.g. duplicate role+target → 409)
+    rolls back the whole batch — re-query ``list_work_item_links`` before
+    retrying. ``link_ids`` are the delete-path ids, input order.
 
-    ``link_ids`` are 5-segment composites in input order (delete path ids). POST
-    is atomic: a 4xx (e.g. duplicate (role,target) → 409) rolls back the batch —
-    re-query before retry. Raises on an id-count mismatch.
-
-    Phantom-success footgun: when the source is in a document,
-    ``move_work_item_to_document`` already auto-created one link. A NEW same-role
-    link returns 201 but is NOT persisted. Verify forward (source) + back
-    (target); if missing, detach → create → re-attach.
+    Phantom success: when the source sits in a document,
+    ``move_work_item_to_document`` already auto-created one heading link; a
+    NEW same-role link 201s but is NOT persisted — verify with
+    ``list_work_item_links``.
     """
     payload = _build_create_links_payload(
         source_project_id=project_id,
@@ -509,28 +506,26 @@ async def delete_work_item_links(
     project_id: str = Field(min_length=1, description="Source work item's project ID."),
     work_item_id: str = Field(
         min_length=1,
-        description="Source work item ID (the links' outgoing endpoint).",
+        description="Source work item ID.",
     ),
     links: list[WorkItemLinkRef] = Field(  # noqa: B008
         min_length=1,
         max_length=MAX_BULK_ITEMS,
-        description="One or more existing outgoing links to delete (1-50).",
+        description="Existing outgoing links to delete (1-50).",
     ),
     dry_run: bool = Field(
         default=False,
-        description="When True, return payload preview without calling Polarion.",
+        description=(
+            "Preview payload without deleting; the pre-read still queries Polarion."
+        ),
     ),
 ) -> WorkItemLinksDeleteResult:
-    """Delete one or more outgoing links (1-50) from a single source work item.
+    """Delete 1-50 outgoing links from one source work item.
 
-    Mirrors ``create_work_item_links``. Only **outgoing** links removed (delete a
-    back link on the other work item). Identify refs from a prior create or from
-    ``list_work_item_links(direction="forward")``.
-
-    Polarion's delete is idempotent and silent (204 even for stale refs). To make
-    no-ops visible the tool pre-reads existing links and splits into
-    ``deleted_link_ids`` / ``not_found_link_ids`` (no-op reported, never raised).
-    Pre-read is fail-closed (``RuntimeError`` before any delete).
+    Outgoing only — delete a back link from its source item. Refs come from
+    ``list_work_item_links(direction="forward")`` or a prior create. Stale
+    refs never raise: a pre-read splits results into ``deleted_link_ids`` /
+    ``not_found_link_ids``.
     """
     link_ids, payload = _build_delete_links_payload(
         source_project_id=project_id,
@@ -599,36 +594,36 @@ async def update_work_item_link(  # noqa: PLR0913
     project_id: str = Field(min_length=1, description="Source work item's project ID."),
     work_item_id: str = Field(
         min_length=1,
-        description="Source work item ID (the link's outgoing endpoint).",
+        description="Source work item ID.",
     ),
-    role: str = Field(min_length=1, description="Link role id of the existing link."),
+    role: str = Field(min_length=1, description="Role id of the existing link."),
     target_work_item_id: str = Field(
         min_length=1,
-        description="Target work item ID (the link's incoming endpoint).",
+        description="Target work item ID.",
     ),
     target_project_id: str | None = Field(
         default=None,
-        description="Target's project; defaults to the source's project.",
+        description="Defaults to the source's project.",
     ),
     suspect: bool | None = Field(
         default=None,
-        description="New suspect flag value; None leaves it unchanged.",
+        description="New suspect flag; ``None`` = unchanged.",
     ),
     revision: str | None = Field(
         default=None,
-        description="New revision pin; None leaves the existing pin unchanged.",
+        description="New revision pin; ``None`` = unchanged.",
     ),
     dry_run: bool = Field(
         default=False,
-        description="When True, return payload preview without calling Polarion.",
+        description="Preview payload without calling Polarion.",
     ),
 ) -> WorkItemLinkUpdateResult:
-    """Update ``suspect`` / ``revision`` on one existing outgoing work item link.
+    """Set ``suspect`` and/or ``revision`` on one existing outgoing link.
 
-    Identify the link via ``list_work_item_links(direction="forward")`` (role +
-    target address one link). ``suspect`` / ``revision`` tri-state: a value
-    updates, ``None`` leaves unchanged — at least one required (all-``None``
-    400s). One link per call (no bulk PATCH). A ``role`` typo 404s.
+    Identify the link via ``list_work_item_links(direction="forward")``
+    (role + target address one link). ``None`` = unchanged; at least one of
+    ``suspect`` / ``revision`` required. One link per call. A ``role`` typo
+    404s.
     """
     if suspect is None and revision is None:
         raise ValueError(

--- a/src/mcp_server_polarion/tools/moves.py
+++ b/src/mcp_server_polarion/tools/moves.py
@@ -69,14 +69,14 @@ def _build_move_to_document_payload(
 )
 async def move_work_item_to_document(  # noqa: PLR0913
     ctx: Context,
-    project_id: str = Field(description="Project containing the work item."),
+    project_id: str = Field(description="Polarion project ID."),
     work_item_id: str = Field(
         min_length=1,
-        description="Short ID of an EXISTING work item (e.g. 'MCPT-042').",
+        description="Work item ID (e.g. 'MCPT-042').",
     ),
     target_space_id: str = Field(
         min_length=1,
-        description="Target space ID (use '_default' for the default space).",
+        description="Target space ID ('_default' for the default space).",
     ),
     target_document_name: str = Field(
         min_length=1,
@@ -84,36 +84,28 @@ async def move_work_item_to_document(  # noqa: PLR0913
     ),
     previous_part_id: str | None = Field(
         default=None,
-        description=(
-            "Insert AFTER this part ID; mutually exclusive with ``next_part_id``. "
-            "Omit both to append at the end of the target document."
-        ),
+        description="Insert AFTER this part ID; exclusive with ``next_part_id``.",
     ),
     next_part_id: str | None = Field(
         default=None,
-        description=(
-            "Insert BEFORE this part ID; mutually exclusive with ``previous_part_id``. "
-            "Omit both to append at the end of the target document."
-        ),
+        description="Insert BEFORE this part ID; exclusive with ``previous_part_id``.",
     ),
     dry_run: bool = Field(
         default=False,
-        description="When True, return payload preview without calling Polarion.",
+        description="Preview payload without calling Polarion.",
     ),
 ) -> WorkItemMoveResult:
-    """Move a work item into a Polarion document at a specific position.
+    """Move an existing work item into a document at a given position.
 
-    ``moveToDocument`` atomically sets ``module`` + ``outline_number`` and
-    inserts a part — the ONLY supported attach path (macro-injection leaves
-    ``module`` unset). Headings rejected (HTTP 400). Already-in-a-document
-    items are moved, not copied; detach via ``move_work_item_from_document``.
+    THE attach path: atomically sets ``module`` and inserts a part. Headings
+    rejected (HTTP 400) — add headings via ``update_document`` ``<hN>``. An
+    item already in a document is moved, not copied.
 
-    AT MOST one of ``previous_part_id`` (AFTER) / ``next_part_id`` (BEFORE);
-    omit both to append. Discover part IDs via ``read_document_parts``.
+    At most one of ``previous_part_id`` (AFTER) / ``next_part_id`` (BEFORE);
+    omit both to append. Part IDs from ``read_document_parts``.
 
-    Side effect: auto-creates one outgoing link to the enclosing heading
-    (project-config role); collides with a same-role ``create_work_item_links``
-    (phantom success). Removed on detach.
+    Auto-creates one link to the enclosing heading; a later same-role
+    ``create_work_item_links`` returns 201 but is NOT persisted.
     """
     if previous_part_id is not None and next_part_id is not None:
         raise ValueError(
@@ -182,25 +174,22 @@ async def move_work_item_to_document(  # noqa: PLR0913
 )
 async def move_work_item_from_document(
     ctx: Context,
-    project_id: str = Field(description="Project containing the work item."),
+    project_id: str = Field(description="Polarion project ID."),
     work_item_id: str = Field(
         min_length=1,
-        description="Short ID of an EXISTING work item (e.g. 'MCPT-042').",
+        description="Work item ID (e.g. 'MCPT-042').",
     ),
     dry_run: bool = Field(
         default=False,
-        description="When True, return payload preview without calling Polarion.",
+        description="Preview payload without calling Polarion.",
     ),
 ) -> WorkItemMoveResult:
-    """Detach a work item from its document, returning it to free-floating state.
+    """Detach a work item from its document — the ONLY detach path.
 
-    Inverse of ``move_work_item_to_document``. ``moveFromDocument`` clears
-    ``module`` and removes the part — the ONLY detach path (PATCH on ``module``
-    rejected). The work item is preserved and re-attachable.
-
-    NOT idempotent: on an already free-floating item returns HTTP 400
-    (``RuntimeError``). Headings CAN be detached (become free-floating with
-    ``space_id=""`` / ``outline_number=""``).
+    NOT idempotent: an already free-floating item returns HTTP 400 — first
+    confirm it is in a document (``get_work_item``: non-empty ``space_id``)
+    and skip the call when already detached. Item preserved, re-attachable
+    via ``move_work_item_to_document``. Headings detachable too.
     """
     if dry_run:
         return WorkItemMoveResult(

--- a/src/mcp_server_polarion/tools/moves.py
+++ b/src/mcp_server_polarion/tools/moves.py
@@ -76,7 +76,7 @@ async def move_work_item_to_document(  # noqa: PLR0913
     ),
     target_space_id: str = Field(
         min_length=1,
-        description="Target space ID ('_default' for the default space).",
+        description="Target space ID ('_default' = default space).",
     ),
     target_document_name: str = Field(
         min_length=1,

--- a/src/mcp_server_polarion/tools/projects.py
+++ b/src/mcp_server_polarion/tools/projects.py
@@ -43,10 +43,10 @@ async def list_projects(
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[ProjectSummary]:
-    """List Polarion projects the authenticated user can access.
+    """List accessible Polarion projects — the source of project IDs.
 
-    Discover project IDs for other tools. Lucene allows trailing wildcards
-    (``name:ILCU*``) but rejects leading ones (``*foo*``, HTTP 400).
+    Lucene ``query`` allows trailing wildcards (``name:ILCU*``); leading ones
+    400.
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -237,36 +237,23 @@ async def create_work_items(
     items: list[WorkItemCreateSpec] = Field(  # noqa: B008
         min_length=1,
         max_length=MAX_BULK_ITEMS,
-        description=(
-            "One or more work items to create in a single request "
-            "(1-50). Pass a single-element list to create just one."
-        ),
+        description="Work items to create in one request (1-50).",
     ),
     dry_run: bool = Field(
         default=False,
-        description=(
-            "When True, return the payload preview without writing; the enum "
-            "guard still calls Polarion's getAvailableOptions, so that "
-            "endpoint must be reachable."
-        ),
+        description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> WorkItemsCreateResult:
-    """Create one or more Polarion work items (1-50) in one request, same project.
+    """Create 1-50 work items in one project in a single bulk request.
 
-    Confirm every enum value (``type`` / ``status`` / ``severity`` / custom
-    enums) via ``list_work_item_enum_options`` first — unverified ids persist as
-    ghosts that never match Lucene. ``custom_fields`` keys are validated against
-    the type's existing schema; a key no item of that ``type`` uses is rejected,
-    and a type with no populated customs blocks the write (nothing to validate
-    against). ``hyperlinks[].role`` validated against ``hyperlink-role``.
+    Enum values (``type`` / ``status`` / ``severity`` / custom enums) must come
+    from ``list_work_item_enum_options`` — unverified ids persist as ghosts
+    invisible to Lucene. ``custom_fields`` keys are validated against the
+    type's schema. Atomic: one bad item rejects the whole batch.
 
-    Atomic: guards + conversion + build run before the POST; one bad item rejects
-    the whole batch (nothing created). Raises if the returned id count differs
-    from submitted — re-query ``list_work_items`` first.
-
-    Items are free-floating; place in a document via ``move_work_item_to_document``
-    (direct ``module`` create lands in the recycle bin). ``description`` is
-    Markdown → sanitized HTML; the post-create round-trip is raw HTML via
+    Items are created free-floating; place into a document with
+    ``move_work_item_to_document`` (this tool cannot). ``description`` is
+    Markdown → sanitized HTML; later edits are raw-HTML round-trip via
     ``get_work_item(include_description_html=True)`` ↔ ``update_work_item``.
     """
     client = get_client(ctx)
@@ -355,38 +342,34 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
     project_id: str = Field(min_length=1, description="Polarion project ID."),
     work_item_id: str = Field(
         min_length=1,
-        description="Short ID of an EXISTING work item (e.g. 'MCPT-042').",
+        description="Work item ID (e.g. 'MCPT-042').",
     ),
     title: str | None = None,
     description_html: str | None = Field(
         default=None,
         max_length=MAX_BODY_HTML_LEN,
-        description="New raw Polarion HTML body (round-trip shape from get_work_item).",
+        description=(
+            "Raw HTML from ``get_work_item(include_description_html=True)``; "
+            "sent verbatim, unsanitized."
+        ),
     ),
     status: str | None = Field(
         default=None,
-        description=(
-            "New workflow status; prefer ``workflow_action`` for real transitions."
-        ),
+        description="New status; prefer ``workflow_action`` for real transitions.",
     ),
     priority: str | None = Field(
         default=None,
-        description="New priority string (e.g. '50.0').",
+        description="e.g. '50.0'.",
     ),
     severity: str | None = None,
-    due_date: str | None = Field(
-        default=None, description="New due date 'YYYY-MM-DD'."
-    ),
+    due_date: str | None = Field(default=None, description="'YYYY-MM-DD'."),
     initial_estimate: str | None = Field(
         default=None,
-        description="New Polarion duration (e.g. '5 1/2d', '1w 2d').",
+        description="Polarion duration (e.g. '5 1/2d', '1w 2d').",
     ),
     resolution: str | None = Field(
         default=None,
-        description=(
-            "New resolution outcome; "
-            "prefer ``workflow_action`` so workflow rules apply."
-        ),
+        description="Prefer ``workflow_action`` so workflow rules apply.",
     ),
     hyperlinks: list[Hyperlink] | None = Field(  # noqa: B008
         default=None,
@@ -399,62 +382,44 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
     custom_fields: dict[str, object] | None = Field(  # noqa: B008
         default=None,
         description=(
-            "Partial custom-field update; "
-            "rich-text values must be ``{'type':'text/html','value':...}``."
+            "Partial update; rich-text values as ``{'type':'text/html','value':...}``."
         ),
     ),
     workflow_action: str | None = Field(
         default=None,
-        description=(
-            "Workflow action ID (e.g. 'close'); "
-            "must be paired with at least one body field."
-        ),
+        description="Workflow action ID (e.g. 'close').",
     ),
     change_type_to: str | None = Field(
         default=None,
-        description=(
-            "Change work-item type; RESETS status; "
-            "must be paired with at least one body field."
-        ),
+        description="New work-item type; RESETS status.",
     ),
     include_current_description_html: bool = Field(
         default=False,
-        description=(
-            "When True, return the post-PATCH raw HTML body in "
-            "``current.description_html``."
-        ),
+        description="Return post-PATCH raw HTML in ``current.description_html``.",
     ),
     dry_run: bool = Field(
         default=False,
-        description=(
-            "When True, return the payload preview without writing; "
-            "enum/custom-field guards still query Polarion, so the work item "
-            "must be readable and the validation endpoint reachable."
-        ),
+        description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> WorkItemUpdateResult:
-    """Update an existing Polarion work item.
+    """Update fields on an existing work item; ``None``/empty = leave unchanged.
 
-    PATCHes supplied fields, then GETs so ``current`` reflects the change.
-    ``None`` / empty all mean leave unchanged — no clear path.
+    Fetch current state with ``get_work_item`` BEFORE updating. PATCHes then
+    GETs (``current`` reflects the result).
 
-    ``description_html`` is RAW Polarion HTML, verbatim, no sanitization (NEVER
-    pass untrusted input); round-trip with
-    ``get_work_item(include_description_html=True)``. Greenfield: use
-    ``create_work_items`` Markdown — paths never mix.
+    ``description_html`` is raw Polarion HTML, sent verbatim/unsanitized —
+    source it from ``get_work_item(include_description_html=True)``. Greenfield
+    bodies go through ``create_work_items`` Markdown; formats never mix.
 
-    ``hyperlinks`` / ``assignee_ids`` REPLACE (full list, not delta); each
-    hyperlink ``role`` validated against ``hyperlink-role`` (before PATCH, on
-    dry_run too). ``custom_fields`` partial; a key absent from the type's
-    sampled schema is rejected (a type with no populated customs blocks it).
+    ``hyperlinks`` / ``assignee_ids`` REPLACE the stored list: resubmit every
+    existing entry plus the change, or omissions are silently deleted.
+    ``custom_fields`` is partial; keys outside the type's schema are rejected.
 
-    ``module`` NOT exposed — use ``move_work_item_to_document`` /
-    ``move_work_item_from_document``. Prefer ``workflow_action`` over raw
-    ``status``; ``workflow_action`` / ``change_type_to`` MUST pair with ≥1 body
-    field (empty PATCH 400s). Unknown ``status`` / ``severity`` / ``resolution``
-    / ``priority`` / ``change_type_to`` raise ``ValueError`` listing valid
-    options; with ``change_type_to`` set, status/severity/resolution scope to
-    the target type.
+    ``module`` not settable here — use ``move_work_item_to_document`` /
+    ``move_work_item_from_document``. ``workflow_action`` / ``change_type_to``
+    must pair with ≥1 body field (400 otherwise). Unknown enum ids raise
+    ``ValueError`` listing valid options; with ``change_type_to``,
+    status/severity/resolution scope to the target type.
     """
     changes: dict[str, JsonValue] = {}
     if title:
@@ -656,27 +621,21 @@ async def list_work_item_enum_options(  # noqa: PLR0913
     project_id: str = Field(description="Polarion project ID."),
     field_id: str = Field(
         description=(
-            "Field id (e.g. 'status', 'type', 'severity', 'priority',"
-            " or a custom field id)."
+            "e.g. 'status', 'type', 'severity', 'priority', or a custom field id."
         ),
     ),
     work_item_type: str = Field(
-        description=(
-            "Work item type id (e.g. 'task', 'requirement')."
-            " Pass '~' for type-agnostic options."
-        ),
+        description="e.g. 'task', 'requirement'; '~' = type-agnostic.",
     ),
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[EnumOption]:
-    """List valid enum options for a work item field of the given type.
+    """List valid enum option ids for a work item field of the given type.
 
-    Call before ``create_work_items`` / ``update_work_item`` to resolve a
-    ``type`` / ``status`` / ``severity`` / ``priority`` / custom-enum value —
-    Polarion does NOT validate on write (unknown ids persist as ghosts).
-    Work-item fields only. Returns the FULL set; ``work_item_type='~'`` is
-    type-agnostic, and an unknown type silently falls back to ``~``, so verify
-    the type id first.
+    Call before ``create_work_items`` / ``update_work_item`` — Polarion does
+    NOT validate enum values on write (unknown ids persist as ghosts). An
+    unknown ``work_item_type`` silently falls back to ``~``, so verify the
+    type id first.
     """
     client = get_client(ctx)
     path = (
@@ -736,10 +695,9 @@ async def list_work_item_enum_options(  # noqa: PLR0913
 async def get_sql_query_recipes() -> SqlRecipeGallery:
     """Fetch copy-paste SQL recipes for the ``list_work_items`` ``SQL:(...)`` prefix.
 
-    Call this before writing a module-scoped, custom-field, or traceability
-    SQL query, then adapt a recipe instead of hand-writing joins from memory.
-    Returns the table schema plus parameterised recipes as one Markdown
-    document; loaded on demand so it never occupies always-on context.
+    Call before writing any SQL query (document scope, custom-field,
+    traceability) and adapt a recipe instead of hand-writing joins; includes
+    the table schema.
     """
     return SqlRecipeGallery(recipes=_SQL_QUERY_RECIPES)
 
@@ -762,18 +720,17 @@ async def list_work_items(
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[WorkItemSummary]:
-    """List and search work items in a Polarion project.
+    """List / search work items in a project.
 
-    Lucene ``query`` (`type:requirement`, `title:SRS*`) or omit for all. Leading
-    wildcards 400. ``module`` and body text are NOT indexed — use the SQL prefix
-    for module scope, ``read_document_parts`` for body.
+    Lucene ``query`` (`type:requirement`, `title:SRS*`; leading wildcards 400)
+    or omit for all. ``module`` and body text are NOT Lucene-indexed — scope by
+    document via ``SQL:(...)`` or ``read_document_parts``, never a Lucene
+    ``module`` term.
 
-    **SQL prefix.** A ``query`` starting with ``SQL:(`` runs native SQL for
-    patterns Lucene can't express. Escape ``'`` as ``''`` (no bind params).
-    ``C_DESCRIPTION LIKE`` does NOT match; ``LIKE`` is rejected inside
-    ``EXISTS`` — keep it top-level via ``INNER JOIN``. Before writing any SQL
-    call ``get_sql_query_recipes`` and adapt a recipe — it holds the common
-    patterns (document scope, custom-field, traceability); do not hand-write.
+    ``SQL:(...)`` runs native SQL. Call ``get_sql_query_recipes`` first and
+    adapt a recipe (document scope, custom-field, traceability); do not
+    hand-write. Escape ``'`` as ``''``; keep ``LIKE`` top-level via ``INNER
+    JOIN`` (rejected inside ``EXISTS``; ``C_DESCRIPTION LIKE`` never matches).
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {
@@ -831,19 +788,17 @@ async def list_work_items(
 async def get_work_item(
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
-    work_item_id: str = Field(description="Work Item ID (e.g. 'MCPT-001')."),
+    work_item_id: str = Field(description="Work item ID (e.g. 'MCPT-001')."),
     include_description_html: bool = Field(
         default=False,
-        description=(
-            "When True, fill ``description_html`` with raw HTML for round-trip editing."
-        ),
+        description="Fill ``description_html`` with raw HTML for round-trip editing.",
     ),
 ) -> WorkItemDetail:
-    """Get full details of a single Polarion work item.
+    """Get full details of one work item by ID.
 
-    With ``include_description_html=True``, ``description_html`` carries the raw
-    Polarion HTML body — the round-trip shape for ``update_work_item``. Only
-    feed it back when the flag was True (False blanks it; ``""`` = unchanged).
+    ``include_description_html=True`` fills ``description_html`` with raw
+    HTML — the required source for ``update_work_item(description_html=...)``.
+    Never feed back a blanked (flag=False) body.
     """
     client = get_client(ctx)
     path = (
@@ -896,13 +851,13 @@ async def get_work_item(
 async def read_work_item(
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
-    work_item_id: str = Field(description="Work Item ID (e.g. 'MCPT-001')."),
+    work_item_id: str = Field(description="Work item ID (e.g. 'MCPT-001')."),
 ) -> WorkItemRead:
-    """Read a Polarion work item with its body rendered as Markdown.
+    """Read one work item with its body rendered as Markdown.
 
-    Synthesis variant of ``get_work_item``: same metadata plus ``description``
-    as Markdown. Read-only (collapses Polarion spans/anchors) — do NOT feed
-    back to ``update_work_item``; round-trip via the HTML pair instead.
+    ``get_work_item`` plus ``description`` as Markdown. Synthesis output
+    (collapses Polarion anchors) — NEVER feed it to ``update_work_item``;
+    round-trip via the HTML pair instead.
     """
     # Pull raw HTML from get_work_item so conversion needs no second round trip.
     detail = await get_work_item(

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -249,7 +249,8 @@ async def create_work_items(
     Enum values (``type`` / ``status`` / ``severity`` / custom enums) must come
     from ``list_work_item_enum_options`` — unverified ids persist as ghosts
     invisible to Lucene. ``custom_fields`` keys are validated against the
-    type's schema. Atomic: one bad item rejects the whole batch.
+    type's schema. Atomic: one bad item rejects the whole batch; an id-count
+    mismatch raises — re-query ``list_work_items`` before retrying.
 
     Items are created free-floating; place into a document with
     ``move_work_item_to_document`` (this tool cannot). ``description`` is

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -246,11 +246,13 @@ async def create_work_items(
 ) -> WorkItemsCreateResult:
     """Create 1-50 work items in one project in a single bulk request.
 
-    Enum values (``type`` / ``status`` / ``severity`` / custom enums) must come
-    from ``list_work_item_enum_options`` — unverified ids persist as ghosts
-    invisible to Lucene. ``custom_fields`` keys are validated against the
-    type's schema. Atomic: one bad item rejects the whole batch; an id-count
-    mismatch raises — re-query ``list_work_items`` before retrying.
+    Standard enums (``type``/``status``/``severity``/``priority``) are
+    validated — unknown ids raise ``ValueError`` with valid options.
+    Custom-field enum values are NOT — an unresolved id persists as a ghost
+    invisible to Lucene; resolve via ``list_work_item_enum_options`` first.
+    ``custom_fields`` keys are validated against the type's schema. Atomic:
+    one bad item rejects the whole batch; an id-count mismatch raises —
+    re-query ``list_work_items`` before retrying.
 
     Items are created free-floating; place into a document with
     ``move_work_item_to_document`` (this tool cannot). ``description`` is
@@ -414,7 +416,9 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
 
     ``hyperlinks`` / ``assignee_ids`` REPLACE the stored list: resubmit every
     existing entry plus the change, or omissions are silently deleted.
-    ``custom_fields`` is partial; keys outside the type's schema are rejected.
+    ``custom_fields`` is partial; keys outside the type's schema are rejected,
+    values are NOT validated — resolve enum values via
+    ``list_work_item_enum_options`` first.
 
     ``module`` not settable here — use ``move_work_item_to_document`` /
     ``move_work_item_from_document``. ``workflow_action`` / ``change_type_to``
@@ -633,9 +637,10 @@ async def list_work_item_enum_options(  # noqa: PLR0913
 ) -> PaginatedResult[EnumOption]:
     """List valid enum option ids for a work item field of the given type.
 
-    Call before ``create_work_items`` / ``update_work_item`` — Polarion does
-    NOT validate enum values on write (unknown ids persist as ghosts). An
-    unknown ``work_item_type`` silently falls back to ``~``, so verify the
+    Resolve enum ids here before ``create_work_items`` / ``update_work_item``.
+    Standard fields are validated on write — invalid ids raise with this set.
+    Custom-field enum values are NOT — an unresolved id persists as a ghost.
+    An unknown ``work_item_type`` silently falls back to ``~``, so verify the
     type id first.
     """
     client = get_client(ctx)

--- a/tests/evals/cases/test_tier2_efficiency.py
+++ b/tests/evals/cases/test_tier2_efficiency.py
@@ -1,0 +1,47 @@
+"""Unit tests for the Tier-2 case definitions.
+
+Mirrors the Tier-1 invariants at the efficiency threshold: every case must
+name a registered check, carry ``min_pass_rate == 0.8``, and keep its name
+unique across BOTH tiers (``run.py --case`` selects by name from the
+concatenated list).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The CASES list pulls in ``strands_evals.Case``, only present when the optional
+# ``evals`` dependency group is installed; skip on the bare dev install.
+pytest.importorskip("strands_evals")
+
+from evals.cases.tier1_prohibitions import CASES as TIER1_CASES
+from evals.cases.tier2_efficiency import CASES, _case
+from evals.evaluators import checks
+
+
+class TestCases:
+    def test_every_case_check_is_registered(self) -> None:
+        registry_keys = set(checks.REGISTRY)
+        for case in CASES:
+            metadata = case.metadata or {}
+            assert metadata["check"] in registry_keys, (
+                f"case '{case.name}' references missing check '{metadata['check']}'"
+            )
+
+    def test_every_case_uses_efficiency_threshold(self) -> None:
+        for case in CASES:
+            assert (case.metadata or {}).get("min_pass_rate") == 0.8
+
+    def test_case_names_are_unique_across_tiers(self) -> None:
+        names = [c.name for c in [*TIER1_CASES, *CASES]]
+        assert len(names) == len(set(names))
+
+    def test_helper_builds_expected_metadata_shape(self) -> None:
+        case = _case("T2-X", "do a thing", "direct_read", foo="bar")
+        assert case.name == "T2-X"
+        assert case.input == "do a thing"
+        assert case.metadata == {
+            "check": "direct_read",
+            "params": {"foo": "bar"},
+            "min_pass_rate": 0.8,
+        }

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -7,7 +7,7 @@ synthetic trajectories. No LLM, no respx — just data in, verdict out.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
@@ -163,3 +163,389 @@ class TestCheckGetBeforeUpdate:
         passed, reason = checks.check_get_before_update(trajectory, {})
         assert passed is False
         assert "update_document" in reason
+
+
+_DOC_ARGS = {"project_id": "P", "space_id": "S", "document_name": "D"}
+
+
+class TestCheckResolveRootComment:
+    _PARAMS: ClassVar[dict[str, Any]] = {"root_ids": ["1"]}
+
+    def test_list_then_resolve_root_passes(self) -> None:
+        trajectory = [
+            _call("list_document_comments", dict(_DOC_ARGS)),
+            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "1"}),
+        ]
+        passed, _ = checks.check_resolve_root_comment(trajectory, self._PARAMS)
+        assert passed is True
+
+    def test_resolving_only_reply_fails(self) -> None:
+        trajectory = [
+            _call("list_document_comments", dict(_DOC_ARGS)),
+            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "2"}),
+        ]
+        passed, reason = checks.check_resolve_root_comment(trajectory, self._PARAMS)
+        assert passed is False
+        assert "root" in reason
+
+    def test_full_segment_only_reply_id_still_fails(self) -> None:
+        trajectory = [
+            _call("list_document_comments", dict(_DOC_ARGS)),
+            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "P/S/D/2"}),
+        ]
+        passed, _ = checks.check_resolve_root_comment(trajectory, self._PARAMS)
+        assert passed is False
+
+    def test_root_plus_stray_reply_passes(self) -> None:
+        # The reply attempt 400s loudly in real Polarion (server-guarded);
+        # the root resolve already did the job.
+        trajectory = [
+            _call("list_document_comments", dict(_DOC_ARGS)),
+            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "1"}),
+            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "2"}),
+        ]
+        passed, _ = checks.check_resolve_root_comment(trajectory, self._PARAMS)
+        assert passed is True
+
+    def test_resolving_without_prior_list_fails(self) -> None:
+        trajectory = [
+            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "1"})
+        ]
+        passed, reason = checks.check_resolve_root_comment(trajectory, self._PARAMS)
+        assert passed is False
+        assert "list_document_comments" in reason
+
+    def test_read_only_trajectory_passes(self) -> None:
+        trajectory = [_call("list_document_comments", dict(_DOC_ARGS))]
+        passed, _ = checks.check_resolve_root_comment(trajectory, self._PARAMS)
+        assert passed is True
+
+
+class TestCheckPreserveHyperlinks:
+    _PARAMS: ClassVar[dict[str, Any]] = {
+        "work_item_id": "MCPT-200",
+        "required_uris": ["https://specs.example.com/fake-spec"],
+    }
+
+    def test_full_list_update_passes(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_item",
+                {
+                    "project_id": "P",
+                    "work_item_id": "MCPT-200",
+                    "hyperlinks": [
+                        {
+                            "role": "ref_ext",
+                            "uri": "https://specs.example.com/fake-spec",
+                        },
+                        {"role": "ref_ext", "uri": "https://example.com/new"},
+                    ],
+                },
+            )
+        ]
+        passed, _ = checks.check_preserve_hyperlinks(trajectory, self._PARAMS)
+        assert passed is True
+
+    def test_dropping_existing_uri_fails(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_item",
+                {
+                    "project_id": "P",
+                    "work_item_id": "MCPT-200",
+                    "hyperlinks": [
+                        {"role": "ref_ext", "uri": "https://example.com/new"}
+                    ],
+                },
+            )
+        ]
+        passed, reason = checks.check_preserve_hyperlinks(trajectory, self._PARAMS)
+        assert passed is False
+        assert "fake-spec" in reason
+
+    def test_update_not_touching_hyperlinks_passes(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_item",
+                {"project_id": "P", "work_item_id": "MCPT-200", "title": "x"},
+            )
+        ]
+        passed, _ = checks.check_preserve_hyperlinks(trajectory, self._PARAMS)
+        assert passed is True
+
+    def test_other_work_item_not_constrained(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_item",
+                {
+                    "project_id": "P",
+                    "work_item_id": "MCPT-999",
+                    "hyperlinks": [{"role": "ref_ext", "uri": "https://x.example"}],
+                },
+            )
+        ]
+        passed, _ = checks.check_preserve_hyperlinks(trajectory, self._PARAMS)
+        assert passed is True
+
+
+class TestCheckRoundTripSource:
+    def test_flagged_get_then_body_write_passes(self) -> None:
+        trajectory = [
+            _call(
+                "get_document",
+                {**_DOC_ARGS, "include_homepage_content_html": True},
+            ),
+            _call(
+                "update_document",
+                {**_DOC_ARGS, "home_page_content_html": "<p id='a'>x</p>"},
+            ),
+        ]
+        passed, _ = checks.check_round_trip_source(trajectory, {})
+        assert passed is True
+
+    def test_unflagged_get_does_not_satisfy(self) -> None:
+        trajectory = [
+            _call("get_document", dict(_DOC_ARGS)),
+            _call(
+                "update_document",
+                {**_DOC_ARGS, "home_page_content_html": "<p id='a'>x</p>"},
+            ),
+        ]
+        passed, reason = checks.check_round_trip_source(trajectory, {})
+        assert passed is False
+        assert "include_homepage_content_html" in reason
+
+    def test_read_document_does_not_satisfy(self) -> None:
+        trajectory = [
+            _call("read_document", dict(_DOC_ARGS)),
+            _call(
+                "update_document",
+                {**_DOC_ARGS, "home_page_content_html": "<p id='a'>x</p>"},
+            ),
+        ]
+        passed, _ = checks.check_round_trip_source(trajectory, {})
+        assert passed is False
+
+    def test_metadata_only_update_not_constrained(self) -> None:
+        trajectory = [_call("update_document", {**_DOC_ARGS, "title": "new"})]
+        passed, _ = checks.check_round_trip_source(trajectory, {})
+        assert passed is True
+
+    def test_work_item_body_write_needs_flagged_get(self) -> None:
+        trajectory = [
+            _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-200"}),
+            _call(
+                "update_work_item",
+                {
+                    "project_id": "P",
+                    "work_item_id": "MCPT-200",
+                    "description_html": "<p>x</p>",
+                },
+            ),
+        ]
+        passed, _ = checks.check_round_trip_source(trajectory, {})
+        assert passed is False
+
+        trajectory[0]["args"]["include_description_html"] = True
+        passed, _ = checks.check_round_trip_source(trajectory, {})
+        assert passed is True
+
+
+class TestCheckNoBlindDetach:
+    _PARAMS: ClassVar[dict[str, Any]] = {"floating_ids": ["MCPT-200"]}
+
+    def test_read_only_answer_passes(self) -> None:
+        trajectory = [
+            _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-200"})
+        ]
+        passed, _ = checks.check_no_blind_detach(trajectory, self._PARAMS)
+        assert passed is True
+
+    def test_detach_on_floating_item_fails(self) -> None:
+        trajectory = [
+            _call(
+                "move_work_item_from_document",
+                {"project_id": "P", "work_item_id": "MCPT-200"},
+            )
+        ]
+        passed, reason = checks.check_no_blind_detach(trajectory, self._PARAMS)
+        assert passed is False
+        assert "MCPT-200" in reason
+
+    def test_project_qualified_id_still_fails(self) -> None:
+        trajectory = [
+            _call(
+                "move_work_item_from_document",
+                {"project_id": "P", "work_item_id": "P/MCPT-200"},
+            )
+        ]
+        passed, _ = checks.check_no_blind_detach(trajectory, self._PARAMS)
+        assert passed is False
+
+    def test_detach_on_attached_item_passes(self) -> None:
+        trajectory = [
+            _call(
+                "move_work_item_from_document",
+                {"project_id": "P", "work_item_id": "MCPT-100"},
+            )
+        ]
+        passed, _ = checks.check_no_blind_detach(trajectory, self._PARAMS)
+        assert passed is True
+
+
+class TestCheckSingleBulkCreate:
+    def test_one_bulk_call_passes(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "a"}, {"title": "b"}]})
+        ]
+        passed, _ = checks.check_single_bulk_create(trajectory, {})
+        assert passed is True
+
+    def test_split_calls_fail(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "a"}]}),
+            _call("create_work_items", {"items": [{"title": "b"}]}),
+        ]
+        passed, reason = checks.check_single_bulk_create(trajectory, {})
+        assert passed is False
+        assert "2" in reason
+
+    def test_dry_run_preview_not_counted(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "a"}], "dry_run": True}),
+            _call("create_work_items", {"items": [{"title": "a"}]}),
+        ]
+        passed, _ = checks.check_single_bulk_create(trajectory, {})
+        assert passed is True
+
+    def test_errored_call_not_counted(self) -> None:
+        trajectory = [
+            _call(
+                "create_work_items",
+                {"items": [{"title": "a"}]},
+                result={"error": "ToolError: bad severity"},
+            ),
+            _call("create_work_items", {"items": [{"title": "a"}]}),
+        ]
+        passed, _ = checks.check_single_bulk_create(trajectory, {})
+        assert passed is True
+
+
+class TestCheckDirectRead:
+    _PARAMS: ClassVar[dict[str, Any]] = {"work_item_id": "MCPT-200"}
+
+    def test_direct_get_passes(self) -> None:
+        trajectory = [
+            _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-200"})
+        ]
+        passed, _ = checks.check_direct_read(trajectory, self._PARAMS)
+        assert passed is True
+
+    def test_list_scan_fails(self) -> None:
+        trajectory = [
+            _call("list_work_items", {"project_id": "P", "query": "id:MCPT-200"}),
+            _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-200"}),
+        ]
+        passed, reason = checks.check_direct_read(trajectory, self._PARAMS)
+        assert passed is False
+        assert "list_work_items" in reason
+
+    def test_no_read_at_all_fails(self) -> None:
+        trajectory = [_call("list_projects", {})]
+        passed, _ = checks.check_direct_read(trajectory, self._PARAMS)
+        assert passed is False
+
+    def test_extra_benign_reads_tolerated(self) -> None:
+        trajectory = [
+            _call("read_work_item", {"project_id": "P", "work_item_id": "MCPT-200"}),
+            _call(
+                "list_work_item_links",
+                {"project_id": "P", "work_item_id": "MCPT-200"},
+            ),
+        ]
+        passed, _ = checks.check_direct_read(trajectory, self._PARAMS)
+        assert passed is True
+
+
+class TestCheckNoDuplicateReads:
+    def test_distinct_reads_pass(self) -> None:
+        trajectory = [
+            _call("get_document", dict(_DOC_ARGS)),
+            _call("list_document_comments", dict(_DOC_ARGS)),
+        ]
+        passed, _ = checks.check_no_duplicate_reads(trajectory, {})
+        assert passed is True
+
+    def test_identical_state_read_fails(self) -> None:
+        trajectory = [
+            _call("get_document", dict(_DOC_ARGS)),
+            _call("get_document", dict(_DOC_ARGS)),
+        ]
+        passed, reason = checks.check_no_duplicate_reads(trajectory, {})
+        assert passed is False
+        assert "get_document" in reason
+
+    def test_state_reread_after_write_passes(self) -> None:
+        trajectory = [
+            _call("get_document", dict(_DOC_ARGS)),
+            _call("update_document", {**_DOC_ARGS, "title": "x"}),
+            _call("get_document", dict(_DOC_ARGS)),
+        ]
+        passed, _ = checks.check_no_duplicate_reads(trajectory, {})
+        assert passed is True
+
+    def test_stable_reread_even_after_write_fails(self) -> None:
+        enum_args = {
+            "project_id": "P",
+            "field_id": "severity",
+            "work_item_type": "task",
+        }
+        trajectory = [
+            _call("list_work_item_enum_options", dict(enum_args)),
+            _call("create_work_items", {"items": [{"title": "a"}]}),
+            _call("list_work_item_enum_options", dict(enum_args)),
+        ]
+        passed, reason = checks.check_no_duplicate_reads(trajectory, {})
+        assert passed is False
+        assert "list_work_item_enum_options" in reason
+
+    def test_different_args_not_duplicates(self) -> None:
+        trajectory = [
+            _call("list_work_items", {"project_id": "P", "page_number": 1}),
+            _call("list_work_items", {"project_id": "P", "page_number": 2}),
+        ]
+        passed, _ = checks.check_no_duplicate_reads(trajectory, {})
+        assert passed is True
+
+
+class TestCheckScopedQueryUsesSql:
+    def test_sql_prefixed_module_query_passes(self) -> None:
+        trajectory = [
+            _call(
+                "list_work_items",
+                {"project_id": "P", "query": "SQL:(... module ...)"},
+            )
+        ]
+        passed, _ = checks.check_scoped_query_uses_sql(trajectory, {})
+        assert passed is True
+
+    def test_lucene_module_query_fails(self) -> None:
+        trajectory = [
+            _call("list_work_items", {"project_id": "P", "query": "module:FakeDoc"})
+        ]
+        passed, reason = checks.check_scoped_query_uses_sql(trajectory, {})
+        assert passed is False
+        assert "module" in reason
+
+    def test_parts_path_passes(self) -> None:
+        trajectory = [_call("read_document_parts", dict(_DOC_ARGS))]
+        passed, _ = checks.check_scoped_query_uses_sql(trajectory, {})
+        assert passed is True
+
+    def test_plain_query_passes(self) -> None:
+        trajectory = [
+            _call("list_work_items", {"project_id": "P", "query": "type:task"})
+        ]
+        passed, _ = checks.check_scoped_query_uses_sql(trajectory, {})
+        assert passed is True

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -118,6 +118,19 @@ class TestCheckGetBeforeUpdate:
         assert passed is False
         assert "MCPT-1" in reason
 
+    def test_qualified_and_short_work_item_ids_match(self) -> None:
+        # A project-qualified id in the get and a short id in the update
+        # target the same item; the check must not false-fail.
+        trajectory = [
+            _call("get_work_item", {"project_id": "P", "work_item_id": "P/MCPT-1"}),
+            _call(
+                "update_work_item",
+                {"project_id": "P", "work_item_id": "MCPT-1", "title": "x"},
+            ),
+        ]
+        passed, _ = checks.check_get_before_update(trajectory, {})
+        assert passed is True
+
     def test_get_after_update_does_not_satisfy(self) -> None:
         trajectory = [
             _call(
@@ -174,7 +187,10 @@ class TestCheckResolveRootComment:
     def test_list_then_resolve_root_passes(self) -> None:
         trajectory = [
             _call("list_document_comments", dict(_DOC_ARGS)),
-            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "1"}),
+            _call(
+                "update_document_comment",
+                {**_DOC_ARGS, "comment_id": "1", "resolved": True},
+            ),
         ]
         passed, _ = checks.check_resolve_root_comment(trajectory, self._PARAMS)
         assert passed is True
@@ -182,7 +198,10 @@ class TestCheckResolveRootComment:
     def test_resolving_only_reply_fails(self) -> None:
         trajectory = [
             _call("list_document_comments", dict(_DOC_ARGS)),
-            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "2"}),
+            _call(
+                "update_document_comment",
+                {**_DOC_ARGS, "comment_id": "2", "resolved": True},
+            ),
         ]
         passed, reason = checks.check_resolve_root_comment(trajectory, self._PARAMS)
         assert passed is False
@@ -191,7 +210,10 @@ class TestCheckResolveRootComment:
     def test_full_segment_only_reply_id_still_fails(self) -> None:
         trajectory = [
             _call("list_document_comments", dict(_DOC_ARGS)),
-            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "P/S/D/2"}),
+            _call(
+                "update_document_comment",
+                {**_DOC_ARGS, "comment_id": "P/S/D/2", "resolved": True},
+            ),
         ]
         passed, _ = checks.check_resolve_root_comment(trajectory, self._PARAMS)
         assert passed is False
@@ -201,15 +223,41 @@ class TestCheckResolveRootComment:
         # the root resolve already did the job.
         trajectory = [
             _call("list_document_comments", dict(_DOC_ARGS)),
-            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "1"}),
-            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "2"}),
+            _call(
+                "update_document_comment",
+                {**_DOC_ARGS, "comment_id": "1", "resolved": True},
+            ),
+            _call(
+                "update_document_comment",
+                {**_DOC_ARGS, "comment_id": "2", "resolved": True},
+            ),
         ]
         passed, _ = checks.check_resolve_root_comment(trajectory, self._PARAMS)
         assert passed is True
 
+    def test_reopened_root_does_not_mask_reply_resolve(self) -> None:
+        # resolved=False on the root is not a resolution; the reply attempt
+        # must still be flagged.
+        trajectory = [
+            _call("list_document_comments", dict(_DOC_ARGS)),
+            _call(
+                "update_document_comment",
+                {**_DOC_ARGS, "comment_id": "1", "resolved": False},
+            ),
+            _call(
+                "update_document_comment",
+                {**_DOC_ARGS, "comment_id": "2", "resolved": True},
+            ),
+        ]
+        passed, _ = checks.check_resolve_root_comment(trajectory, self._PARAMS)
+        assert passed is False
+
     def test_resolving_without_prior_list_fails(self) -> None:
         trajectory = [
-            _call("update_document_comment", {**_DOC_ARGS, "comment_id": "1"})
+            _call(
+                "update_document_comment",
+                {**_DOC_ARGS, "comment_id": "1", "resolved": True},
+            )
         ]
         passed, reason = checks.check_resolve_root_comment(trajectory, self._PARAMS)
         assert passed is False
@@ -348,6 +396,28 @@ class TestCheckRoundTripSource:
         assert passed is False
 
         trajectory[0]["args"]["include_description_html"] = True
+        passed, _ = checks.check_round_trip_source(trajectory, {})
+        assert passed is True
+
+    def test_qualified_get_id_satisfies_short_id_write(self) -> None:
+        trajectory = [
+            _call(
+                "get_work_item",
+                {
+                    "project_id": "P",
+                    "work_item_id": "P/MCPT-200",
+                    "include_description_html": True,
+                },
+            ),
+            _call(
+                "update_work_item",
+                {
+                    "project_id": "P",
+                    "work_item_id": "MCPT-200",
+                    "description_html": "<p>x</p>",
+                },
+            ),
+        ]
         passed, _ = checks.check_round_trip_source(trajectory, {})
         assert passed is True
 
@@ -549,3 +619,21 @@ class TestCheckScopedQueryUsesSql:
         ]
         passed, _ = checks.check_scoped_query_uses_sql(trajectory, {})
         assert passed is True
+
+    def test_module_as_plain_text_passes(self) -> None:
+        # "module" as a search term, not a Lucene field name.
+        trajectory = [
+            _call("list_work_items", {"project_id": "P", "query": "title:module*"})
+        ]
+        passed, _ = checks.check_scoped_query_uses_sql(trajectory, {})
+        assert passed is True
+
+    def test_module_subfield_query_fails(self) -> None:
+        trajectory = [
+            _call(
+                "list_work_items",
+                {"project_id": "P", "query": "module.id:FakeDoc"},
+            )
+        ]
+        passed, _ = checks.check_scoped_query_uses_sql(trajectory, {})
+        assert passed is False

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -17,6 +17,9 @@ from evals.harness.fake_polarion import (
     API_PREFIX,
     DOC,
     DOC_HEADING_ID,
+    DOC_INTRO_PARAGRAPH_ID,
+    FLOATING_TASK_HYPERLINK_URI,
+    FLOATING_TASK_ID,
     MODULE_ID,
     POLARION_HOST,
     PROJECT,
@@ -127,6 +130,38 @@ class TestReadRouting:
         )
         assert response.status_code == 404
 
+    def test_document_body_has_anchored_intro_paragraph(self) -> None:
+        response = _get(
+            FakePolarion(), f"/projects/{PROJECT}/spaces/{SPACE}/documents/{DOC}"
+        )
+        body = _json(response)["data"]["attributes"]["homePageContent"]["value"]
+        assert f'id="{DOC_INTRO_PARAGRAPH_ID}"' in body
+
+    def test_floating_task_carries_seed_hyperlink(self) -> None:
+        response = _get(
+            FakePolarion(), f"/projects/{PROJECT}/workitems/{FLOATING_TASK_ID}"
+        )
+        hyperlinks = _json(response)["data"]["attributes"]["hyperlinks"]
+        assert hyperlinks == [{"role": "ref_ext", "uri": FLOATING_TASK_HYPERLINK_URI}]
+
+    def test_project_enum_hyperlink_role_is_dict_shaped(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/enumerations/~/hyperlink-role/~",
+        )
+        assert response.status_code == 200
+        data = _json(response)["data"]
+        assert isinstance(data, dict)
+        ids = [o["id"] for o in data["attributes"]["options"]]
+        assert ids == ["ref_int", "ref_ext"]
+
+    def test_unknown_project_enum_is_404(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/enumerations/~/not-a-real-enum/~",
+        )
+        assert response.status_code == 404
+
 
 class TestWorkItemResource:
     def test_module_relationship_only_for_module_items(self) -> None:
@@ -146,6 +181,18 @@ class TestMutations:
         response = _mutate(fake, "POST", f"/projects/{PROJECT}/workitems", {"data": []})
         assert response.status_code == 201
         assert _json(response)["data"][0]["type"] == "workitems"
+
+    def test_post_workitems_echoes_one_id_per_submitted_entry(self) -> None:
+        fake = FakePolarion()
+        response = _mutate(
+            fake,
+            "POST",
+            f"/projects/{PROJECT}/workitems",
+            {"data": [{"x": 1}, {"x": 2}, {"x": 3}]},
+        )
+        ids = [entry["id"] for entry in _json(response)["data"]]
+        assert len(ids) == 3
+        assert len(set(ids)) == 3
 
     def test_post_documents_echoes_module_id(self) -> None:
         fake = FakePolarion()

--- a/tests/evals/harness/test_model.py
+++ b/tests/evals/harness/test_model.py
@@ -38,6 +38,14 @@ class TestBuildModel:
         model = build_model()
         assert model.get_config()["params"]["temperature"] == 0.0
 
+    def test_parallel_tool_calls_pinned_off(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("EVAL_MODEL_BASE_URL", raising=False)
+        params = build_model().get_config()["params"]
+        assert params["parallel_tool_calls"] is False
+        assert params["drop_params"] is True
+
     def test_retries_and_timeout_from_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -18,6 +18,8 @@ pytest.importorskip("strands_evals")
 from strands_evals import Case
 
 from evals import run
+from evals.cases.tier1_prohibitions import CASES as TIER1_CASES
+from evals.cases.tier2_efficiency import CASES as TIER2_CASES
 from evals.harness.runner import AGENT_ERROR_PREFIX
 
 
@@ -93,3 +95,9 @@ class TestMain:
     def test_unknown_case_returns_2(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("sys.argv", ["run", "--case", "T1-DOES-NOT-EXIST"])
         assert run.main() == 2
+
+
+class TestAllCases:
+    def test_gate_loads_both_tiers(self) -> None:
+        expected = [*TIER1_CASES, *TIER2_CASES]
+        assert expected == run.ALL_CASES

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -2915,6 +2915,17 @@ class TestUpdateDocumentPitfallDocumentation:
             "relationship stays unset after a macro <div> injection"
         )
 
+    def test_docstring_directs_get_before_update(self) -> None:
+        """Partial-PATCH semantics demand observing current state first."""
+        document = update_document.__doc__ or ""
+        assert "get_document" in document, (
+            "update_document docstring must direct callers to read the "
+            "document before patching it"
+        )
+        assert "BEFORE" in document, (
+            "update_document docstring must state the read happens BEFORE the update"
+        )
+
 
 class TestBuildCreateDocumentPayload:
     """Tests for the private ``_build_create_document_payload`` helper."""
@@ -3472,8 +3483,9 @@ class TestCreateDocumentRegistration:
 class TestCreateDocumentDocstringGuidance:
     """Verify enum-resolution and ghost-write guidance lives in the docstring.
 
-    Per CLAUDE.md, the write tools' docstrings are the only enforcement
-    against ghost-enum writes — the server does not validate enum IDs.
+    Standard enums are tool-guarded (``guard_document_enums``), but
+    custom-field enum values are not — the docstring is the only steer
+    toward ``list_document_enum_options``.
     """
 
     def test_docstring_mentions_list_document_enum_options(self) -> None:

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -1572,6 +1572,20 @@ class TestUpdateWorkItemFieldValidation:
             adapter.validate_python("x" * (2_000_000 + 1))
 
 
+class TestUpdateWorkItemDocstringGuidance:
+    """Lock the read-before-update steer into the public docstring."""
+
+    def test_docstring_directs_get_before_update(self) -> None:
+        document = update_work_item.__doc__ or ""
+        assert "get_work_item" in document, (
+            "update_work_item docstring must direct callers to read the "
+            "work item before patching it"
+        )
+        assert "BEFORE" in document, (
+            "update_work_item docstring must state the read happens BEFORE the update"
+        )
+
+
 class TestEnumGuardCreateWorkItem:
     """Integration: ``create_work_items`` rejects ghost enum ids before POST."""
 


### PR DESCRIPTION
## Summary

Adds a Tier-2 efficiency layer to the eval deploy gate and aggressively slims all LLM-facing text: `@mcp.tool` docstrings / param descriptions (~26% fewer chars shipped to MCP clients) and CLAUDE.md (dev-session context). Tier-1 prohibitions stay zero-tolerance; Tier-2 cases gate at 0.8 pass rate.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Documentation update
- [x] CI / tooling / dependency update

## Changes

- Tier-1 gate caught corruption only, and tool descriptions cost ~19k always-on chars per MCP client session
- Add 5 tier-2 efficiency cases (0.8 gate) and compress LLM-facing docstrings + CLAUDE.md ~26%, behavior unchanged

## Testing

- `evals.run --runs 1`: GATE PASS, 13/13 cases (8 tier-1 + 5 tier-2, `openai/gpt-4o-mini`)
- `pytest`: 1140 passed (includes docstring-lock and transport schema tests); `ruff check` / `ruff format --check` / `mypy` clean
- Docstring changes verified against the served schema (`mcp.list_tools()`): only description/param text changed, signatures identical

## Notes for Reviewers

- Pre-existing, unrelated to this PR: with `OPENAI_API_KEY` present in a local `.env`, `PolarionConfig` (pydantic-settings, extra forbidden) fails to construct, breaking local pytest/eval runs from the repo root. CI is unaffected (no `.env`). Suggest a follow-up adding `extra="ignore"` to `SettingsConfigDict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)