### PR TITLE
feat(tool): auto-stamp anchorless blocks in update_document / create_document

### DIFF
--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -8,8 +8,8 @@ Rules:
   1. English-only — no non-ASCII characters in the body.
   2. Template checkboxes preserved — every checkbox from PULL_REQUEST_TEMPLATE.md
      must appear (PR create/edit only).
-  3. ## Changes section — exactly two non-empty bullets, each <= 120 chars
-     (PR create/edit only).
+  3. ## Changes section — required, with exactly two non-empty bullets, each
+     <= 120 chars (PR create/edit only).
 
 Exit 0 = allow, exit 2 = block.
 """
@@ -164,7 +164,10 @@ def missing_template_boxes(body: str) -> list[str]:
 def changes_format_errors(body: str) -> list[str]:
     header = CHANGES_HEADER_RE.search(body)
     if header is None:
-        return []
+        return [
+            "Body is missing the required '## Changes' section "
+            "(see .github/PULL_REQUEST_TEMPLATE.md)."
+        ]
     nxt = NEXT_SECTION_RE.search(body, header.end())
     section = body[header.end() : nxt.start()] if nxt else body[header.end() :]
     lines = (ln.rstrip() for ln in section.splitlines())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Applies to ALL comments/docstrings incl. CLAUDE.md.
 ### Document writes
 
 - Body edits via `homePageContent` PATCH, not `/parts` (those wrappers reject heading-type items). Empty `home_page_content_html` rejected (would orphan headings).
-- Anchorless `<p>`/`<ul>`/`<ol>`/`<table>`/`<div>`/`<blockquote>`/`<pre>` break `/parts` (PATCH 200, next GET 500); each needs unique non-empty `id=`. `create_document` runs `stamp_block_ids`; `update_document` hard-rejects via `first_anchorless_block`. For body text, prefer `create_work_items` + `move_work_item_to_document`.
+- Anchorless `<p>`/`<ul>`/`<ol>`/`<table>`/`<div>`/`<blockquote>`/`<pre>` break `/parts` (PATCH 200, next GET 500); each needs unique non-empty `id=`. Both `create_document` and `update_document` run `stamp_block_ids`. `stamp_block_ids` returns input verbatim when every target block already has a non-blank id (no `str(soup)` reserialize → no `&nbsp;`→`\xa0` drift on an anchored round-trip body), else stamps the gaps; both tools follow with a `first_anchorless_block` defensive guard. For body text, prefer `create_work_items` + `move_work_item_to_document`.
 - `module` cannot be set via PATCH or HTML injection — only `move_work_item_to_document` / `move_work_item_from_document` (atomic action pair). `create_work_item` doesn't expose `module` (would land in recycle bin) — create free-floating, then move. `moveFromDocument` not idempotent (400 if detached). `moveToDocument` auto-creates one link to enclosing heading; later same-role `create_work_item_links` 201s but isn't persisted (phantom success).
 
 ### Work item & comment quirks

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -902,10 +902,6 @@ async def update_document(  # noqa: PLR0913
     - Inline ``<h1>..<h4>`` auto-create heading work items — THE way to add a
       heading. For body text or work items use ``create_work_items`` +
       ``move_work_item_to_document``, NOT this tool.
-    - Every anchorless ``<p>``/``<ul>``/``<ol>``/``<table>``/``<div>``/
-      ``<blockquote>``/``<pre>`` block is rejected before PATCH — give each a
-      unique ``id=``. (Unguarded, the PATCH would 200 and the next
-      ``read_document_parts`` would return HTTP 500.)
     - A ``polarion_wiki macro name=module-workitem`` ``<div>`` leaves the work
       item's ``module`` unset — attach via ``move_work_item_to_document``.
 
@@ -922,15 +918,11 @@ async def update_document(  # noqa: PLR0913
             "to leave the body unchanged."
         )
     if home_page_content_html is not None:
-        anchorless = first_anchorless_block(home_page_content_html)
-        if anchorless is not None:
-            raise ValueError(
-                f"home_page_content_html contains an anchorless <{anchorless}> "
-                "block. Every non-heading block (<p>/<ul>/<ol>/<table>/<div>/"
-                "<blockquote>/<pre>) must carry a unique non-empty id= or the "
-                "next read_document_parts returns HTTP 500. Stamp ids "
-                '(e.g. id="polarion_mcp_0") on each such block before updating; '
-                "<h1>..<h6> headings are exempt."
+        home_page_content_html = stamp_block_ids(home_page_content_html)
+        if first_anchorless_block(home_page_content_html) is not None:
+            raise RuntimeError(
+                "stamp_block_ids left an anchorless block; refusing to PATCH "
+                "(next read_document_parts would return HTTP 500)."
             )
 
     has_attrs = (
@@ -1110,6 +1102,10 @@ async def create_document(  # noqa: PLR0913
         if home_page_content
         else ""
     )
+    if home_page_content_html and first_anchorless_block(home_page_content_html):
+        raise RuntimeError(
+            "stamp_block_ids left an anchorless block in new document body."
+        )
 
     payload = _build_create_document_payload(
         module_name=module_name,

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -871,7 +871,8 @@ async def update_document(  # noqa: PLR0913
         max_length=MAX_BODY_HTML_LEN,
         description=(
             "New body as raw HTML from "
-            "``get_document(include_homepage_content_html=True)``; '' rejected."
+            "``get_document(include_homepage_content_html=True)``; '' rejected; "
+            "anchorless blocks get ``id=`` auto-stamped."
         ),
     ),
     custom_fields: dict[str, object] | None = Field(  # noqa: B008
@@ -893,9 +894,11 @@ async def update_document(  # noqa: PLR0913
 
     PATCHes only the supplied attributes (omitted preserved); no follow-up GET.
     Fetch via ``get_document`` BEFORE updating. ``home_page_content_html`` is
-    sent verbatim/unsanitized — source it from
-    ``get_document(include_homepage_content_html=True)``; empty string rejected
-    (orphans headings), pass ``'<p></p>'`` for near-empty.
+    never sanitized or converted — source it from
+    ``get_document(include_homepage_content_html=True)``. Body blocks lacking
+    an ``id=`` get one auto-stamped; a fully anchored body is sent
+    byte-for-byte. Empty string rejected (orphans headings), pass
+    ``'<p></p>'`` for near-empty.
 
     Body rules:
 

--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -439,14 +439,13 @@ def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
 def first_anchorless_block(html: str) -> str | None:
     """Return the name of the first block lacking a non-empty ``id=``.
 
