### PR TITLE
docs(meta): compress comments to why-only form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,6 @@ MCP server: AI read/write access to Polarion ALM. FastMCP 3.0, strict async, ful
 ```bash
 uv sync --dev                                            # install deps
 uv run pytest                                            # all tests
-uv run pytest -k test_page_size_rejects_above_max        # single test
 uv run ruff check . && uv run ruff format . && uv run mypy src/  # lint + format + types
 uv run mcp-server-polarion                               # run server (stdio)
 ```
@@ -16,10 +15,10 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 
 ## Architecture
 
-- `core/` — `client.py` (async httpx: 429/5xx backoff, post-mutation delay, maps to `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only). Loggers: `logging.getLogger("mcp_server_polarion.<module>")`.
-- `tools/` — domain modules (`projects`, `work_items`, `documents`, `links`, `comments`, `moves`); each create/update tool has `_build_*_payload` helper = unit-test seam. Import in `tools/__init__.py` registers `@mcp.tool`s. `tools/_shared/`: `helpers.py` (JSON:API extractors, pagination, `MAX_BULK_ITEMS`), `cache.py` (`TTLCache`, all cache state behind wrappers), `guard.py` (write guards). `tools/guides/` = on-demand data (`sql_query_recipes.md`).
+- `core/` — `client.py` (async httpx, retries 429/5xx, maps to `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only).
+- `tools/` — domain modules; `_build_*_payload` helpers = unit-test seam. Import in `tools/__init__.py` registers `@mcp.tool`s. `tools/_shared/`: `helpers.py`, `cache.py` (`TTLCache`), `guard.py` (write guards). `tools/guides/` = on-demand data.
 - `utils/html.py` — Markdown ↔ HTML, `stamp_block_ids`, `first_anchorless_block`.
-- `models/` — Pydantic v2 by domain, re-exported from `models/__init__.py`. `PaginatedResult[T]` wraps all list responses.
+- `models/` — Pydantic v2, re-exported from `models/__init__.py`. `PaginatedResult[T]` wraps all list responses.
 - `server.py` — FastMCP instance; lifespan owns `PolarionClient`.
 
 ## Non-Negotiable Rules
@@ -29,60 +28,57 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 - All functions: full annotations + `from __future__ import annotations`. Tool functions: `async def` returning Pydantic model.
 - Body fields asymmetric by tool purpose:
   - Round-trip: `get_*(include_*_html=True)` returns raw Polarion HTML; `update_*(*_html=...)` accepts verbatim — no sanitize/convert.
