### PR TITLE
test(meta): tier-3 orchestration evals + staged publish gate

### DIFF
--- a/.github/actions/run-evals/action.yml
+++ b/.github/actions/run-evals/action.yml
@@ -1,11 +1,15 @@
-name: Run Tier-1 evals
+name: Run evals
 description: >-
-  Set up uv + Python 3.13, install the eval dependency group, drive the
-  Tier-1 gate, and upload the JSON report as an artifact. Shared by the
-  publish gate (`publish.yml`) and the manual pre-deploy workflow
+  Set up uv + Python 3.13, install the eval dependency group, drive the eval
+  gate for one tier (or all), and upload the JSON report as an artifact. Shared
+  by the publish gate (`publish.yml`) and the manual pre-deploy workflow
   (`evals.yml`) so they cannot drift on setup steps.
 
 inputs:
+  tier:
+    description: Tier to run (1, 2, 3, or all).
+    required: false
+    default: all
   model:
     description: LiteLLM model id (sets EVAL_MODEL).
     required: false
@@ -32,17 +36,17 @@ runs:
       shell: bash
       run: uv sync --group evals
 
-    - name: Run Tier-1 gate
+    - name: Run eval gate (tier ${{ inputs.tier }})
       shell: bash
       env:
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         EVAL_MODEL: ${{ inputs.model }}
         EVAL_RUNS: ${{ inputs.runs }}
-      run: uv run python -m evals.run
+      run: uv run python -m evals.run --tier "${{ inputs.tier }}"
 
-    - name: Upload Tier-1 report
+    - name: Upload eval report
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: tier1-report
+        name: eval-report-tier-${{ inputs.tier }}
         path: evals/reports/

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,10 +1,20 @@
-name: Tier-1 Evals
+name: Evals
 
 # Manual pre-deploy gate run. Same checks as the publish gate, but triggered
-# on demand so results can be reviewed before tagging a release.
+# on demand so results can be reviewed before tagging a release. Pick a single
+# tier or run all of them.
 on:
   workflow_dispatch:
     inputs:
+      tier:
+        description: "Tier to run"
+        default: "all"
+        type: choice
+        options:
+          - all
+          - "1"
+          - "2"
+          - "3"
       model:
         description: "LiteLLM model id (EVAL_MODEL)"
         default: "openai/gpt-4o-mini"
@@ -21,6 +31,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals
         with:
+          tier: ${{ inputs.tier }}
           model: ${{ inputs.model }}
           runs: ${{ inputs.runs }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,18 +6,42 @@ on:
       - "v*"
 
 jobs:
-  evals:
-    # Tier-1 forbidden-behaviour gate. Blocks publish if the agent takes any
-    # destructive / footgun action against the mocked Polarion backend.
+  evals-tier1:
+    # Tier-1 forbidden-behaviour gate (zero tolerance). Cheapest tier, runs
+    # first so a destructive / footgun action blocks the publish before any
+    # agent tokens are spent on the later tiers.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals
         with:
+          tier: "1"
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+
+  evals-tier2:
+    # Tier-2 efficiency gate; only runs once Tier-1 passed.
+    needs: evals-tier1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/run-evals
+        with:
+          tier: "2"
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+
+  evals-tier3:
+    # Tier-3 orchestration gate; only runs once Tier-2 passed.
+    needs: evals-tier2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/run-evals
+        with:
+          tier: "3"
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
 
   publish-test:
-    needs: evals
+    needs: evals-tier3
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:

--- a/evals/README.md
+++ b/evals/README.md
@@ -5,7 +5,7 @@ Drives an LLM agent through the **real** in-memory MCP server against a
 behaviour. Runs as a hard gate ahead of the PyPI publish jobs in
 [`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
 
-Two tiers, same harness and evaluator, different tolerance:
+Three tiers, same harness and evaluator, different tolerance:
 
 - **Tier 1 — prohibitions** ([`cases/tier1_prohibitions.py`](cases/tier1_prohibitions.py)):
   destructive / corrupting / footgun actions. `min_pass_rate = 1.0` — a single
@@ -15,6 +15,11 @@ Two tiers, same harness and evaluator, different tolerance:
   direct get by known id, no redundant identical reads, right query
   mechanism). `min_pass_rate = 0.8` — occasional wasteful runs tolerated,
   systematic waste blocks.
+- **Tier 3 — orchestration** ([`cases/tier3_orchestration.py`](cases/tier3_orchestration.py)):
+  multi-step tasks where the agent must walk the correct ordered tool sequence
+  and thread ids between steps (e.g. `create_work_items → read_document_parts →
+  move_work_item_to_document` with the move's part-id observed from the read).
+  One generic `ordered_trajectory` check; cases are data. `min_pass_rate = 0.8`.
 
 No tier needs an **LLM judge**: every verdict is a pure function of the
 tool-call trajectory. The only model cost is the agent under test.
@@ -120,8 +125,11 @@ first tagged release.
 1. Add a pure check to `evaluators/checks.py` and register it in `REGISTRY`
    (or reuse an existing one). Keep it a function of the trajectory only.
 2. Add a `Case` to `cases/tier1_prohibitions.py` (prohibition,
-   `min_pass_rate: 1.0`) or `cases/tier2_efficiency.py` (efficiency,
-   `min_pass_rate: 0.8`); `run.py` loads both lists.
+   `min_pass_rate: 1.0`), `cases/tier2_efficiency.py` (efficiency,
+   `min_pass_rate: 0.8`), or `cases/tier3_orchestration.py` (multi-step
+   orchestration, `min_pass_rate: 0.8`); `run.py` loads all three lists. A
+   Tier-3 case usually reuses the `ordered_trajectory` check and just declares
+   its step sequence in `params` — no new check needed.
 3. Phrase the task neutrally — never state the rule, or you test the prompt
    instead of the tool docstrings (the only guard).
 
@@ -133,3 +141,11 @@ hyperlink, `MCPT-201` heading, `MCPT-202` ghost-typed task, comment thread
 [`harness/fake_polarion.py`](harness/fake_polarion.py). Mirror the real
 server's *structure* there; keep all content synthetic. Bulk POSTs echo one
 id per submitted entry, so bulk cases exercise the tools' count-match rule.
+
+Tier-3 adds: a second document `FakeParentDoc`; requirements `MCPT-300` (in
+`FakeDoc`, links `satisfies`→`MCPT-400` and `verifies`→`MCPT-500`), `MCPT-301`
+(in `FakeDoc`, no test-case link — coverage-gap signal), `MCPT-400` (parent, in
+`FakeParentDoc`), test case `MCPT-500`; a `FakeDoc` `/parts` response with the
+`Section A` heading part (`heading_MCPT-100`, the positional-move anchor); and
+project enum `workitem-link-role`. Forward links come from `_LINKS`; the back
+direction is served via `list_work_items` `query=linkedWorkItems:{wi}`.

--- a/evals/cases/tier3_orchestration.py
+++ b/evals/cases/tier3_orchestration.py
@@ -1,0 +1,193 @@
+"""Tier-3 orchestration cases: "walked the correct multi-step path".
+
+Each case asserts an ordered tool subsequence (other calls may interleave) plus
+id threading between steps via the single ``ordered_trajectory`` check; the
+sequence lives entirely in ``metadata["params"]``. ``min_pass_rate = 0.8`` like
+Tier-2 — ordered+observed-id is flaky on weak models, so occasional waste is
+tolerated, systematic mis-orchestration fails.
+
+Groups: W = document authoring (write), R = traceability/analysis (read-only),
+M = read-then-write (gated). Design principle: enumerating a document's work
+items uses ``get_sql_query_recipes`` + ``list_work_items`` (SQL), never
+``read_document_parts`` — the latter appears only to fetch a part-id anchor for
+a positional ``move_work_item_to_document``.
+"""
+
+from __future__ import annotations
+
+from strands_evals import Case
+
+from evals.harness.fake_polarion import (
+    CHILD_REQ_ID,
+    DOC,
+    FLOATING_TASK_ID,
+    SPACE,
+)
+
+MIN_PASS_RATE = 0.8
+
+# Reused step fragments. The move must run after the create (needs the new id)
+# and after read_document_parts (the anchor) -- the latter is enforced by the
+# observed-id source, the former by ``after``.
+_READ_PARTS = {"tool": "read_document_parts", "match": {"document_name": DOC}}
+_MOVE_ANCHORED = {
+    "tool": "move_work_item_to_document",
+    "match": {"target_document_name": DOC},
+    "after": ["create_work_items"],
+    "observed_arg": ["previous_part_id", "next_part_id"],
+    "observed_in": "read_document_parts",
+    "observed_path": "items[].id",
+}
+
+
+def _case(name: str, prompt: str, **params: object) -> Case:
+    return Case(
+        name=name,
+        input=prompt,
+        metadata={
+            "check": "ordered_trajectory",
+            "params": params,
+            "min_pass_rate": MIN_PASS_RATE,
+        },
+    )
+
+
+CASES: list[Case] = [
+    # --- W: document authoring ----------------------------------------------
+    _case(
+        "T3-SPEC-INTO-DOC",
+        f"In the document '{DOC}' in space '{SPACE}', add a new requirement work "
+        f"item titled 'Cache size limit' immediately after the 'Section A' heading.",
+        steps=[
+            {"tool": "create_work_items"},
+            _READ_PARTS,
+            _MOVE_ANCHORED,
+        ],
+        forbid=["update_document"],
+    ),
+    _case(
+        "T3-MIXED-DOC-UPDATE",
+        f"In the document '{DOC}' in space '{SPACE}', first add a new 'Performance' "
+        f"section heading with a one-sentence intro. Then add a requirement work "
+        f"item titled 'p95 latency under 200ms' into the document under that heading.",
+        # Crux is the split: prose/heading via update_document, the spec via
+        # create + move (not everything through one tool). No anchored move --
+        # the fresh heading isn't in the static fake parts.
+        steps=[
+            {"tool": "update_document", "match": {"document_name": DOC}},
+            {"tool": "create_work_items"},
+            {
+                "tool": "move_work_item_to_document",
+                "match": {"target_document_name": DOC},
+                "after": ["create_work_items"],
+            },
+        ],
+    ),
+    _case(
+        "T3-BULK-SPEC-INTO-DOC",
+        f"Add these three requirement work items to the document '{DOC}' in space "
+        f"'{SPACE}', right after the 'Section A' heading: 'Throughput target', "
+        f"'Error budget', and 'Retry policy'.",
+        steps=[
+            {"tool": "create_work_items"},
+            _READ_PARTS,
+            _MOVE_ANCHORED,
+        ],
+        max_create_calls=1,
+        no_dup_reads=True,
+    ),
+    _case(
+        "T3-SPEC-WITH-LINK",
+        f"Add a new requirement work item titled 'Session timeout' to the document "
+        f"'{DOC}' in space '{SPACE}' after 'Section A', then add a 'relates_to' "
+        f"link from it to work item {FLOATING_TASK_ID}.",
+        steps=[
+            {"tool": "create_work_items"},
+            _READ_PARTS,
+            _MOVE_ANCHORED,
+            {
+                "tool": "create_work_item_links",
+                "after": ["move_work_item_to_document"],
+            },
+        ],
+    ),
+    # --- R: traceability / analysis (read-only) -----------------------------
+    _case(
+        "T3-CONSISTENCY",
+        f"Check the consistency between the document '{DOC}' in space '{SPACE}' and "
+        f"its parent document: for a requirement in '{DOC}' that links to a parent "
+        f"requirement, compare their contents.",
+        # Enumerate the doc's reqs, follow a link, read the linked parent's
+        # content. Enumeration and the target read each accept the equivalent
+        # tools the model picks; "SQL vs read_document_parts" is owned by Tier-2.
+        steps=[
+            {"tool": ["list_work_items", "read_document_parts"]},
+            {"tool": "list_work_item_links"},
+            {
+                "tool": ["read_work_item", "get_work_item"],
+                "observed_arg": "work_item_id",
+                "observed_in": "list_work_item_links",
+                "observed_path": "items[].id",
+            },
+        ],
+        read_only=True,
+    ),
+    _case(
+        "T3-IMPACT-ANALYSIS",
+        f"For each work item linked to {CHILD_REQ_ID}, give a short summary of its "
+        f"description.",
+        # The link summary already carries title/type/status, so a description
+        # summary forces a follow-up read of each linked target.
+        steps=[
+            {
+                "tool": "list_work_item_links",
+                "match": {"work_item_id": CHILD_REQ_ID},
+            },
+            {
+                "tool": ["read_work_item", "get_work_item"],
+                "observed_arg": "work_item_id",
+                "observed_in": "list_work_item_links",
+                "observed_path": "items[].id",
+            },
+        ],
+        read_only=True,
+    ),
+    _case(
+        "T3-COVERAGE-GAP",
+        f"Which requirements in the document '{DOC}' in space '{SPACE}' have no "
+        f"linked test case?",
+        # Enumerate the doc's reqs, then inspect each one's links. Enumeration
+        # accepts the equivalent tools the model picks.
+        steps=[
+            {"tool": ["list_work_items", "read_document_parts"]},
+            {"tool": "list_work_item_links"},
+        ],
+        read_only=True,
+    ),
+    # --- M: read -> decide -> write (gated) ---------------------------------
+    _case(
+        "T3-CONDITIONAL-UPDATE",
+        f"If work item {FLOATING_TASK_ID} is still open, raise its priority by one "
+        f"level.",
+        steps=[
+            {"tool": "get_work_item", "match": {"work_item_id": FLOATING_TASK_ID}},
+            {
+                "tool": "update_work_item",
+                "match": {"work_item_id": FLOATING_TASK_ID},
+                "after": ["get_work_item"],
+            },
+        ],
+    ),
+    _case(
+        "T3-DEDUP-BEFORE-CREATE",
+        f"Add a requirement work item titled 'Cache eviction policy' to the document "
+        f"'{DOC}' in space '{SPACE}' after 'Section A', but only if no work item "
+        f"with that title already exists.",
+        steps=[
+            {"tool": "list_work_items"},
+            {"tool": "create_work_items", "after": ["list_work_items"]},
+            _READ_PARTS,
+            _MOVE_ANCHORED,
+        ],
+    ),
+]

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -380,6 +380,169 @@ def check_scoped_query_uses_sql(
     return True, "no Lucene module query issued"
 
 
+def _resolve_observed_path(result: object, path: str) -> list[str]:
+    """Collect string leaf values at ``path`` from a recorded tool result.
+
+    Grammar: dotted with at most one ``[]`` list-spread per segment, e.g.
+    ``items[].id`` walks ``result["items"]`` then each element's ``id``. Missing
+    keys yield ``[]`` rather than raising.
+    """
+    current: list[object] = [result]
+    for segment in path.split("."):
+        spread = segment.endswith("[]")
+        key = segment[:-2] if spread else segment
+        nxt: list[object] = []
+        for node in current:
+            if not isinstance(node, dict):
+                continue
+            value = node.get(key)
+            if spread:
+                if isinstance(value, list):
+                    nxt.extend(value)
+            elif value is not None:
+                nxt.append(value)
+        current = nxt
+    return [str(v) for v in current]
+
+
+def _args_match(args: dict[str, Any], match: dict[str, Any]) -> bool:
+    """All ``match`` entries equal the call's args (``*_id`` via ``_short_id``)."""
+    for key, expected in match.items():
+        actual = args.get(key)
+        if key.endswith("_id"):
+            if _short_id(actual) != _short_id(expected):
+                return False
+        elif actual != expected:
+            return False
+    return True
+
+
+def _step_tools(step: dict[str, Any]) -> list[str]:
+    """A step's accepted tool names -- ``tool`` is one name or a list of
+    semantically-equivalent alternatives (e.g. ``get_work_item``/``read_work_item``).
+    """
+    tool = step["tool"]
+    return [tool] if isinstance(tool, str) else list(tool)
+
+
+def _observed_value(call: dict[str, Any], arg_spec: object) -> str:
+    """Short-id value a call threads, from the first ``observed_arg`` it set
+    (``arg_spec`` is one arg name or a list of alternatives)."""
+    candidates = [arg_spec] if isinstance(arg_spec, str) else list(arg_spec)
+    args = _args(call)
+    return next((_short_id(args[a]) for a in candidates if args.get(a)), "")
+
+
+def check_ordered_trajectory(
+    trajectory: Trajectory, params: dict[str, Any]
+) -> CheckResult:
+    """Composite orchestration over a partial order: every ``params['steps']``
+    must be satisfied by a trajectory call whose name is the step's ``tool`` (or
+    one of its alternatives) and whose args match ``match``. A step's ``after``
+    deps and its ``observed_in`` source must be earlier steps that ran before it;
+    an ``observed_arg`` value must appear in the source step's result. Steps are
+    matched greedily in declaration order, each picking the earliest call that
+    satisfies all its constraints (so a later read is chosen over an unrelated
+    earlier one). Order between independent steps is unconstrained. Optional
+    flags AND existing primitives.
+    """
+    if params.get("read_only") and not (r := check_readonly(trajectory, params))[0]:
+        return r
+    if (
+        params.get("scoped_sql")
+        and not (r := check_scoped_query_uses_sql(trajectory, params))[0]
+    ):
+        return r
+    if (
+        params.get("max_create_calls") is not None
+        and not (
+            r := check_single_bulk_create(
+                trajectory, {"max_calls": params["max_create_calls"]}
+            )
+        )[0]
+    ):
+        return r
+    if (
+        params.get("no_dup_reads")
+        and not (r := check_no_duplicate_reads(trajectory, params))[0]
+    ):
+        return r
+
+    forbidden = sorted(set(params.get("forbid", [])).intersection(_names(trajectory)))
+    if forbidden:
+        return False, f"used forbidden tool(s): {forbidden}"
+
+    steps = params.get("steps", [])
+    step_at: list[int] = []  # matched trajectory index per step
+    name_to_step: dict[str, int] = {}  # tool name -> earliest step producing it
+
+    for step_no, step in enumerate(steps):
+        tools = set(_step_tools(step))
+        match = step.get("match", {})
+
+        floor = -1
+        for dep in step.get("after", []):
+            dep_step = name_to_step.get(dep)
+            if dep_step is None:
+                return (
+                    False,
+                    f"step {step_no}: 'after' dep {dep} is not an earlier step",
+                )
+            floor = max(floor, step_at[dep_step])
+
+        observed = step.get("observed_arg") is not None
+        source_seen: set[str] = set()
+        if observed:
+            source = step["observed_in"]
+            src_step = name_to_step.get(source)
+            if src_step is None:
+                return False, (
+                    f"step {step_no}: observed_in {source} is not an earlier step"
+                )
+            floor = max(floor, step_at[src_step])
+            source_seen = {
+                _short_id(v)
+                for v in _resolve_observed_path(
+                    trajectory[step_at[src_step]].get("result"), step["observed_path"]
+                )
+            }
+
+        found = -1
+        for i in range(floor + 1, len(trajectory)):
+            call = trajectory[i]
+            if call.get("name") not in tools or not _args_match(_args(call), match):
+                continue
+            if (
+                observed
+                and _observed_value(call, step["observed_arg"]) not in source_seen
+            ):
+                continue
+            found = i
+            break
+
+        if found < 0:
+            label = "/".join(sorted(tools))
+            if observed:
+                return False, (
+                    f"step {step_no} ({label}) never ran after "
+                    f"{step['observed_in']} with an id observed from it -- "
+                    "threaded id missing or guessed"
+                )
+            if floor >= 0:
+                return False, (
+                    f"step {step_no} ({label}) never ran after its dependencies "
+                    f"{step.get('after')}"
+                )
+            return False, (
+                f"step {step_no} ({label}) was never called with the expected args"
+            )
+
+        step_at.append(found)
+        for name in tools:
+            name_to_step.setdefault(name, step_no)
+    return True, "orchestration satisfied"
+
+
 REGISTRY: dict[str, Callable[[Trajectory, dict[str, Any]], CheckResult]] = {
     "readonly": check_readonly,
     "no_update_document": check_no_update_document,
@@ -393,4 +556,5 @@ REGISTRY: dict[str, Callable[[Trajectory, dict[str, Any]], CheckResult]] = {
     "direct_read": check_direct_read,
     "no_duplicate_reads": check_no_duplicate_reads,
     "scoped_query_uses_sql": check_scoped_query_uses_sql,
+    "ordered_trajectory": check_ordered_trajectory,
 }

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -42,6 +42,19 @@ FLOATING_TASK_HYPERLINK_URI = "https://specs.example.com/fake-spec"
 # Anchored intro paragraph in the doc body; T1-ROUNDTRIP-SOURCE edits it.
 DOC_INTRO_PARAGRAPH_ID = "p-1"
 
+# Second document + requirement traceability seeds (Tier-3 orchestration).
+PARENT_DOC = "FakeParentDoc"
+PARENT_MODULE_ID = f"{PROJECT}/{SPACE}/{PARENT_DOC}"
+CHILD_REQ_ID = (
+    "MCPT-300"  # in FakeDoc; satisfies PARENT_REQ_ID, verified by TESTCASE_ID
+)
+PARENT_REQ_ID = "MCPT-400"  # in FakeParentDoc
+UNCOVERED_REQ_ID = "MCPT-301"  # in FakeDoc; no test-case link (coverage-gap signal)
+TESTCASE_ID = "MCPT-500"  # test case linked from CHILD_REQ_ID
+
+# Section A heading part id served by read_document_parts; anchors positional moves.
+SECTION_A_PART_ID = f"heading_{DOC_HEADING_ID}"
+
 _TS = "2026-01-01T00:00:00.000Z"
 
 
@@ -53,7 +66,7 @@ class _WorkItem:
     status: str = "open"
     priority: str = "50.0"
     severity: str = "should_have"
-    module: bool = False
+    module_id: str = ""  # full module id (PROJECT/SPACE/DOC) if in a document, else ""
     outline_number: str = ""
     hyperlinks: list[dict[str, str]] = field(default_factory=list)
     # Keys MUST stay outside ``STANDARD_WORK_ITEM_ATTRIBUTES`` so the merge
@@ -64,7 +77,7 @@ class _WorkItem:
 # Structure mirrored from MCP_Test_Project; every string is synthetic.
 _WORK_ITEMS: dict[str, _WorkItem] = {
     DOC_HEADING_ID: _WorkItem(
-        DOC_HEADING_ID, "Section A", "heading", module=True, outline_number="1"
+        DOC_HEADING_ID, "Section A", "heading", module_id=MODULE_ID, outline_number="1"
     ),
     FLOATING_TASK_ID: _WorkItem(
         FLOATING_TASK_ID,
@@ -75,6 +88,28 @@ _WORK_ITEMS: dict[str, _WorkItem] = {
     ),
     FLOATING_HEADING_ID: _WorkItem(FLOATING_HEADING_ID, "Floating heading", "heading"),
     FLOATING_GHOST_ID: _WorkItem(FLOATING_GHOST_ID, "Ghost type", "not_a_real_type"),
+    CHILD_REQ_ID: _WorkItem(
+        CHILD_REQ_ID, "Child requirement", "systemrequirement", module_id=MODULE_ID
+    ),
+    UNCOVERED_REQ_ID: _WorkItem(
+        UNCOVERED_REQ_ID,
+        "Uncovered requirement",
+        "systemrequirement",
+        module_id=MODULE_ID,
+    ),
+    PARENT_REQ_ID: _WorkItem(
+        PARENT_REQ_ID,
+        "Parent requirement",
+        "systemrequirement",
+        module_id=PARENT_MODULE_ID,
+    ),
+    TESTCASE_ID: _WorkItem(TESTCASE_ID, "Coverage test case", "systemtestcase"),
+}
+
+# Forward (outgoing) work-item links: source short id -> [(role, target short id)].
+# CHILD_REQ has a parent + a test case; UNCOVERED_REQ deliberately has none.
+_LINKS: dict[str, list[tuple[str, str]]] = {
+    CHILD_REQ_ID: [("satisfies", PARENT_REQ_ID), ("verifies", TESTCASE_ID)],
 }
 
 # (resource, field_id) -> enum option ids (+ which is the default).
@@ -125,6 +160,7 @@ _ENUMS: dict[tuple[str, str], list[tuple[str, bool]]] = {
 # with ``attributes.options[].id``, unlike getAvailableOptions' list.
 _PROJECT_ENUMS: dict[str, list[str]] = {
     "hyperlink-role": ["ref_int", "ref_ext"],
+    "workitem-link-role": ["relates_to", "parent", "satisfies", "verifies"],
 }
 
 
@@ -139,8 +175,10 @@ class FakePolarion:
             "assignee": {"data": []},
             "author": {"data": {"type": "users", "id": f"{PROJECT}/{AUTHOR}"}},
         }
-        if wi.module:
-            relationships["module"] = {"data": {"type": "documents", "id": MODULE_ID}}
+        if wi.module_id:
+            relationships["module"] = {
+                "data": {"type": "documents", "id": wi.module_id}
+            }
         return {
             "type": "workitems",
             "id": f"{PROJECT}/{wi.short_id}",
@@ -161,25 +199,91 @@ class FakePolarion:
             "relationships": relationships,
         }
 
-    def _document_resource(self) -> dict[str, Any]:
+    def _document_resource(self, name: str) -> dict[str, Any]:
+        if name == PARENT_DOC:
+            title, body = "Fake Parent Doc", '<h1 id="ph-1">Fake Parent Doc</h1>'
+        else:
+            title = "Fake Doc"
+            body = (
+                '<h1 id="h-1">Fake Doc</h1>'
+                f'<p id="{DOC_INTRO_PARAGRAPH_ID}">Fake intro paragraph.</p>'
+            )
         return {
             "type": "documents",
-            "id": MODULE_ID,
+            "id": f"{PROJECT}/{SPACE}/{name}",
             "attributes": {
-                "title": "Fake Doc",
+                "title": title,
                 "type": "systemRequirementSpecification",
                 "status": "draft",
-                "moduleName": DOC,
+                "moduleName": name,
                 "moduleFolder": SPACE,
-                "homePageContent": {
-                    "type": "text/html",
-                    "value": (
-                        '<h1 id="h-1">Fake Doc</h1>'
-                        f'<p id="{DOC_INTRO_PARAGRAPH_ID}">Fake intro paragraph.</p>'
-                    ),
-                },
+                "homePageContent": {"type": "text/html", "value": body},
             },
         }
+
+    def _document_parts_response(self) -> dict[str, Any]:
+        """FakeDoc's parts: a Section A heading (the move anchor) + one work-item
+        part, chained via ``nextPart``. ``include=workItem`` resources supply
+        titles so ``read_document_parts`` returns populated ``items``.
+        """
+        base = f"{PROJECT}/{SPACE}/{DOC}"
+        heading_part_id = f"{base}/{SECTION_A_PART_ID}"
+        wi_part_id = f"{base}/workitem_{CHILD_REQ_ID}"
+        data = [
+            {
+                "type": "document_parts",
+                "id": heading_part_id,
+                "attributes": {"type": "heading", "level": 1},
+                "relationships": {
+                    "workItem": {
+                        "data": {
+                            "type": "workitems",
+                            "id": f"{PROJECT}/{DOC_HEADING_ID}",
+                        }
+                    },
+                    "nextPart": {"data": {"type": "document_parts", "id": wi_part_id}},
+                },
+            },
+            {
+                "type": "document_parts",
+                "id": wi_part_id,
+                "attributes": {"type": "workitem"},
+                "relationships": {
+                    "workItem": {
+                        "data": {"type": "workitems", "id": f"{PROJECT}/{CHILD_REQ_ID}"}
+                    },
+                },
+            },
+        ]
+        included = [
+            self._work_item_resource(_WORK_ITEMS[DOC_HEADING_ID]),
+            self._work_item_resource(_WORK_ITEMS[CHILD_REQ_ID]),
+        ]
+        return {"data": data, "included": included, "meta": {"totalCount": len(data)}}
+
+    def _linked_work_items_response(self, source_id: str) -> dict[str, Any]:
+        """Forward links for ``source_id`` from ``_LINKS``; targets supplied as
+        ``include=workItem`` resources (the parser derives targets from
+        ``relationships.workItem``, never the composite id).
+        """
+        data: list[dict[str, Any]] = []
+        included: list[dict[str, Any]] = []
+        for role, target in _LINKS.get(source_id, []):
+            target_full = f"{PROJECT}/{target}"
+            data.append(
+                {
+                    "type": "linkedworkitems",
+                    "id": f"{PROJECT}/{source_id}/{role}/{PROJECT}/{target}",
+                    "attributes": {"role": role, "suspect": False},
+                    "relationships": {
+                        "workItem": {"data": {"type": "workitems", "id": target_full}}
+                    },
+                }
+            )
+            target_wi = _WORK_ITEMS.get(target)
+            if target_wi is not None:
+                included.append(self._work_item_resource(target_wi))
+        return {"data": data, "included": included, "meta": {"totalCount": len(data)}}
 
     def _comment_resources(self) -> list[dict[str, Any]]:
         base = f"{PROJECT}/{SPACE}/{DOC}"
@@ -290,15 +394,26 @@ class FakePolarion:
                 return httpx.Response(404, json={"errors": [{"status": "404"}]})
             return httpx.Response(200, json={"data": self._work_item_resource(wi)})
 
-        # Always empty: no traceability seeded.
-        if path.endswith("/linkedworkitems"):
-            return httpx.Response(200, json={"data": [], "meta": {"totalCount": 0}})
+        # Forward links from a single source work item (empty if none seeded).
+        linked = re.search(r"/workitems/([^/]+)/linkedworkitems$", path)
+        if linked:
+            return httpx.Response(
+                200, json=self._linked_work_items_response(linked.group(1))
+            )
 
-        # Work item list / discovery (query=type:heading narrows to headings).
+        # Work item list / discovery: query=type:heading narrows to headings;
+        # query=linkedWorkItems:{wi} is the back-link fallback (sources -> target).
         if path.endswith("/workitems"):
             query = params.get("query", "")
             if query == "type:heading":
                 items = [w for w in _WORK_ITEMS.values() if w.type == "heading"]
+            elif query.startswith("linkedWorkItems:"):
+                target = query.split(":", 1)[1].strip().rsplit("/", maxsplit=1)[-1]
+                items = [
+                    w
+                    for w in _WORK_ITEMS.values()
+                    if any(t == target for _, t in _LINKS.get(w.short_id, []))
+                ]
             else:
                 items = list(_WORK_ITEMS.values())
             data = [self._work_item_resource(w) for w in items]
@@ -306,8 +421,11 @@ class FakePolarion:
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
             )
 
-        # Empty: no case depends on part structure.
-        if path.endswith("/parts"):
+        # Parts seeded only for FakeDoc (Section A anchor); others stay empty.
+        parts = re.search(r"/documents/([^/]+)/parts$", path)
+        if parts:
+            if parts.group(1) == DOC:
+                return httpx.Response(200, json=self._document_parts_response())
             return httpx.Response(200, json={"data": [], "meta": {"totalCount": 0}})
 
         if path.endswith("/comments"):
@@ -316,10 +434,13 @@ class FakePolarion:
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
             )
 
-        # Exact match on FakeDoc: a broad "/documents/" would claim every name
-        # as existing, masking bugs in cases probing alternate names.
-        if path.endswith(f"/spaces/{SPACE}/documents/{DOC}"):
-            return httpx.Response(200, json={"data": self._document_resource()})
+        # Exact match on the two seeded docs: a broad "/documents/" would claim
+        # every name as existing, masking bugs in cases probing alternate names.
+        doc_match = re.search(rf"/spaces/{SPACE}/documents/([^/]+)$", path)
+        if doc_match and doc_match.group(1) in (DOC, PARENT_DOC):
+            return httpx.Response(
+                200, json={"data": self._document_resource(doc_match.group(1))}
+            )
 
         return httpx.Response(404, json={"errors": [{"status": "404", "path": path}]})
 

--- a/evals/run.py
+++ b/evals/run.py
@@ -2,6 +2,7 @@
 exits non-zero below ``min_pass_rate`` (1.0 Tier-1, 0.8 Tier-2/Tier-3).
 
     uv run python -m evals.run                 # all cases, EVAL_RUNS (default 10)
+    uv run python -m evals.run --tier 1        # one tier (publish gate stages tiers)
     uv run python -m evals.run --case T1-READONLY --runs 1
 """
 
@@ -34,6 +35,15 @@ from evals.harness.runner import AGENT_ERROR_PREFIX, run_case
 _REPORT_DIR = Path(__file__).parent / "reports"
 
 ALL_CASES = [*TIER1_CASES, *TIER2_CASES, *TIER3_CASES]
+
+# Staged publish gate: each tier runs as its own CI job so a cheap early-tier
+# failure skips the pricier later tiers, saving agent-API tokens.
+TIERS: dict[str, list[Case]] = {
+    "1": TIER1_CASES,
+    "2": TIER2_CASES,
+    "3": TIER3_CASES,
+    "all": ALL_CASES,
+}
 
 
 def _git_sha() -> str:
@@ -98,6 +108,12 @@ def _run_case_n_times(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Eval deploy gate")
+    parser.add_argument(
+        "--tier",
+        choices=("1", "2", "3", "all"),
+        default="all",
+        help="tier to run (default all)",
+    )
     parser.add_argument("--case", help="run only this case name (e.g. T1-READONLY)")
     parser.add_argument(
         "--runs",
@@ -107,16 +123,19 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    cases = ALL_CASES
+    cases = TIERS[args.tier]
     if args.case:
-        cases = [c for c in ALL_CASES if c.name == args.case]
+        cases = [c for c in cases if c.name == args.case]
         if not cases:
             print(f"no case named '{args.case}'", file=sys.stderr)
             return 2
 
     evaluator = ForbiddenBehaviorEvaluator()
     model = resolve_model_id()
-    print(f"Eval gate · model={model} · runs={args.runs} · cases={len(cases)}\n")
+    print(
+        f"Eval gate · tier={args.tier} · model={model} · "
+        f"runs={args.runs} · cases={len(cases)}\n"
+    )
 
     results = [_run_case_n_times(c, args.runs, evaluator) for c in cases]
     gate_passed = all(r["passed"] for r in results)

--- a/evals/run.py
+++ b/evals/run.py
@@ -1,5 +1,5 @@
 """Eval deploy gate (wired into ``publish.yml``): runs every case N times,
-exits non-zero below ``min_pass_rate`` (1.0 Tier-1, 0.8 Tier-2).
+exits non-zero below ``min_pass_rate`` (1.0 Tier-1, 0.8 Tier-2/Tier-3).
 
     uv run python -m evals.run                 # all cases, EVAL_RUNS (default 10)
     uv run python -m evals.run --case T1-READONLY --runs 1
@@ -26,13 +26,14 @@ from strands_evals.types.evaluation import EvaluationData
 
 from evals.cases.tier1_prohibitions import CASES as TIER1_CASES
 from evals.cases.tier2_efficiency import CASES as TIER2_CASES
+from evals.cases.tier3_orchestration import CASES as TIER3_CASES
 from evals.evaluators.tier1 import ForbiddenBehaviorEvaluator
 from evals.harness.model import resolve_model_id
 from evals.harness.runner import AGENT_ERROR_PREFIX, run_case
 
 _REPORT_DIR = Path(__file__).parent / "reports"
 
-ALL_CASES = [*TIER1_CASES, *TIER2_CASES]
+ALL_CASES = [*TIER1_CASES, *TIER2_CASES, *TIER3_CASES]
 
 
 def _git_sha() -> str:

--- a/src/mcp_server_polarion/core/config.py
+++ b/src/mcp_server_polarion/core/config.py
@@ -14,6 +14,9 @@ class PolarionConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        # A shared .env may hold unrelated secrets (e.g. OPENAI_API_KEY for the
+        # eval gate); ignore extras instead of failing client construction.
+        extra="ignore",
     )
 
     polarion_url: str = Field(

--- a/tests/evals/cases/test_tier3_orchestration.py
+++ b/tests/evals/cases/test_tier3_orchestration.py
@@ -1,0 +1,94 @@
+"""Tier-3 case-definition invariants: registered check, ``min_pass_rate ==
+0.8``, names unique across all tiers, and a well-formed step DSL (each step
+names a tool; every ``observed_in`` references a tool that appears earlier in
+the same case's steps, so the threaded id can actually have been produced).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The CASES list pulls in ``strands_evals.Case``, only present when the optional
+# ``evals`` dependency group is installed; skip on the bare dev install.
+pytest.importorskip("strands_evals")
+
+from evals.cases.tier1_prohibitions import CASES as TIER1_CASES
+from evals.cases.tier2_efficiency import CASES as TIER2_CASES
+from evals.cases.tier3_orchestration import CASES, _case
+from evals.evaluators import checks
+
+
+def _params(case: object) -> dict[str, object]:
+    metadata = getattr(case, "metadata", None) or {}
+    params = metadata.get("params", {})
+    assert isinstance(params, dict)
+    return params
+
+
+def _tools(step: dict[str, object]) -> list[str]:
+    tool = step["tool"]
+    return [tool] if isinstance(tool, str) else list(tool)
+
+
+class TestCases:
+    def test_every_case_uses_the_ordered_trajectory_check(self) -> None:
+        for case in CASES:
+            assert (case.metadata or {})["check"] == "ordered_trajectory"
+
+    def test_ordered_trajectory_check_is_registered(self) -> None:
+        assert "ordered_trajectory" in checks.REGISTRY
+
+    def test_every_case_uses_efficiency_threshold(self) -> None:
+        for case in CASES:
+            assert (case.metadata or {}).get("min_pass_rate") == 0.8
+
+    def test_case_names_are_unique_across_tiers(self) -> None:
+        names = [c.name for c in [*TIER1_CASES, *TIER2_CASES, *CASES]]
+        assert len(names) == len(set(names))
+
+    def test_every_case_declares_at_least_one_step(self) -> None:
+        for case in CASES:
+            steps = _params(case).get("steps", [])
+            assert isinstance(steps, list) and steps, case.name
+
+    def test_every_step_names_a_tool(self) -> None:
+        for case in CASES:
+            for step in _params(case)["steps"]:
+                assert isinstance(step, dict)
+                assert _tools(step), case.name
+
+    def test_observed_source_appears_earlier_in_steps(self) -> None:
+        # An ``observed_in`` tool with no earlier matching step can never be
+        # satisfied -- guard against a typo'd sequence.
+        for case in CASES:
+            steps = _params(case)["steps"]
+            seen_tools: set[str] = set()
+            for step in steps:
+                if step.get("observed_arg") is not None:
+                    source = step["observed_in"]
+                    assert source in seen_tools, (
+                        f"{case.name}: observed_in '{source}' precedes no matching step"
+                    )
+                    assert step.get("observed_path"), case.name
+                seen_tools.update(_tools(step))
+
+    def test_after_references_an_earlier_step_tool(self) -> None:
+        for case in CASES:
+            steps = _params(case)["steps"]
+            seen_tools: set[str] = set()
+            for step in steps:
+                for dep in step.get("after", []):
+                    assert dep in seen_tools, (
+                        f"{case.name}: 'after' dep '{dep}' precedes no matching step"
+                    )
+                seen_tools.update(_tools(step))
+
+    def test_helper_builds_expected_metadata_shape(self) -> None:
+        case = _case("T3-X", "do a thing", steps=[{"tool": "get_document"}])
+        assert case.name == "T3-X"
+        assert case.input == "do a thing"
+        assert case.metadata == {
+            "check": "ordered_trajectory",
+            "params": {"steps": [{"tool": "get_document"}]},
+            "min_pass_rate": 0.8,
+        }

--- a/tests/evals/cases/test_tier3_orchestration.py
+++ b/tests/evals/cases/test_tier3_orchestration.py
@@ -30,6 +30,13 @@ def _tools(step: dict[str, object]) -> list[str]:
     return [tool] if isinstance(tool, str) else list(tool)
 
 
+def _single_tool(step: dict[str, object]) -> set[str]:
+    """A step's tool name only if it names exactly one tool -- the names an
+    ``after``/``observed_in`` dep may resolve to unambiguously."""
+    tools = _tools(step)
+    return set(tools) if len(tools) == 1 else set()
+
+
 class TestCases:
     def test_every_case_uses_the_ordered_trajectory_check(self) -> None:
         for case in CASES:
@@ -59,7 +66,10 @@ class TestCases:
 
     def test_observed_source_appears_earlier_in_steps(self) -> None:
         # An ``observed_in`` tool with no earlier matching step can never be
-        # satisfied -- guard against a typo'd sequence.
+        # satisfied -- guard against a typo'd sequence. The source must be a
+        # single-tool step: ``name_to_step`` resolves a multi-tool alternative
+        # group ambiguously (a dep could point at a step that matched the *other*
+        # alternative), so the threaded id would not provably come from it.
         for case in CASES:
             steps = _params(case)["steps"]
             seen_tools: set[str] = set()
@@ -67,21 +77,24 @@ class TestCases:
                 if step.get("observed_arg") is not None:
                     source = step["observed_in"]
                     assert source in seen_tools, (
-                        f"{case.name}: observed_in '{source}' precedes no matching step"
+                        f"{case.name}: observed_in '{source}' precedes no "
+                        "single-tool step"
                     )
                     assert step.get("observed_path"), case.name
-                seen_tools.update(_tools(step))
+                seen_tools.update(_single_tool(step))
 
     def test_after_references_an_earlier_step_tool(self) -> None:
+        # ``after`` deps must reference a single-tool step for the same reason as
+        # ``observed_in`` -- a multi-tool group's index is ambiguous.
         for case in CASES:
             steps = _params(case)["steps"]
             seen_tools: set[str] = set()
             for step in steps:
                 for dep in step.get("after", []):
                     assert dep in seen_tools, (
-                        f"{case.name}: 'after' dep '{dep}' precedes no matching step"
+                        f"{case.name}: 'after' dep '{dep}' precedes no single-tool step"
                     )
-                seen_tools.update(_tools(step))
+                seen_tools.update(_single_tool(step))
 
     def test_helper_builds_expected_metadata_shape(self) -> None:
         case = _case("T3-X", "do a thing", steps=[{"tool": "get_document"}])

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -634,3 +634,227 @@ class TestCheckScopedQueryUsesSql:
         ]
         passed, _ = checks.check_scoped_query_uses_sql(trajectory, {})
         assert passed is False
+
+
+def _parts_result(*ids: str) -> dict[str, Any]:
+    return {"items": [{"id": i} for i in ids]}
+
+
+# create + read_parts (any order) -> move(anchored) -- the authoring partial order.
+_SPEC_STEPS: list[dict[str, Any]] = [
+    {"tool": "create_work_items"},
+    {"tool": "read_document_parts", "match": {"document_name": "D"}},
+    {
+        "tool": "move_work_item_to_document",
+        "match": {"target_document_name": "D"},
+        "after": ["create_work_items"],
+        "observed_arg": ["previous_part_id", "next_part_id"],
+        "observed_in": "read_document_parts",
+        "observed_path": "items[].id",
+    },
+]
+
+
+class TestResolveObservedPath:
+    def test_list_spread_collects_leaf_values(self) -> None:
+        result = _parts_result("a", "b")
+        assert checks._resolve_observed_path(result, "items[].id") == ["a", "b"]
+
+    def test_missing_key_yields_empty(self) -> None:
+        assert checks._resolve_observed_path({"items": []}, "items[].id") == []
+        assert checks._resolve_observed_path(None, "items[].id") == []
+
+
+class TestCheckOrderedTrajectory:
+    def test_canonical_spec_sequence_passes(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "x"}]}),
+            _call(
+                "read_document_parts",
+                {"document_name": "D"},
+                result=_parts_result("heading_MCPT-100"),
+            ),
+            _call(
+                "move_work_item_to_document",
+                {"target_document_name": "D", "previous_part_id": "heading_MCPT-100"},
+            ),
+        ]
+        passed, _ = checks.check_ordered_trajectory(trajectory, {"steps": _SPEC_STEPS})
+        assert passed is True
+
+    def test_next_part_id_alternative_anchor_passes(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "x"}]}),
+            _call(
+                "read_document_parts",
+                {"document_name": "D"},
+                result=_parts_result("heading_MCPT-100", "workitem_MCPT-300"),
+            ),
+            _call(
+                "move_work_item_to_document",
+                {"target_document_name": "D", "next_part_id": "workitem_MCPT-300"},
+            ),
+        ]
+        passed, _ = checks.check_ordered_trajectory(trajectory, {"steps": _SPEC_STEPS})
+        assert passed is True
+
+    def test_read_before_create_tolerated(self) -> None:
+        # inspect-then-create: read_document_parts before create_work_items is a
+        # valid order; only the move's dependencies are constrained.
+        trajectory = [
+            _call(
+                "read_document_parts",
+                {"document_name": "D"},
+                result=_parts_result("heading_MCPT-100"),
+            ),
+            _call("create_work_items", {"items": [{"title": "x"}]}),
+            _call(
+                "move_work_item_to_document",
+                {"target_document_name": "D", "previous_part_id": "heading_MCPT-100"},
+            ),
+        ]
+        passed, _ = checks.check_ordered_trajectory(trajectory, {"steps": _SPEC_STEPS})
+        assert passed is True
+
+    def test_after_dependency_violation_fails(self) -> None:
+        # update_work_item before its required get_work_item.
+        steps = [
+            {"tool": "get_work_item", "match": {"work_item_id": "MCPT-1"}},
+            {
+                "tool": "update_work_item",
+                "match": {"work_item_id": "MCPT-1"},
+                "after": ["get_work_item"],
+            },
+        ]
+        trajectory = [
+            _call("update_work_item", {"work_item_id": "MCPT-1"}),
+            _call("get_work_item", {"work_item_id": "MCPT-1"}),
+        ]
+        passed, reason = checks.check_ordered_trajectory(trajectory, {"steps": steps})
+        assert passed is False
+        assert "get_work_item" in reason
+
+    def test_out_of_order_move_before_read_fails(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "x"}]}),
+            _call(
+                "move_work_item_to_document",
+                {"target_document_name": "D", "previous_part_id": "heading_MCPT-100"},
+            ),
+            _call(
+                "read_document_parts",
+                {"document_name": "D"},
+                result=_parts_result("heading_MCPT-100"),
+            ),
+        ]
+        passed, reason = checks.check_ordered_trajectory(
+            trajectory, {"steps": _SPEC_STEPS}
+        )
+        assert passed is False
+        assert "move_work_item_to_document" in reason
+
+    def test_missing_step_fails(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "x"}]}),
+            _call(
+                "read_document_parts",
+                {"document_name": "D"},
+                result=_parts_result("heading_MCPT-100"),
+            ),
+        ]
+        passed, reason = checks.check_ordered_trajectory(
+            trajectory, {"steps": _SPEC_STEPS}
+        )
+        assert passed is False
+        assert "move_work_item_to_document" in reason
+
+    def test_guessed_anchor_not_in_read_fails(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "x"}]}),
+            _call(
+                "read_document_parts",
+                {"document_name": "D"},
+                result=_parts_result("heading_MCPT-100"),
+            ),
+            _call(
+                "move_work_item_to_document",
+                {"target_document_name": "D", "previous_part_id": "heading_GUESS"},
+            ),
+        ]
+        passed, reason = checks.check_ordered_trajectory(
+            trajectory, {"steps": _SPEC_STEPS}
+        )
+        assert passed is False
+        assert "guessed" in reason
+
+    def test_observed_threads_qualified_id_via_short_id(self) -> None:
+        # link result carries a short target id; the read uses a qualified id.
+        steps = [
+            {"tool": "list_work_item_links", "match": {"work_item_id": "MCPT-300"}},
+            {
+                "tool": "read_work_item",
+                "observed_arg": "work_item_id",
+                "observed_in": "list_work_item_links",
+                "observed_path": "items[].id",
+            },
+        ]
+        trajectory = [
+            _call(
+                "list_work_item_links",
+                {"project_id": "P", "work_item_id": "P/MCPT-300"},
+                result={"items": [{"id": "MCPT-400"}]},
+            ),
+            _call("read_work_item", {"project_id": "P", "work_item_id": "P/MCPT-400"}),
+        ]
+        passed, _ = checks.check_ordered_trajectory(trajectory, {"steps": steps})
+        assert passed is True
+
+    def test_forbidden_tool_fails(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "x"}]}),
+            _call("update_document", {"document_name": "D"}),
+            _call(
+                "read_document_parts",
+                {"document_name": "D"},
+                result=_parts_result("heading_MCPT-100"),
+            ),
+            _call(
+                "move_work_item_to_document",
+                {"target_document_name": "D", "previous_part_id": "heading_MCPT-100"},
+            ),
+        ]
+        passed, reason = checks.check_ordered_trajectory(
+            trajectory, {"steps": _SPEC_STEPS, "forbid": ["update_document"]}
+        )
+        assert passed is False
+        assert "forbidden" in reason
+
+    def test_read_only_flag_fails_on_write(self) -> None:
+        trajectory = [
+            _call("list_work_items", {"query": "SQL:(...)"}),
+            _call("update_work_item", {"work_item_id": "MCPT-1"}),
+        ]
+        passed, _ = checks.check_ordered_trajectory(
+            trajectory,
+            {"steps": [{"tool": "list_work_items"}], "read_only": True},
+        )
+        assert passed is False
+
+    def test_max_create_calls_flag_fails_on_split(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "a"}]}),
+            _call("create_work_items", {"items": [{"title": "b"}]}),
+        ]
+        passed, _ = checks.check_ordered_trajectory(
+            trajectory,
+            {"steps": [{"tool": "create_work_items"}], "max_create_calls": 1},
+        )
+        assert passed is False
+
+    def test_scoped_sql_flag_fails_on_lucene_module_query(self) -> None:
+        trajectory = [_call("list_work_items", {"query": "module:FakeDoc"})]
+        passed, _ = checks.check_ordered_trajectory(
+            trajectory,
+            {"steps": [{"tool": "list_work_items"}], "scoped_sql": True},
+        )
+        assert passed is False

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -10,16 +10,22 @@ from typing import Any
 import httpx
 
 from evals.harness.fake_polarion import (
+    _WORK_ITEMS,
     API_PREFIX,
+    CHILD_REQ_ID,
     DOC,
     DOC_HEADING_ID,
     DOC_INTRO_PARAGRAPH_ID,
     FLOATING_TASK_HYPERLINK_URI,
     FLOATING_TASK_ID,
     MODULE_ID,
+    PARENT_DOC,
+    PARENT_REQ_ID,
     POLARION_HOST,
     PROJECT,
+    SECTION_A_PART_ID,
     SPACE,
+    TESTCASE_ID,
     FakePolarion,
 )
 
@@ -76,7 +82,7 @@ class TestReadRouting:
     def test_work_item_list_returns_all(self) -> None:
         response = _get(FakePolarion(), f"/projects/{PROJECT}/workitems")
         assert response.status_code == 200
-        assert _json(response)["meta"]["totalCount"] == 4
+        assert _json(response)["meta"]["totalCount"] == len(_WORK_ITEMS)
 
     def test_work_item_list_filters_headings(self) -> None:
         response = _get(
@@ -86,17 +92,26 @@ class TestReadRouting:
         assert all(i["attributes"]["type"] == "heading" for i in items)
         assert len(items) == 2
 
-    def test_linked_work_items_empty(self) -> None:
+    def test_linked_work_items_empty_when_unlinked(self) -> None:
         response = _get(
             FakePolarion(),
             f"/projects/{PROJECT}/workitems/{DOC_HEADING_ID}/linkedworkitems",
         )
         assert _json(response)["meta"]["totalCount"] == 0
 
-    def test_parts_empty(self) -> None:
+    def test_parts_seeded_for_fakedoc(self) -> None:
         response = _get(
             FakePolarion(),
             f"/projects/{PROJECT}/spaces/{SPACE}/documents/{DOC}/parts",
+        )
+        data = _json(response)["data"]
+        ids = [p["id"].rsplit("/", 1)[-1] for p in data]
+        assert SECTION_A_PART_ID in ids
+
+    def test_parts_empty_for_other_document(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/spaces/{SPACE}/documents/{PARENT_DOC}/parts",
         )
         assert _json(response)["meta"]["totalCount"] == 0
 
@@ -246,3 +261,50 @@ class TestMutations:
         fake = FakePolarion()
         _get(fake, "/projects")
         assert fake.mutations == []
+
+
+class TestTier3Seeding:
+    def test_parent_document_resolves(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/spaces/{SPACE}/documents/{PARENT_DOC}",
+        )
+        assert response.status_code == 200
+        assert _json(response)["data"]["attributes"]["moduleName"] == PARENT_DOC
+
+    def test_forward_links_carry_role_and_included_target(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/workitems/{CHILD_REQ_ID}/linkedworkitems",
+        )
+        payload = _json(response)
+        roles = {item["attributes"]["role"] for item in payload["data"]}
+        assert roles == {"satisfies", "verifies"}
+        target_ids = {item["id"] for item in payload["included"]}
+        assert f"{PROJECT}/{PARENT_REQ_ID}" in target_ids
+        assert f"{PROJECT}/{TESTCASE_ID}" in target_ids
+
+    def test_uncovered_requirement_has_no_links(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/workitems/MCPT-301/linkedworkitems",
+        )
+        assert _json(response)["meta"]["totalCount"] == 0
+
+    def test_back_direction_query_finds_source(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/workitems",
+            query=f"linkedWorkItems:{PARENT_REQ_ID}",
+        )
+        ids = {i["id"].rsplit("/", 1)[-1] for i in _json(response)["data"]}
+        assert ids == {CHILD_REQ_ID}
+
+    def test_workitem_link_role_enum_resolves(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/enumerations/~/workitem-link-role/~",
+        )
+        assert response.status_code == 200
+        ids = [o["id"] for o in _json(response)["data"]["attributes"]["options"]]
+        assert "relates_to" in ids

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -93,8 +93,39 @@ class TestMain:
         monkeypatch.setattr("sys.argv", ["run", "--case", "T1-DOES-NOT-EXIST"])
         assert run.main() == 2
 
+    def test_tier_flag_runs_only_that_tier(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        seen: list[str] = []
+
+        def _stub(case: Case, runs: int, evaluator: Any) -> dict[str, Any]:
+            seen.append(case.name)
+            return {
+                "name": case.name,
+                "runs": runs,
+                "pass_count": runs,
+                "pass_rate": 1.0,
+                "min_pass_rate": 1.0,
+                "passed": True,
+                "failures": [],
+            }
+
+        monkeypatch.setattr(run, "_run_case_n_times", _stub)
+        monkeypatch.setattr(run, "resolve_model_id", lambda: "test/model")
+        monkeypatch.setattr(run, "_REPORT_DIR", tmp_path)
+        monkeypatch.setattr("sys.argv", ["run", "--tier", "2", "--runs", "1"])
+
+        assert run.main() == 0
+        assert seen == [c.name for c in TIER2_CASES]
+
 
 class TestAllCases:
     def test_gate_loads_all_tiers(self) -> None:
         expected = [*TIER1_CASES, *TIER2_CASES, *TIER3_CASES]
         assert expected == run.ALL_CASES
+
+    def test_tiers_map_to_expected_case_lists(self) -> None:
+        assert run.TIERS["1"] == TIER1_CASES
+        assert run.TIERS["2"] == TIER2_CASES
+        assert run.TIERS["3"] == TIER3_CASES
+        assert run.TIERS["all"] == run.ALL_CASES

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -16,6 +16,7 @@ from strands_evals import Case
 from evals import run
 from evals.cases.tier1_prohibitions import CASES as TIER1_CASES
 from evals.cases.tier2_efficiency import CASES as TIER2_CASES
+from evals.cases.tier3_orchestration import CASES as TIER3_CASES
 from evals.harness.runner import AGENT_ERROR_PREFIX
 
 
@@ -94,6 +95,6 @@ class TestMain:
 
 
 class TestAllCases:
-    def test_gate_loads_both_tiers(self) -> None:
-        expected = [*TIER1_CASES, *TIER2_CASES]
+    def test_gate_loads_all_tiers(self) -> None:
+        expected = [*TIER1_CASES, *TIER2_CASES, *TIER3_CASES]
         assert expected == run.ALL_CASES


### PR DESCRIPTION
## Summary

Adds a third eval tier covering multi-step tool **orchestration** (ordered tool
sequences with ids threaded between steps), and restructures the publish gate so
tiers run sequentially and fail fast -- an early-tier failure skips the pricier
later tiers, saving agent-API tokens. Also relaxes config so a shared `.env`
(holding the eval gate's `OPENAI_API_KEY`) no longer breaks client construction.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- Multi-step orchestration was untested, and the publish gate spent agent tokens past early-tier failures.
- Add tier-3 orchestration evals, stage publish tier1->2->3 fail-stop with a --tier flag, ignore extra .env keys.

## Testing

- ruff check, ruff format --check, mypy src/ -- all clean
- uv run --group evals pytest -- 1227 passed
- Verified tier-3 id-threading end-to-end: read_document_parts / list_work_item_links
  structured_content exposes items[].id matching the move anchor and linked targets.

## Notes for Reviewers

- Three feature commits: tier-3 evals, config extra="ignore", staged CI gate.
- Staged gate trades 3x CI setup (uv/deps per tier job) for token savings on early failure.