-    Write-side counterpart to :func:`stamp_block_ids`: rejects anchorless
-    blocks in raw ``update_document`` body HTML before they reach Polarion,
-    since each makes the next ``GET .../parts`` return HTTP 500. Headings
-    are exempt (Polarion rewrites their ids). ``None`` when every
-    ``_BLOCK_TAGS_NEEDING_IDS`` block has an id, or input is empty.
-
-    Stricter than ``stamp_block_ids``'s skip test: a whitespace-only ``id``
-    counts as anchorless here. Erring toward rejection is the safe direction.
+    Defensive counterpart to :func:`stamp_block_ids`: ``create_document`` and
+    ``update_document`` run it after stamping so a stamping regression cannot
+    reach Polarion, where each anchorless block makes the next
+    ``GET .../parts`` return HTTP 500. Headings are exempt (Polarion rewrites
+    their ids). ``None`` when every ``_BLOCK_TAGS_NEEDING_IDS`` block has an
+    id, or input is empty. A whitespace-only ``id`` counts as anchorless,
+    matching ``stamp_block_ids``'s skip test.
     """
     if not html or not html.strip():
         return None

--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -393,9 +393,12 @@ def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
     ids. An anchorless ``<p>`` (or any ``_BLOCK_TAGS_NEEDING_IDS`` tag)
     saves fine but makes the next ``GET .../parts`` return HTTP 500.
     Heading tags (``<h1>..<h6>``) are skipped — Polarion rewrites their ids
-    into the ``module-workitem`` macro on save. Existing non-empty ids are
+    into the ``module-workitem`` macro on save. Existing non-blank ids are
     preserved; generated ids skip values already in the document so the
-    PATCH never trips Polarion's HTTP 400 duplicate-id rule.
+    PATCH never trips Polarion's HTTP 400 duplicate-id rule. Returns the
+    input unchanged (verbatim, not reserialized) when every target block
+    already carries a non-blank id, so an anchored round-trip body is never
+    perturbed.
 
     Args:
         html: HTML string (typically ``sanitize_html`` output).
@@ -416,8 +419,10 @@ def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
             used_ids.add(existing)
 
     counter = 0
+    stamped = False
     for tag in soup.find_all(list(_BLOCK_TAGS_NEEDING_IDS)):
-        if tag.get("id"):
+        existing = tag.get("id")
+        if isinstance(existing, str) and existing.strip():
             continue
         while f"{prefix}_{counter}" in used_ids:
             counter += 1
@@ -425,7 +430,10 @@ def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
         tag["id"] = new_id
         used_ids.add(new_id)
         counter += 1
-    return str(soup)
+        stamped = True
+    # Verbatim when nothing changed: str(soup) reserializes the whole string
+    # (e.g. &nbsp; -> \xa0), which would corrupt an already-anchored round-trip body.
+    return str(soup) if stamped else html
 
 
 def first_anchorless_block(html: str) -> str | None:

--- a/tests/claude_hooks/test_validate_pr_body.py
+++ b/tests/claude_hooks/test_validate_pr_body.py
@@ -170,8 +170,9 @@ class TestChangesFormatErrors:
         errs = body.changes_format_errors(text)
         assert any("limit: 120" in e for e in errs)
 
-    def test_absent_section_is_tolerant(self) -> None:
-        assert body.changes_format_errors("## Summary\nno changes section\n") == []
+    def test_absent_section_is_rejected(self) -> None:
+        errs = body.changes_format_errors("## Summary\nno changes section\n")
+        assert any("Changes" in e for e in errs)
 
     def test_section_at_end_of_body(self) -> None:
         # no trailing section header after Changes

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -2882,27 +2882,15 @@ class TestUpdateDocumentFieldValidation:
 
 
 class TestUpdateDocumentPitfallDocumentation:
-    """Lock the two body-edit pitfalls into the public docstring so a
-    future slim pass cannot silently delete them.
+    """Lock the macro-div body-edit pitfall into the public docstring so a
+    future slim pass cannot silently delete it.
 
-    The pitfalls were reproduced against the live testdrive server and are
+    The pitfall was reproduced against the live testdrive server and is
     user-facing (MCP hosts on other platforms never load CLAUDE.md), so the
-    warnings must stay inside ``update_document.__doc__``.
+    warning must stay inside ``update_document.__doc__``. The anchorless-block
+    pitfall is gone from the docstring on purpose: the tool now stamps ids
+    automatically, so surfacing it would only distract the LLM.
     """