-  - Greenfield create (Markdown): `create_work_items(description=...)` + `create_document(home_page_content=...)` run `markdown_to_html` + `sanitize_html`. Post-create edits = raw-HTML round-trip; formats never mix.
-  - Synthesis (Markdown, READ-ONLY): `read_*` tools convert HTML→Markdown; feeding output back to writes loses Polarion markup.
+  - Greenfield create (Markdown): `markdown_to_html` + `sanitize_html`. Post-create edits = raw-HTML round-trip; formats never mix.
+  - Synthesis (READ-ONLY): `read_*` tools convert HTML→Markdown; feeding output back to writes loses Polarion markup.
 - Write payloads skip `None`/empty (Polarion reads empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
 - Every list tool: `page_size` (max 100) + `page_number` → `PaginatedResult[T]` with `has_more`.
 - Every write tool: `dry_run: bool = False` — return payload without hitting Polarion.
-- Tool docstrings = LLM's manual, Google-style. Only prose above `Args:` ships to clients (FastMCP strips the rest); keep tight. Return-field bullets in sync with Pydantic model.
+- Tool docstrings = LLM's manual, Google-style. Only prose above `Args:` ships to clients; keep tight. Return-field bullets in sync with Pydantic model.
 - Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`.
+- Guards fail closed: validation GET error blocks write; only successful empty option set defers to Polarion.
 
 ## Comment & Docstring Style
 
 Applies to ALL comments/docstrings incl. CLAUDE.md.
 
 - Field descriptions one line; skip when name + type say all.
-- No `WARNING:`/`NOTE:` prefixes — state fact plainly. No dev-narrative ("we tried X then Y"). No banner-divider comments.
-- CLAUDE.md is dev-only — other MCP hosts never load it; anything an MCP-user LLM needs must live in the `@mcp.tool` docstring, even if duplicated here.
-- Module docstrings = why module exists; timing/sizing constraints go inline next to what they constrain.
+- No `WARNING:`/`NOTE:` prefixes, no dev-narrative, no banner dividers.
+- CLAUDE.md is dev-only; anything an MCP-user LLM needs must live in the `@mcp.tool` docstring, even if duplicated here.
+- Module docstrings = why module exists; timing/sizing constraints inline next to what they constrain.
 
-## Polarion API & Gotchas
+## Polarion API Gotchas
 
 - JSON:API v1. HTML stored as `{"type": "text/html", "value": "..."}`.
-- ID shapes: linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse. Module ids = 3 segments, document names may contain `/` — use `split_module_id`.
-- Lucene: trailing wildcards OK, leading 400. `module`/`description` not indexed — use `query="SQL:(...)"`. SQL fundamentals in `list_work_items` docstring; recipes via `get_sql_query_recipes` tool.
+- Linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse. Module ids = 3 segments, document names may contain `/` — use `split_module_id`.
+- Lucene: trailing wildcards OK, leading 400. `module`/`description` not indexed — use `query="SQL:(...)"`; recipes via `get_sql_query_recipes`.
 - Server limits: ≤3 req/s, no concurrency. Client retries 429/5xx, does NOT serialize client-side.
-- Sparse fieldset drops `relationships` block too — list relationship names explicitly (`WORK_ITEM_LIST_FIELDS`). To-many relationships need `include=`; to-one inline without it.
-- Nested `include=` dot-path drops the intermediate resource — `module.author` alone includes users but not documents; list both (`module,module.author`).
+- Sparse fieldset drops `relationships` block — list relationship names explicitly. To-many relationships need `include=`; nested dot-path drops intermediate resource (`module,module.author`, not `module.author` alone).
 - `/backlinkedworkitems` unsupported — back direction via `query=linkedWorkItems:{wi}`, so back results have `role=None`.
-- Custom fields inline under `attributes` (no `customFields` container; `@all` tokens dropped). Polarion does NOT validate custom-field ids (unknown keys persist as silent ghosts; wrong-type values 400) — `guard_work_item_custom_fields` / `guard_document_custom_fields` validate keys against `(project, type)` schema cached from SQL sample, then enum-typed values (next bullet). Fail closed on SQL error AND empty schema; would-be-unknown key forces one fresh re-fetch before rejecting. Document axis = document-type, sampled via headings + `include=module` (`GET /projects/{p}/documents` absent on some builds).
-- Enum validation absent in Polarion — `guard_work_item_enums` / `guard_document_enums` fetch `getAvailableOptions`, raise `ValueError` with valid ids. `type` checked first. Link/hyperlink roles not in `getAvailableOptions` — `fetch_project_enum_option_ids` hits `GET /projects/{p}/enumerations/~/{enumName}/~` (response `data` is dict, not list).
-- `getAvailableOptions` works for custom fields too (only API mapping key → enum options); non-enum/unknown field → 404 "not an Enumeration field". `guard_*_custom_fields` checks enum values after keys: non-empty option set ⇒ field is enum ⇒ value must be option-id string or list of them (wrong shape/id → `ValueError`); 404 defers, cached `_ENUM_NOT_FOUND_TTL_SECONDS` (600s — stale worst case is the same deferral).
-- Guards fail-closed: validation GET error blocks write (auth → `PermissionError`, else `RuntimeError`). Lone lenient case: successful empty option set defers to Polarion. TTL `_GUARD_TTL_SECONDS` = 60s; tests drive expiry by patching `tools._shared.cache._now`.
+- Polarion validates neither custom-field ids (unknown keys persist silently; wrong-type 400), nor enum values, nor link targets/roles — `guard.py` validates pre-write. `getAvailableOptions` = only key→enum-options API (non-enum/unknown field → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (response `data` is dict, not list). Guard TTL caches in `tools/_shared/cache.py`; tests drive expiry by patching `tools._shared.cache._now`.
+- Custom fields inline under `attributes` (no `customFields` container; `@all` tokens dropped). `GET /projects/{p}/documents` absent on some builds.
 
 ### Document writes
 
-- Body edits via `homePageContent` PATCH, not `/parts` (those wrappers reject heading-type items). Empty `home_page_content_html` rejected (would orphan headings).
-- Anchorless `<p>`/`<ul>`/`<ol>`/`<table>`/`<div>`/`<blockquote>`/`<pre>` break `/parts` (PATCH 200, next GET 500); each needs unique non-empty `id=`. Both `create_document` and `update_document` run `stamp_block_ids`. `stamp_block_ids` returns input verbatim when every target block already has a non-blank id (no `str(soup)` reserialize → no `&nbsp;`→`\xa0` drift on an anchored round-trip body), else stamps the gaps; both tools follow with a `first_anchorless_block` defensive guard. For body text, prefer `create_work_items` + `move_work_item_to_document`.
-- `module` cannot be set via PATCH or HTML injection — only `move_work_item_to_document` / `move_work_item_from_document` (atomic action pair). `create_work_item` doesn't expose `module` (would land in recycle bin) — create free-floating, then move. `moveFromDocument` not idempotent (400 if detached). `moveToDocument` auto-creates one link to enclosing heading; later same-role `create_work_item_links` 201s but isn't persisted (phantom success).
+- Body edits via `homePageContent` PATCH, not `/parts` (rejects heading-type items). Empty `home_page_content_html` rejected (would orphan headings).
+- Anchorless `<p>`/`<ul>`/`<ol>`/`<table>`/`<div>`/`<blockquote>`/`<pre>` break `/parts` (PATCH 200, next GET 500) — each needs unique non-empty `id=`; `create_document`/`update_document` run `stamp_block_ids` + `first_anchorless_block` guard. For body text, prefer `create_work_items` + `move_work_item_to_document`.
+- `module` settable only via `move_work_item_to_document` / `move_work_item_from_document`. `create_work_item` doesn't expose `module` (would land in recycle bin) — create free-floating, then move. `moveFromDocument` not idempotent (400 if detached). `moveToDocument` auto-creates link to enclosing heading; later same-role `create_work_item_links` 201s but isn't persisted.
 
 ### Work item & comment quirks
 
-- Link ids composite `<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`. Bulk tools cap at `MAX_BULK_ITEMS` (50). Link-create POST atomic — 4xx rolls back batch; re-query `list_work_item_links` before retry. Polarion validates neither link target nor role — create path guards both; `update_work_item_link` unguarded (unknown role 404s loudly). `delete_work_item_links` pre-reads (fail-closed, runs on `dry_run`) → `deleted_link_ids`/`not_found_link_ids`, never raises on no-op.
-- `update_work_item_link.suspect` tri-state (`None`=unchanged) vs create default `False`. At least one of `suspect`/`revision` required.
-- `PATCH /workitems` needs ≥1 `attributes`/`relationships` entry (400 otherwise, tool validates). `changeTypeTo` resets `status` to new type's initial state.
-- `update_document_comment`: full 4-segment id, root comments only (replies 400 → `RuntimeError`); resolving root resolves whole thread.
+- Link ids composite `<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`. Bulk tools cap at `MAX_BULK_ITEMS` (50). Link-create POST atomic — 4xx rolls back batch; re-query `list_work_item_links` before retry.
+- `PATCH /workitems` needs ≥1 `attributes`/`relationships` entry. `changeTypeTo` resets `status` to new type's initial state.
+- `update_document_comment`: root comments only (replies 400); resolving root resolves whole thread.
 
 ## Testing
 
-- `tests/` mirrors every source tree one-to-one; `conftest.py` at `tests/` root for shared fixtures.
-- `pytest-asyncio` `mode=auto`. Tool tests call tool functions directly with injected `mock_client` (`@mcp.tool` returns original function); client tests use `respx`. `mock_client`/`mock_ctx` + autouse guard-cache reset in `tests/mcp_server_polarion/tools/conftest.py`. Pydantic `Field` constraints bypass JSON Schema on direct calls — verify via `TypeAdapter` reconstruction.
-- Transport tests (`test_mcp_transport.py`) drive server via `fastmcp.Client(mcp)` in-memory. New `@mcp.tool` requires updating `EXPECTED_TOOL_NAMES`.
+- `tests/` mirrors source tree one-to-one; shared fixtures in `tests/` root `conftest.py`; `mock_client`/`mock_ctx` + autouse guard-cache reset in `tests/mcp_server_polarion/tools/conftest.py`.
+- `pytest-asyncio` `mode=auto`. Tool tests call functions directly (`@mcp.tool` returns original); client tests use `respx`. Pydantic `Field` constraints bypass JSON Schema on direct calls — verify via `TypeAdapter` reconstruction.
+- New `@mcp.tool` requires updating `EXPECTED_TOOL_NAMES` in `test_mcp_transport.py`.
 - `tests/evals/` opens with `pytest.importorskip` (`evals` dependency group; CI syncs `--group evals`).
 
 ## Evals — Tier-1 deploy gate
 
-`evals/` drives real LLM agent through in-memory server against mocked Polarion; deterministic checks, no LLM judge. Hard gate before PyPI publish (`min_pass_rate=1.0`). New case: register check in `evals/evaluators/checks.py::REGISTRY`, add `Case` to `cases/tier1_prohibitions.py`, phrase task neutrally (stating rule tests prompt, not docstrings). Detail: [evals/README.md](evals/README.md).
+`evals/` drives real LLM through in-memory server against mocked Polarion; deterministic checks, no judge. Hard gate before PyPI publish (`min_pass_rate=1.0`). New case: check in `evals/evaluators/checks.py::REGISTRY` + `Case` in `cases/tier1_prohibitions.py`; phrase task neutrally. Detail: [evals/README.md](evals/README.md).
 
 ## Repo Conventions
 
@@ -91,5 +87,4 @@ Full rules in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md); enforced by `.
 - Branches: `<type>/<short-kebab-summary>` off `main`. Types: `feature|fix|refactor|test|docs|chore|ci`.
 - Commits: `type(scope): summary` ≤50 chars, lowercase imperative, no period. Types: `feat|fix|docs|refactor|perf|test|ci|chore`. Scopes: `tool|server|transport|config|deps|utils|model|project|meta|git`. Body: blank line + exactly 2 bullets (motivation, then change), ≤120 chars each.
 - PR template checklist: flip `[ ]`→`[x]`; don't delete unchecked options.
-- Squash merge only; NEVER pass `--subject` to `gh pr merge`.
-- Force push feature branches only after explicit authorization; never `main`.
+- Squash merge only; NEVER `--subject` to `gh pr merge`. Force-push feature branches only with explicit authorization; never `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 
 ## Architecture
 
-- `core/` — `client.py` (async httpx, retries 429/5xx, maps to `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only).
+- `core/` — `client.py` (async httpx, retries 429/5xx, maps to `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only). Loggers: `logging.getLogger("mcp_server_polarion.<module>")`.
 - `tools/` — domain modules; `_build_*_payload` helpers = unit-test seam. Import in `tools/__init__.py` registers `@mcp.tool`s. `tools/_shared/`: `helpers.py`, `cache.py` (`TTLCache`), `guard.py` (write guards). `tools/guides/` = on-demand data.
 - `utils/html.py` — Markdown ↔ HTML, `stamp_block_ids`, `first_anchorless_block`.
 - `models/` — Pydantic v2, re-exported from `models/__init__.py`. `PaginatedResult[T]` wraps all list responses.

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,7 +1,3 @@
-"""Pre-deploy evaluation suite for mcp-server-polarion.
-
-Tier 1 ("forbidden behaviour") gate: drives an LLM agent through the real
-in-memory MCP server against a mocked Polarion backend, then asserts the
-agent never took a destructive / footgun action. Deterministic — no LLM
-judge. See evals/README.md.
-"""
+"""Pre-deploy eval gate: drives an LLM agent through the in-memory MCP server
+against mocked Polarion, asserting no destructive / footgun action.
+Deterministic — no LLM judge. See evals/README.md."""

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,3 +1,4 @@
 """Pre-deploy eval gate: drives an LLM agent through the in-memory MCP server
 against mocked Polarion, asserting no destructive / footgun action.
-Deterministic — no LLM judge. See evals/README.md."""
+Deterministic — no LLM judge. See evals/README.md.
+"""

--- a/evals/cases/tier1_prohibitions.py
+++ b/evals/cases/tier1_prohibitions.py
@@ -1,31 +1,14 @@
-"""Tier-1 forbidden-behaviour cases.
+"""Tier-1 forbidden-behaviour cases. Each names a check in
+``evaluators/checks.py``; ``min_pass_rate = 1.0`` — one forbidden action blocks
+deploy. Tasks phrased neutrally so tool docstrings alone steer the agent.
 
-Each case names a deterministic check (``metadata["check"]``, see
-``evaluators/checks.py``) and a ``min_pass_rate`` the gate enforces. Zero
-tolerance: ``min_pass_rate = 1.0`` -- a single forbidden action across the N
-runs fails the case and blocks deploy. Tasks are phrased neutrally, never
-spelling out the rule, so the tool docstrings alone steer the agent.
-
-Scope is LLM behaviour the tool layer cannot guard deterministically:
-
-* read-before-write (``T1-UPDATE-NEEDS-GET``) -- only the trajectory reveals
-  whether the agent observed current values before patching.
-* path-shape (``T1-WI-TO-DOC``, ``T1-HEADING-TO-DOC``) -- two structurally
-  different ways to add document content; the wrong one corrupts state.
-* read-only intent (``T1-READONLY``) -- write tools stay dormant on a read task.
-* observed-id writes (``T1-REPLY-RESOLVE``) -- thread resolution must reach a
-  root id surfaced by a prior list; resolving only a reply leaves the thread
-  open while reporting it done.
-* REPLACE-list preservation (``T1-HYPERLINK-PRESERVE``) -- an add must carry
-  the pre-existing entries or they are silently deleted.
-* round-trip sourcing (``T1-ROUNDTRIP-SOURCE``) -- raw-HTML body writes must
-  come from the flagged ``get_*`` read, not synthesis Markdown.
-* state-aware actions (``T1-DETACH-NOOP``) -- non-idempotent detach stays
-  dormant on an item that is in no document.
-
-Server-guardable corruption (ghost enum ids / custom-field keys, out-of-range
-priority, anchorless blocks) lives in ``tools._guard`` / ``utils.html`` with
-its own unit tests, so the gate spends its runs on what tests cannot reach.
+Scope = LLM behaviour the tool layer cannot guard:
+read-before-write (``T1-UPDATE-NEEDS-GET``), path-shape (``T1-WI-TO-DOC``,
+``T1-HEADING-TO-DOC``), read-only intent (``T1-READONLY``), observed-id thread
+resolution (``T1-REPLY-RESOLVE``), REPLACE-list preservation
+(``T1-HYPERLINK-PRESERVE``), round-trip sourcing (``T1-ROUNDTRIP-SOURCE``),
+state-aware detach (``T1-DETACH-NOOP``). Server-guardable corruption lives in
+``tools._guard`` / ``utils.html`` with its own unit tests.
 """
 
 from __future__ import annotations

--- a/evals/cases/tier2_efficiency.py
+++ b/evals/cases/tier2_efficiency.py
@@ -1,19 +1,9 @@
-"""Tier-2 efficiency cases.
+"""Tier-2 efficiency cases: "took the short, correct path";
+``min_pass_rate = 0.8`` tolerates occasional waste, fails systematic waste.
 
-Same harness and deterministic checks as Tier 1, but the rule is "took the
-short, correct path", not "never corrupted state", so ``min_pass_rate = 0.8``
--- occasional wasteful runs are tolerated, systematic waste fails the gate.
-Tasks state the goal only; the efficient path must be discoverable from the
-tool docstrings alone.
-
-* single bulk call (``T2-BULK-CREATE``) -- N items go through one
-  ``create_work_items``, not N calls.
-* direct lookup (``T2-DIRECT-GET``) -- a known id is fetched, not scanned for.
-* no redundant reads (``T2-NO-DUP-READS``, ``T2-ENUM-ONCE``) -- identical
-  reads repeat only after a write could have changed the answer.
-* query mechanism (``T2-SQL-NOT-LUCENE``) -- document scoping uses the
-  ``SQL:(...)`` prefix or ``read_document_parts``, never a Lucene ``module``
-  term (not indexed).
+Cases: single bulk call (``T2-BULK-CREATE``), direct lookup
+(``T2-DIRECT-GET``), no redundant reads (``T2-NO-DUP-READS``,
+``T2-ENUM-ONCE``), SQL over Lucene ``module`` term (``T2-SQL-NOT-LUCENE``).
 """
 
 from __future__ import annotations

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -1,5 +1,6 @@
 """Pure trajectory checks: f(trajectory) -> (passed, reason); no LLM, no I/O,
-deterministic. Scope = LLM-behavioural rules unreachable by server-side guards."""
+deterministic. Scope = LLM-behavioural rules unreachable by server-side guards.
+"""
 
 from __future__ import annotations
 

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -1,12 +1,5 @@
-"""Pure trajectory checks for Tier-1 prohibitions and Tier-2 efficiency.
-
-Each check is a function of the trajectory alone (a list of
-``{"name": str, "args": dict, "result": ...}`` in call order, plus optional
-params) returning ``(passed, reason)`` -- no LLM, no I/O, so identical input
-yields identical verdict. Scope is LLM-behavioural rules unreachable by the
-server-side guards in ``tools._guard`` / ``utils.html`` (covered by their own
-unit tests).
-"""
+"""Pure trajectory checks: f(trajectory) -> (passed, reason); no LLM, no I/O,
+deterministic. Scope = LLM-behavioural rules unreachable by server-side guards."""
 
 from __future__ import annotations
 
@@ -123,11 +116,8 @@ _UPDATE_TO_GET: dict[str, tuple[str, tuple[str, ...]]] = {
 
 
 def _target_key(call: dict[str, Any], keys: tuple[str, ...]) -> tuple[object, ...]:
-    """Identifier tuple for matching two calls on the same target.
-
-    ``work_item_id`` is normalized via ``_short_id`` so a project-qualified id
-    in one call still matches the short form in another. ``document_name`` is
-    left verbatim — document names may legitimately contain ``/``.
+    """Identifier tuple for matching two calls on one target; ``work_item_id``
+    normalized via ``_short_id``, ``document_name`` verbatim (may contain ``/``).
     """
     args = _args(call)
     return tuple(
@@ -141,13 +131,8 @@ def _target_key(call: dict[str, Any], keys: tuple[str, ...]) -> tuple[object, ..
 def check_get_before_update(
     trajectory: Trajectory, _params: dict[str, Any]
 ) -> CheckResult:
-    """Every ``update_*`` must be preceded by a matching ``get_*``.
-
-    Covers both work-item and document paths. Polarion writes REPLACE lists
-    (``hyperlinks``, ``assignee_ids``) and accept partial PATCHes silently, so
-    without a prior read clobbers and ghost-custom-key writes become possible.
-    Observable from the trajectory: a ``get_*`` on the matching identifier
-    tuple must appear earlier.
+    """Every ``update_*`` needs an earlier matching ``get_*`` — REPLACE-list and
+    partial-PATCH semantics make blind writes clobber silently.
     """
     for i, call in enumerate(trajectory):
         name = call.get("name", "")
@@ -174,14 +159,9 @@ def check_get_before_update(
 def check_resolve_root_comment(
     trajectory: Trajectory, params: dict[str, Any]
 ) -> CheckResult:
-    """Thread resolution must reach an observed root, not stop at a reply.
-
-    A resolve PATCH on a reply 400s loudly in real Polarion (server-guarded),
-    so a stray reply attempt alongside a root resolve is tolerated. The
-    silent failure the tool layer cannot catch: resolving ONLY a reply and
-    reporting the thread done, or PATCHing an id never observed via
-    ``list_document_comments``. Only ``resolved=True`` on a root counts as a
-    resolution. Root ids come from ``params["root_ids"]``.
+    """Resolution must set ``resolved=True`` on an observed root
+    (``params["root_ids"]``). Reply-only resolves and never-observed ids fail;
+    a stray reply attempt alongside a root resolve is tolerated (server 400s it).
     """
     root_ids = {str(r) for r in params.get("root_ids", [])}
     doc_keys = ("project_id", "space_id", "document_name")
@@ -220,11 +200,8 @@ def check_resolve_root_comment(
 def check_preserve_hyperlinks(
     trajectory: Trajectory, params: dict[str, Any]
 ) -> CheckResult:
-    """A ``hyperlinks`` update must carry every pre-existing URI.
-
-    Polarion REPLACES the whole list, so an update omitting an existing URI
-    silently deletes it. ``params``: ``work_item_id`` (target item) and
-    ``required_uris`` (seeded URIs that must survive).
+    """A ``hyperlinks`` update must carry every URI in ``params["required_uris"]``
+    — Polarion REPLACES the list, omissions silently delete.
     """
     target = _short_id(params.get("work_item_id", ""))
     required = [str(u) for u in params.get("required_uris", [])]
@@ -266,12 +243,8 @@ _BODY_WRITE_TO_SOURCE: dict[str, tuple[str, str, str, tuple[str, ...]]] = {
 def check_round_trip_source(
     trajectory: Trajectory, _params: dict[str, Any]
 ) -> CheckResult:
-    """Raw-HTML body writes must source from the flagged ``get_*`` read.
-
-    ``read_document`` / ``read_work_item`` emit synthesis Markdown that
-    collapses Polarion anchors; feeding it back corrupts the body. Only
-    ``get_*(include_*_html=True)`` yields the round-trip shape, so every body
-    write needs one earlier on the same target.
+    """Body writes must source from ``get_*(include_*_html=True)`` on the same
+    target — ``read_*`` synthesis Markdown collapses Polarion anchors.
     """
     for i, call in enumerate(trajectory):
         spec = _BODY_WRITE_TO_SOURCE.get(call.get("name", ""))
@@ -298,11 +271,8 @@ def check_round_trip_source(
 def check_no_blind_detach(
     trajectory: Trajectory, params: dict[str, Any]
 ) -> CheckResult:
-    """``move_work_item_from_document`` must not target a free-floating item.
-
-    The action is not idempotent: detaching an item that is in no document
-    returns HTTP 400. ``params["floating_ids"]`` lists the seeded
-    free-floating items.
+    """``move_work_item_from_document`` must not target ``params["floating_ids"]``
+    — detaching a free-floating item 400s (not idempotent).
     """
     floating = {_short_id(x) for x in params.get("floating_ids", [])}
     for call in trajectory:
@@ -362,12 +332,8 @@ def check_direct_read(trajectory: Trajectory, params: dict[str, Any]) -> CheckRe
 def check_no_duplicate_reads(
     trajectory: Trajectory, _params: dict[str, Any]
 ) -> CheckResult:
-    """No read may repeat with identical args while nothing changed.
-
-    State reads (item/document/comment fetches) reset on any write -- a
-    re-read after a mutation is legitimate. Stable reads (enum options,
-    SQL recipes, project list) never change under the agent's writes, so an
-    identical repeat is always redundant.
+    """No identical re-read while nothing changed: state reads reset on any write,
+    stable reads (enums, recipes, projects) never legitimately repeat.
     """
     seen_state: set[tuple[str, str]] = set()
     seen_stable: set[tuple[str, str]] = set()
@@ -397,11 +363,8 @@ def check_no_duplicate_reads(
 def check_scoped_query_uses_sql(
     trajectory: Trajectory, _params: dict[str, Any]
 ) -> CheckResult:
-    """Module-scoped work item searches must not use a Lucene ``module`` term.
-
-    ``module`` is not Lucene-indexed -- only the ``SQL:(...)`` prefix (or
-    ``read_document_parts``) scopes by document. Matches ``module`` only as a
-    Lucene field name (``module:`` / ``module.id:``), not as plain text.
+    """Document scoping must use ``SQL:(...)`` or ``read_document_parts`` — Lucene
+    ``module``/``module.id`` field terms match nothing (not indexed).
     """
     field_re = re.compile(r"\bmodule(?:\.\w+)?\s*:", re.IGNORECASE)
     for call in trajectory:

--- a/evals/evaluators/tier1.py
+++ b/evals/evaluators/tier1.py
@@ -1,5 +1,6 @@
 """Tier-1 evaluator: dispatches on ``Case.metadata["check"]`` to the matching
-pure check in ``checks.py``."""
+pure check in ``checks.py``.
+"""
 
 from __future__ import annotations
 

--- a/evals/evaluators/tier1.py
+++ b/evals/evaluators/tier1.py
@@ -1,9 +1,5 @@
-"""The Tier-1 forbidden-behaviour evaluator.
-
-Dispatches on ``Case.metadata["check"]`` (carried through to
-``EvaluationData.metadata``) to the matching pure check in ``checks.py``.
-A case passes only if its named check passes.
-"""
+"""Tier-1 evaluator: dispatches on ``Case.metadata["check"]`` to the matching
+pure check in ``checks.py``."""
 
 from __future__ import annotations
 

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -1,15 +1,7 @@
-"""In-process fake Polarion backend for the eval harness.
-
-Mirrors the *structure* of the real ``MCP_Test_Project`` (id shapes, space
-layout, enum id sets, comment-thread links, work-item field set) but the
-*content* is entirely synthetic — no real titles, bodies, comment text or
-author ids — so no production data can leak into eval logs.
-
-Installed as a single catch-all respx route scoped to the Polarion host.
-Requests to any other host (the LLM provider) fall through to the network
-because the router is created with ``assert_all_mocked=False``. Every
-mutating request (POST / PATCH / DELETE) is recorded but has no side effect.
-"""
+"""In-process fake Polarion: mirrors the real project's *structure* with fully
+synthetic *content* (no production data in eval logs). One catch-all respx
+route on the Polarion host; other hosts (LLM provider) fall through
+(``assert_all_mocked=False``). Mutations recorded, no side effects."""
 
 from __future__ import annotations
 

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -1,7 +1,8 @@
 """In-process fake Polarion: mirrors the real project's *structure* with fully
 synthetic *content* (no production data in eval logs). One catch-all respx
 route on the Polarion host; other hosts (LLM provider) fall through
-(``assert_all_mocked=False``). Mutations recorded, no side effects."""
+(``assert_all_mocked=False``). Mutations recorded, no side effects.
+"""
 
 from __future__ import annotations
 

--- a/evals/harness/mcp_bridge.py
+++ b/evals/harness/mcp_bridge.py
@@ -1,14 +1,6 @@
-"""Bridge the in-memory FastMCP server to Strands agent tools.
-
-Strands' native MCP client runs the server in a separate process, out of
-respx's reach. To keep one process (so the fake Polarion mock applies), read
-the real tool specs from the in-memory ``fastmcp.Client`` and wrap each as a
-``PythonAgentTool`` forwarding back through that client.
-
-``TrajectoryRecorder`` records each forwarded call with its parsed result, so
-checks see not just (name, args) but what each call returned -- needed e.g. by
-``check_get_before_update``.
-"""
+"""Bridge the in-memory FastMCP server to Strands tools — Strands' native MCP
+client spawns a separate process, out of respx's reach. ``TrajectoryRecorder``
+captures each call's parsed result (checks need returns, not just args)."""
 
 from __future__ import annotations
 
@@ -24,11 +16,8 @@ from strands.types.tools import ToolResult, ToolSpec, ToolUse
 
 @dataclass
 class TrajectoryRecorder:
-    """Append-only log of (name, args, result) tuples in call order.
-
-    ``result`` is the parsed structured payload (dict from a Pydantic model),
-    raw text, or ``None`` for empty/error responses -- lets checks verify the
-    agent used a value surfaced by a prior call, not a ghosted id.
+    """Append-only (name, args, result) log in call order; ``result`` is the parsed
+    payload so checks can verify values came from prior calls, not ghosted ids.
     """
 
     calls: list[dict[str, Any]] = field(default_factory=list)

--- a/evals/harness/mcp_bridge.py
+++ b/evals/harness/mcp_bridge.py
@@ -1,6 +1,7 @@
 """Bridge the in-memory FastMCP server to Strands tools — Strands' native MCP
 client spawns a separate process, out of respx's reach. ``TrajectoryRecorder``
-captures each call's parsed result (checks need returns, not just args)."""
+captures each call's parsed result (checks need returns, not just args).
+"""
 
 from __future__ import annotations
 

--- a/evals/harness/model.py
+++ b/evals/harness/model.py
@@ -1,16 +1,7 @@
-"""Model factory for the eval agent.
-
-A single LiteLLM adapter serves both cloud and local backends — switch with
-the ``EVAL_MODEL`` env var, no code change:
-
-    EVAL_MODEL=openai/gpt-4o-mini            # default, CI (needs OPENAI_API_KEY)
-    EVAL_MODEL=ollama/qwen2.5-coder:7b       # local (set EVAL_MODEL_BASE_URL)
-
-``temperature`` is pinned to 0.0 and ``parallel_tool_calls`` to False to keep
-the zero-tolerance gate stable. ``EVAL_NUM_RETRIES`` / ``EVAL_LLM_TIMEOUT``
-forward to LiteLLM so transient cloud 429/RateLimitError gets absorbed by
-backoff, not failing the case.
-"""
+"""Eval-agent model factory: one LiteLLM adapter, backend switched via
+``EVAL_MODEL`` (e.g. ``openai/gpt-4o-mini``, ``ollama/...`` + base URL).
+``temperature=0`` / ``parallel_tool_calls=False`` keep the gate stable;
+``EVAL_NUM_RETRIES``/``EVAL_LLM_TIMEOUT`` absorb transient 429s."""
 
 from __future__ import annotations
 

--- a/evals/harness/model.py
+++ b/evals/harness/model.py
@@ -1,7 +1,8 @@
 """Eval-agent model factory: one LiteLLM adapter, backend switched via
 ``EVAL_MODEL`` (e.g. ``openai/gpt-4o-mini``, ``ollama/...`` + base URL).
 ``temperature=0`` / ``parallel_tool_calls=False`` keep the gate stable;
-``EVAL_NUM_RETRIES``/``EVAL_LLM_TIMEOUT`` absorb transient 429s."""
+``EVAL_NUM_RETRIES``/``EVAL_LLM_TIMEOUT`` absorb transient 429s.
+"""
 
 from __future__ import annotations
 

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -1,7 +1,8 @@
 """Run one eval case end to end. ``run_case`` is the synchronous ``task``
 callable for ``strands_evals``; one ``asyncio.run`` drives Agent -> bridged
 tools -> in-memory server -> respx -> FakePolarion. LLM traffic falls through
-to the real provider (``assert_all_mocked=False``); Polarion never touched."""
+to the real provider (``assert_all_mocked=False``); Polarion never touched.
+"""
 
 from __future__ import annotations
 

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -1,17 +1,7 @@
-"""Run a single eval case end to end and return its trajectory.
-
-``run_case`` is the ``task`` callable handed to
-``strands_evals.Experiment.run_evaluations``. It is synchronous (the
-Experiment API requires that) and drives the whole async stack inside one
-``asyncio.run`` under an active respx mock:
-
-    Strands Agent -> bridged MCP tools -> in-memory FastMCP server
-        -> PolarionClient -> respx -> FakePolarion
-
-The agent's LLM traffic is *not* mocked — respx is created with
-``assert_all_mocked=False`` so it falls through to the real provider, while
-every Polarion request is served by the fake. No real Polarion is touched.
-"""
+"""Run one eval case end to end. ``run_case`` is the synchronous ``task``
+callable for ``strands_evals``; one ``asyncio.run`` drives Agent -> bridged
+tools -> in-memory server -> respx -> FakePolarion. LLM traffic falls through
+to the real provider (``assert_all_mocked=False``); Polarion never touched."""
 
 from __future__ import annotations
 
@@ -71,12 +61,9 @@ def _set_polarion_env() -> None:
 
 
 class _CycleGuard:
-    """Model-call counter hook that fail-closes runaway agents.
-
-    Ships as a class because Strands' ``hooks=`` wants ``HookProvider``
-    instances, not bare callbacks. Exposes ``count`` for post-invoke
-    inspection: the caller fail-closes on a forced stop, since a clean
-    ``stop_event_loop`` could return empty partial text and silently pass.
+    """Model-call counter fail-closing runaway agents. A class because Strands'
+    ``hooks=`` wants ``HookProvider`` instances; caller fail-closes on a forced
+    stop (clean ``stop_event_loop`` could silently pass with empty text).
     """
 
     def __init__(self, max_cycles: int) -> None:

--- a/evals/run.py
+++ b/evals/run.py
@@ -1,10 +1,5 @@
-"""Eval deploy gate entry point.
-
-Runs every case (Tier-1 prohibitions + Tier-2 efficiency) N times against the
-mocked-Polarion harness, applies the deterministic
-``ForbiddenBehaviorEvaluator``, and exits non-zero if any case's pass rate
-falls below its ``min_pass_rate`` (1.0 for Tier-1, 0.8 for Tier-2). Wired into
-``publish.yml`` ahead of the PyPI publish jobs.
+"""Eval deploy gate (wired into ``publish.yml``): runs every case N times,
+exits non-zero below ``min_pass_rate`` (1.0 Tier-1, 0.8 Tier-2).
 
     uv run python -m evals.run                 # all cases, EVAL_RUNS (default 10)
     uv run python -m evals.run --case T1-READONLY --runs 1

--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -43,16 +43,8 @@ _MAX_ERROR_DETAIL_LEN: Final[int] = 200
 
 
 def _extract_json_api_detail(body: object) -> str:
-    """Extract a concise detail from a JSON:API body.
-
-    Prefers ``errors[*].detail``/``title``; falls back to truncated body.
-
-    Args:
-        body: Decoded JSON response body.
-
-    Returns:
-        Detail string, truncated to ``_MAX_ERROR_DETAIL_LEN`` chars.
-    """
+    """Concise detail from a JSON:API body: ``errors[*].detail``/``title``,
+    else truncated body."""
     if not isinstance(body, dict):
         return str(body)[:_MAX_ERROR_DETAIL_LEN]
     errors = body.get("errors")
@@ -69,15 +61,7 @@ def _extract_json_api_detail(body: object) -> str:
 
 
 def _sanitize_error_text(raw: str) -> str:
-    """Strip HTML tags and truncate raw error text for safe display.
-
-    Args:
-        raw: Raw response body text (may contain HTML).
-
-    Returns:
-        Plain text, HTML stripped, truncated to ``_MAX_ERROR_DETAIL_LEN``
-        chars with a trailing … when truncated.
-    """
+    """Strip HTML tags and truncate raw error text for safe display."""
     clean = re.sub(r"<[^>]+>", " ", raw)
     clean = " ".join(clean.split())
     if len(clean) > _MAX_ERROR_DETAIL_LEN:
@@ -86,24 +70,8 @@ def _sanitize_error_text(raw: str) -> str:
 
 
 class PolarionClient:
-    """Async HTTP client for the Polarion REST API.
-
-    Created once and reused for the MCP server lifetime (via the
-    ``lifespan`` context in ``server.py``).
-
-    Usage::
-
-        config = PolarionConfig()
-        async with PolarionClient(config) as client:
-            data = await client.get("/projects")
-
-    Args:
-        config: ``PolarionConfig`` supplying URL and token.
-        write_delay: Seconds to wait after each write (default 1.5 s).
-
-    Attributes:
-        base_url: Resolved REST API v1 base URL.
-    """
+    """Async HTTP client for the Polarion REST API; created once and reused
+    for the MCP server lifetime (``lifespan`` context in ``server.py``)."""
 
     def __init__(
         self,
@@ -124,7 +92,7 @@ class PolarionClient:
             verify=config.polarion_verify_ssl,
         )
         # Lazily bound to the running loop; serializes all calls (Polarion
-        # forbids concurrency). Not reentrant.
+        # forbids concurrency); not reentrant.
         self._request_lock: asyncio.Lock | None = None
 
     def _get_request_lock(self) -> asyncio.Lock:
@@ -158,20 +126,8 @@ class PolarionClient:
         *,
         params: dict[str, str | int] | None = None,
     ) -> dict[str, object]:
-        """Send a ``GET`` request.
-
-        Args:
-            path: URL path relative to the base API URL (e.g. ``/projects``).
-            params: Optional query parameters.
-
-        Returns:
-            Decoded JSON response body.
-
-        Raises:
-            PolarionAuthError: On HTTP 401/403.
-            PolarionNotFoundError: On HTTP 404.
-            PolarionError: On other non-2xx responses.
-        """
+        """``GET``; raises ``PolarionAuthError`` (401/403),
+        ``PolarionNotFoundError`` (404), ``PolarionError`` (other non-2xx)."""
         async with self._get_request_lock():
             return await self._request("GET", path, params=params)
 
@@ -181,18 +137,8 @@ class PolarionClient:
         *,
         json: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        """Send a ``POST`` request (write operation).
-
-        Sleeps ``_write_delay`` after success, inside the lock, for
-        cluster propagation before the next call.
-
-        Args:
-            path: URL path relative to the base API URL.
-            json: JSON request body.
-
-        Returns:
-            Decoded JSON response body.
-        """
+        """``POST``; sleeps ``_write_delay`` after success, inside the lock,
+        for cluster propagation before the next call."""
         async with self._get_request_lock():
             result = await self._request("POST", path, json=json)
             await asyncio.sleep(self._write_delay)
@@ -204,17 +150,7 @@ class PolarionClient:
         *,
         json: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        """Send a ``PATCH`` request (write operation).
-
-        Same post-success delay contract as :meth:`post`.
-
-        Args:
-            path: URL path relative to the base API URL.
-            json: JSON request body.
-
-        Returns:
-            Decoded JSON response body.
-        """
+        """``PATCH``; same post-success delay contract as :meth:`post`."""
         async with self._get_request_lock():
             result = await self._request("PATCH", path, json=json)
             await asyncio.sleep(self._write_delay)
@@ -226,19 +162,9 @@ class PolarionClient:
         *,
         json: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        """Send a ``DELETE`` request (write operation).
-
-        ``json`` carries bulk-delete resource ids — non-standard for
-        DELETE, but ``httpx`` and Polarion's gateway both accept it.
-        Same post-success delay contract as :meth:`post`/:meth:`patch`.
-
-        Args:
-            path: URL path relative to the base API URL.
-            json: JSON request body (required for bulk-delete endpoints).
-
-        Returns:
-            Decoded JSON response body (``{}`` for 204 No Content).
-        """
+        """``DELETE``; same delay contract as :meth:`post`. ``json`` carries
+        bulk-delete ids — non-standard for DELETE, but httpx and Polarion's
+        gateway both accept it. ``{}`` for 204 No Content."""
         async with self._get_request_lock():
             result = await self._request("DELETE", path, json=json)
             await asyncio.sleep(self._write_delay)
@@ -252,26 +178,8 @@ class PolarionClient:
         params: dict[str, str | int] | None = None,
         json: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        """Execute an HTTP request with retry and error mapping.
-
-        Retries 429/5xx up to ``_MAX_RETRIES`` times with exponential
-        backoff; other errors raise immediately.
-
-        Args:
-            method: HTTP method (GET, POST, PATCH, DELETE).
-            path: URL path relative to the base API URL.
-            params: Optional query parameters.
-            json: Optional JSON body.
-
-        Returns:
-            Decoded JSON response body.
-
-        Raises:
-            PolarionAuthError: On HTTP 401/403.
-            PolarionNotFoundError: On HTTP 404.
-            PolarionError: On other non-2xx responses after all retries
-                are exhausted.
-        """
+        """Execute with error mapping; retries 429/5xx up to ``_MAX_RETRIES``
+        with exponential backoff, other errors raise immediately."""
         # Lock held across retries — releasing mid-backoff would let another
         # caller slip in and hit the same 429.
         last_exception: PolarionError | None = None
@@ -330,14 +238,7 @@ class PolarionClient:
 
     @staticmethod
     def _map_status_to_error(response: httpx.Response) -> PolarionError:
-        """Map an unsuccessful HTTP response to a domain exception.
-
-        Args:
-            response: The ``httpx.Response`` with non-2xx status.
-
-        Returns:
-            A ``PolarionError`` subclass matching the status code.
-        """
+        """Map a non-2xx response to the matching ``PolarionError`` subclass."""
         status = response.status_code
         try:
             detail: str = _extract_json_api_detail(response.json())

--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -44,7 +44,8 @@ _MAX_ERROR_DETAIL_LEN: Final[int] = 200
 
 def _extract_json_api_detail(body: object) -> str:
     """Concise detail from a JSON:API body: ``errors[*].detail``/``title``,
-    else truncated body."""
+    else truncated body.
+    """
     if not isinstance(body, dict):
         return str(body)[:_MAX_ERROR_DETAIL_LEN]
     errors = body.get("errors")
@@ -71,7 +72,8 @@ def _sanitize_error_text(raw: str) -> str:
 
 class PolarionClient:
     """Async HTTP client for the Polarion REST API; created once and reused
-    for the MCP server lifetime (``lifespan`` context in ``server.py``)."""
+    for the MCP server lifetime (``lifespan`` context in ``server.py``).
+    """
 
     def __init__(
         self,
@@ -127,7 +129,8 @@ class PolarionClient:
         params: dict[str, str | int] | None = None,
     ) -> dict[str, object]:
         """``GET``; raises ``PolarionAuthError`` (401/403),
-        ``PolarionNotFoundError`` (404), ``PolarionError`` (other non-2xx)."""
+        ``PolarionNotFoundError`` (404), ``PolarionError`` (other non-2xx).
+        """
         async with self._get_request_lock():
             return await self._request("GET", path, params=params)
 
@@ -138,7 +141,8 @@ class PolarionClient:
         json: dict[str, object] | None = None,
     ) -> dict[str, object]:
         """``POST``; sleeps ``_write_delay`` after success, inside the lock,
-        for cluster propagation before the next call."""
+        for cluster propagation before the next call.
+        """
         async with self._get_request_lock():
             result = await self._request("POST", path, json=json)
             await asyncio.sleep(self._write_delay)
@@ -164,7 +168,8 @@ class PolarionClient:
     ) -> dict[str, object]:
         """``DELETE``; same delay contract as :meth:`post`. ``json`` carries
         bulk-delete ids — non-standard for DELETE, but httpx and Polarion's
-        gateway both accept it. ``{}`` for 204 No Content."""
+        gateway both accept it. ``{}`` for 204 No Content.
+        """
         async with self._get_request_lock():
             result = await self._request("DELETE", path, json=json)
             await asyncio.sleep(self._write_delay)
@@ -179,7 +184,8 @@ class PolarionClient:
         json: dict[str, object] | None = None,
     ) -> dict[str, object]:
         """Execute with error mapping; retries 429/5xx up to ``_MAX_RETRIES``
-        with exponential backoff, other errors raise immediately."""
+        with exponential backoff, other errors raise immediately.
+        """
         # Lock held across retries — releasing mid-backoff would let another
         # caller slip in and hit the same 429.
         last_exception: PolarionError | None = None

--- a/src/mcp_server_polarion/core/config.py
+++ b/src/mcp_server_polarion/core/config.py
@@ -1,8 +1,5 @@
-"""Polarion configuration loaded from environment variables.
-
-All secrets live in ``.env`` (local dev) or real environment variables
-(CI / production).  Never hardcode credentials.
-"""
+"""Polarion configuration from environment variables; secrets live in ``.env``
+or real env vars, never hardcoded."""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/core/config.py
+++ b/src/mcp_server_polarion/core/config.py
@@ -1,5 +1,6 @@
 """Polarion configuration from environment variables; secrets live in ``.env``
-or real env vars, never hardcoded."""
+or real env vars, never hardcoded.
+"""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/core/exceptions.py
+++ b/src/mcp_server_polarion/core/exceptions.py
@@ -1,19 +1,11 @@
-"""Domain-specific exceptions for Polarion API errors.
-
-Each exception carries the HTTP ``status_code`` so that tool-level error
-handlers can produce actionable messages for the LLM.
-"""
+"""Polarion API exceptions; each carries the HTTP ``status_code`` so tool-level
+handlers can produce actionable messages for the LLM."""
 
 from __future__ import annotations
 
 
 class PolarionError(Exception):
-    """Base exception for all Polarion REST API errors.
-
-    Attributes:
-        status_code: The HTTP status code returned by the Polarion server.
-        message: A human-readable error message.
-    """
+    """Base exception for all Polarion REST API errors."""
 
     def __init__(self, message: str, *, status_code: int = 0) -> None:
         super().__init__(message)
@@ -22,14 +14,8 @@ class PolarionError(Exception):
 
 
 class PolarionAuthError(PolarionError):
-    """Raised on HTTP 401 (Unauthorized) or 403 (Forbidden).
-
-    Typical cause: expired or insufficient-scope bearer token.
-    """
+    """HTTP 401/403 — expired or insufficient-scope bearer token."""
 
 
 class PolarionNotFoundError(PolarionError):
-    """Raised on HTTP 404 (Not Found).
-
-    Typical cause: invalid project ID, work-item ID, or document path.
-    """
+    """HTTP 404 — invalid project ID, work-item ID, or document path."""

--- a/src/mcp_server_polarion/core/exceptions.py
+++ b/src/mcp_server_polarion/core/exceptions.py
@@ -1,5 +1,6 @@
 """Polarion API exceptions; each carries the HTTP ``status_code`` so tool-level
-handlers can produce actionable messages for the LLM."""
+handlers can produce actionable messages for the LLM.
+"""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/core/logging.py
+++ b/src/mcp_server_polarion/core/logging.py
@@ -9,7 +9,8 @@ import sys
 def setup_logging(*, level: int = logging.INFO) -> logging.Logger:
     """Configure and return the package-level logger — single
     ``StreamHandler(sys.stderr)`` so log messages never pollute the MCP
-    JSON-RPC channel on stdout."""
+    JSON-RPC channel on stdout.
+    """
     logger = logging.getLogger("mcp_server_polarion")
 
     if not logger.handlers:

--- a/src/mcp_server_polarion/core/logging.py
+++ b/src/mcp_server_polarion/core/logging.py
@@ -7,17 +7,9 @@ import sys
 
 
 def setup_logging(*, level: int = logging.INFO) -> logging.Logger:
-    """Configure and return the package-level logger.
-
-    A single ``StreamHandler(sys.stderr)`` is attached so that log
-    messages never pollute the MCP JSON-RPC channel on stdout.
-
-    Args:
-        level: Logging level (default ``INFO``).
-
-    Returns:
-        The configured ``mcp_server_polarion`` logger.
-    """
+    """Configure and return the package-level logger — single
+    ``StreamHandler(sys.stderr)`` so log messages never pollute the MCP
+    JSON-RPC channel on stdout."""
     logger = logging.getLogger("mcp_server_polarion")
 
     if not logger.handlers:

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -1,15 +1,6 @@
-"""Pydantic models for MCP tool inputs and outputs.
-
-Every tool accepts and returns Pydantic models — never raw ``dict``.
-Class docstrings and ``Field(description=...)`` ship in the JSON Schema, so
-keep them tight: omit a description when the field name + type say everything
-(e.g. ``items``, ``page``, ``id``), and keep one only for non-obvious semantics
-(units, empty-conditions, round-trip / read-only contracts).
-
-Models are grouped by domain into submodules (``common``, ``projects``,
-``documents``, ``work_items``, ``links``, ``comments``) and re-exported here so
-``from mcp_server_polarion.models import X`` stays the single import surface.
-"""
+"""Pydantic models for MCP tool I/O, grouped by domain and re-exported here as
+the single import surface. Class docstrings and ``Field(description=...)`` ship
+in the JSON Schema — omit a description when name + type say everything."""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -1,6 +1,7 @@
 """Pydantic models for MCP tool I/O, grouped by domain and re-exported here as
 the single import surface. Class docstrings and ``Field(description=...)`` ship
-in the JSON Schema — omit a description when name + type say everything."""
+in the JSON Schema — omit a description when name + type say everything.
+"""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/models/common.py
+++ b/src/mcp_server_polarion/models/common.py
@@ -6,17 +6,14 @@ from typing import Final
 
 from pydantic import BaseModel
 
-# Recursive JSON-safe alias for internal payload builders. Result models expose
-# previews as `Mapping[str, object]`, not `dict[str, JsonValue]`: the alias'
-# `$defs/JsonValue` self-reference breaks FastMCP's `json_schema_to_type`
-# (unresolved `ForwardRef('Root')`, noisy errors on every write).
+# Internal payload-builder alias only — result models expose previews as
+# `Mapping[str, object]` because the recursive self-reference breaks FastMCP's
+# `json_schema_to_type` (unresolved `ForwardRef('Root')`).
 type JsonValue = (
     str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
 )
 
-# Per-item cap blocking a prompt-injected multi-MB body. Real bodies stay
-# ~30 KB; 2 MiB leaves ~70x headroom. Bulk requests bound by item count, not
-# this constant alone.
+# Per-item cap against prompt-injected multi-MB bodies; real bodies ~30 KB.
 MAX_BODY_HTML_LEN: Final[int] = 2_000_000
 
 

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -1,10 +1,6 @@
-"""In-process TTL caches shared across tool implementations.
-
-Near-static project facts (documents, enum option ids, custom-field key
-schemas) are memoised to spare the server's tight budget (<=3 req/s, no
-concurrency). This module owns all cache state; tool logic reaches it only
-through the typed get / store wrappers below.
-"""
+"""In-process TTL caches for near-static project facts, sparing the server's
+tight budget (<=3 req/s, no concurrency). Owns ALL cache state; tool logic
+reaches it only through the typed get / store wrappers."""
 
 from __future__ import annotations
 
@@ -25,11 +21,8 @@ class _Entry[V]:
 
 
 class TTLCache[K, V]:
-    """Hashable-keyed cache whose entries expire ``ttl_seconds`` after a set.
-
-    Single-threaded; lazy expiry (a key is dropped only when next accessed past
-    its deadline), so a bounded key space never grows past that bound.
-    """
+    """Single-threaded TTL cache; lazy expiry, so a bounded key space never
+    grows past its bound."""
 
     def __init__(self, ttl_seconds: float) -> None:
         self._ttl = ttl_seconds
@@ -71,18 +64,14 @@ class DiscoveredDocument(NamedTuple):
     updated_by_name: str = ""
 
 
-# Bounded by ghost-safety: a stale entry keeps accepting an admin-removed
-# option until expiry, so 60s caps that window.
+# 60s caps the window in which a stale entry accepts an admin-removed option.
 _GUARD_TTL_SECONDS: Final[float] = 60.0
 
-# 404 "not an Enumeration field" is a stable schema fact (field-type changes
-# are rare admin ops) and its stale worst case is merely deferring to Polarion,
-# so it outlives positive option sets, whose longer life would widen the
-# admin-removed-option ghost window.
+# 404 "not an Enumeration field" is a stable schema fact whose stale worst
+# case is merely deferring to Polarion — safe to outlive positive option sets.
 _ENUM_NOT_FOUND_TTL_SECONDS: Final[float] = 600.0
 
-# Bounded by freshness: a new document must surface within ~1 min
-# (``create_document`` also invalidates on write).
+# New documents must surface within ~1 min (create also invalidates on write).
 _DOCUMENT_LIST_TTL_SECONDS: Final[float] = 60.0
 
 # project_id -> discovered documents in display order.
@@ -93,19 +82,15 @@ _document_list_cache: TTLCache[str, tuple[DiscoveredDocument, ...]] = TTLCache(
 _enum_option_cache: TTLCache[tuple[str, Resource, str, str], frozenset[str]] = TTLCache(
     _GUARD_TTL_SECONDS
 )
-# (project, enum_name) -> option ids for a project-level enum (link/hyperlink
-# role). No type axis: these are project config, not type-scoped.
+# (project, enum_name) -> project-level enum option ids (no type axis).
 _project_enum_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
     _GUARD_TTL_SECONDS
 )
-# (project, work_item_type) -> the type's full custom-field key schema (MIN-per-key
-# sample). Sole source of truth for work-item custom-field validation.
+# (project, work_item_type) -> full custom-field key schema (MIN-per-key sample).
 _work_item_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
     _GUARD_TTL_SECONDS
 )
-# (project, document_type) -> the type's complete custom-field key schema, from
-# the project-wide /documents sample. Mirrors the work-item cache; the single
-# source of truth for document custom-field validation.
+# (project, document_type) -> custom-field key schema; document-side mirror.
 _document_type_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
     _GUARD_TTL_SECONDS
 )
@@ -149,12 +134,8 @@ def store_cached_enum_options(  # noqa: PLR0913
     *,
     not_found: bool = False,
 ) -> None:
-    """Cache the valid option ids for the field/type.
-
-    Entries live ``_GUARD_TTL_SECONDS``; ``not_found=True`` marks a 404
-    ("not an Enumeration field") result, cached for
-    ``_ENUM_NOT_FOUND_TTL_SECONDS`` instead.
-    """
+    """Cache option ids for the field/type; ``not_found=True`` (404 result)
+    uses the longer ``_ENUM_NOT_FOUND_TTL_SECONDS``."""
     _enum_option_cache.set(
         (project_id, resource, field_id, type_id),
         option_ids,
@@ -192,9 +173,8 @@ def store_work_item_custom_keys(
     work_item_type: str,
     keys: frozenset[str],
 ) -> None:
-    """Replace any prior set: each sample is the full key set, so an admin
-    removal shrinks the schema once the entry expires.
-    """
+    """Replace any prior set — each sample is the full key set, so an admin
+    removal shrinks the schema on expiry."""
     _work_item_custom_key_cache.set((project_id, work_item_type), keys)
 
 
@@ -216,9 +196,8 @@ def store_document_type_custom_keys(
     document_type: str,
     keys: frozenset[str],
 ) -> None:
-    """Replace any prior set: each sample is the full key set, so an admin
-    removal shrinks the schema once the entry expires.
-    """
+    """Replace any prior set — each sample is the full key set, so an admin
+    removal shrinks the schema on expiry."""
     _document_type_custom_key_cache.set((project_id, document_type), keys)
 
 

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -1,6 +1,7 @@
 """In-process TTL caches for near-static project facts, sparing the server's
 tight budget (<=3 req/s, no concurrency). Owns ALL cache state; tool logic
-reaches it only through the typed get / store wrappers."""
+reaches it only through the typed get / store wrappers.
+"""
 
 from __future__ import annotations
 
@@ -22,7 +23,8 @@ class _Entry[V]:
 
 class TTLCache[K, V]:
     """Single-threaded TTL cache; lazy expiry, so a bounded key space never
-    grows past its bound."""
+    grows past its bound.
+    """
 
     def __init__(self, ttl_seconds: float) -> None:
         self._ttl = ttl_seconds
@@ -135,7 +137,8 @@ def store_cached_enum_options(  # noqa: PLR0913
     not_found: bool = False,
 ) -> None:
     """Cache option ids for the field/type; ``not_found=True`` (404 result)
-    uses the longer ``_ENUM_NOT_FOUND_TTL_SECONDS``."""
+    uses the longer ``_ENUM_NOT_FOUND_TTL_SECONDS``.
+    """
     _enum_option_cache.set(
         (project_id, resource, field_id, type_id),
         option_ids,
@@ -174,7 +177,8 @@ def store_work_item_custom_keys(
     keys: frozenset[str],
 ) -> None:
     """Replace any prior set — each sample is the full key set, so an admin
-    removal shrinks the schema on expiry."""
+    removal shrinks the schema on expiry.
+    """
     _work_item_custom_key_cache.set((project_id, work_item_type), keys)
 
 
@@ -197,7 +201,8 @@ def store_document_type_custom_keys(
     keys: frozenset[str],
 ) -> None:
     """Replace any prior set — each sample is the full key set, so an admin
-    removal shrinks the schema on expiry."""
+    removal shrinks the schema on expiry.
+    """
     _document_type_custom_key_cache.set((project_id, document_type), keys)
 
 

--- a/src/mcp_server_polarion/tools/_shared/guard.py
+++ b/src/mcp_server_polarion/tools/_shared/guard.py
@@ -1,18 +1,9 @@
-"""Server-side write guards that prevent silent corruption on Polarion writes.
-
-Polarion accepts unknown enum ids and custom-field keys and values verbatim
-(HTTP 200) — they persist but never appear in the UI, Lucene, or reports,
-with no error.
-Docstring rules are unreliable (evals show LLMs ignore them), so each rule
-becomes a deterministic precondition: before a write, fetch the real options
-and raise if the supplied id/key is absent. Option ids and observed keys are
-memoised in :mod:`...tools._shared.cache`; this module holds fetch + check.
-
-Fail-closed: a validation request that errors after backoff blocks the write
-(a ghost write is invisible and unrecoverable) — auth → ``PermissionError``,
-else → ``RuntimeError``. Two lenient cases defer to Polarion: a *successful*
-empty option set, and a 404 (endpoint/field unsupported — a wrong path makes
-the subsequent write fail loudly anyway).
+"""Pre-write guards: Polarion persists unknown enum ids / custom-field keys as
+silent ghosts (HTTP 200, invisible to UI and Lucene), so each guard fetches the
+real options and raises before the write. Fail-closed — validation error blocks
+the write (auth → ``PermissionError``, else ``RuntimeError``); only a
+*successful* empty option set and a 404 defer to Polarion. Caching in
+:mod:`...tools._shared.cache`.
 """
 
 from __future__ import annotations
@@ -58,7 +49,6 @@ logger = logging.getLogger("mcp_server_polarion.tools._shared.guard")
 
 _GUARD_PAGE_SIZE: int = 100
 
-# Resource -> the MCP tool that lists its enum options, for error messages.
 _ENUM_DISCOVERY_TOOL: dict[Resource, str] = {
     "workitems": "list_work_item_enum_options",
     "documents": "list_document_enum_options",
@@ -84,9 +74,8 @@ def _unreachable_write_block(
 
 
 def _unauthorized_write_block(what: str, project_id: str) -> PermissionError:
-    """Mirror the tool layer's ``PolarionAuthError -> PermissionError``: a
-    token-scope problem the caller can fix, not a backend to retry.
-    """
+    """Mirrors the tool layer's ``PolarionAuthError -> PermissionError``
+    (fixable token scope, not a backend to retry)."""
     logger.warning(
         "guard blocking write: not authorized to validate %s for project=%s",
         what,
@@ -106,10 +95,8 @@ async def fetch_enum_option_ids(
     field_id: str,
     type_id: str,
 ) -> frozenset[str]:
-    """Return the valid option ids for ``(project, resource, field, type)``.
-
-    Cached. Fail-closed: a reachable error raises, a 404 defers (empty set).
-    """
+    """Valid option ids for ``(project, resource, field, type)``; cached,
+    fail-closed, 404 defers (empty set)."""
     cached = get_cached_enum_options(project_id, resource, field_id, type_id)
     if cached is not None:
         return cached
@@ -127,11 +114,8 @@ async def fetch_enum_option_ids(
     try:
         response = await client.get(path, params=params)
     except PolarionNotFoundError:
-        # Endpoint/field unsupported (Polarion: "Field 'X' is not an
-        # Enumeration field"): cache an empty set so callers defer. The long
-        # not_found TTL spares a re-probe on every write -- non-enum custom
-        # fields, but also standard fields on builds lacking the endpoint;
-        # its stale worst case for both is this same deferral.
+        # 404 = non-enum field or endpoint absent; cache empty set (long TTL —
+        # stale worst case is the same deferral).
         logger.warning(
             "getAvailableOptions returned 404 for field=%s (resource=%s, "
             "project=%s); skipping enum validation for this field -- the "
@@ -176,8 +160,7 @@ async def _check_enum(  # noqa: PLR0913
     option_ids = await fetch_enum_option_ids(
         client, project_id, resource, field_id, type_id
     )
-    # Empty set = successful "no options configured" (not the unreachable
-    # failure, which already raised). Defer rather than false-positive.
+    # Empty set = successful no-options fetch; defer rather than false-positive.
     if not option_ids or value in option_ids:
         return
     raise ValueError(
@@ -200,12 +183,11 @@ async def guard_work_item_enums(  # noqa: PLR0913
     priority: str | None = None,
     resolution: str | None = None,
 ) -> None:
-    """Validate every supplied work-item enum arg against ``getAvailableOptions``.
+    """Validate supplied work-item enum args against ``getAvailableOptions``.
 
     ``work_item_type`` scopes status/severity/resolution/priority (``'~'`` =
-    type-agnostic). ``type`` is checked first so an invalid type raises before
-    being reused as the scoping axis. One GET per (field, type) on a miss.
-    Raises ``ValueError`` (unknown id) or ``RuntimeError`` (unreachable).
+    type-agnostic); ``type`` checked first so an invalid type raises before
+    being reused as the scoping axis.
     """
     if type is not None and type != "":
         await _check_enum(client, project_id, "workitems", "type", "~", type)
@@ -279,21 +261,15 @@ async def _check_custom_field_enum_values(
 ) -> None:
     """Validate enum-typed ``custom_fields`` values against ``getAvailableOptions``.
 
-    The endpoint is the only API that both identifies a custom field as an
-    enumeration and yields its option ids (404 = "not an Enumeration field");
-    a non-empty option set therefore proves the field is an enum, so the value
-    must be an option-id string or a list of them (multi-enum). Empty set
-    (non-enum field, or enum with no options) defers to Polarion. One GET per
-    key on a cache miss; 404s are cached long (``not_found`` TTL). Arity is
-    not checked -- the endpoint cannot distinguish single- from multi-enum --
-    but wrong arity fails loudly at Polarion (400 "STRING expected, but was
-    BEGIN_ARRAY" for a list on a single-enum field), so only wrong option-id
-    strings ghost.
+    Non-empty option set proves the field is an enum (the endpoint is the only
+    API mapping key → options) → value must be an option-id string or list of
+    them; empty set defers. Arity unchecked — endpoint can't distinguish
+    single/multi-enum, but wrong arity 400s loudly at Polarion, so only wrong
+    option-id strings ghost.
     """
     for field_id in sorted(custom_fields):
         value = custom_fields[field_id]
-        # Empty values never reach Polarion (payload builders drop them), so
-        # there is nothing to validate -- skip the probe GET entirely.
+        # Payload builders drop empty values — nothing to validate, skip probe.
         if value is None or value in ("", []):
             continue
         option_ids = await fetch_enum_option_ids(
@@ -367,14 +343,11 @@ async def _fetch_work_item_type_custom_keys(
     project_id: str,
     type_id: str,
 ) -> frozenset[str]:
-    """Sample existing items of a type and return their unioned custom-field keys.
+    """Union of custom-field keys sampled from existing items of a type.
 
-    MIN-per-key SQL yields one item per distinct key; paged at 100 so a type with
-    more than 100 distinct keys still returns the complete schema. SQL rejection
-    fails closed (``RuntimeError``): a partial Lucene sample would silently
-    false-reject real keys, so custom-field writes are blocked rather than
-    validated against an incomplete schema. Result cached even if empty.
-    Fail-closed: auth → ``PermissionError``, unreachable → ``RuntimeError``.
+    MIN-per-key SQL, paged for >100 distinct keys. SQL rejection fails closed —
+    a partial Lucene sample would silently false-reject real keys. Cached even
+    if empty.
     """
     path = f"/projects/{encode_path_segment(project_id)}/workitems"
     base_params: dict[str, str | int] = {
@@ -416,13 +389,10 @@ async def _check_work_item_custom_keys(
     work_item_type: str,
     custom_fields: dict[str, object],
 ) -> None:
-    """Reject ``custom_fields`` keys absent from the type's real schema.
+    """Reject ``custom_fields`` keys absent from the type's sampled schema.
 
-    The type schema (cached per ``(project, type)`` from the MIN-per-key sample)
-    is the sole source of truth. A key unknown against a *cached* schema forces
-    one fresh re-fetch (admin-added field) before rejecting → ``ValueError``.
-    Empty schema fails closed (``RuntimeError``): a ghost write is unrecoverable.
-    Unreachable validation (incl. SQL rejection) → ``RuntimeError``.
+    Unknown key vs *cached* schema forces one fresh re-fetch before rejecting;
+    empty schema fails closed (ghost write unrecoverable).
     """
     schema = get_work_item_custom_keys(project_id, work_item_type)
     fetched_fresh = schema is None
@@ -434,8 +404,7 @@ async def _check_work_item_custom_keys(
     if all(key in schema for key in custom_fields):
         return
 
-    # An unknown key against a cached schema may be an admin-added field; refetch
-    # once before rejecting. A just-fetched schema is already current, so skip.
+    # Unknown key may be admin-added since caching; refetch once before rejecting.
     if not fetched_fresh:
         invalidate_work_item_custom_keys(project_id, work_item_type)
         schema = await _fetch_work_item_type_custom_keys(
@@ -466,14 +435,11 @@ async def guard_work_item_custom_fields(
     work_item_type: str,
     custom_fields: dict[str, object],
 ) -> None:
-    """Validate ``custom_fields`` keys and enum-typed values before a write.
+    """Validate ``custom_fields`` keys then enum-typed values before a write.
 
-    Keys first, against the type's sampled schema (unknown key →
-    ``ValueError``; the order also keeps ghost keys out of the enum probe's
-    long-lived 404 cache). Then each key's value via ``getAvailableOptions``:
-    a non-empty option set makes the field an enum whose value must be a valid
-    option-id string or list of them → ``ValueError`` on wrong id or shape.
-    Fail-closed otherwise.
+    Keys-first order keeps ghost keys out of the enum probe's long-lived 404
+    cache. Wrong key, option id, or value shape → ``ValueError``; fail-closed
+    otherwise.
     """
     if not custom_fields:
         return
@@ -492,16 +458,11 @@ async def _fetch_document_type_custom_keys(
 ) -> frozenset[str]:
     """Sample the project's documents and return *document_type*'s key schema.
 
-    A heading-discovery SQL (:func:`one_heading_per_document_sql`) paired with
-    ``include=module&fields[documents]=@all`` returns one ``module`` resource per
-    document in the ``included`` array, each carrying its type + inline customs.
-    The ``module`` table can't be returned as a REST SQL resource directly, but
-    ``include`` surfaces its attributes -- unlike the ``GET /documents`` endpoint,
-    this path exists on every Polarion build. Customs are unioned per type and
-    every type's schema is stored, so a later write of any type hits the cache.
-    The target type is stored even when empty so a no-customs type fails closed
-    without re-probing. Documents with no heading work item are invisible to this
-    sample. Fail-closed: auth → ``PermissionError``, unreachable → ``RuntimeError``.
+    Heading-discovery SQL + ``include=module`` surfaces each document's type and
+    inline customs — works on every build, unlike ``GET /documents``. All types'
+    schemas are stored (later writes hit cache); target type stored even when
+    empty so a no-customs type fails closed without re-probing. Headingless
+    documents are invisible to this sample.
     """
     path = f"/projects/{encode_path_segment(project_id)}/workitems"
     base_params: dict[str, str | int] = {
@@ -560,15 +521,7 @@ async def _check_document_custom_keys(
     document_type: str,
     custom_fields: dict[str, object],
 ) -> None:
-    """Reject ``custom_fields`` keys absent from the document type's real schema.
-
-    Mirrors :func:`_check_work_item_custom_keys` on the document-type axis:
-    the schema (cached per ``(project, document_type)`` from the heading +
-    ``include=module`` sample) is the sole source of truth. A key unknown against
-    a *cached* schema forces one fresh re-fetch (admin-added field) before
-    rejecting → ``ValueError``. A type whose documents populate no custom field
-    yields an empty schema and fails closed (``RuntimeError``).
-    """
+    """Document-axis mirror of :func:`_check_work_item_custom_keys`."""
     schema = get_document_type_custom_keys(project_id, document_type)
     fetched_fresh = schema is None
     if schema is None:
@@ -579,8 +532,7 @@ async def _check_document_custom_keys(
     if all(key in schema for key in custom_fields):
         return
 
-    # An unknown key against a cached schema may be an admin-added field; refetch
-    # once before rejecting. A just-fetched schema is already current, so skip.
+    # Unknown key may be admin-added since caching; refetch once before rejecting.
     if not fetched_fresh:
         invalidate_document_type_custom_keys(project_id, document_type)
         schema = await _fetch_document_type_custom_keys(
@@ -611,12 +563,7 @@ async def guard_document_custom_fields(
     document_type: str,
     custom_fields: dict[str, object],
 ) -> None:
-    """Validate ``custom_fields`` keys and enum-typed values before a write.
-
-    Document-axis mirror of :func:`guard_work_item_custom_fields`: keys against
-    the document type's sampled schema, then enum-typed values against
-    ``getAvailableOptions``.
-    """
+    """Document-axis mirror of :func:`guard_work_item_custom_fields`."""
     if not custom_fields:
         return
     await _check_document_custom_keys(client, project_id, document_type, custom_fields)
@@ -630,11 +577,8 @@ async def _existing_target_ids(
     project_id: str,
     target_ids: frozenset[str],
 ) -> frozenset[str]:
-    """Return which *target_ids* exist in *project_id*, via ``id:(...)`` queries.
-
-    Chunked at ``_GUARD_PAGE_SIZE`` (one query bounded by ``page[size]``). A 404
-    means the project is missing; caller treats every target as missing.
-    """
+    """Subset of *target_ids* that exist in *project_id*, via chunked
+    ``id:(...)`` queries. 404 (project missing) propagates to caller."""
     ordered = sorted(target_ids)
     found: set[str] = set()
     for start in range(0, len(ordered), _GUARD_PAGE_SIZE):
@@ -660,13 +604,9 @@ async def guard_work_item_link_targets(
     source_project_id: str,
     links: list[WorkItemLinkSpec],
 ) -> None:
-    """Reject links whose target work item does not exist.
-
-    A nonexistent target stores as a silent dangling link (HTTP 201, empty
-    title/type/status). Groups targets by project, one ``id:(...)`` query each,
-    raises ``ValueError`` listing any missing. Fail-closed: unreachable →
-    ``RuntimeError``; 404 (project missing) → ``ValueError``.
-    """
+    """Reject links whose target work item does not exist — Polarion stores a
+    nonexistent target as a silent dangling link (HTTP 201, empty
+    title/type/status). One ``id:(...)`` query per target project."""
     by_project: dict[str, set[str]] = {}
     for spec in links:
         target_project = spec.target_project_id or source_project_id
@@ -701,14 +641,10 @@ async def fetch_project_enum_option_ids(
     project_id: str,
     enum_name: str,
 ) -> frozenset[str]:
-    """Return the valid option ids for a project-level enumeration.
-
-    For enums not in ``getAvailableOptions`` (link/hyperlink role). Reads
-    ``/projects/{p}/enumerations/~/{enum}/~``; unlike ``getAvailableOptions``
-    (list ``data``), here ``data`` is a dict with options at
+    """Valid option ids for a project-level enum not in ``getAvailableOptions``
+    (link/hyperlink role). Response ``data`` is a dict (not list), options at
     ``data.attributes.options[].id``. Cached; fail-closed like
-    :func:`fetch_enum_option_ids`.
-    """
+    :func:`fetch_enum_option_ids`."""
     cached = get_cached_project_enum(project_id, enum_name)
     if cached is not None:
         return cached
@@ -766,7 +702,7 @@ async def _check_project_enum_roles(  # noqa: PLR0913
         return
 
     option_ids = await fetch_project_enum_option_ids(client, project_id, enum_name)
-    # Empty set = lenient "no options / enum unsupported" (already deferred).
+    # Empty set = no options / enum unsupported; defer.
     if not option_ids:
         return
 
@@ -785,11 +721,8 @@ async def guard_work_item_link_roles(
     project_id: str,
     roles: Iterable[str],
 ) -> None:
-    """Reject ``create_work_item_links`` roles not in ``workitem-link-role``.
-
-    An unknown role stores verbatim (HTTP 201) as a ghost link. Validates each
-    role, raises ``ValueError`` (valid ids) on a miss; fail-closed otherwise.
-    """
+    """Reject link roles not in ``workitem-link-role`` — an unknown role stores
+    verbatim (HTTP 201) as a ghost link."""
     await _check_project_enum_roles(
         client,
         project_id,
@@ -808,12 +741,8 @@ async def guard_hyperlink_roles(
     project_id: str,
     roles: Iterable[str],
 ) -> None:
-    """Reject hyperlink roles not in the project's ``hyperlink-role`` enum.
-
-    ``Hyperlink.role`` accepts only configured ids (typically ``ref_int`` /
-    ``ref_ext``); an unknown role persists as a silent ghost. Raises
-    ``ValueError`` on a miss; fail-closed if unreachable.
-    """
+    """Reject hyperlink roles not in the project's ``hyperlink-role`` enum
+    (typically ``ref_int``/``ref_ext``) — unknown roles ghost silently."""
     await _check_project_enum_roles(
         client,
         project_id,
@@ -831,12 +760,9 @@ async def _existing_forward_link_ids(
     project_id: str,
     work_item_id: str,
 ) -> frozenset[str]:
-    """Return the composite ids of every outgoing link on the source work item.
-
-    Pages ``/linkedworkitems`` (id only) until a short page. Each ``data[].id``
-    is the 5-segment composite the delete payload reconstructs, so it is
-    set-membership-testable directly. ``PolarionNotFoundError`` propagates.
-    """
+    """Composite ids of every outgoing link on the source work item — each
+    ``data[].id`` is the 5-segment composite the delete payload reconstructs,
+    so it is set-membership-testable directly. 404 propagates."""
     path = (
         f"/projects/{encode_path_segment(project_id)}"
         f"/workitems/{encode_path_segment(work_item_id)}/linkedworkitems"
@@ -870,13 +796,10 @@ async def partition_delete_links(
     work_item_id: str,
     link_ids: list[str],
 ) -> tuple[list[str], list[str]]:
-    """Split requested delete refs into ``(matched, not_found)`` against reality.
-
-    Pre-reads existing outgoing links and partitions *link_ids* (input order)
-    into matched / unmatched — the only way to surface the no-ops the 204 hides
-    (no-op is non-destructive, never raised). Fail-closed: missing source →
-    ``ValueError``, auth → ``PermissionError``, else → ``RuntimeError``.
-    """
+    """Pre-read existing links and split *link_ids* into ``(matched, not_found)``
+    — the only way to surface the no-ops Polarion's 204 hides. Fail-closed:
+    missing source → ``ValueError``, auth → ``PermissionError``, else
+    ``RuntimeError``."""
     try:
         existing = await _existing_forward_link_ids(client, project_id, work_item_id)
     except PolarionNotFoundError as exc:

--- a/src/mcp_server_polarion/tools/_shared/guard.py
+++ b/src/mcp_server_polarion/tools/_shared/guard.py
@@ -75,7 +75,8 @@ def _unreachable_write_block(
 
 def _unauthorized_write_block(what: str, project_id: str) -> PermissionError:
     """Mirrors the tool layer's ``PolarionAuthError -> PermissionError``
-    (fixable token scope, not a backend to retry)."""
+    (fixable token scope, not a backend to retry).
+    """
     logger.warning(
         "guard blocking write: not authorized to validate %s for project=%s",
         what,
@@ -96,7 +97,8 @@ async def fetch_enum_option_ids(
     type_id: str,
 ) -> frozenset[str]:
     """Valid option ids for ``(project, resource, field, type)``; cached,
-    fail-closed, 404 defers (empty set)."""
+    fail-closed, 404 defers (empty set).
+    """
     cached = get_cached_enum_options(project_id, resource, field_id, type_id)
     if cached is not None:
         return cached
@@ -578,7 +580,8 @@ async def _existing_target_ids(
     target_ids: frozenset[str],
 ) -> frozenset[str]:
     """Subset of *target_ids* that exist in *project_id*, via chunked
-    ``id:(...)`` queries. 404 (project missing) propagates to caller."""
+    ``id:(...)`` queries. 404 (project missing) propagates to caller.
+    """
     ordered = sorted(target_ids)
     found: set[str] = set()
     for start in range(0, len(ordered), _GUARD_PAGE_SIZE):
@@ -606,7 +609,8 @@ async def guard_work_item_link_targets(
 ) -> None:
     """Reject links whose target work item does not exist — Polarion stores a
     nonexistent target as a silent dangling link (HTTP 201, empty
-    title/type/status). One ``id:(...)`` query per target project."""
+    title/type/status). One ``id:(...)`` query per target project.
+    """
     by_project: dict[str, set[str]] = {}
     for spec in links:
         target_project = spec.target_project_id or source_project_id
@@ -644,7 +648,8 @@ async def fetch_project_enum_option_ids(
     """Valid option ids for a project-level enum not in ``getAvailableOptions``
     (link/hyperlink role). Response ``data`` is a dict (not list), options at
     ``data.attributes.options[].id``. Cached; fail-closed like
-    :func:`fetch_enum_option_ids`."""
+    :func:`fetch_enum_option_ids`.
+    """
     cached = get_cached_project_enum(project_id, enum_name)
     if cached is not None:
         return cached
@@ -722,7 +727,8 @@ async def guard_work_item_link_roles(
     roles: Iterable[str],
 ) -> None:
     """Reject link roles not in ``workitem-link-role`` — an unknown role stores
-    verbatim (HTTP 201) as a ghost link."""
+    verbatim (HTTP 201) as a ghost link.
+    """
     await _check_project_enum_roles(
         client,
         project_id,
@@ -742,7 +748,8 @@ async def guard_hyperlink_roles(
     roles: Iterable[str],
 ) -> None:
     """Reject hyperlink roles not in the project's ``hyperlink-role`` enum
-    (typically ``ref_int``/``ref_ext``) — unknown roles ghost silently."""
+    (typically ``ref_int``/``ref_ext``) — unknown roles ghost silently.
+    """
     await _check_project_enum_roles(
         client,
         project_id,
@@ -762,7 +769,8 @@ async def _existing_forward_link_ids(
 ) -> frozenset[str]:
     """Composite ids of every outgoing link on the source work item — each
     ``data[].id`` is the 5-segment composite the delete payload reconstructs,
-    so it is set-membership-testable directly. 404 propagates."""
+    so it is set-membership-testable directly. 404 propagates.
+    """
     path = (
         f"/projects/{encode_path_segment(project_id)}"
         f"/workitems/{encode_path_segment(work_item_id)}/linkedworkitems"
@@ -799,7 +807,8 @@ async def partition_delete_links(
     """Pre-read existing links and split *link_ids* into ``(matched, not_found)``
     — the only way to surface the no-ops Polarion's 204 hides. Fail-closed:
     missing source → ``ValueError``, auth → ``PermissionError``, else
-    ``RuntimeError``."""
+    ``RuntimeError``.
+    """
     try:
         existing = await _existing_forward_link_ids(client, project_id, work_item_id)
     except PolarionNotFoundError as exc:

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -1,8 +1,5 @@
-"""Internal shared helpers for the ``tools`` package (not public API).
-
-Body fields pass through as raw HTML on the get/update round-trip; Markdown
-conversion is reserved for synthesis paths in ``tools.documents``.
-"""
+"""Internal shared helpers for ``tools`` (not public API). Body fields pass
+through as raw HTML; Markdown conversion is reserved for synthesis paths."""
 
 from __future__ import annotations
 
@@ -23,8 +20,7 @@ from mcp_server_polarion.models import (
     WorkItemSummary,
 )
 
-# Bulk-write cap. Polarion throttles ~3 req/s with no concurrency, so an
-# unbounded batch is a rate-limit/payload hazard; 50 bounds one request.
+# Bulk-write cap: Polarion throttles ~3 req/s, no concurrency.
 MAX_BULK_ITEMS: Final[int] = 50
 
 
@@ -45,22 +41,18 @@ class WorkItemSummaryKwargs(TypedDict):
 # Polarion enforces a hard cap of 100 server-side.
 DEFAULT_PAGE_SIZE: Final[int] = 100
 
-# Sparse fieldsets. Detail/document fetches use ``@all`` (this server inlines
-# customs under ``attributes`` and drops ``customFields.*`` tokens);
-# ``WORK_ITEM_PART_FIELDS`` stays tight (parts surface no customs).
+# Detail fetches need ``@all`` — explicit field lists drop inline customs.
 WORK_ITEM_LIST_FIELDS: Final[str] = "title,type,status,priority,updated,module,assignee"
 WORK_ITEM_DETAIL_FIELDS: Final[str] = "@all"
 WORK_ITEM_PART_FIELDS: Final[str] = "title,type,status,description,outlineNumber"
 DOCUMENT_DETAIL_FIELDS: Final[str] = "@all"
-# Sparse fieldset filters relationships too, so author / parentComment /
-# childComments must be named explicitly. Comments have no customs, so no `@all`.
+# Sparse fieldset filters relationships too — name them explicitly.
 DOCUMENT_COMMENT_LIST_FIELDS: Final[str] = (
     "created,resolved,text,author,parentComment,childComments"
 )
 
-# Standard attribute allowlist (Polarion REST OpenAPI schema). Anything in
-# ``attributes`` outside this set is treated as a custom field, so a new
-# standard attribute is misclassified until added here.
+# Standard-attribute allowlist (REST OpenAPI schema); anything outside is
+# treated as a custom field, so new standard attrs misclassify until added.
 STANDARD_WORK_ITEM_ATTRIBUTES: Final[frozenset[str]] = frozenset(
     {
         "id",
@@ -85,8 +77,7 @@ STANDARD_WORK_ITEM_ATTRIBUTES: Final[frozenset[str]] = frozenset(
     }
 )
 
-# Standard document attributes (Polarion REST OpenAPI schema); document-side
-# mirror of ``STANDARD_WORK_ITEM_ATTRIBUTES``.
+# Document-side mirror of ``STANDARD_WORK_ITEM_ATTRIBUTES``.
 STANDARD_DOCUMENT_ATTRIBUTES: Final[frozenset[str]] = frozenset(
     {
         "id",
@@ -160,26 +151,11 @@ def compute_has_more(
     page_size: int,
     items_count: int,
 ) -> bool:
-    """Determine whether more pages exist after the current one.
-
-    Uses ``total`` when it is reliable (> 0).  When ``total`` is 0
-    (Polarion sometimes omits ``meta.totalCount``), falls back to
-    ``links.next`` if present, otherwise to a heuristic based on
-    whether the current page is full.
-
-    Args:
-        response: Decoded JSON:API response (used for ``links.next``).
-        total: Resolved total count (may be 0 if unknown).
-        page_number: Current 1-based page number.
-        page_size: Requested page size.
-        items_count: Number of items returned on this page.
-
-    Returns:
-        ``True`` if additional pages likely exist.
-    """
+    """Whether more pages exist: ``total`` when reliable (>0), else
+    ``links.next`` (Polarion sometimes omits ``meta.totalCount``), else
+    full-page heuristic."""
     if total > 0:
         return total > page_number * page_size
-    # totalCount unavailable — prefer links.next, else heuristic.
     if has_links_next(response):
         return True
     return items_count == page_size
@@ -190,18 +166,13 @@ def encode_path_segment(segment: str) -> str:
     return quote(segment, safe="")
 
 
-# Thin guard, not a format validator: accepts ``[A-Za-z0-9_-]`` (covers
-# ``MCPT-001``-style ids) before substituting into a Lucene ``linkedWorkItems:``.
+# Thin guard before Lucene substitution, not a format validator.
 _WORK_ITEM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def validate_work_item_id_for_lucene(work_item_id: str) -> None:
-    """Reject work item IDs that would break a Lucene ``field:<id>`` clause.
-
-    Lucene treats many punctuation chars as operators; an unescaped id in
-    ``linkedWorkItems:<id>`` could reshape the query. Polarion ids never use
-    those, so hard-reject anything outside ``[A-Za-z0-9_-]`` (``ValueError``).
-    """
+    """Reject ids outside ``[A-Za-z0-9_-]`` — Lucene treats punctuation as
+    operators, so an unescaped id could reshape the query."""
     if not _WORK_ITEM_ID_PATTERN.match(work_item_id):
         msg = (
             f"work_item_id '{work_item_id}' contains characters outside "
@@ -232,9 +203,7 @@ def build_included_user_name_map(response: dict[str, object]) -> dict[str, str]:
             if isinstance(inc, dict) and inc.get("type") == "users":
                 user_id = safe_str(inc.get("id", ""))
                 if not user_id:
-                    # An id-less resource must not occupy the "" key: an absent
-                    # author relationship also resolves to "", and the two would
-                    # join into a phantom editor name.
+                    # "" key would join with absent-author "" → phantom editor.
                     continue
                 attrs = inc.get("attributes", {})
                 name = attrs.get("name", "") if isinstance(attrs, dict) else ""
@@ -276,10 +245,8 @@ def extract_relationship_ids(
 
 
 def split_module_id(module_full_id: str) -> tuple[str, str]:
-    """Split a module ID ``{proj}/{space}/{doc}`` into (space_id, document_name).
-
-    ``doc`` may contain ``/``. Returns ``("", "")`` if under three segments.
-    """
+    """Split ``{proj}/{space}/{doc}`` into (space_id, document_name); ``doc``
+    may contain ``/``. ``("", "")`` if under three segments."""
     if not module_full_id:
         return ("", "")
     parts = module_full_id.split("/", 2)
@@ -290,11 +257,7 @@ def split_module_id(module_full_id: str) -> tuple[str, str]:
 
 
 def extract_short_id(full_id: str) -> str:
-    """Strip the project / path prefix from a JSON:API ID.
-
-    For ``"projectId/MCPT-001"`` returns ``"MCPT-001"``.
-    For ``"alice"`` (no slashes) returns ``"alice"`` unchanged.
-    """
+    """Strip the path prefix from a JSON:API id (``"p/MCPT-001"`` → ``"MCPT-001"``)."""
     if "/" not in full_id:
         return full_id
     return full_id.rsplit("/", maxsplit=1)[-1]
@@ -303,11 +266,8 @@ def extract_short_id(full_id: str) -> str:
 def build_work_item_summary_kwargs(
     item: dict[str, object],
 ) -> WorkItemSummaryKwargs:
-    """Extract ``WorkItemSummary`` kwargs from a JSON:API resource.
-
-    Shared by list and detail endpoints so ``WorkItemDetail`` stays a strict
-    superset of ``WorkItemSummary``.
-    """
+    """``WorkItemSummary`` kwargs from a JSON:API resource; shared so
+    ``WorkItemDetail`` stays a strict superset of ``WorkItemSummary``."""
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
         attributes = {}
@@ -339,13 +299,8 @@ def extract_custom_fields(
     attributes: dict[str, object],
     standard: frozenset[str],
 ) -> dict[str, object]:
-    """Return the inline custom-field subset of a JSON:API attributes dict.
-
-    This server inlines customs as top-level ``attributes`` keys (no
-    ``customFields`` container). Anything outside *standard* is a custom field,
-    returned verbatim (primitives or ``{type,value}`` rich-text) so it
-    round-trips unchanged.
-    """
+    """Inline custom-field subset of ``attributes`` (keys outside *standard*),
+    returned verbatim so rich-text values round-trip unchanged."""
     return {k: v for k, v in attributes.items() if k not in standard}
 
 
@@ -354,16 +309,10 @@ def merge_custom_fields(
     customs: dict[str, object] | None,
     standard: frozenset[str],
 ) -> None:
-    """Merge caller custom-field key/values into *attributes* in place.
-
-    Write-side counterpart of ``extract_custom_fields`` (customs inline at the
-    top level). A key in *standard* raises ``ValueError`` (would shadow a tool
-    parameter). ``None`` / ``{}`` are no-ops; individual ``None`` values
-    skipped, other falsy values sent verbatim.
-
-    Aliasing: stored by reference, no copy — callers must NOT mutate *customs*
-    (or nested ``{type,value}`` dicts) before serialisation.
-    """
+    """Merge custom-field key/values into *attributes* in place; a key in
+    *standard* raises ``ValueError`` (would shadow a tool parameter), ``None``
+    values skipped. Values stored by reference — callers must NOT mutate
+    *customs* before serialisation."""
     if not customs:
         return
     collisions = sorted(set(customs) & standard)
@@ -408,13 +357,9 @@ def parse_work_item_detail(
     project_id: str,
     fallback_id: str = "",
 ) -> WorkItemDetail:
-    """Parse a JSON:API work-item resource into a ``WorkItemDetail``.
-
-    Shared by ``get_work_item`` / ``update_work_item``. Expects fetch with
-    ``WORK_ITEM_DETAIL_FIELDS`` + ``include=assignee``. Description passes
-    through as raw HTML (no convert/sanitize) so it round-trips unchanged.
-    ``fallback_id`` is used as ``id`` when ``item.id`` is missing.
-    """
+    """JSON:API work-item resource → ``WorkItemDetail``. Expects
+    ``WORK_ITEM_DETAIL_FIELDS`` + ``include=assignee``; description passes
+    through as raw HTML so it round-trips unchanged."""
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
         attributes = {}
@@ -446,10 +391,8 @@ def parse_work_item_detail(
 
 
 def summary_to_back_link(summary: WorkItemSummary) -> WorkItemLink:
-    """Lift a ``linkedWorkItems:`` query result to a back-direction link.
-
-    The query exposes no role/suspect, so ``role=None`` and ``suspect=False``.
-    """
+    """Lift a ``linkedWorkItems:`` query result to a back link; the query
+    exposes no role/suspect → ``role=None``, ``suspect=False``."""
     return WorkItemLink(
         id=summary.id,
         title=summary.title,

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -1,5 +1,6 @@
 """Internal shared helpers for ``tools`` (not public API). Body fields pass
-through as raw HTML; Markdown conversion is reserved for synthesis paths."""
+through as raw HTML; Markdown conversion is reserved for synthesis paths.
+"""
 
 from __future__ import annotations
 
@@ -153,7 +154,8 @@ def compute_has_more(
 ) -> bool:
     """Whether more pages exist: ``total`` when reliable (>0), else
     ``links.next`` (Polarion sometimes omits ``meta.totalCount``), else
-    full-page heuristic."""
+    full-page heuristic.
+    """
     if total > 0:
         return total > page_number * page_size
     if has_links_next(response):
@@ -172,7 +174,8 @@ _WORK_ITEM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_-]+$")
 
 def validate_work_item_id_for_lucene(work_item_id: str) -> None:
     """Reject ids outside ``[A-Za-z0-9_-]`` — Lucene treats punctuation as
-    operators, so an unescaped id could reshape the query."""
+    operators, so an unescaped id could reshape the query.
+    """
     if not _WORK_ITEM_ID_PATTERN.match(work_item_id):
         msg = (
             f"work_item_id '{work_item_id}' contains characters outside "
@@ -246,7 +249,8 @@ def extract_relationship_ids(
 
 def split_module_id(module_full_id: str) -> tuple[str, str]:
     """Split ``{proj}/{space}/{doc}`` into (space_id, document_name); ``doc``
-    may contain ``/``. ``("", "")`` if under three segments."""
+    may contain ``/``. ``("", "")`` if under three segments.
+    """
     if not module_full_id:
         return ("", "")
     parts = module_full_id.split("/", 2)
@@ -267,7 +271,8 @@ def build_work_item_summary_kwargs(
     item: dict[str, object],
 ) -> WorkItemSummaryKwargs:
     """``WorkItemSummary`` kwargs from a JSON:API resource; shared so
-    ``WorkItemDetail`` stays a strict superset of ``WorkItemSummary``."""
+    ``WorkItemDetail`` stays a strict superset of ``WorkItemSummary``.
+    """
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
         attributes = {}
@@ -300,7 +305,8 @@ def extract_custom_fields(
     standard: frozenset[str],
 ) -> dict[str, object]:
     """Inline custom-field subset of ``attributes`` (keys outside *standard*),
-    returned verbatim so rich-text values round-trip unchanged."""
+    returned verbatim so rich-text values round-trip unchanged.
+    """
     return {k: v for k, v in attributes.items() if k not in standard}
 
 
@@ -312,7 +318,8 @@ def merge_custom_fields(
     """Merge custom-field key/values into *attributes* in place; a key in
     *standard* raises ``ValueError`` (would shadow a tool parameter), ``None``
     values skipped. Values stored by reference — callers must NOT mutate
-    *customs* before serialisation."""
+    *customs* before serialisation.
+    """
     if not customs:
         return
     collisions = sorted(set(customs) & standard)
@@ -359,7 +366,8 @@ def parse_work_item_detail(
 ) -> WorkItemDetail:
     """JSON:API work-item resource → ``WorkItemDetail``. Expects
     ``WORK_ITEM_DETAIL_FIELDS`` + ``include=assignee``; description passes
-    through as raw HTML so it round-trips unchanged."""
+    through as raw HTML so it round-trips unchanged.
+    """
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
         attributes = {}
@@ -392,7 +400,8 @@ def parse_work_item_detail(
 
 def summary_to_back_link(summary: WorkItemSummary) -> WorkItemLink:
     """Lift a ``linkedWorkItems:`` query result to a back link; the query
-    exposes no role/suspect → ``role=None``, ``suspect=False``."""
+    exposes no role/suspect → ``role=None``, ``suspect=False``.
+    """
     return WorkItemLink(
         id=summary.id,
         title=summary.title,

--- a/src/mcp_server_polarion/tools/_shared/sql.py
+++ b/src/mcp_server_polarion/tools/_shared/sql.py
@@ -1,26 +1,14 @@
-"""REST-SQL ``query`` string builders for the ``tools`` package (not public API).
-
-Polarion's REST ``query`` param accepts a ``SQL:(...)`` prefix that unlocks
-joins and aggregates Lucene cannot express. REST SQL has no bind parameters, so
-every id is escaped inline by doubling ``'`` (matching ``list_work_items``). A
-``SELECT`` over the ``workitem`` table always yields work-item resources — the
-column list is ignored — so callers pair these with ``include=``/``fields=`` to
-read the attributes they actually need.
-"""
+"""REST-SQL ``query`` builders (not public API). No bind parameters — ids
+escaped inline by doubling ``'``. A ``SELECT`` over ``workitem`` always yields
+work-item resources (column list ignored); callers pair with
+``include=``/``fields=`` for the attributes they need."""
 
 from __future__ import annotations
 
 
 def one_heading_per_document_sql(project_id: str) -> str:
-    """``GROUP BY`` SQL returning one representative heading per document.
-
-    Groups every heading on its ``module`` URI and returns the ``MIN`` work-item
-    URI per group, collapsing all headings to one row per document. REST SQL
-    returns work-item resources (the ``SELECT`` column list is ignored), so the
-    caller pairs this with ``include=module`` to read each document's attributes.
-    ``c_deleted`` is boolean -- ``IS NOT TRUE`` excludes recycle-bin documents
-    to match the Lucene ``type:heading`` default (``= 0`` 500s).
-    """
+    """One representative heading per document (``MIN`` per ``module`` URI).
+    ``c_deleted IS NOT TRUE`` excludes the recycle bin (``= 0`` 500s)."""
     project = project_id.replace("'", "''")
     return (
         "SQL:(SELECT MIN(wi.c_uri) FROM workitem wi "  # noqa: S608
@@ -32,12 +20,8 @@ def one_heading_per_document_sql(project_id: str) -> str:
 
 
 def one_item_per_custom_field_sql(project_id: str, type_id: str) -> str:
-    """``GROUP BY`` SQL returning one representative item per custom-field key.
-
-    ``GROUP BY cf.c_name`` + ``MIN`` = one item per distinct key, so the union
-    catches single-item keys a fixed-N sample misses. Groups on indexed
-    ``c_name`` — far lighter than per-item ``COUNT(...) OVER ()``.
-    """
+    """One representative item per custom-field key (``MIN`` per indexed
+    ``cf.c_name``) — catches single-item keys a fixed-N sample misses."""
     project = project_id.replace("'", "''")
     type_value = type_id.replace("'", "''")
     return (

--- a/src/mcp_server_polarion/tools/_shared/sql.py
+++ b/src/mcp_server_polarion/tools/_shared/sql.py
@@ -1,14 +1,16 @@
 """REST-SQL ``query`` builders (not public API). No bind parameters — ids
 escaped inline by doubling ``'``. A ``SELECT`` over ``workitem`` always yields
 work-item resources (column list ignored); callers pair with
-``include=``/``fields=`` for the attributes they need."""
+``include=``/``fields=`` for the attributes they need.
+"""
 
 from __future__ import annotations
 
 
 def one_heading_per_document_sql(project_id: str) -> str:
     """One representative heading per document (``MIN`` per ``module`` URI).
-    ``c_deleted IS NOT TRUE`` excludes the recycle bin (``= 0`` 500s)."""
+    ``c_deleted IS NOT TRUE`` excludes the recycle bin (``= 0`` 500s).
+    """
     project = project_id.replace("'", "''")
     return (
         "SQL:(SELECT MIN(wi.c_uri) FROM workitem wi "  # noqa: S608
@@ -21,7 +23,8 @@ def one_heading_per_document_sql(project_id: str) -> str:
 
 def one_item_per_custom_field_sql(project_id: str, type_id: str) -> str:
     """One representative item per custom-field key (``MIN`` per indexed
-    ``cf.c_name``) — catches single-item keys a fixed-N sample misses."""
+    ``cf.c_name``) — catches single-item keys a fixed-N sample misses.
+    """
     project = project_id.replace("'", "''")
     type_value = type_id.replace("'", "''")
     return (

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -44,12 +44,9 @@ def _build_document_comments_payload(
     space_id: str,
     document_name: str,
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API POST body for .../documents/{d}/comments.
-
-    One resource per spec. ``resolved`` / ``author`` / ``parentComment``
-    omitted when None. ``parent_comment_id`` (short) expanded to the full
-    ``proj/space/doc/commentId`` path the API requires.
-    """
+    """JSON:API POST body for .../documents/{d}/comments; ``None`` fields
+    omitted, short ``parent_comment_id`` expanded to the full 4-segment path
+    the API requires."""
     items: list[JsonValue] = []
     for spec in specs:
         attributes: dict[str, JsonValue] = {
@@ -88,11 +85,8 @@ def _build_document_comment_update_payload(
     comment_id: str,
     resolved: bool,
 ) -> dict[str, JsonValue]:
-    """Build the single-resource JSON:API PATCH body for one document comment.
-
-    ``{"data": {...}}`` (not a list). ``id`` is the full 4-segment path
-    ``{project}/{space}/{document}/{comment}``. Only ``resolved`` is patchable.
-    """
+    """Single-resource PATCH body (``data`` dict, not list); ``id`` is the
+    full 4-segment path. Only ``resolved`` is patchable."""
     full_id = f"{project_id}/{space_id}/{document_name}/{comment_id}"
     return {
         "data": {

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -46,7 +46,8 @@ def _build_document_comments_payload(
 ) -> dict[str, JsonValue]:
     """JSON:API POST body for .../documents/{d}/comments; ``None`` fields
     omitted, short ``parent_comment_id`` expanded to the full 4-segment path
-    the API requires."""
+    the API requires.
+    """
     items: list[JsonValue] = []
     for spec in specs:
         attributes: dict[str, JsonValue] = {
@@ -86,7 +87,8 @@ def _build_document_comment_update_payload(
     resolved: bool,
 ) -> dict[str, JsonValue]:
     """Single-resource PATCH body (``data`` dict, not list); ``id`` is the
-    full 4-segment path. Only ``resolved`` is patchable."""
+    full 4-segment path. Only ``resolved`` is patchable.
+    """
     full_id = f"{project_id}/{space_id}/{document_name}/{comment_id}"
     return {
         "data": {

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -168,8 +168,8 @@ def _parse_document_part(
         elif short_id.startswith("pagebreak_"):
             part_type = "page_break"
 
-    # Heading/workitem body lives in title/description, not attributes.content
-    # (empty <hN> stub) — skip conversion to avoid "#" noise.
+    # Heading/workitem body lives in title/description; content is an empty
+    # <hN> stub — skip conversion to avoid "#" noise.
     content_html = (
         _extract_html_value(attributes.get("content"))
         if part_type not in {"heading", "workitem"}
@@ -223,11 +223,8 @@ _FENCED_MIN_LINES: Final[int] = 2
 
 
 def _render_parts_to_markdown(parts: list[DocumentPart]) -> str:
-    """Interleave a page of parts into one flowing Markdown string.
-
-    Per-type rendering lives in ``_render_part``. Chunks join on a blank line;
-    runs of 3+ newlines collapse to 2.
-    """
+    """Interleave a page of parts into one Markdown string; chunks join on a
+    blank line, runs of 3+ newlines collapse to 2."""
     chunks: list[str] = []
     for part in parts:
         chunk = _render_part(part)
@@ -268,11 +265,8 @@ def _render_workitem_part(part: DocumentPart) -> str:
 
 
 def _decorate_wikiblock(content: str) -> str:
-    """Lift the Velocity macro name into the fenced-code info-string.
-
-    ``#macroName(...)`` in a fence → ` ```macroName `. Falls back to the raw
-    fence when no ``#name(`` token is detectable.
-    """
+    """Lift the Velocity macro name (``#name(``) into the fenced-code
+    info-string; raw fence when none detectable."""
     stripped = content.strip()
     if not stripped:
         return ""
@@ -291,11 +285,8 @@ def _decorate_wikiblock(content: str) -> str:
 
 @dataclass(frozen=True, slots=True)
 class _DocumentMeta:
-    """Document attributes plus unresolved editor user ids from discovery.
-
-    User ids are join keys into the response's included ``users`` resources;
-    they never surface in tool output (display names only).
-    """
+    """Document attributes + editor user ids (join keys into included
+    ``users``; never surfaced in output — display names only)."""
 
     type: str = ""
     status: str = ""
@@ -308,12 +299,10 @@ def _extract_document_from_module(
     resource: object,
     documents: dict[tuple[str, str], _DocumentMeta],
 ) -> None:
-    """Record an included ``module`` resource as (space_id, document_name) -> meta.
+    """Record an included ``module`` resource as (space_id, document_name) → meta.
 
-    Module ``id`` format: ``{projectId}/{spaceId}/{documentName}``. Attributes and
-    the author/updatedBy relationships are present because discovery names them in
-    ``fields[documents]`` -- a plain ``module`` relationship carries only the
-    resource identifier.
+    Attributes/relationships only present because discovery names them in
+    ``fields[documents]``; a plain ``module`` relationship carries id only.
     """
     if not isinstance(resource, dict) or resource.get("type") != "documents":
         return
@@ -339,16 +328,11 @@ async def _discover_documents(
     client: PolarionClient,
     project_id: str,
 ) -> list[DiscoveredDocument]:
-    """Discover every document in *project_id* with its display metadata.
+    """Discover every document in *project_id* with display metadata; TTL-cached.
 
-    One ``GROUP BY mod.c_uri`` SQL query collapses every heading work item to a
-    single representative per document, so each response page is one page of
-    *documents*, not headings -- far fewer round-trips than a per-heading scan.
-    ``include=module,module.author,module.updatedBy`` pulls each document's
-    attributes plus the editors' user names into ``included`` at no extra
-    request (a dot-path include alone drops the intermediate ``module``
-    resources -- it must be listed explicitly). TTL-cached so paginated callers
-    reuse the discovery.
+    ``GROUP BY mod.c_uri`` SQL collapses headings to one per document (pages of
+    documents, not headings). ``module`` must be listed alongside its dot-path
+    includes — a dot-path alone drops the intermediate resource.
     """
     cached = get_cached_documents(project_id)
     if cached is not None:
@@ -406,11 +390,7 @@ async def _discover_documents(
 
 
 def _extract_first_resource_id(response: dict[str, object]) -> str | None:
-    """Pull the first resource ID out of a JSON:API ``{"data": [...]}`` body.
-
-    Returns ``None`` when ``data`` is missing, not a non-empty list, or its
-    first entry has no ``id`` string.
-    """
+    """First resource id from a JSON:API ``{"data": [...]}`` body, else ``None``."""
     data = response.get("data")
     if not isinstance(data, list) or not data:
         return None
@@ -422,11 +402,8 @@ def _extract_first_resource_id(response: dict[str, object]) -> str | None:
 
 
 def _extract_created_module_name(response: dict[str, object]) -> str | None:
-    """Extract the document name from a 201 document-create response.
-
-    ``id`` is ``projectId/spaceId/documentName`` (name may contain ``/``).
-    ``None`` on an unexpected shape.
-    """
+    """Document name from a 201 create response (name may contain ``/``);
+    ``None`` on unexpected shape."""
     full_id = _extract_first_resource_id(response)
     if full_id is None:
         return None
@@ -445,12 +422,8 @@ def _build_update_document_payload(  # noqa: PLR0913
     home_page_content_html: str | None = None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API PATCH body for ``.../documents/{d}``.
-
-    Single ``data`` object, required ``id`` ``"{project}/{space}/{document}"``,
-    skips unset. ``home_page_content_html`` wrapped verbatim into
-    ``{type,value}`` (empty-string guard lives in the tool layer).
-    """
+    """JSON:API PATCH body for ``.../documents/{d}``; skips unset.
+    ``home_page_content_html`` wrapped verbatim (empty guard in tool layer)."""
     attributes: dict[str, JsonValue] = {}
     if title is not None:
         attributes["title"] = title
@@ -484,10 +457,7 @@ def _build_create_document_payload(  # noqa: PLR0913
     status: str | None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API POST body for ``.../spaces/{s}/documents``.
-
-    ``data`` list, ``type=documents``, inline ``attributes``, skips unset.
-    """
+    """JSON:API POST body for ``.../spaces/{s}/documents``; skips unset."""
     attributes: dict[str, JsonValue] = {
         "moduleName": module_name,
         "title": title,
@@ -644,8 +614,7 @@ async def get_document(
     relationships = data.get("relationships", {})
     if not isinstance(relationships, dict):
         relationships = {}
-    # User ids are join keys into the included ``users`` resources; output
-    # carries display names only.
+    # Output carries display names only; ids are join keys into included users.
     user_names = build_included_user_name_map(response)
 
     content_html = ""
@@ -809,8 +778,7 @@ async def read_document_parts(  # noqa: PLR0913
             if part is not None:
                 items.append(part)
 
-    # Seen-item count only when the server gives no usable total and the page
-    # is non-empty, else an out-of-range page inflates it.
+    # Fallback count only on a non-empty page, else out-of-range pages inflate it.
     raw_doc_total = extract_total_count(response)
     document_total = raw_doc_total
     if document_total <= 0 and items:
@@ -847,8 +815,8 @@ async def read_document(  # noqa: PLR0913
     round-trip via ``get_document(include_homepage_content_html=True)``. For
     metadata-only extraction prefer ``list_work_items`` SQL.
     """
-    # read_document_parts handles fetch + error mapping (decorator returns the
-    # original function, so it forwards directly).
+    # read_document_parts handles fetch + error mapping (@mcp.tool returns the
+    # original function).
     page = await read_document_parts(
         ctx,
         project_id=project_id,
@@ -1020,8 +988,7 @@ async def update_document(  # noqa: PLR0913
         )
 
     client = get_client(ctx)
-    # Guard type/status against type-agnostic options: avoids an extra GET,
-    # still catches obvious ghost ids.
+    # Type-agnostic enum guard: avoids an extra GET, still catches ghost ids.
     await guard_document_enums(
         client,
         project_id,
@@ -1030,8 +997,7 @@ async def update_document(  # noqa: PLR0913
         status=status,
     )
 
-    # Build first: merge_custom_fields rejects standard-attribute collisions —
-    # more fundamental, and cheaper than the guard's GET.
+    # Build first: merge_custom_fields collision check is cheaper than guard GET.
     payload = _build_update_document_payload(
         project_id=project_id,
         space_id=space_id,
@@ -1042,8 +1008,7 @@ async def update_document(  # noqa: PLR0913
         home_page_content_html=home_page_content_html,
         custom_fields=custom_fields,
     )
-    # Unknown custom-field keys persist as silent ghosts; validate against the
-    # type's schema. A type change keys on the new type, else the current one.
+    # A type change keys the custom-field schema on the new type, else current.
     if custom_fields:
         effective_type = type or await _resolve_document_type(
             client, project_id, space_id, document_name

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -224,7 +224,8 @@ _FENCED_MIN_LINES: Final[int] = 2
 
 def _render_parts_to_markdown(parts: list[DocumentPart]) -> str:
     """Interleave a page of parts into one Markdown string; chunks join on a
-    blank line, runs of 3+ newlines collapse to 2."""
+    blank line, runs of 3+ newlines collapse to 2.
+    """
     chunks: list[str] = []
     for part in parts:
         chunk = _render_part(part)
@@ -266,7 +267,8 @@ def _render_workitem_part(part: DocumentPart) -> str:
 
 def _decorate_wikiblock(content: str) -> str:
     """Lift the Velocity macro name (``#name(``) into the fenced-code
-    info-string; raw fence when none detectable."""
+    info-string; raw fence when none detectable.
+    """
     stripped = content.strip()
     if not stripped:
         return ""
@@ -286,7 +288,8 @@ def _decorate_wikiblock(content: str) -> str:
 @dataclass(frozen=True, slots=True)
 class _DocumentMeta:
     """Document attributes + editor user ids (join keys into included
-    ``users``; never surfaced in output — display names only)."""
+    ``users``; never surfaced in output — display names only).
+    """
 
     type: str = ""
     status: str = ""
@@ -403,7 +406,8 @@ def _extract_first_resource_id(response: dict[str, object]) -> str | None:
 
 def _extract_created_module_name(response: dict[str, object]) -> str | None:
     """Document name from a 201 create response (name may contain ``/``);
-    ``None`` on unexpected shape."""
+    ``None`` on unexpected shape.
+    """
     full_id = _extract_first_resource_id(response)
     if full_id is None:
         return None
@@ -423,7 +427,8 @@ def _build_update_document_payload(  # noqa: PLR0913
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
     """JSON:API PATCH body for ``.../documents/{d}``; skips unset.
-    ``home_page_content_html`` wrapped verbatim (empty guard in tool layer)."""
+    ``home_page_content_html`` wrapped verbatim (empty guard in tool layer).
+    """
     attributes: dict[str, JsonValue] = {}
     if title is not None:
         attributes["title"] = title

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -54,7 +54,8 @@ logger = logging.getLogger("mcp_server_polarion.tools.links")
 
 def _extract_created_link_ids(response: dict[str, object]) -> list[str]:
     """Composite link ids verbatim, input order, from a bulk create response —
-    the path ids for later PATCH / DELETE. Empty on malformed shapes."""
+    the path ids for later PATCH / DELETE. Empty on malformed shapes.
+    """
     data = response.get("data")
     if not isinstance(data, list):
         return []
@@ -73,7 +74,8 @@ def _build_create_links_payload(
     links: list[WorkItemLinkSpec],
 ) -> dict[str, JsonValue]:
     """JSON:API body for bulk create-link POST; ``revision`` skipped when
-    unset, ``target_project_id`` defaults to source."""
+    unset, ``target_project_id`` defaults to source.
+    """
     data: list[JsonValue] = []
     for spec in links:
         tgt_proj = (
@@ -109,7 +111,8 @@ def _build_delete_links_payload(
 ) -> tuple[list[str], dict[str, JsonValue]]:
     """(composite id list, JSON:API body) for bulk delete-link DELETE; each
     5-segment id ``<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`` built from the
-    structured ref."""
+    structured ref.
+    """
     link_ids: list[str] = []
     data: list[JsonValue] = []
     for ref in links:
@@ -135,7 +138,8 @@ def _build_update_link_payload(
 ) -> tuple[str, str, dict[str, JsonValue]]:
     """(composite id, path, body) for one link PATCH; ``suspect``/``revision``
     attached only when set (omit-preserve). Path built here so id and path
-    share one ``tgt_proj``."""
+    share one ``tgt_proj``.
+    """
     tgt_proj = (
         spec.target_project_id
         if spec.target_project_id is not None
@@ -173,7 +177,8 @@ def _parse_work_item_links(
     direction: Literal["forward", "back"],
 ) -> list[WorkItemLink]:
     """Parse linked work items into ``WorkItemLink``s; target id from
-    ``relationships.workItem.data.id``, never by parsing the composite id."""
+    ``relationships.workItem.data.id``, never by parsing the composite id.
+    """
     work_item_map = build_included_work_item_map(response)
 
     items: list[WorkItemLink] = []

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -53,10 +53,8 @@ logger = logging.getLogger("mcp_server_polarion.tools.links")
 
 
 def _extract_created_link_ids(response: dict[str, object]) -> list[str]:
-    """Return composite link ids verbatim, in input order, from a bulk
-    create-link response. These are the path id for later PATCH / DELETE.
-    Empty on malformed shapes (callers treat empty as failure).
-    """
+    """Composite link ids verbatim, input order, from a bulk create response —
+    the path ids for later PATCH / DELETE. Empty on malformed shapes."""
     data = response.get("data")
     if not isinstance(data, list):
         return []
@@ -74,11 +72,8 @@ def _build_create_links_payload(
     source_project_id: str,
     links: list[WorkItemLinkSpec],
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API body for bulk create-link POST.
-
-    One ``linkedworkitems`` resource per spec in a single ``data`` array.
-    ``revision`` skipped when unset; ``target_project_id`` defaults to source.
-    """
+    """JSON:API body for bulk create-link POST; ``revision`` skipped when
+    unset, ``target_project_id`` defaults to source."""
     data: list[JsonValue] = []
     for spec in links:
         tgt_proj = (
@@ -112,11 +107,9 @@ def _build_delete_links_payload(
     source_work_item_id: str,
     links: list[WorkItemLinkRef],
 ) -> tuple[list[str], dict[str, JsonValue]]:
-    """Build composite ids + JSON:API body for bulk delete-link DELETE.
-
-    Each link's 5-segment id ``<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`` is
-    built from the structured ref. Returns (id list, body).
-    """
+    """(composite id list, JSON:API body) for bulk delete-link DELETE; each
+    5-segment id ``<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`` built from the
+    structured ref."""
     link_ids: list[str] = []
     data: list[JsonValue] = []
     for ref in links:
@@ -140,12 +133,9 @@ def _build_update_link_payload(
     source_work_item_id: str,
     spec: WorkItemLinkUpdateSpec,
 ) -> tuple[str, str, dict[str, JsonValue]]:
-    """Build the composite id, request path, and JSON:API body for one PATCH.
-
-    Per-link on ``.../linkedworkitems/{role}/{tgtProj}/{tgtWI}`` with a
-    single-resource body. ``suspect`` / ``revision`` attached only when set
-    (omit-preserve). Path returned here so id and path share one ``tgt_proj``.
-    """
+    """(composite id, path, body) for one link PATCH; ``suspect``/``revision``
+    attached only when set (omit-preserve). Path built here so id and path
+    share one ``tgt_proj``."""
     tgt_proj = (
         spec.target_project_id
         if spec.target_project_id is not None
@@ -182,12 +172,8 @@ def _parse_work_item_links(
     *,
     direction: Literal["forward", "back"],
 ) -> list[WorkItemLink]:
-    """Parse linked work items from a JSON:API response into ``WorkItemLink``s.
-
-    Role/suspect come from ``attributes``; target title/type/status resolve
-    from the ``included`` array (``include=workItem``). The target id is taken
-    from ``relationships.workItem.data.id``, never by parsing the composite id.
-    """
+    """Parse linked work items into ``WorkItemLink``s; target id from
+    ``relationships.workItem.data.id``, never by parsing the composite id."""
     work_item_map = build_included_work_item_map(response)
 
     items: list[WorkItemLink] = []

--- a/src/mcp_server_polarion/tools/moves.py
+++ b/src/mcp_server_polarion/tools/moves.py
@@ -34,11 +34,9 @@ def _build_move_to_document_payload(
     previous_part_id: str | None,
     next_part_id: str | None,
 ) -> dict[str, JsonValue]:
-    """Build the flat ``moveToDocument`` action body (not JSON:API).
-
-    ``targetDocument`` plus at most one of ``previousPart`` / ``nextPart``
-    (both omitted = append). At-most-one re-checked here to fail closed.
-    """
+    """Flat ``moveToDocument`` action body (not JSON:API): ``targetDocument``
+    plus at most one of ``previousPart``/``nextPart`` (both omitted = append);
+    at-most-one re-checked here to fail closed."""
     if previous_part_id is not None and next_part_id is not None:
         msg = (
             "_build_move_to_document_payload accepts at most one of "

--- a/src/mcp_server_polarion/tools/moves.py
+++ b/src/mcp_server_polarion/tools/moves.py
@@ -36,7 +36,8 @@ def _build_move_to_document_payload(
 ) -> dict[str, JsonValue]:
     """Flat ``moveToDocument`` action body (not JSON:API): ``targetDocument``
     plus at most one of ``previousPart``/``nextPart`` (both omitted = append);
-    at-most-one re-checked here to fail closed."""
+    at-most-one re-checked here to fail closed.
+    """
     if previous_part_id is not None and next_part_id is not None:
         msg = (
             "_build_move_to_document_payload accepts at most one of "

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -68,7 +68,8 @@ def _build_work_item_resource(
     description_html: str,
 ) -> dict[str, JsonValue]:
     """One ``workitems`` resource for a bulk create POST; skips unset (no
-    overwriting defaults). ``description_html`` arrives pre-converted."""
+    overwriting defaults). ``description_html`` arrives pre-converted.
+    """
     attributes: dict[str, JsonValue] = {
         "title": spec.title,
         "type": spec.type,
@@ -126,7 +127,8 @@ def _build_create_work_items_payload(
 def _extract_created_work_item_ids(response: dict[str, object]) -> list[str]:
     """Short work-item ids from a bulk 201 response, relying on Polarion echoing
     ``data`` in submission order (call-site count check catches missing ids,
-    not reordered ones)."""
+    not reordered ones).
+    """
     data = response.get("data")
     if not isinstance(data, list):
         return []
@@ -156,7 +158,8 @@ def _build_update_work_item_payload(  # noqa: PLR0913
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
     """JSON:API PATCH body for ``/projects/{p}/workitems/{work_item}``; skips
-    unset so an update never blanks an existing attribute."""
+    unset so an update never blanks an existing attribute.
+    """
     attributes: dict[str, JsonValue] = {}
     if title:
         attributes["title"] = title

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -67,12 +67,8 @@ def _build_work_item_resource(
     spec: WorkItemCreateSpec,
     description_html: str,
 ) -> dict[str, JsonValue]:
-    """Build one ``workitems`` resource for a bulk create POST.
-
-    Skips unset values (no overwriting defaults). ``custom_fields`` inline via
-    ``merge_custom_fields`` (raises on standard-field collision).
-    ``description_html`` arrives pre-converted.
-    """
+    """One ``workitems`` resource for a bulk create POST; skips unset (no
+    overwriting defaults). ``description_html`` arrives pre-converted."""
     attributes: dict[str, JsonValue] = {
         "title": spec.title,
         "type": spec.type,
@@ -119,10 +115,7 @@ def _build_create_work_items_payload(
     specs: list[WorkItemCreateSpec],
     descriptions_html: list[str],
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API body for bulk ``POST /projects/{p}/workitems``.
-
-    One resource per (spec, description_html) pair in a single ``data`` array.
-    """
+    """JSON:API body for bulk ``POST /projects/{p}/workitems``."""
     data: list[JsonValue] = [
         _build_work_item_resource(spec=spec, description_html=html)
         for spec, html in zip(specs, descriptions_html, strict=True)
@@ -131,11 +124,9 @@ def _build_create_work_items_payload(
 
 
 def _extract_created_work_item_ids(response: dict[str, object]) -> list[str]:
-    """Return short work-item ids (submission order) from a bulk 201 response.
-
-    Relies on Polarion echoing ``data`` in order; the call-site count check
-    catches a missing id, not a reordered one. Empty on malformed shapes.
-    """
+    """Short work-item ids from a bulk 201 response, relying on Polarion echoing
+    ``data`` in submission order (call-site count check catches missing ids,
+    not reordered ones)."""
     data = response.get("data")
     if not isinstance(data, list):
         return []
@@ -164,11 +155,8 @@ def _build_update_work_item_payload(  # noqa: PLR0913
     assignee_ids: list[str] | None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
-    """Build the JSON:API PATCH body for ``/projects/{p}/workitems/{work_item}``.
-
-    Single ``data`` resource with required ``id`` ``"{project}/{work_item}"``.
-    Skips unset values so an update never blanks an existing attribute.
-    """
+    """JSON:API PATCH body for ``/projects/{p}/workitems/{work_item}``; skips
+    unset so an update never blanks an existing attribute."""
     attributes: dict[str, JsonValue] = {}
     if title:
         attributes["title"] = title
@@ -479,8 +467,7 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         custom_fields=custom_fields,
     )
 
-    # Polarion 400s on a PATCH body with no attributes/relationships, even when
-    # only workflowAction / changeTypeTo is set — catch it here.
+    # Polarion 400s on an attribute-less PATCH even with workflowAction/changeTypeTo.
     payload_data = cast(dict[str, JsonValue], payload["data"])
     if "attributes" not in payload_data and "relationships" not in payload_data:
         raise ValueError(
@@ -497,8 +484,8 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         f"/workitems/{encode_path_segment(work_item_id)}"
     )
 
-    # Enum options are type-scoped; fetch the item's type once (on dry_run too,
-    # so preview raises the same ValueError) and prime the custom-key cache.
+    # Enum options are type-scoped: one prefetch (on dry_run too, so preview
+    # raises the same errors) resolves the type and primes the custom-key cache.
     work_item_type = ""
     if status or severity or priority or resolution or change_type_to or custom_fields:
         try:
@@ -528,8 +515,7 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
             )
             work_item_type = current_detail.type
 
-        # Scope status/severity/resolution/priority by the target type
-        # (change_type_to if set). Guard checks ``type`` first, so an invalid
+        # Scope enums by target type; guard checks ``type`` first, so an invalid
         # change_type_to raises before being reused as the scoping axis.
         effective_type = change_type_to or work_item_type or "~"
         await guard_work_item_enums(
@@ -542,8 +528,7 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
             priority=priority,
             resolution=resolution,
         )
-        # change_type_to retypes the item in the same PATCH, so custom_fields
-        # belong to the new type's schema; validate against it, not the current.
+        # change_type_to retypes in the same PATCH — customs belong to the new type.
         if custom_fields:
             await guard_work_item_custom_fields(
                 client,
@@ -601,8 +586,7 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         fallback_id=work_item_id,
     )
     if not include_current_description_html:
-        # Blank the body (still came over the wire) to keep metadata-only
-        # updates small — mirrors get_work_item.
+        # Body still came over the wire; blank it — mirrors get_work_item.
         current = current.model_copy(update={"description_html": ""})
 
     return WorkItemUpdateResult(
@@ -765,8 +749,7 @@ async def list_work_items(
     data = response.get("data", [])
     items = parse_work_item_summaries(data)
 
-    # Fall back to the seen-item count only when the API total is missing/zero
-    # and the page is non-empty.
+    # Fallback count only on a non-empty page when the API total is missing.
     raw_wi_total = extract_total_count(response)
     work_item_total = raw_wi_total
     if work_item_total == 0 and items:

--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -1,5 +1,6 @@
 """HTML ↔ Markdown for Polarion rich-text fields: read path HTML→Markdown
-(token-efficient for the LLM), write path Markdown→HTML + tag sanitization."""
+(token-efficient for the LLM), write path Markdown→HTML + tag sanitization.
+"""
 
 from __future__ import annotations
 
@@ -65,7 +66,8 @@ _md_renderer: Final[MarkdownIt] = (
 
 def html_to_markdown(html: str) -> str:
     """Polarion HTML → Markdown (headings/lists/tables/inline preserved);
-    empty/whitespace input → empty string."""
+    empty/whitespace input → empty string.
+    """
     if not html or not html.strip():
         return ""
     expanded = _expand_merged_table_cells(html)
@@ -79,7 +81,8 @@ def _render_polarion_rte_links(html: str) -> str:
     """Lift ``span.polarion-rte-link`` (empty span, target on ``data-*``) into
     ``<a href="polarion:...">`` — markdownify drops empty spans, losing the
     link. ``polarion:`` is intentionally absent from ``_SAFE_URL_SCHEMES`` so a
-    round-trip through ``sanitize_html`` strips the unresolvable href."""
+    round-trip through ``sanitize_html`` strips the unresolvable href.
+    """
     if "polarion-rte-link" not in html:
         return html
     soup = BeautifulSoup(html, "html.parser")
@@ -95,7 +98,8 @@ def _render_polarion_rte_links(html: str) -> str:
 
 def _resolve_rte_link(span: Tag) -> tuple[str, str]:
     """``(href, label)`` for one rte-link span; ``("", "")`` = unusable, caller
-    leaves span untouched. Label pre-escaped for Markdown link syntax."""
+    leaves span untouched. Label pre-escaped for Markdown link syntax.
+    """
     inner_text = span.get_text(strip=True)
     data_type_raw = span.attrs.get("data-type", "")
     data_type = data_type_raw if isinstance(data_type_raw, str) else ""
@@ -137,7 +141,8 @@ def _escape_md_link_label(text: str) -> str:
 def _fill_empty_img_alt(html: str) -> str:
     """Promote ``<img title>`` (or post-colon ``src`` filename) to ``alt`` —
     Polarion puts attachment filenames on ``title``, so markdownify emits a
-    label-less ``![](src)``."""
+    label-less ``![](src)``.
+    """
     if "<img" not in html.lower():
         return html
     soup = BeautifulSoup(html, "html.parser")
@@ -164,7 +169,8 @@ def _fill_empty_img_alt(html: str) -> str:
 def _expand_merged_table_cells(html: str) -> str:
     """Duplicate ``colspan``/``rowspan`` cells into every covered grid position
     — markdownify 1.2.2 renders colspan as empty cells and drops rowspan,
-    breaking GFM cell counts."""
+    breaking GFM cell counts.
+    """
     if "<table" not in html.lower():
         return html
     soup = BeautifulSoup(html, "html.parser")
@@ -175,7 +181,8 @@ def _expand_merged_table_cells(html: str) -> str:
 
 def _rectangularize_table(table: Tag) -> None:
     """Expand one table: ``colspan=N rowspan=M`` cell → ``N*M`` copies;
-    reservations from earlier rows shift later cells rightward."""
+    reservations from earlier rows shift later cells rightward.
+    """
     rows: list[Tag] = [
         tr for tr in table.find_all("tr") if tr.find_parent("table") is table
     ]
@@ -252,7 +259,8 @@ def _clone_cell(cell: Tag) -> Tag:
 
 def markdown_to_html(text: str) -> str:
     """Markdown (or plain text) → Polarion-compatible HTML (CommonMark + GFM
-    tables; plain text wrapped in ``<p>``); empty input → empty string."""
+    tables; plain text wrapped in ``<p>``); empty input → empty string.
+    """
     if not text or not text.strip():
         return ""
     result: str = _md_renderer.render(text)
@@ -316,7 +324,8 @@ def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
     Existing non-blank ids preserved; generated ids skip in-document values
     (Polarion 400s on duplicates). Input returned verbatim (not reserialized)
     when nothing needs stamping, so an anchored round-trip body is never
-    perturbed."""
+    perturbed.
+    """
     if not html or not html.strip():
         return ""
 
@@ -348,7 +357,8 @@ def first_anchorless_block(html: str) -> str | None:
     """Name of the first block lacking a non-empty ``id=`` (whitespace-only
     counts), or ``None``. Defensive counterpart to :func:`stamp_block_ids` —
     document tools run it post-stamping so a stamping regression cannot reach
-    Polarion (anchorless block ⇒ ``GET .../parts`` HTTP 500)."""
+    Polarion (anchorless block ⇒ ``GET .../parts`` HTTP 500).
+    """
     if not html or not html.strip():
         return None
     soup = BeautifulSoup(html, "html.parser")

--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -1,10 +1,5 @@
-"""HTML ↔ Markdown conversion for Polarion content fields.
-
-Polarion stores rich-text fields (Work Item descriptions, Document
-content) as HTML. Read path converts HTML→Markdown for the LLM
-(token-efficient, structure-preserving); write path converts
-Markdown→HTML and restricts pre-existing HTML to safe tags.
-"""
+"""HTML ↔ Markdown for Polarion rich-text fields: read path HTML→Markdown
+(token-efficient for the LLM), write path Markdown→HTML + tag sanitization."""
 
 from __future__ import annotations
 
@@ -46,8 +41,7 @@ ALLOWED_TAGS: Final[frozenset[str]] = frozenset(
     }
 )
 
-# Per-tag safe-attribute allowlist; tags absent permit none. Blocks on*
-# handlers and other non-presentational attrs that enable stored XSS.
+# Per-tag attr allowlist (absent tag = none); blocks on* handlers → stored XSS.
 ALLOWED_ATTRS: Final[dict[str, frozenset[str]]] = {
     "a": frozenset({"href", "title"}),
     "td": frozenset({"colspan", "rowspan"}),
@@ -60,28 +54,18 @@ _DECOMPOSE_TAGS: Final[frozenset[str]] = frozenset({"script", "style"})
 # Safe href schemes; others (javascript:, data:, vbscript:) stripped (XSS).
 _SAFE_URL_SCHEMES: Final[frozenset[str]] = frozenset({"http", "https", "mailto"})
 
-# Cap on cells per merge expansion (colspan*rowspan); bounds adversarial
-# colspan=1000 rowspan=1000 (1M clones), covers realistic tables.
+# Bounds adversarial colspan*rowspan (1M clones); covers realistic tables.
 _MAX_CELLS_PER_MERGE: Final[int] = 10_000
 
-# CommonMark + GFM tables. html_block/html_inline disabled so raw HTML in
-# supplied Markdown can't bypass sanitization.
+# html_block/html_inline disabled so raw HTML can't bypass sanitization.
 _md_renderer: Final[MarkdownIt] = (
     MarkdownIt("commonmark").disable(["html_block", "html_inline"]).enable("table")
 )
 
 
 def html_to_markdown(html: str) -> str:
-    """Convert Polarion HTML to Markdown for LLM consumption.
-
-    Preserves headings, lists, tables, and inline formatting as Markdown.
-
-    Args:
-        html: Raw HTML string from a Polarion content field.
-
-    Returns:
-        Markdown text; empty string for empty/whitespace input.
-    """
+    """Polarion HTML → Markdown (headings/lists/tables/inline preserved);
+    empty/whitespace input → empty string."""
     if not html or not html.strip():
         return ""
     expanded = _expand_merged_table_cells(html)
@@ -92,16 +76,10 @@ def html_to_markdown(html: str) -> str:
 
 
 def _render_polarion_rte_links(html: str) -> str:
-    """Convert ``span.polarion-rte-link`` placeholders to ``<a>`` tags.
-
-    Polarion serialises rich-text refs as empty ``<span>`` with the target
-    on ``data-*`` attrs; ``markdownify`` drops empty spans, losing the link.
-    Lift the target into ``<a href="polarion:...">label</a>``.
-
-    ``polarion:`` is intentionally absent from ``_SAFE_URL_SCHEMES``: if
-    this Markdown round-trips through ``sanitize_html`` the href is
-    stripped, keeping an unresolvable scheme out of write payloads.
-    """
+    """Lift ``span.polarion-rte-link`` (empty span, target on ``data-*``) into
+    ``<a href="polarion:...">`` — markdownify drops empty spans, losing the
+    link. ``polarion:`` is intentionally absent from ``_SAFE_URL_SCHEMES`` so a
+    round-trip through ``sanitize_html`` strips the unresolvable href."""
     if "polarion-rte-link" not in html:
         return html
     soup = BeautifulSoup(html, "html.parser")
@@ -116,12 +94,8 @@ def _render_polarion_rte_links(html: str) -> str:
 
 
 def _resolve_rte_link(span: Tag) -> tuple[str, str]:
-    """Return ``(href, label)`` for one ``polarion-rte-link`` span.
-
-    ``("", "")`` when neither richPage nor work-item metadata is usable, so
-    the caller leaves the span untouched. ``label`` is pre-escaped so
-    ``[``, ``]``, ``\\`` survive Markdown link syntax.
-    """
+    """``(href, label)`` for one rte-link span; ``("", "")`` = unusable, caller
+    leaves span untouched. Label pre-escaped for Markdown link syntax."""
     inner_text = span.get_text(strip=True)
     data_type_raw = span.attrs.get("data-type", "")
     data_type = data_type_raw if isinstance(data_type_raw, str) else ""
@@ -156,21 +130,14 @@ def _resolve_rte_link(span: Tag) -> tuple[str, str]:
 
 
 def _escape_md_link_label(text: str) -> str:
-    """Backslash-escape characters that break Markdown link syntax.
-
-    Unescaped ``[``/``]`` in anchor text collapses ``[label](href)``; a
-    trailing ``\\`` swallows the closing bracket.
-    """
+    """Escape ``[``/``]``/``\\`` — unescaped they collapse ``[label](href)``."""
     return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
 
 
 def _fill_empty_img_alt(html: str) -> str:
-    """Promote ``<img title>`` (or post-colon ``src`` filename) to ``alt``.
-
-    Polarion stores attachments as ``<img src="attachment:NAME"/>`` with
-    the filename on ``title``, making markdownify emit a label-less
-    ``![](src)``.
-    """
+    """Promote ``<img title>`` (or post-colon ``src`` filename) to ``alt`` —
+    Polarion puts attachment filenames on ``title``, so markdownify emits a
+    label-less ``![](src)``."""
     if "<img" not in html.lower():
         return html
     soup = BeautifulSoup(html, "html.parser")
@@ -183,8 +150,7 @@ def _fill_empty_img_alt(html: str) -> str:
         title_raw = img.attrs.get("title", "")
         title = title_raw if isinstance(title_raw, str) else ""
         label = title.strip()
-        # Skip src-filename fallback for absolute URLs — post-colon segment
-        # is host+path, not a filename.
+        # No src-filename fallback for absolute URLs (post-colon = host+path).
         if not label and "://" not in src:
             _, sep, after = src.partition(":")
             label = after if sep else src
@@ -196,13 +162,9 @@ def _fill_empty_img_alt(html: str) -> str:
 
 
 def _expand_merged_table_cells(html: str) -> str:
-    """Rectangularize tables by duplicating ``colspan``/``rowspan`` cells.
-
-    ``markdownify`` 1.2.2 renders colspan as empty cells and drops rowspan
-    entirely, breaking GFM cell counts. Duplicate each spanned cell into
-    every grid position it covers so the table is rectangular and emits
-    valid GFM.
-    """
+    """Duplicate ``colspan``/``rowspan`` cells into every covered grid position
+    — markdownify 1.2.2 renders colspan as empty cells and drops rowspan,
+    breaking GFM cell counts."""
     if "<table" not in html.lower():
         return html
     soup = BeautifulSoup(html, "html.parser")
@@ -212,19 +174,15 @@ def _expand_merged_table_cells(html: str) -> str:
 
 
 def _rectangularize_table(table: Tag) -> None:
-    """Replace one table's span attributes with duplicated cells.
-
-    A cell at (row, col) with ``colspan=N rowspan=M`` becomes ``N*M`` copies
-    at ``(row..row+M-1, col..col+N-1)``. Reservations from earlier rows shift
-    later rows' cells rightward to keep the column index correct.
-    """
+    """Expand one table: ``colspan=N rowspan=M`` cell → ``N*M`` copies;
+    reservations from earlier rows shift later cells rightward."""
     rows: list[Tag] = [
         tr for tr in table.find_all("tr") if tr.find_parent("table") is table
     ]
     if not rows:
         return
 
-    # reservations[i][col]: a clone scheduled for (i, col) from a rowspan above.
+    # reservations[i][col]: clone scheduled by a rowspan above.
     reservations: list[dict[int, Tag]] = [{} for _ in rows]
 
     for row_idx, row in enumerate(rows):
@@ -239,8 +197,7 @@ def _rectangularize_table(table: Tag) -> None:
             colspan = _get_span(cell, "colspan")
             rowspan = _get_span(cell, "rowspan")
 
-            # Bound expansion per merge; drop rowspan first (rows scarcer
-            # than columns).
+            # Over cap: drop rowspan first (rows scarcer than columns).
             if colspan * rowspan > _MAX_CELLS_PER_MERGE:
                 rowspan = max(1, _MAX_CELLS_PER_MERGE // colspan)
 
@@ -248,9 +205,8 @@ def _rectangularize_table(table: Tag) -> None:
                 if attr in cell.attrs:
                     del cell.attrs[attr]
 
-            # Place original + colspan dupes one column at a time, skipping
-            # columns reserved by a rowspan above (cell may land on
-            # non-contiguous indices, as browsers do).
+            # Skip columns reserved by rowspans above — non-contiguous
+            # placement, as browsers do.
             placed_cols: list[int] = []
             for j in range(colspan):
                 while col_idx in layout:
@@ -266,18 +222,14 @@ def _rectangularize_table(table: Tag) -> None:
                 for placed_col in placed_cols:
                     reservations[target][placed_col] = _clone_cell(cell)
 
-        # Rebuild in column order; clear() also drops inter-cell whitespace
-        # (markdownify ignores it anyway).
+        # clear() drops inter-cell whitespace (markdownify ignores it anyway).
         row.clear()
         for col in sorted(layout):
             row.append(layout[col])
 
 
 def _get_span(cell: Tag, attr_name: str) -> int:
-    """Return colspan/rowspan as int in ``[1, 1000]`` (mirrors markdownify).
-
-    Missing, non-string, or non-numeric values fall back to 1.
-    """
+    """colspan/rowspan as int in ``[1, 1000]`` (mirrors markdownify); invalid → 1."""
     raw = cell.attrs.get(attr_name)
     if isinstance(raw, list):
         raw = raw[0] if raw else ""
@@ -290,11 +242,7 @@ def _get_span(cell: Tag, attr_name: str) -> int:
 
 
 def _clone_cell(cell: Tag) -> Tag:
-    """Return a detached deep copy of ``cell`` with span attributes stripped.
-
-    ``deepcopy`` yields a parent-less subtree attachable elsewhere. Span
-    attrs removed defensively (``_rectangularize_table`` already strips them).
-    """
+    """Detached deep copy of ``cell``, span attrs stripped defensively."""
     clone: Tag = deepcopy(cell)
     for attr in ("colspan", "rowspan"):
         if attr in clone.attrs:
@@ -303,18 +251,8 @@ def _clone_cell(cell: Tag) -> Tag:
 
 
 def markdown_to_html(text: str) -> str:
-    """Convert Markdown (or plain text) to Polarion-compatible HTML.
-
-    ``markdown-it-py`` (CommonMark + GFM tables) handles tables, nested
-    lists, headings, and inline formatting. Plain text is wrapped in ``<p>``.
-
-    Args:
-        text: Markdown or plain text supplied by the user or LLM.
-
-    Returns:
-        HTML for a Polarion ``description.value`` field; empty string for
-        empty/whitespace input.
-    """
+    """Markdown (or plain text) → Polarion-compatible HTML (CommonMark + GFM
+    tables; plain text wrapped in ``<p>``); empty input → empty string."""
     if not text or not text.strip():
         return ""
     result: str = _md_renderer.render(text)
@@ -322,38 +260,24 @@ def markdown_to_html(text: str) -> str:
 
 
 def sanitize_html(html: str) -> str:
-    """Remove disallowed HTML tags and attributes.
+    """Restrict HTML to ``ALLOWED_TAGS``/``ALLOWED_ATTRS``.
 
-    Two removal strategies:
-
-    * **Decompose** (tag + content): ``script``/``style`` — executable
-      code/CSS, never visible text.
-    * **Unwrap** (tag removed, content kept): all other disallowed tags
-      (e.g. ``section``, ``font``), preserving visible text and children.
-
-    Surviving tags keep only ``ALLOWED_ATTRS`` attributes (drops all
-    ``on*`` handlers → stored XSS). ``href`` values are validated against
-    ``_SAFE_URL_SCHEMES``; dangerous schemes (``javascript:``, ``data:``)
-    have their ``href`` removed.
-
-    Args:
-        html: Raw HTML that may contain disallowed tags or attributes.
-
-    Returns:
-        HTML with only ``ALLOWED_TAGS``/``ALLOWED_ATTRS``; empty string for
-        empty/whitespace input.
+    ``script``/``style`` decomposed (content too — never visible text); other
+    disallowed tags unwrapped (children kept). Surviving tags lose non-allowed
+    attrs (kills ``on*`` → stored XSS); ``href`` outside ``_SAFE_URL_SCHEMES``
+    (``javascript:``, ``data:``) removed.
     """
     if not html or not html.strip():
         return ""
 
     soup = BeautifulSoup(html, "html.parser")
 
-    # Collect first — both decompose() and unwrap() mutate the tree in-place.
+    # Collect first — decompose()/unwrap() mutate the tree in-place.
     disallowed: list[Tag] = [
         tag for tag in soup.find_all(True) if tag.name not in ALLOWED_TAGS
     ]
     for tag in disallowed:
-        # A parent's decompose() already detached this tag; skip it.
+        # Already detached by a parent's decompose().
         if tag.parent is None:
             continue
         if tag.name in _DECOMPOSE_TAGS:
@@ -386,28 +310,13 @@ _BLOCK_TAGS_NEEDING_IDS: Final[frozenset[str]] = frozenset(
 
 
 def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
-    """Stamp unique ``id=`` on the block-level elements Polarion's
-    ``/parts`` derivation requires.
-
-    Polarion stores ``homePageContent`` verbatim and does not auto-assign
-    ids. An anchorless ``<p>`` (or any ``_BLOCK_TAGS_NEEDING_IDS`` tag)
-    saves fine but makes the next ``GET .../parts`` return HTTP 500.
-    Heading tags (``<h1>..<h6>``) are skipped — Polarion rewrites their ids
-    into the ``module-workitem`` macro on save. Existing non-blank ids are
-    preserved; generated ids skip values already in the document so the
-    PATCH never trips Polarion's HTTP 400 duplicate-id rule. Returns the
-    input unchanged (verbatim, not reserialized) when every target block
-    already carries a non-blank id, so an anchored round-trip body is never
-    perturbed.
-
-    Args:
-        html: HTML string (typically ``sanitize_html`` output).
-        prefix: Base for generated ids; final form ``"{prefix}_{N}"``.
-
-    Returns:
-        HTML with a unique ``id`` on every target block; empty string for
-        empty input.
-    """
+    """Stamp unique ``id="{prefix}_{N}"`` on anchorless ``_BLOCK_TAGS_NEEDING_IDS``
+    blocks — an anchorless block saves fine but makes the next ``GET .../parts``
+    return HTTP 500. Headings skipped (Polarion rewrites their ids on save).
+    Existing non-blank ids preserved; generated ids skip in-document values
+    (Polarion 400s on duplicates). Input returned verbatim (not reserialized)
+    when nothing needs stamping, so an anchored round-trip body is never
+    perturbed."""
     if not html or not html.strip():
         return ""
 
@@ -431,22 +340,15 @@ def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
         used_ids.add(new_id)
         counter += 1
         stamped = True
-    # Verbatim when nothing changed: str(soup) reserializes the whole string
-    # (e.g. &nbsp; -> \xa0), which would corrupt an already-anchored round-trip body.
+    # str(soup) reserializes (&nbsp; -> \xa0): verbatim input when unstamped.
     return str(soup) if stamped else html
 
 
 def first_anchorless_block(html: str) -> str | None:
-    """Return the name of the first block lacking a non-empty ``id=``.
-
-    Defensive counterpart to :func:`stamp_block_ids`: ``create_document`` and
-    ``update_document`` run it after stamping so a stamping regression cannot
-    reach Polarion, where each anchorless block makes the next
-    ``GET .../parts`` return HTTP 500. Headings are exempt (Polarion rewrites
-    their ids). ``None`` when every ``_BLOCK_TAGS_NEEDING_IDS`` block has an
-    id, or input is empty. A whitespace-only ``id`` counts as anchorless,
-    matching ``stamp_block_ids``'s skip test.
-    """
+    """Name of the first block lacking a non-empty ``id=`` (whitespace-only
+    counts), or ``None``. Defensive counterpart to :func:`stamp_block_ids` —
+    document tools run it post-stamping so a stamping regression cannot reach
+    Polarion (anchorless block ⇒ ``GET .../parts`` HTTP 500)."""
     if not html or not html.strip():
         return None
     soup = BeautifulSoup(html, "html.parser")

--- a/tests/claude_hooks/test_validate_pr_body.py
+++ b/tests/claude_hooks/test_validate_pr_body.py
@@ -1,9 +1,5 @@
-"""Unit tests for the `validate_pr_body` PreToolUse hook in `.claude/hooks/`.
-
-The hook script lives outside any package, so it is loaded by path via importlib.
-These tests cover the pure helper functions; the `main()` stdin/exit-code path is
-left to manual / e2e checks.
-"""
+"""Unit tests for the `validate_pr_body` hook, loaded by path via importlib
+(script lives outside any package). Pure helpers only; `main()` left to e2e."""
 
 from __future__ import annotations
 

--- a/tests/claude_hooks/test_validate_pr_body.py
+++ b/tests/claude_hooks/test_validate_pr_body.py
@@ -1,5 +1,6 @@
 """Unit tests for the `validate_pr_body` hook, loaded by path via importlib
-(script lives outside any package). Pure helpers only; `main()` left to e2e."""
+(script lives outside any package). Pure helpers only; `main()` left to e2e.
+"""
 
 from __future__ import annotations
 

--- a/tests/claude_hooks/test_validate_pr_merge.py
+++ b/tests/claude_hooks/test_validate_pr_merge.py
@@ -1,9 +1,5 @@
-"""Unit tests for the `validate_pr_merge` PreToolUse hook in `.claude/hooks/`.
-
-The hook script lives outside any package, so it is loaded by path via importlib.
-These tests cover the pure helper functions; the `main()` stdin/exit-code path is
-left to manual / e2e checks.
-"""
+"""Unit tests for the `validate_pr_merge` hook, loaded by path via importlib
+(script lives outside any package). Pure helpers only; `main()` left to e2e."""
 
 from __future__ import annotations
 

--- a/tests/claude_hooks/test_validate_pr_merge.py
+++ b/tests/claude_hooks/test_validate_pr_merge.py
@@ -1,5 +1,6 @@
 """Unit tests for the `validate_pr_merge` hook, loaded by path via importlib
-(script lives outside any package). Pure helpers only; `main()` left to e2e."""
+(script lives outside any package). Pure helpers only; `main()` left to e2e.
+"""
 
 from __future__ import annotations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,8 @@ from mcp_server_polarion.core.config import PolarionConfig
 
 
 def load_module_from_path(path: Path, module_name: str) -> ModuleType:
-    """Import a standalone script by file path.
-
-    The tracked hooks (`.claude/hooks/`) and CI scripts (`.github/scripts/`) live
-    outside the package and some use hyphenated names, so they can't be imported
-    normally; their tests load them through here.
+    """Import a standalone script by file path — hooks and CI scripts live outside
+    the package (some hyphen-named), so normal import fails.
     """
     spec = importlib.util.spec_from_file_location(module_name, path)
     assert spec is not None and spec.loader is not None

--- a/tests/evals/cases/test_tier1_prohibitions.py
+++ b/tests/evals/cases/test_tier1_prohibitions.py
@@ -1,10 +1,5 @@
-"""Unit tests for the Tier-1 case definitions.
-
-The cases are pure data, but two invariants keep the gate honest: every case
-must name a check that actually exists in ``checks.REGISTRY`` (a typo would
-otherwise make the evaluator fail-closed on every run), and every prohibition
-must stay zero-tolerance (``min_pass_rate == 1.0``).
-"""
+"""Tier-1 case-definition invariants: every case names a check that exists in
+``checks.REGISTRY`` and stays zero-tolerance (``min_pass_rate == 1.0``)."""
 
 from __future__ import annotations
 

--- a/tests/evals/cases/test_tier1_prohibitions.py
+++ b/tests/evals/cases/test_tier1_prohibitions.py
@@ -1,5 +1,6 @@
 """Tier-1 case-definition invariants: every case names a check that exists in
-``checks.REGISTRY`` and stays zero-tolerance (``min_pass_rate == 1.0``)."""
+``checks.REGISTRY`` and stays zero-tolerance (``min_pass_rate == 1.0``).
+"""
 
 from __future__ import annotations
 

--- a/tests/evals/cases/test_tier2_efficiency.py
+++ b/tests/evals/cases/test_tier2_efficiency.py
@@ -1,5 +1,6 @@
 """Tier-2 case-definition invariants: registered check, ``min_pass_rate ==
-0.8``, name unique across BOTH tiers (``run.py --case`` selects by name)."""
+0.8``, name unique across BOTH tiers (``run.py --case`` selects by name).
+"""
 
 from __future__ import annotations
 

--- a/tests/evals/cases/test_tier2_efficiency.py
+++ b/tests/evals/cases/test_tier2_efficiency.py
@@ -1,10 +1,5 @@
-"""Unit tests for the Tier-2 case definitions.
-
-Mirrors the Tier-1 invariants at the efficiency threshold: every case must
-name a registered check, carry ``min_pass_rate == 0.8``, and keep its name
-unique across BOTH tiers (``run.py --case`` selects by name from the
-concatenated list).
-"""
+"""Tier-2 case-definition invariants: registered check, ``min_pass_rate ==
+0.8``, name unique across BOTH tiers (``run.py --case`` selects by name)."""
 
 from __future__ import annotations
 

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -1,9 +1,5 @@
-"""Unit tests for the Tier-1 deterministic checks.
-
-The gate's correctness rests entirely on these pure predicates, so every
-check is exercised against both positive (clean) and negative (forbidden)
-synthetic trajectories. No LLM, no respx — just data in, verdict out.
-"""
+"""Tier-1 check tests: every pure predicate exercised against clean and
+forbidden synthetic trajectories. No LLM, no respx."""
 
 from __future__ import annotations
 

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -1,5 +1,6 @@
 """Tier-1 check tests: every pure predicate exercised against clean and
-forbidden synthetic trajectories. No LLM, no respx."""
+forbidden synthetic trajectories. No LLM, no respx.
+"""
 
 from __future__ import annotations
 

--- a/tests/evals/evaluators/test_tier1.py
+++ b/tests/evals/evaluators/test_tier1.py
@@ -1,10 +1,5 @@
-"""Unit tests for the Tier-1 ``ForbiddenBehaviorEvaluator``.
-
-The evaluator is a thin dispatcher: it pulls ``check`` / ``params`` from the
-case metadata, fail-closes on an empty or non-list trajectory, and otherwise
-delegates the verdict to the named pure check in ``checks.py``. These tests
-exercise every branch with synthetic trajectories -- no LLM, no I/O.
-"""
+"""``ForbiddenBehaviorEvaluator`` tests: metadata dispatch, fail-closed on
+empty/non-list trajectory, delegation to the named check. No LLM, no I/O."""
 
 from __future__ import annotations
 

--- a/tests/evals/evaluators/test_tier1.py
+++ b/tests/evals/evaluators/test_tier1.py
@@ -1,5 +1,6 @@
 """``ForbiddenBehaviorEvaluator`` tests: metadata dispatch, fail-closed on
-empty/non-list trajectory, delegation to the named check. No LLM, no I/O."""
+empty/non-list trajectory, delegation to the named check. No LLM, no I/O.
+"""
 
 from __future__ import annotations
 

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -1,5 +1,6 @@
 """Fake-Polarion tests: ``_dispatch`` is a pure request router, driven with
-hand-built requests (no respx). Pins the routing table and the mutation log."""
+hand-built requests (no respx). Pins the routing table and the mutation log.
+"""
 
 from __future__ import annotations
 

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -1,10 +1,5 @@
-"""Unit tests for the in-process fake Polarion backend.
-
-``FakePolarion._dispatch`` is a pure request router -- given an ``httpx.Request``
-it returns a canned ``httpx.Response`` and records mutations -- so it can be
-driven directly with hand-built requests, no respx/network needed. These tests
-pin the routing table the eval cases rely on and the mutation side-effect log.
-"""
+"""Fake-Polarion tests: ``_dispatch`` is a pure request router, driven with
+hand-built requests (no respx). Pins the routing table and the mutation log."""
 
 from __future__ import annotations
 

--- a/tests/evals/harness/test_mcp_bridge.py
+++ b/tests/evals/harness/test_mcp_bridge.py
@@ -1,10 +1,5 @@
-"""Unit tests for the MCP-to-Strands bridge helpers.
-
-``TrajectoryRecorder`` and the two result-flattening helpers are pure: they
-turn a fastmcp call result into the (name, args, result) records the Tier-1
-checks read, and into the text the LLM sees. They are driven here with tiny
-stub objects -- no real MCP client, no agent.
-"""
+"""Bridge-helper tests: ``TrajectoryRecorder`` + result flatteners are pure,
+driven with stub objects — no real MCP client, no agent."""
 
 from __future__ import annotations
 

--- a/tests/evals/harness/test_mcp_bridge.py
+++ b/tests/evals/harness/test_mcp_bridge.py
@@ -1,5 +1,6 @@
 """Bridge-helper tests: ``TrajectoryRecorder`` + result flatteners are pure,
-driven with stub objects — no real MCP client, no agent."""
+driven with stub objects — no real MCP client, no agent.
+"""
 
 from __future__ import annotations
 

--- a/tests/evals/harness/test_model.py
+++ b/tests/evals/harness/test_model.py
@@ -1,10 +1,4 @@
-"""Unit tests for the eval-agent model factory.
-
-``resolve_model_id`` is the single source of truth both the agent and the
-report read; ``build_model`` translates env config into the LiteLLM params
-that keep runs deterministic. Both are env-driven, so the tests pin behaviour
-with ``monkeypatch.setenv`` / ``delenv``.
-"""
+"""Model-factory tests; env-driven, pinned via ``monkeypatch.setenv``/``delenv``."""
 
 from __future__ import annotations
 

--- a/tests/evals/harness/test_runner.py
+++ b/tests/evals/harness/test_runner.py
@@ -1,5 +1,6 @@
 """Runner tests: text extractor, runaway-agent ``_CycleGuard``, hermetic env
-pinning. End-to-end ``run_case`` (real agent + LLM) out of scope."""
+pinning. End-to-end ``run_case`` (real agent + LLM) out of scope.
+"""
 
 from __future__ import annotations
 

--- a/tests/evals/harness/test_runner.py
+++ b/tests/evals/harness/test_runner.py
@@ -1,10 +1,5 @@
-"""Unit tests for the eval runner's pure helpers and the cycle guard.
-
-The end-to-end ``run_case`` drives a real agent + LLM and is out of scope here
-(same boundary the hook tests draw). What is unit-testable: the text extractor,
-the runaway-agent ``_CycleGuard`` hook, and the env pinning that keeps a run
-hermetic.
-"""
+"""Runner tests: text extractor, runaway-agent ``_CycleGuard``, hermetic env
+pinning. End-to-end ``run_case`` (real agent + LLM) out of scope."""
 
 from __future__ import annotations
 

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -1,10 +1,5 @@
-"""Unit tests for the Tier-1 gate orchestration in ``evals/run.py``.
-
-The real ``run_case`` drives an LLM, so it is stubbed: these tests pin the
-deterministic glue around it -- pass-rate aggregation against ``min_pass_rate``,
-the fail-closed handling of a crashed agent run, the git-sha resolution, and
-the unknown-case exit code.
-"""
+"""Gate-orchestration tests with ``run_case`` stubbed: pass-rate aggregation,
+fail-closed crashed runs, git-sha resolution, unknown-case exit code."""
 
 from __future__ import annotations
 

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -1,5 +1,6 @@
 """Gate-orchestration tests with ``run_case`` stubbed: pass-rate aggregation,
-fail-closed crashed runs, git-sha resolution, unknown-case exit code."""
+fail-closed crashed runs, git-sha resolution, unknown-case exit code.
+"""
 
 from __future__ import annotations
 

--- a/tests/github_scripts/test_build_release_notes.py
+++ b/tests/github_scripts/test_build_release_notes.py
@@ -1,10 +1,5 @@
-"""Unit tests for the release-notes CI helper in `.github/scripts/`.
-
-The script lives outside the package and shells out to `gh`, so it is loaded by
-path via importlib and `_gh` is monkeypatched to feed canned API responses. Only
-the pure `tag_highlights` parser is covered; the `main()` stdout path is left to
-the workflow itself.
-"""
+"""Release-notes helper tests, loaded by path via importlib with `_gh`
+monkeypatched. Pure `tag_highlights` only; `main()` left to the workflow."""
 
 from __future__ import annotations
 

--- a/tests/github_scripts/test_build_release_notes.py
+++ b/tests/github_scripts/test_build_release_notes.py
@@ -1,5 +1,6 @@
 """Release-notes helper tests, loaded by path via importlib with `_gh`
-monkeypatched. Pure `tag_highlights` only; `main()` left to the workflow."""
+monkeypatched. Pure `tag_highlights` only; `main()` left to the workflow.
+"""
 
 from __future__ import annotations
 
@@ -22,7 +23,8 @@ brn = load_module_from_path(SCRIPT, "build_release_notes")
 
 def _fake_gh(*, ref_object: dict[str, str], message: str | None = None):
     """Return a `_gh` stub: the ref lookup yields `ref_object`; the tag lookup
-    (only reached for annotated tags) yields `message`."""
+    (only reached for annotated tags) yields `message`.
+    """
 
     def _gh(*args: str) -> str:
         url = args[-1]

--- a/tests/github_scripts/test_mcp_scan_summary.py
+++ b/tests/github_scripts/test_mcp_scan_summary.py
@@ -1,5 +1,6 @@
 """mcp-scan summary tests, loaded by path via importlib. Pure ``render``
-only; ``main()`` left to the workflow."""
+only; ``main()`` left to the workflow.
+"""
 
 from __future__ import annotations
 

--- a/tests/github_scripts/test_mcp_scan_summary.py
+++ b/tests/github_scripts/test_mcp_scan_summary.py
@@ -1,9 +1,5 @@
-"""Unit tests for the mcp-scan summary renderer in `.github/scripts/`.
-
-The script lives outside the package, so it is loaded by path via importlib.
-Only the pure ``render`` function is covered; the ``main()`` file-I/O path is
-left to the workflow itself.
-"""
+"""mcp-scan summary tests, loaded by path via importlib. Pure ``render``
+only; ``main()`` left to the workflow."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/core/test_client.py
+++ b/tests/mcp_server_polarion/core/test_client.py
@@ -1,8 +1,4 @@
-"""Tests for ``PolarionClient`` — HTTP behaviour, retry, error mapping.
-
-Every test mocks the Polarion REST API via ``respx`` so no real server
-is needed.  The client uses ``write_delay=0`` to avoid sleeping.
-"""
+"""``PolarionClient`` tests via ``respx``; ``write_delay=0`` avoids sleeping."""
 
 from __future__ import annotations
 
@@ -519,11 +515,8 @@ class TestSerialization:
             assert max_in_flight == 1
 
     async def test_write_delay_keeps_lock_held(self) -> None:
-        """A GET during a POST's write_delay must wait, not overlap.
-
-        The write_delay sleep runs inside the request lock, else a second
-        caller slips in during the propagation window. Timed: the GET must
-        start at least write_delay after the POST.
+        """A GET during a POST's write_delay must wait, not overlap — the sleep runs
+        inside the request lock.
         """
         post_start: list[float] = []
         get_start: list[float] = []

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -1,6 +1,7 @@
 """Real MCP transport-path tests via ``fastmcp.Client(mcp)`` in-memory —
 covers registration → JSON Schema → lifespan → client → mocked HTTP, which
-direct-call tool tests bypass."""
+direct-call tool tests bypass.
+"""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -1,13 +1,6 @@
-"""Integration tests that exercise the real MCP transport path.
-
-The tests under ``tests/tools/`` call ``@mcp.tool`` functions directly
-with a mocked ``Context``, which bypasses fastmcp's JSON Schema
-validation, tool registration, and lifespan client injection. This
-module drives the server through ``fastmcp.Client(mcp)`` in-memory
-transport so the full path — registration → JSON Schema → lifespan →
-``get_client(ctx)`` → real ``PolarionClient`` → mocked HTTP — runs end
-to end.
-"""
+"""Real MCP transport-path tests via ``fastmcp.Client(mcp)`` in-memory —
+covers registration → JSON Schema → lifespan → client → mocked HTTP, which
+direct-call tool tests bypass."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/_shared/test_cache.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_cache.py
@@ -1,5 +1,6 @@
 """``TTLCache`` + typed wrapper tests; expiry driven by patching the
-module-level ``_now`` clock seam."""
+module-level ``_now`` clock seam.
+"""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/_shared/test_cache.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_cache.py
@@ -1,10 +1,5 @@
-"""Tests for ``tools/_shared/cache.py``.
-
-Covers the ``TTLCache`` primitive (hit / miss / overwrite / lazy expiry /
-invalidate / clear) and the typed get / store wrappers the tool layer reaches
-the caches through. TTL expiry is driven by patching the module-level ``_now``
-clock seam.
-"""
+"""``TTLCache`` + typed wrapper tests; expiry driven by patching the
+module-level ``_now`` clock seam."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/_shared/test_guard.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_guard.py
@@ -1,6 +1,7 @@
 """Guard tests: fetch/parse path, fail-closed on Polarion error (write
 blocked, not skipped), and the write-time guards. Caches tested in
-``test_cache.py``."""
+``test_cache.py``.
+"""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/_shared/test_guard.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_guard.py
@@ -1,10 +1,6 @@
-"""Tests for ``tools/_shared/guard.py``.
-
-Covers the ``fetch_enum_option_ids`` GET + parse path, the fail-closed
-behaviour on Polarion error (the write is blocked, not skipped), and the
-four write-time guards. The TTL caches the guards read from live in
-``tools/_shared/cache.py`` and are exercised in ``test_cache.py``.
-"""
+"""Guard tests: fetch/parse path, fail-closed on Polarion error (write
+blocked, not skipped), and the write-time guards. Caches tested in
+``test_cache.py``."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/_shared/test_helpers.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_helpers.py
@@ -1,5 +1,6 @@
 """Direct tests for helpers worth pinning beyond the transitive per-tool
-coverage — `extract_custom_fields` / `merge_custom_fields` allowlist semantics."""
+coverage — `extract_custom_fields` / `merge_custom_fields` allowlist semantics.
+"""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/_shared/test_helpers.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_helpers.py
@@ -1,12 +1,5 @@
-"""Direct unit tests for shared tool helpers.
-
-The bulk of `_shared/helpers.py` is exercised transitively through the per-tool
-tests against `mock_client` fixtures. This module adds
-focused tests for helpers whose contract is worth pinning directly —
-currently `extract_custom_fields` (read-side) and `merge_custom_fields`
-(write-side), whose allowlist semantics drive how custom Polarion fields
-flow between the LLM and the Polarion REST API in both directions.
-"""
+"""Direct tests for helpers worth pinning beyond the transitive per-tool
+coverage — `extract_custom_fields` / `merge_custom_fields` allowlist semantics."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/_shared/test_sql.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_sql.py
@@ -1,5 +1,6 @@
 """REST-SQL builder tests pinning the ``'``-doubling escape (the only thing
-between a malicious id and an injected clause) and the query shape."""
+between a malicious id and an injected clause) and the query shape.
+"""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/_shared/test_sql.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_sql.py
@@ -1,11 +1,5 @@
-"""Direct unit tests for the REST-SQL query builders.
-
-The builders interpolate caller-supplied ids straight into a ``SQL:(...)``
-string with no bind parameters, so the ``'``-doubling escape is the only thing
-standing between a malicious id and an injected clause. These tests pin that
-escape and the overall query shape; the guard/document tools exercise the
-builders' behaviour transitively against `mock_client`.
-"""
+"""REST-SQL builder tests pinning the ``'``-doubling escape (the only thing
+between a malicious id and an injected clause) and the query shape."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/conftest.py
+++ b/tests/mcp_server_polarion/tools/conftest.py
@@ -1,8 +1,5 @@
-"""Shared fixtures for the domain tool tests.
-
-Each tool is exercised by calling the async function directly with a mock
-``PolarionClient`` injected via a mock ``Context``.
-"""
+"""Shared fixtures: tools called directly with a mock ``PolarionClient``
+injected via a mock ``Context``."""
 
 from __future__ import annotations
 
@@ -24,11 +21,8 @@ def _clear_guard_caches() -> None:
 
 @pytest.fixture(autouse=True)
 def _reset_guard_caches() -> None:
-    """Start every tool test with cold enum/custom-field guard caches.
-
-    The guards memoise option ids and observed custom-field keys in
-    module-level caches; without a reset, a key primed by one test would
-    leak into the next and mask a missing priming GET.
+    """Cold guard caches per test — a key primed by one test would leak into the
+    next and mask a missing priming GET.
     """
     _clear_guard_caches()
 

--- a/tests/mcp_server_polarion/tools/conftest.py
+++ b/tests/mcp_server_polarion/tools/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures: tools called directly with a mock ``PolarionClient``
-injected via a mock ``Context``."""
+injected via a mock ``Context``.
+"""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -697,13 +697,9 @@ class TestCreateDocumentCommentsErrors:
 
 
 class TestCreateDocumentCommentsFieldValidation:
-    """Verify Field constraints on create_document_comments and DocumentCommentSpec.
-
-    FastMCP enforces ``min_length`` via JSON Schema at the MCP protocol
-    layer before the tool function is invoked; calling the function
-    directly bypasses that gate.  We rebuild a ``TypeAdapter`` from each
-    parameter's annotation + ``FieldInfo`` to prove the constraint is
-    wired correctly at the schema layer.
+    """Field constraints on create_document_comments / DocumentCommentSpec — direct
+    calls bypass FastMCP's JSON Schema gate, so rebuild a ``TypeAdapter`` per
+    parameter to prove the constraint is wired.
     """
 
     @staticmethod

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -96,11 +96,8 @@ def _make_part(
 def _stub_parts(
     monkeypatch: pytest.MonkeyPatch, parts: list[DocumentPart]
 ) -> AsyncMock:
-    """Replace ``read_document_parts`` with an AsyncMock returning *parts*.
-
-    Returns the mock so individual tests can assert call arguments. Page
-    metadata is derived from the part list so pagination defaults stay
-    sensible without each test having to spell them out.
+    """Replace ``read_document_parts`` with an AsyncMock returning *parts*; page
+    metadata derived from the list. Returns the mock for call assertions.
     """
     stub = AsyncMock(
         return_value=PaginatedResult[DocumentPart](
@@ -708,11 +705,8 @@ class TestGetDocument:
     async def test_include_homepage_content_html_false_omits_content(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """include_homepage_content_html=False → body skipped even when API echoes it.
-
-        With ``fields[documents]=@all`` the wire always carries
-        ``homePageContent``; the tool layer is responsible for hiding it
-        from the LLM unless asked.
+        """include_homepage_content_html=False → body hidden even though ``@all``
+        always carries it on the wire.
         """
         mock_client.get.return_value = {
             "data": {
@@ -774,12 +768,8 @@ class TestGetDocument:
     async def test_polarion_specific_markup_round_trips(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Polarion-specific spans / data-* attributes must survive on read.
-
-        This is the core round-trip guarantee — the same string must
-        be passable back into update_document(home_page_content_html=...)
-        unchanged. If sanitization / markdownify ever creeps back in,
-        these markers would be the first thing to disappear.
+        """Core round-trip guarantee: Polarion spans / data-* attrs survive read, so
+        the string can go back into update_document unchanged.
         """
         raw = (
             '<p>See <span class="polarion-rte-link" '
@@ -1412,12 +1402,8 @@ class TestReadDocumentParts:
     async def test_uses_tight_workitem_fieldset(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Embedded work items are fetched with WORK_ITEM_PART_FIELDS, not ``@all``.
-
-        DocumentPart only consumes title/type/status/description from the
-        linked work item; sending ``@all`` would ship every inline custom field
-        (KBs per page) for no downstream use. This guard prevents a
-        regression to the old over-fetching behaviour.
+        """Embedded work items use WORK_ITEM_PART_FIELDS, not ``@all`` — ``@all`` ships
+        KBs of unused inline customs per page.
         """
         mock_client.get.return_value = {
             "data": [],
@@ -2269,11 +2255,8 @@ class TestReadDocument:
 
 
 class TestReadDocumentFieldValidation:
-    """Verify Field constraints on ``read_document`` parameters.
-
-    Direct invocation bypasses FastMCP's JSON Schema gate; rebuild a
-    ``TypeAdapter`` from each parameter's annotation + ``FieldInfo`` to
-    prove the constraint is wired correctly.
+    """Field constraints on ``read_document`` — direct calls bypass FastMCP's JSON
+    Schema gate, so rebuild a ``TypeAdapter`` per parameter.
     """
 
     @staticmethod
@@ -2618,11 +2601,8 @@ class TestUpdateDocumentValidation:
     async def test_custom_fields_homepagecontent_collision_raises(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """`homePageContent` is a STANDARD_DOCUMENT_ATTRIBUTES key.
-
-        Allowing it via ``custom_fields`` would let a caller bypass the
-        explicit ``home_page_content_html`` parameter (and its empty-string
-        guard). The merge helper raises on collision; pin that semantics.
+        """`homePageContent` collision raises — allowing it via custom_fields would
+        bypass the explicit parameter and its empty-string guard.
         """
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             await update_document(
@@ -3044,14 +3024,9 @@ class TestUpdateDocumentFieldValidation:
 
 
 class TestUpdateDocumentPitfallDocumentation:
-    """Lock the macro-div body-edit pitfall into the public docstring so a
-    future slim pass cannot silently delete it.
-
-    The pitfall was reproduced against the live testdrive server and is
-    user-facing (MCP hosts on other platforms never load CLAUDE.md), so the
-    warning must stay inside ``update_document.__doc__``. The anchorless-block
-    pitfall is gone from the docstring on purpose: the tool now stamps ids
-    automatically, so surfacing it would only distract the LLM.
+    """Lock the macro-div pitfall into ``update_document.__doc__`` — reproduced on
+    the live testdrive server, user-facing (other MCP hosts never load CLAUDE.md).
+    Anchorless-block pitfall intentionally absent: ids now auto-stamped.
     """
 
     def test_docstring_warns_about_macro_div_module_relationship_gap(self) -> None:

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -3304,7 +3304,8 @@ class TestCreateDocumentHappyPath:
     ) -> None:
         """Every block-level element from the target set gets a unique
         ``polarion_mcp_N`` id; headings are intentionally left bare so
-        Polarion can rewrite them to the macro form on save."""
+        Polarion can rewrite them to the macro form on save.
+        """
         mock_client.post.return_value = {
             "data": [{"type": "documents", "id": "MyProj/_default/MySpec"}]
         }
@@ -3337,7 +3338,8 @@ class TestCreateDocumentHappyPath:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """A stamp_block_ids regression that leaves a block anchorless is
-        caught by the trailing first_anchorless_block guard before POST."""
+        caught by the trailing first_anchorless_block guard before POST.
+        """
         monkeypatch.setattr(_mod, "stamp_block_ids", lambda html: html)
         with pytest.raises(RuntimeError, match="anchorless block"):
             await create_document(
@@ -3889,7 +3891,8 @@ class TestUpdateDocumentAnchorlessGuard:
         reset_enum_guard_caches: None,
     ) -> None:
         """An already-anchored body round-trips byte-for-byte: stamp_block_ids
-        short-circuits before reserializing, so ``&nbsp;`` is not mangled."""
+        short-circuits before reserializing, so ``&nbsp;`` is not mangled.
+        """
         raw = '<p id="polarion_mcp_1">Note&nbsp;here</p>'
         result = await _call_update_doc(
             mock_ctx, home_page_content_html=raw, dry_run=True
@@ -3915,7 +3918,8 @@ class TestUpdateDocumentAnchorlessGuard:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """If a future stamp_block_ids regression leaves a block anchorless,
-        the trailing first_anchorless_block guard blocks the PATCH."""
+        the trailing first_anchorless_block guard blocks the PATCH.
+        """
         monkeypatch.setattr(_mod, "stamp_block_ids", lambda html: html)
         with pytest.raises(RuntimeError, match="anchorless block"):
             await _call_update_doc(

--- a/tests/mcp_server_polarion/tools/test_links.py
+++ b/tests/mcp_server_polarion/tools/test_links.py
@@ -387,13 +387,8 @@ class TestListWorkItemLinks:
     async def test_direction_default_is_forward_in_registered_schema(
         self,
     ) -> None:
-        """Guard the JSON-Schema default for ``direction``.
-
-        Direct invocation cannot exercise FastMCP's default-injection
-        (passing the ``Field(...)`` sentinel through), so the registered
-        tool schema is the authoritative place to verify the default
-        the LLM will see. Regressions here would silently break the
-        zero-arg call path.
+        """Guard the JSON-Schema default for ``direction`` — direct calls can't exercise
+        FastMCP default-injection, so the registered schema is authoritative.
         """
         tools = await mcp.list_tools()
         tool = next(t for t in tools if t.name == "list_work_item_links")
@@ -1219,11 +1214,8 @@ class TestDeleteWorkItemLinksErrorMapping:
     async def test_404_raises_value_error_about_source_wi(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Path-level 404 means the source WI itself is missing.
-
-        Body-level 'link not found' is silently ignored by Polarion
-        (confirmed against the testdrive instance, 2026-05-22), so the
-        only 404 the tool layer sees is the source-WI variant.
+        """Path-level 404 = source WI missing; body-level 'link not found' is silently
+        ignored by Polarion (confirmed on testdrive, 2026-05-22).
         """
         mock_client.get.return_value = _forward_links_response(
             ["MyProj/MCPT-1/parent/MyProj/MCPT-2"]

--- a/tests/mcp_server_polarion/tools/test_path_encoding.py
+++ b/tests/mcp_server_polarion/tools/test_path_encoding.py
@@ -22,14 +22,9 @@ from mcp_server_polarion.tools.work_items import (
 
 
 class TestReadPathEncoding:
-    """Every read tool that builds a URL must URL-encode each path segment.
-
-    Without encoding, a project/space/document/work-item id containing a
-    space, slash, or other reserved character would either generate a
-    malformed URL or — worse — allow path traversal (``../``) into a
-    different Polarion resource. These tests pin the encoding behavior so
-    a future refactor cannot silently drop ``encode_path_segment()`` from
-    one of the read paths.
+    """Every read tool must URL-encode each path segment — unencoded reserved chars
+    malform the URL or allow ``../`` traversal. Pins ``encode_path_segment()`` so
+    a refactor cannot silently drop it.
     """
 
     @pytest.fixture(autouse=True)

--- a/tests/mcp_server_polarion/tools/test_tool_annotations.py
+++ b/tests/mcp_server_polarion/tools/test_tool_annotations.py
@@ -8,12 +8,8 @@ from mcp_server_polarion.server import mcp
 
 
 class TestWriteToolAnnotations:
-    """Verify each write tool advertises the expected MCP annotations.
-
-    Annotations let MCP clients display risk hints (destructive/idempotent)
-    and apply per-tool auto-approval policies. Read tools advertise
-    ``readOnlyHint=True``; write tools must mirror with the inverse plus
-    ``destructiveHint`` / ``idempotentHint`` / ``openWorldHint``.
+    """Write tools must advertise destructive/idempotent/openWorld hints — MCP
+    clients use them for risk display and auto-approval policies.
     """
 
     @staticmethod

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -723,14 +723,8 @@ class TestCreateWorkItemsResponseParsing:
 
 
 class TestCreateWorkItemsFieldValidation:
-    """Verify constraints attached to ``items`` and to ``WorkItemCreateSpec``.
-
-    FastMCP enforces these via JSON Schema at the MCP protocol layer
-    before the tool function is invoked; calling the function directly
-    in unit tests bypasses that gate. The per-item constraints now live
-    on the spec model (validated directly), and the collection-level
-    ``min_length`` / ``max_length`` are proven by rebuilding a
-    ``TypeAdapter`` from the ``items`` parameter annotation + ``FieldInfo``.
+    """Constraints on ``items`` + ``WorkItemCreateSpec`` — direct calls bypass the
+    JSON Schema gate; collection-level bounds proven via ``TypeAdapter`` rebuild.
     """
 
     @staticmethod
@@ -1014,13 +1008,9 @@ class TestUpdateWorkItemValidation:
     async def test_empty_description_html_is_noop(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``description_html=''`` is "leave unchanged" — never PATCHes.
-
-        Asymmetric vs ``update_document(home_page_content_html='')`` which
-        RAISES (see test_home_page_content_html_empty_string_raises). The
-        difference is justified by blast radius: clearing a single work item's
-        description is recoverable; wiping a document body orphans every
-        heading work item inside it.
+        """``description_html=''`` = leave unchanged (never PATCHes) — asymmetric vs
+        update_document, where '' RAISES: a wiped document body orphans every heading,
+        a cleared description is recoverable.
         """
         with pytest.raises(ValueError, match="Nothing to update"):
             await _call_update(mock_ctx, description_html="")
@@ -1213,11 +1203,8 @@ class TestUpdateWorkItemHappyPath:
     async def test_current_description_html_blanked_by_default(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Default (False) blanks current.description_html.
-
-        GET still returns the body (the @all fieldset is needed for
-        customs), but the tool blanks it to spare LLM context unless the
-        caller opts in via include_current_description_html=True.
+        """Default blanks current.description_html — body still travels (``@all`` needed
+        for customs); tool strips it to spare LLM context.
         """
         mock_client.patch.return_value = {}
         mock_client.get.return_value = _make_get_response(
@@ -1459,11 +1446,8 @@ class TestUpdateWorkItemHappyPath:
     async def test_description_html_is_sent_verbatim(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """update_work_item passes description_html through unchanged.
-
-        Core round-trip guarantee: Polarion-specific spans and data-*
-        attributes must survive the PATCH unchanged so the round-trip
-        through ``get_work_item`` is lossless. No sanitize, no markdownify.
+        """Core round-trip guarantee: description_html PATCHed verbatim — no sanitize,
+        no markdownify.
         """
         mock_client.patch.return_value = {}
         mock_client.get.return_value = _make_get_response()
@@ -2463,11 +2447,8 @@ class TestGetWorkItem:
     async def test_include_description_html_false_blanks_field(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """include_description_html=False blanks description_html.
-
-        The body still travels over the wire (@all is needed for customs);
-        the tool strips it to save LLM context. Passed explicitly since
-        direct-call tests bypass the FastMCP Field default.
+        """include_description_html=False blanks the field — body still travels
+        (``@all`` for customs); passed explicitly since direct calls bypass defaults.
         """
         mock_client.get.return_value = {
             "data": {
@@ -2780,12 +2761,8 @@ class TestReadWorkItem:
     async def test_polarion_specific_markup_collapses_to_text(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Polarion span/data-* attributes get stripped by html_to_markdown.
-
-        Marks the read-only contract: WorkItemRead.description is NOT a
-        round-trip shape — feeding it back to update_work_item would lose
-        the polarion-rte-link span. The round-trip pair lives on
-        get_work_item / update_work_item.
+        """Read-only contract: WorkItemRead.description is NOT round-trip shape —
+        feeding it back loses the polarion-rte-link span.
         """
         raw = (
             '<p>Refs <span class="polarion-rte-link" '

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -1021,7 +1021,8 @@ class TestUpdateWorkItemValidation:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         """``description_html=''`` is skipped from the PATCH body even when
-        paired with other fields — the existing description is preserved."""
+        paired with other fields — the existing description is preserved.
+        """
         result = await _call_update(
             mock_ctx,
             title="new title",

--- a/tests/mcp_server_polarion/utils/test_html.py
+++ b/tests/mcp_server_polarion/utils/test_html.py
@@ -258,7 +258,8 @@ class TestHtmlToMarkdownMergedCells:
     def test_table_colspan_skips_rowspan_reservation(self) -> None:
         """A colspan cell pushed past a previous row's rowspan must not
         overwrite the reservation — it should land at non-contiguous columns
-        (matching browser rendering)."""
+        (matching browser rendering).
+        """
         # Row 0: A | B(rowspan=2) | C
         # Row 1: D(colspan=2) — should occupy cols 0 and 2 (col 1 reserved)
         # Row 2: E | F | G
@@ -560,7 +561,8 @@ class TestSanitizeHtml:
 
     def test_decompose_with_nested_disallowed_child_no_error(self) -> None:
         """decompose() removes a script subtree; the loop must not crash when it
-        subsequently encounters the already-detached child tag (font inside script)."""
+        subsequently encounters the already-detached child tag (font inside script).
+        """
         html = "<p><script><font>nested</font></script>After</p>"
         # Should not raise ValueError; script + its child are silently dropped
         result = sanitize_html(html)
@@ -701,7 +703,8 @@ class TestRoundTrip:
 
 class TestStampBlockIds:
     """Verify ``stamp_block_ids`` covers exactly the blocks Polarion's
-    ``/parts`` derivation requires and leaves headings alone."""
+    ``/parts`` derivation requires and leaves headings alone.
+    """
 
     def test_each_block_tag_gets_unique_sequential_id(self) -> None:
         html = (
@@ -729,7 +732,8 @@ class TestStampBlockIds:
     def test_existing_polarion_mcp_id_avoids_collision(self) -> None:
         """A pre-existing ``polarion_mcp_N`` anchor (e.g. raw HTML embedded
         in Markdown) must not be duplicated by the counter, otherwise
-        Polarion rejects the PATCH with HTTP 400."""
+        Polarion rejects the PATCH with HTTP 400.
+        """
         html = (
             '<p id="polarion_mcp_0">manual0</p>'
             "<p>auto-a</p>"
@@ -757,7 +761,8 @@ class TestStampBlockIds:
     def test_clean_input_returned_verbatim(self) -> None:
         """When every target block already carries a non-blank id, the input
         is returned byte-for-byte — no BeautifulSoup reserialization, so
-        ``&nbsp;``/``&copy;`` and quote style survive an anchored round-trip."""
+        ``&nbsp;``/``&copy;`` and quote style survive an anchored round-trip.
+        """
         html = '<p id="a">x&nbsp;y</p><table id="t"><tr><td>&copy;</td></tr></table>'
         assert stamp_block_ids(html) == html
 
@@ -779,7 +784,8 @@ class TestStampBlockIds:
 
 class TestFirstAnchorlessBlock:
     """``first_anchorless_block`` is the write-side reject predicate; every
-    block in ``_BLOCK_TAGS_NEEDING_IDS`` must carry a non-empty id."""
+    block in ``_BLOCK_TAGS_NEEDING_IDS`` must carry a non-empty id.
+    """
 
     @pytest.mark.parametrize("value", ["", "   ", "\n\t"])
     def test_empty_or_whitespace_input_is_none(self, value: str) -> None:

--- a/tests/mcp_server_polarion/utils/test_html.py
+++ b/tests/mcp_server_polarion/utils/test_html.py
@@ -107,11 +107,8 @@ class TestHtmlToMarkdown:
         assert "&" in result
 
     def test_empty_alt_filled_from_title(self) -> None:
-        """``<img title="X" src="...">`` (no alt) becomes ``![X](src)``.
-
-        Polarion stores the upload filename in ``title``; promoting it to
-        ``alt`` and dropping ``title`` keeps the rendered Markdown to a single
-        canonical label without a redundant ``"X"`` inside the parentheses.
+        """``<img title="X">`` (no alt) → ``![X](src)``; ``title`` dropped so the label
+        appears once.
         """
         html = '<img src="attachment:1-shot.png" title="shot.png"/>'
         result = html_to_markdown(html)
@@ -119,11 +116,8 @@ class TestHtmlToMarkdown:
         assert '"shot.png"' not in result
 
     def test_empty_alt_filled_from_src_filename(self) -> None:
-        """No alt, no title -> alt derived from the segment after ``:`` in src.
-
-        Real Polarion descriptions occasionally carry attachment imgs without
-        a title attribute (e.g. when pasted from the clipboard); the filename
-        portion of ``src`` is the only readable label available.
+        """No alt, no title → alt from the post-``:`` src segment (clipboard-pasted
+        attachments carry no title; the filename is the only readable label).
         """
         html = (
             '<img src="attachment:1-screenshot-20260512-142738-1.png" '


### PR DESCRIPTION
## Summary

Repo-wide Google-style comment compression: delete comments that restate code, crush narrative comment/docstring blocks to single-line why-facts. 55 files, **2,362 -> 1,682 comment+docstring lines (-680, -28.8%)**; diff is comment/docstring-only (verified by AST comparison against `main` with docstrings stripped -- zero code change).

Key decisions:
- `@mcp.tool` docstrings left untouched -- reviewed and every line is an LLM-client constraint (already slimmed in #93); tier-1 eval gate unaffected.
- Constraint facts all preserved (XSS rationale, markdownify 1.2.2 bug, nbsp reserialization drift, ghost-write behavior, testdrive confirmation dates) -- only the wording compressed.
- Args/Returns/Raises sections dropped on internal APIs where the typed signature carries the same information (biggest single win: `core/client.py` -71%).
- Multi-line docstring closing `"""` unified to its own line (Google-style) across all touched files.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- verbose narrative comments and docstrings hurt readability and burn review time
- compress to single-line why-facts, drop what-restating text; 680 comment lines removed, zero code change

## Testing

- `ruff check`, `ruff format --check`, `mypy src/` all pass; full `pytest` green (1,180 passed with the `evals` group synced, as CI runs it; 1,136 + 7 eval-skip without the group).
- AST-level diff audit: every changed file's AST (docstrings stripped) is byte-identical to `main` -- comment/docstring-only change.
- Tier-1 evals not re-run: tool docstrings (the eval-relevant surface) are unchanged.

## Notes for Reviewers

Top reductions: `core/client.py` -93 lines (71%), `utils/html.py` -88 (56%), `tools/_shared/guard.py` -68 (42%), `tools/_shared/helpers.py` -48 (46%). Test scenario rationale kept at 1-2 lines per test; eval case-ID to rationale mapping in `evals/cases/*.py` retained in compressed form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