-
-    def test_docstring_warns_about_anchorless_paragraph_returning_500(self) -> None:
-        """Anchorless <p> appended via update_document breaks read_document_parts."""
-        document = update_document.__doc__ or ""
-        assert "anchorless" in document, (
-            "update_document docstring must mention the anchorless <p> pitfall"
-        )
-        assert "HTTP 500" in document, (
-            "update_document docstring must surface that the next read_document_parts "
-            "call returns HTTP 500 after an anchorless <p> append"
-        )
-        assert "move_work_item_to_document" in document, (
-            "update_document docstring must point callers at the correct attach path"
-        )
 
     def test_docstring_warns_about_macro_div_module_relationship_gap(self) -> None:
         """Macro <div> reference injected via update_document leaves module unset."""
@@ -3204,6 +3192,30 @@ class TestCreateDocumentHappyPath:
         assert '<p id="polarion_mcp_2">' in body_html
         assert "<h1>" in body_html
         assert "<h1 id=" not in body_html
+
+    async def test_defensive_guard_raises_when_stamp_leaves_anchorless(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stamp_block_ids regression that leaves a block anchorless is
+        caught by the trailing first_anchorless_block guard before POST."""
+        monkeypatch.setattr(_mod, "stamp_block_ids", lambda html: html)
+        with pytest.raises(RuntimeError, match="anchorless block"):
+            await create_document(
+                mock_ctx,
+                project_id="MyProj",
+                space_id="_default",
+                module_name="MySpec",
+                title="t",
+                type="generic",
+                status=None,
+                home_page_content="plain para",
+                custom_fields=None,
+                dry_run=False,
+            )
+        mock_client.post.assert_not_called()
 
     async def test_home_page_content_strips_dangerous_link_schemes(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -3654,33 +3666,46 @@ class TestEnumGuardUpdateDocument:
         assert result.dry_run is True  # type: ignore[attr-defined]
 
 
+def _doc_body_value(result: object) -> str:
+    """Pull ``homePageContent.value`` out of an update_document dry-run preview."""
+    preview = result.payload_preview  # type: ignore[attr-defined]
+    assert preview is not None
+    data = cast(dict[str, object], preview["data"])
+    attrs = cast(dict[str, object], data["attributes"])
+    body = cast(dict[str, object], attrs["homePageContent"])
+    return cast(str, body["value"])
+
+
 class TestUpdateDocumentAnchorlessGuard:
-    """Integration: ``update_document`` rejects anchorless body blocks."""
+    """Integration: ``update_document`` auto-stamps anchorless body blocks."""
 
-    async def test_anchorless_paragraph_raises(
-        self,
-        mock_ctx: MagicMock,
-        mock_client: AsyncMock,
-        reset_enum_guard_caches: None,
-    ) -> None:
-        with pytest.raises(ValueError, match="anchorless <p>"):
-            await _call_update_doc(
-                mock_ctx, home_page_content_html="<p>Note</p>", dry_run=True
-            )
-        mock_client.patch.assert_not_called()
-
-    async def test_stamped_paragraph_passes(
+    async def test_anchorless_paragraph_is_stamped(
         self,
         mock_ctx: MagicMock,
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
         result = await _call_update_doc(
-            mock_ctx,
-            home_page_content_html='<p id="polarion_mcp_1">Note</p>',
-            dry_run=True,
+            mock_ctx, home_page_content_html="<p>Note</p>", dry_run=True
         )
-        assert result.dry_run is True  # type: ignore[attr-defined]
+        body = _doc_body_value(result)
+        assert "Note" in body
+        assert 'id="polarion_mcp_' in body
+        mock_client.patch.assert_not_called()
+
+    async def test_anchored_body_sent_verbatim(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        """An already-anchored body round-trips byte-for-byte: stamp_block_ids
+        short-circuits before reserializing, so ``&nbsp;`` is not mangled."""
+        raw = '<p id="polarion_mcp_1">Note&nbsp;here</p>'
+        result = await _call_update_doc(
+            mock_ctx, home_page_content_html=raw, dry_run=True
+        )
+        assert _doc_body_value(result) == raw
 
     async def test_heading_only_passes(
         self,
@@ -3692,3 +3717,19 @@ class TestUpdateDocumentAnchorlessGuard:
             mock_ctx, home_page_content_html="<h1>Title</h1>", dry_run=True
         )
         assert result.dry_run is True  # type: ignore[attr-defined]
+
+    async def test_defensive_guard_raises_when_stamp_leaves_anchorless(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If a future stamp_block_ids regression leaves a block anchorless,
+        the trailing first_anchorless_block guard blocks the PATCH."""
+        monkeypatch.setattr(_mod, "stamp_block_ids", lambda html: html)
+        with pytest.raises(RuntimeError, match="anchorless block"):
+            await _call_update_doc(
+                mock_ctx, home_page_content_html="<p>Note</p>", dry_run=True
+            )
+        mock_client.patch.assert_not_called()

--- a/tests/mcp_server_polarion/utils/test_html.py
+++ b/tests/mcp_server_polarion/utils/test_html.py
@@ -760,6 +760,24 @@ class TestStampBlockIds:
         assert '<p id="anchor_0">x</p>' in result
         assert '<p id="anchor_1">y</p>' in result
 
+    def test_clean_input_returned_verbatim(self) -> None:
+        """When every target block already carries a non-blank id, the input
+        is returned byte-for-byte — no BeautifulSoup reserialization, so
+        ``&nbsp;``/``&copy;`` and quote style survive an anchored round-trip."""
+        html = '<p id="a">x&nbsp;y</p><table id="t"><tr><td>&copy;</td></tr></table>'
+        assert stamp_block_ids(html) == html
+
+    def test_heading_only_input_returned_verbatim(self) -> None:
+        # No target block at all -> nothing to stamp -> verbatim passthrough.
+        html = "<h1>a</h1><h2>b&nbsp;c</h2>"
+        assert stamp_block_ids(html) == html
+
+    def test_whitespace_only_id_is_stamped(self) -> None:
+        # A blank id does not anchor the block (mirrors first_anchorless_block);
+        # it gets restamped rather than skipped.
+        result = stamp_block_ids('<p id="   ">x</p>')
+        assert '<p id="polarion_mcp_0">x</p>' in result
+
     @pytest.mark.parametrize("value", ["", "   ", "\n\t"])
     def test_empty_or_whitespace_input_returns_empty(self, value: str) -> None:
         assert stamp_block_ids(value) == ""


### PR DESCRIPTION
## Summary

`update_document` previously hard-rejected body HTML containing anchorless `<p>`/`<ul>`/`<ol>`/`<table>`/`<div>`/`<blockquote>`/`<pre>` blocks (those without a non-empty `id=`). The LLM had to re-emit the entire body with ids stamped -- expensive for large documents. This PR swaps the reject for `stamp_block_ids`, bringing `update_document` to parity with `create_document`.

`stamp_block_ids` gains a verbatim short-circuit: when every target block already has a non-blank id, the original string is returned byte-for-byte (no BeautifulSoup reserialisation), so HTML entities and quote style are not mangled on an already-anchored round-trip body. A whitespace-only `id=` is now treated as anchorless (mirrors `first_anchorless_block` strictness). Both tools also gain a trailing `first_anchorless_block` defensive guard as defence-in-depth against future regressions.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- update_document hard-rejected anchorless body blocks, forcing the LLM into a costly full-document re-emit
- Swap reject for stamp_block_ids (verbatim short-circuit when anchored) + first_anchorless_block guard on both tools

## Testing

- `uv run pytest tests/mcp_server_polarion/utils/test_html.py tests/mcp_server_polarion/tools/test_documents.py -q` -- 279 pass
- `uv run ruff check . && uv run ruff format --check . && uv run mypy src/` -- clean
- Full suite from outside repo dir (avoids local `.env` conflict): `cd /tmp && uv run --project <repo> pytest <repo>/tests -q` -- 1151 pass
- Manual / real server (cannot run in CI): round-trip a body with literal non-breaking spaces verbatim, then append an anchorless `<p>` and confirm the stamped id persists and `read_document_parts` returns 200.

## Notes for Reviewers

Manual real-server check is the only path that exercises the byte-for-byte round-trip and the `/parts` 500 regression; CI cannot reach a live Polarion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
