### PR TITLE
refactor(meta): extract fake polarion fixtures

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -138,8 +138,9 @@ intro paragraph, free-floating `MCPT-200` task carrying
 `custom_fields={"acceptance_criteria_id": "AC-1"}` and one `ref_ext`
 hyperlink, `MCPT-201` heading, `MCPT-202` ghost-typed task, comment thread
 `1`→`2`, project enum `hyperlink-role`) live in
-[`harness/fake_polarion.py`](harness/fake_polarion.py). Mirror the real
-server's *structure* there; keep all content synthetic. Bulk POSTs echo one
+[`harness/fixtures.py`](harness/fixtures.py) as `SEEDS`;
+[`harness/fake_polarion.py`](harness/fake_polarion.py) serves them. Mirror the
+real server's *structure* there; keep all content synthetic. Bulk POSTs echo one
 id per submitted entry, so bulk cases exercise the tools' count-match rule.
 
 Tier-3 adds: a second document `FakeParentDoc`; requirements `MCPT-300` (in
@@ -147,5 +148,5 @@ Tier-3 adds: a second document `FakeParentDoc`; requirements `MCPT-300` (in
 (in `FakeDoc`, no test-case link — coverage-gap signal), `MCPT-400` (parent, in
 `FakeParentDoc`), test case `MCPT-500`; a `FakeDoc` `/parts` response with the
 `Section A` heading part (`heading_MCPT-100`, the positional-move anchor); and
-project enum `workitem-link-role`. Forward links come from `_LINKS`; the back
+project enum `workitem-link-role`. Forward links come from `SEEDS.links`; the back
 direction is served via `list_work_items` `query=linkedWorkItems:{wi}`.

--- a/evals/cases/tier1_prohibitions.py
+++ b/evals/cases/tier1_prohibitions.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from strands_evals import Case
 
-from evals.harness.fake_polarion import (
+from evals.harness.fixtures import (
     DOC,
     FLOATING_TASK_HYPERLINK_URI,
     FLOATING_TASK_ID,

--- a/evals/cases/tier2_efficiency.py
+++ b/evals/cases/tier2_efficiency.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from strands_evals import Case
 
-from evals.harness.fake_polarion import (
+from evals.harness.fixtures import (
     DOC,
     FLOATING_TASK_ID,
     SPACE,

--- a/evals/cases/tier3_orchestration.py
+++ b/evals/cases/tier3_orchestration.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from strands_evals import Case
 
-from evals.harness.fake_polarion import (
+from evals.harness.fixtures import (
     CHILD_REQ_ID,
     DOC,
     FLOATING_TASK_ID,

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -1,7 +1,9 @@
 """In-process fake Polarion: mirrors the real project's *structure* with fully
 synthetic *content* (no production data in eval logs). One catch-all respx
 route on the Polarion host; other hosts (LLM provider) fall through
-(``assert_all_mocked=False``). Mutations recorded, no side effects.
+(``assert_all_mocked=False``). Mutations recorded, no side effects. Seed data
+and identifiers live in ``fixtures``; ``seeds`` is injectable so a case can
+serve an alternate set without touching the global.
 """
 
 from __future__ import annotations
@@ -14,163 +16,29 @@ from typing import Any
 import httpx
 import respx
 
-POLARION_HOST = "https://polarion.example.com"
-API_PREFIX = "/polarion/rest/v1"
-PROJECT = "MCP_Test_Project"
-SPACE = "_default"
-DOC = "FakeDoc"
-AUTHOR = "u-fake-0001"
-MODULE_ID = f"{PROJECT}/{SPACE}/{DOC}"
-
-# Heading work items that carry a `module` relationship — the only ones
-# `list_documents`' discovery scan (query=type:heading) surfaces.
-DOC_HEADING_ID = "MCPT-100"
-
-# Free-floating (space_id == "") seeds used by the move/heading cases.
-FLOATING_TASK_ID = "MCPT-200"
-FLOATING_HEADING_ID = "MCPT-201"
-FLOATING_GHOST_ID = "MCPT-202"
-
-# Reply comment id (parent == root "1") used by T1-REPLY-RESOLVE.
-ROOT_COMMENT_ID = "1"
-REPLY_COMMENT_ID = "2"
-
-# Pre-existing hyperlink on the floating task; T1-HYPERLINK-PRESERVE asserts
-# an update keeps it (Polarion REPLACES the whole list).
-FLOATING_TASK_HYPERLINK_URI = "https://specs.example.com/fake-spec"
-
-# Anchored intro paragraph in the doc body; T1-ROUNDTRIP-SOURCE edits it.
-DOC_INTRO_PARAGRAPH_ID = "p-1"
-
-# Second document + requirement traceability seeds (Tier-3 orchestration).
-PARENT_DOC = "FakeParentDoc"
-PARENT_MODULE_ID = f"{PROJECT}/{SPACE}/{PARENT_DOC}"
-CHILD_REQ_ID = (
-    "MCPT-300"  # in FakeDoc; satisfies PARENT_REQ_ID, verified by TESTCASE_ID
+from .fixtures import (
+    API_PREFIX,
+    AUTHOR,
+    DOC,
+    MODULE_ID,
+    POLARION_HOST,
+    PROJECT,
+    SEEDS,
+    SPACE,
+    TS,
+    Seeds,
+    WorkItem,
 )
-PARENT_REQ_ID = "MCPT-400"  # in FakeParentDoc
-UNCOVERED_REQ_ID = "MCPT-301"  # in FakeDoc; no test-case link (coverage-gap signal)
-TESTCASE_ID = "MCPT-500"  # test case linked from CHILD_REQ_ID
-
-# Section A heading part id served by read_document_parts; anchors positional moves.
-SECTION_A_PART_ID = f"heading_{DOC_HEADING_ID}"
-
-_TS = "2026-01-01T00:00:00.000Z"
-
-
-@dataclass
-class _WorkItem:
-    short_id: str
-    title: str
-    type: str
-    status: str = "open"
-    priority: str = "50.0"
-    severity: str = "should_have"
-    module_id: str = ""  # full module id (PROJECT/SPACE/DOC) if in a document, else ""
-    outline_number: str = ""
-    hyperlinks: list[dict[str, str]] = field(default_factory=list)
-    # Keys MUST stay outside ``STANDARD_WORK_ITEM_ATTRIBUTES`` so the merge
-    # into the resource attributes dict doesn't shadow real attributes.
-    custom_fields: dict[str, str] = field(default_factory=dict)
-
-
-# Structure mirrored from MCP_Test_Project; every string is synthetic.
-_WORK_ITEMS: dict[str, _WorkItem] = {
-    DOC_HEADING_ID: _WorkItem(
-        DOC_HEADING_ID, "Section A", "heading", module_id=MODULE_ID, outline_number="1"
-    ),
-    FLOATING_TASK_ID: _WorkItem(
-        FLOATING_TASK_ID,
-        "Floating task",
-        "task",
-        hyperlinks=[{"role": "ref_ext", "uri": FLOATING_TASK_HYPERLINK_URI}],
-        custom_fields={"acceptance_criteria_id": "AC-1"},
-    ),
-    FLOATING_HEADING_ID: _WorkItem(FLOATING_HEADING_ID, "Floating heading", "heading"),
-    FLOATING_GHOST_ID: _WorkItem(FLOATING_GHOST_ID, "Ghost type", "not_a_real_type"),
-    CHILD_REQ_ID: _WorkItem(
-        CHILD_REQ_ID, "Child requirement", "systemrequirement", module_id=MODULE_ID
-    ),
-    UNCOVERED_REQ_ID: _WorkItem(
-        UNCOVERED_REQ_ID,
-        "Uncovered requirement",
-        "systemrequirement",
-        module_id=MODULE_ID,
-    ),
-    PARENT_REQ_ID: _WorkItem(
-        PARENT_REQ_ID,
-        "Parent requirement",
-        "systemrequirement",
-        module_id=PARENT_MODULE_ID,
-    ),
-    TESTCASE_ID: _WorkItem(TESTCASE_ID, "Coverage test case", "systemtestcase"),
-}
-
-# Forward (outgoing) work-item links: source short id -> [(role, target short id)].
-# CHILD_REQ has a parent + a test case; UNCOVERED_REQ deliberately has none.
-_LINKS: dict[str, list[tuple[str, str]]] = {
-    CHILD_REQ_ID: [("satisfies", PARENT_REQ_ID), ("verifies", TESTCASE_ID)],
-}
-
-# (resource, field_id) -> enum option ids (+ which is the default).
-_ENUMS: dict[tuple[str, str], list[tuple[str, bool]]] = {
-    ("workitems", "type"): [
-        ("systemrequirement", False),
-        ("softwarerequirement", False),
-        ("systemtestcase", False),
-        ("softwaretestcase", False),
-        ("risk", False),
-        ("release", False),
-        ("workpackage", False),
-        ("task", True),
-        ("changerequest", False),
-        ("issue", False),
-        ("testcase", False),
-        ("unittestcase", False),
-    ],
-    ("workitems", "severity"): [
-        ("must_have", False),
-        ("should_have", True),
-        ("nice_to_have", False),
-        ("will_not_have", False),
-    ],
-    ("workitems", "status"): [
-        ("open", True),
-        ("inProgress", False),
-        ("done", False),
-        ("reopened", False),
-    ],
-    ("workitems", "priority"): [
-        ("90.0", False),
-        ("50.0", True),
-        ("10.0", False),
-    ],
-    ("documents", "type"): [
-        ("systemRequirementSpecification", True),
-        ("softwareRequirementSpecification", False),
-    ],
-    ("documents", "status"): [
-        ("draft", True),
-        ("inReview", False),
-        ("approved", False),
-    ],
-}
-
-# Project-level enums (``/enumerations/~/{name}/~``) -- dict-shaped ``data``
-# with ``attributes.options[].id``, unlike getAvailableOptions' list.
-_PROJECT_ENUMS: dict[str, list[str]] = {
-    "hyperlink-role": ["ref_int", "ref_ext"],
-    "workitem-link-role": ["relates_to", "parent", "satisfies", "verifies"],
-}
 
 
 @dataclass
 class FakePolarion:
     """Seeded, structure-faithful fake Polarion served over respx."""
 
+    seeds: Seeds = SEEDS
     mutations: list[dict[str, Any]] = field(default_factory=list)
 
-    def _work_item_resource(self, wi: _WorkItem) -> dict[str, Any]:
+    def _work_item_resource(self, wi: WorkItem) -> dict[str, Any]:
         relationships: dict[str, Any] = {
             "assignee": {"data": []},
             "author": {"data": {"type": "users", "id": f"{PROJECT}/{AUTHOR}"}},
@@ -190,8 +58,8 @@ class FakePolarion:
                 "severity": wi.severity,
                 "resolution": "",
                 "outlineNumber": wi.outline_number,
-                "created": _TS,
-                "updated": _TS,
+                "created": TS,
+                "updated": TS,
                 "description": {"type": "text/html", "value": ""},
                 "hyperlinks": list(wi.hyperlinks),
                 **wi.custom_fields,
@@ -200,75 +68,71 @@ class FakePolarion:
         }
 
     def _document_resource(self, name: str) -> dict[str, Any]:
-        if name == PARENT_DOC:
-            title, body = "Fake Parent Doc", '<h1 id="ph-1">Fake Parent Doc</h1>'
-        else:
-            title = "Fake Doc"
-            body = (
-                '<h1 id="h-1">Fake Doc</h1>'
-                f'<p id="{DOC_INTRO_PARAGRAPH_ID}">Fake intro paragraph.</p>'
-            )
+        doc = self.seeds.documents[name]
         return {
             "type": "documents",
             "id": f"{PROJECT}/{SPACE}/{name}",
             "attributes": {
-                "title": title,
-                "type": "systemRequirementSpecification",
-                "status": "draft",
+                "title": doc.title,
+                "type": doc.type,
+                "status": doc.status,
                 "moduleName": name,
                 "moduleFolder": SPACE,
-                "homePageContent": {"type": "text/html", "value": body},
+                "homePageContent": {"type": "text/html", "value": doc.body_html},
             },
         }
 
-    def _document_parts_response(self) -> dict[str, Any]:
-        """FakeDoc's parts: a Section A heading (the move anchor) + one work-item
-        part, chained via ``nextPart``. ``include=workItem`` resources supply
-        titles so ``read_document_parts`` returns populated ``items``.
+    def _document_parts_response(self, name: str) -> dict[str, Any]:
+        """A document's ``parts`` from its seed: each part chained to the next via
+        ``nextPart``; ``include=workItem`` resources supply titles so
+        ``read_document_parts`` returns populated ``items``. Empty for docs with
+        no seeded parts.
         """
-        base = f"{PROJECT}/{SPACE}/{DOC}"
-        heading_part_id = f"{base}/{SECTION_A_PART_ID}"
-        wi_part_id = f"{base}/workitem_{CHILD_REQ_ID}"
-        data = [
-            {
-                "type": "document_parts",
-                "id": heading_part_id,
-                "attributes": {"type": "heading", "level": 1},
-                "relationships": {
-                    "workItem": {
-                        "data": {
-                            "type": "workitems",
-                            "id": f"{PROJECT}/{DOC_HEADING_ID}",
-                        }
-                    },
-                    "nextPart": {"data": {"type": "document_parts", "id": wi_part_id}},
-                },
-            },
-            {
-                "type": "document_parts",
-                "id": wi_part_id,
-                "attributes": {"type": "workitem"},
-                "relationships": {
-                    "workItem": {
-                        "data": {"type": "workitems", "id": f"{PROJECT}/{CHILD_REQ_ID}"}
-                    },
-                },
-            },
-        ]
-        included = [
-            self._work_item_resource(_WORK_ITEMS[DOC_HEADING_ID]),
-            self._work_item_resource(_WORK_ITEMS[CHILD_REQ_ID]),
-        ]
+        doc = self.seeds.documents.get(name)
+        parts = doc.parts if doc else []
+        base = f"{PROJECT}/{SPACE}/{name}"
+        data: list[dict[str, Any]] = []
+        included: list[dict[str, Any]] = []
+        for i, part in enumerate(parts):
+            relationships: dict[str, Any] = {
+                "workItem": {
+                    "data": {
+                        "type": "workitems",
+                        "id": f"{PROJECT}/{part.work_item_id}",
+                    }
+                }
+            }
+            if i + 1 < len(parts):
+                nxt = parts[i + 1]
+                next_id = f"{base}/{nxt.kind}_{nxt.work_item_id}"
+                relationships["nextPart"] = {
+                    "data": {"type": "document_parts", "id": next_id}
+                }
+            if part.kind == "heading":
+                attributes = {"type": "heading", "level": part.level}
+            else:
+                attributes = {"type": part.kind}
+            data.append(
+                {
+                    "type": "document_parts",
+                    "id": f"{base}/{part.kind}_{part.work_item_id}",
+                    "attributes": attributes,
+                    "relationships": relationships,
+                }
+            )
+            included.append(
+                self._work_item_resource(self.seeds.work_items[part.work_item_id])
+            )
         return {"data": data, "included": included, "meta": {"totalCount": len(data)}}
 
     def _linked_work_items_response(self, source_id: str) -> dict[str, Any]:
-        """Forward links for ``source_id`` from ``_LINKS``; targets supplied as
-        ``include=workItem`` resources (the parser derives targets from
+        """Forward links for ``source_id`` from ``seeds.links``; targets supplied
+        as ``include=workItem`` resources (the parser derives targets from
         ``relationships.workItem``, never the composite id).
         """
         data: list[dict[str, Any]] = []
         included: list[dict[str, Any]] = []
-        for role, target in _LINKS.get(source_id, []):
+        for role, target in self.seeds.links.get(source_id, []):
             target_full = f"{PROJECT}/{target}"
             data.append(
                 {
@@ -280,46 +144,50 @@ class FakePolarion:
                     },
                 }
             )
-            target_wi = _WORK_ITEMS.get(target)
+            target_wi = self.seeds.work_items.get(target)
             if target_wi is not None:
                 included.append(self._work_item_resource(target_wi))
         return {"data": data, "included": included, "meta": {"totalCount": len(data)}}
 
-    def _comment_resources(self) -> list[dict[str, Any]]:
-        base = f"{PROJECT}/{SPACE}/{DOC}"
-        return [
-            {
-                "type": "document_comments",
-                "id": f"{base}/{ROOT_COMMENT_ID}",
-                "attributes": {
-                    "created": _TS,
-                    "resolved": False,
-                    "text": {"type": "text/html", "value": "fake root comment"},
-                },
-                "relationships": {
-                    "author": {"data": {"id": f"{PROJECT}/{AUTHOR}"}},
-                    "parentComment": {"data": None},
-                    "childComments": {"data": [{"id": f"{base}/{REPLY_COMMENT_ID}"}]},
-                },
-            },
-            {
-                "type": "document_comments",
-                "id": f"{base}/{REPLY_COMMENT_ID}",
-                "attributes": {
-                    "created": _TS,
-                    "resolved": False,
-                    "text": {"type": "text/html", "value": "fake reply comment"},
-                },
-                "relationships": {
-                    "author": {"data": {"id": f"{PROJECT}/{AUTHOR}"}},
-                    "parentComment": {"data": {"id": f"{base}/{ROOT_COMMENT_ID}"}},
-                    "childComments": {"data": []},
-                },
-            },
-        ]
+    def _comment_resources(self, name: str) -> list[dict[str, Any]]:
+        """A document's comment thread from its seed; child links derived from
+        ``parent_id`` (no redundant child-id lists in the seed).
+        """
+        doc = self.seeds.documents.get(name)
+        comments = doc.comments if doc else []
+        base = f"{PROJECT}/{SPACE}/{name}"
+        resources: list[dict[str, Any]] = []
+        for comment in comments:
+            children = [
+                {"id": f"{base}/{c.comment_id}"}
+                for c in comments
+                if c.parent_id == comment.comment_id
+            ]
+            parent = (
+                {"data": {"id": f"{base}/{comment.parent_id}"}}
+                if comment.parent_id
+                else {"data": None}
+            )
+            resources.append(
+                {
+                    "type": "document_comments",
+                    "id": f"{base}/{comment.comment_id}",
+                    "attributes": {
+                        "created": TS,
+                        "resolved": comment.resolved,
+                        "text": {"type": "text/html", "value": comment.text},
+                    },
+                    "relationships": {
+                        "author": {"data": {"id": f"{PROJECT}/{AUTHOR}"}},
+                        "parentComment": parent,
+                        "childComments": {"data": children},
+                    },
+                }
+            )
+        return resources
 
     def _enum_response(self, resource: str, field_id: str) -> dict[str, Any]:
-        options = _ENUMS.get((resource, field_id), [])
+        options = self.seeds.enums.get((resource, field_id), [])
         data = [
             {
                 "id": opt_id,
@@ -373,7 +241,7 @@ class FakePolarion:
         project_enum = re.search(r"/enumerations/~/([^/]+)/~$", path)
         if project_enum:
             name = project_enum.group(1)
-            options = _PROJECT_ENUMS.get(name)
+            options = self.seeds.project_enums.get(name)
             if options is None:
                 return httpx.Response(404, json={"errors": [{"status": "404"}]})
             return httpx.Response(
@@ -389,7 +257,7 @@ class FakePolarion:
 
         single_wi = re.search(r"/workitems/([^/]+)$", path)
         if single_wi and "/fields/" not in path:
-            wi = _WORK_ITEMS.get(single_wi.group(1))
+            wi = self.seeds.work_items.get(single_wi.group(1))
             if wi is None:
                 return httpx.Response(404, json={"errors": [{"status": "404"}]})
             return httpx.Response(200, json={"data": self._work_item_resource(wi)})
@@ -406,38 +274,41 @@ class FakePolarion:
         if path.endswith("/workitems"):
             query = params.get("query", "")
             if query == "type:heading":
-                items = [w for w in _WORK_ITEMS.values() if w.type == "heading"]
+                items = [
+                    w for w in self.seeds.work_items.values() if w.type == "heading"
+                ]
             elif query.startswith("linkedWorkItems:"):
                 target = query.split(":", 1)[1].strip().rsplit("/", maxsplit=1)[-1]
                 items = [
                     w
-                    for w in _WORK_ITEMS.values()
-                    if any(t == target for _, t in _LINKS.get(w.short_id, []))
+                    for w in self.seeds.work_items.values()
+                    if any(t == target for _, t in self.seeds.links.get(w.short_id, []))
                 ]
             else:
-                items = list(_WORK_ITEMS.values())
+                items = list(self.seeds.work_items.values())
             data = [self._work_item_resource(w) for w in items]
             return httpx.Response(
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
             )
 
-        # Parts seeded only for FakeDoc (Section A anchor); others stay empty.
+        # Parts derive from the document's seed; unseeded/absent docs stay empty.
         parts = re.search(r"/documents/([^/]+)/parts$", path)
         if parts:
-            if parts.group(1) == DOC:
-                return httpx.Response(200, json=self._document_parts_response())
-            return httpx.Response(200, json={"data": [], "meta": {"totalCount": 0}})
+            return httpx.Response(
+                200, json=self._document_parts_response(parts.group(1))
+            )
 
-        if path.endswith("/comments"):
-            data = self._comment_resources()
+        comments = re.search(r"/documents/([^/]+)/comments$", path)
+        if comments:
+            data = self._comment_resources(comments.group(1))
             return httpx.Response(
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
             )
 
-        # Exact match on the two seeded docs: a broad "/documents/" would claim
-        # every name as existing, masking bugs in cases probing alternate names.
+        # Exact match on a seeded doc: a broad "/documents/" would claim every
+        # name as existing, masking bugs in cases probing alternate names.
         doc_match = re.search(rf"/spaces/{SPACE}/documents/([^/]+)$", path)
-        if doc_match and doc_match.group(1) in (DOC, PARENT_DOC):
+        if doc_match and doc_match.group(1) in self.seeds.documents:
             return httpx.Response(
                 200, json={"data": self._document_resource(doc_match.group(1))}
             )

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -68,6 +68,8 @@ class FakePolarion:
         }
 
     def _document_resource(self, name: str) -> dict[str, Any]:
+        # Direct index, not .get: only reached after the dispatch guard confirms
+        # name is a seeded document.
         doc = self.seeds.documents[name]
         return {
             "type": "documents",

--- a/evals/harness/fixtures.py
+++ b/evals/harness/fixtures.py
@@ -1,0 +1,240 @@
+"""Synthetic seed data + identifiers for the in-process fake Polarion. Every
+string is invented (no production data in eval logs) but the *structure*
+mirrors MCP_Test_Project. Eval cases import these ids; ``fake_polarion``
+serves resources built from ``SEEDS``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+POLARION_HOST = "https://polarion.example.com"
+API_PREFIX = "/polarion/rest/v1"
+PROJECT = "MCP_Test_Project"
+SPACE = "_default"
+DOC = "FakeDoc"
+AUTHOR = "u-fake-0001"
+MODULE_ID = f"{PROJECT}/{SPACE}/{DOC}"
+
+# Heading work items that carry a `module` relationship — the only ones
+# `list_documents`' discovery scan (query=type:heading) surfaces.
+DOC_HEADING_ID = "MCPT-100"
+
+# Free-floating (space_id == "") seeds used by the move/heading cases.
+FLOATING_TASK_ID = "MCPT-200"
+FLOATING_HEADING_ID = "MCPT-201"
+FLOATING_GHOST_ID = "MCPT-202"
+
+# Reply comment id (parent == root "1") used by T1-REPLY-RESOLVE.
+ROOT_COMMENT_ID = "1"
+REPLY_COMMENT_ID = "2"
+
+# Pre-existing hyperlink on the floating task; T1-HYPERLINK-PRESERVE asserts
+# an update keeps it (Polarion REPLACES the whole list).
+FLOATING_TASK_HYPERLINK_URI = "https://specs.example.com/fake-spec"
+
+# Anchored intro paragraph in the doc body; T1-ROUNDTRIP-SOURCE edits it.
+DOC_INTRO_PARAGRAPH_ID = "p-1"
+
+# Second document + requirement traceability seeds (Tier-3 orchestration).
+PARENT_DOC = "FakeParentDoc"
+PARENT_MODULE_ID = f"{PROJECT}/{SPACE}/{PARENT_DOC}"
+CHILD_REQ_ID = (
+    "MCPT-300"  # in FakeDoc; satisfies PARENT_REQ_ID, verified by TESTCASE_ID
+)
+PARENT_REQ_ID = "MCPT-400"  # in FakeParentDoc
+UNCOVERED_REQ_ID = "MCPT-301"  # in FakeDoc; no test-case link (coverage-gap signal)
+TESTCASE_ID = "MCPT-500"  # test case linked from CHILD_REQ_ID
+
+# Section A heading part id served by read_document_parts; anchors positional moves.
+SECTION_A_PART_ID = f"heading_{DOC_HEADING_ID}"
+
+# public: now crosses the module boundary into fake_polarion.
+TS = "2026-01-01T00:00:00.000Z"
+
+
+@dataclass
+class WorkItem:
+    short_id: str
+    title: str
+    type: str
+    status: str = "open"
+    priority: str = "50.0"
+    severity: str = "should_have"
+    module_id: str = ""  # full module id (PROJECT/SPACE/DOC) if in a document, else ""
+    outline_number: str = ""
+    hyperlinks: list[dict[str, str]] = field(default_factory=list)
+    # Keys MUST stay outside ``STANDARD_WORK_ITEM_ATTRIBUTES`` so the merge
+    # into the resource attributes dict doesn't shadow real attributes.
+    custom_fields: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DocumentPart:
+    """One entry in a document's ordered part chain. ``part_id`` suffix derives
+    as ``{kind}_{work_item_id}``; ``nextPart`` links are derived from order.
+    """
+
+    kind: str  # "heading" | "workitem"
+    work_item_id: str
+    level: int = 1  # heading level; ignored for workitem parts
+
+
+@dataclass
+class Comment:
+    """A document comment. ``parent_id is None`` marks a thread root; child
+    links are derived from the set (no redundant child-id lists).
+    """
+
+    comment_id: str
+    text: str
+    resolved: bool = False
+    parent_id: str | None = None
+
+
+@dataclass
+class Document:
+    name: str
+    title: str
+    body_html: str
+    type: str = "systemRequirementSpecification"
+    status: str = "draft"
+    parts: list[DocumentPart] = field(default_factory=list)
+    comments: list[Comment] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Seeds:
+    """Read-only seed tables. ``frozen`` blocks attribute rebind, not dict
+    mutation — sufficient since nothing mutates these (writes record into
+    ``FakePolarion.mutations`` instead). Add an entity by adding a table entry;
+    ``FakePolarion`` serves it without per-entity branching.
+    """
+
+    work_items: dict[str, WorkItem]
+    documents: dict[str, Document]
+    links: dict[str, list[tuple[str, str]]]
+    enums: dict[tuple[str, str], list[tuple[str, bool]]]
+    project_enums: dict[str, list[str]]
+
+
+SEEDS = Seeds(
+    # Structure mirrored from MCP_Test_Project; every string is synthetic.
+    work_items={
+        DOC_HEADING_ID: WorkItem(
+            DOC_HEADING_ID,
+            "Section A",
+            "heading",
+            module_id=MODULE_ID,
+            outline_number="1",
+        ),
+        FLOATING_TASK_ID: WorkItem(
+            FLOATING_TASK_ID,
+            "Floating task",
+            "task",
+            hyperlinks=[{"role": "ref_ext", "uri": FLOATING_TASK_HYPERLINK_URI}],
+            custom_fields={"acceptance_criteria_id": "AC-1"},
+        ),
+        FLOATING_HEADING_ID: WorkItem(
+            FLOATING_HEADING_ID, "Floating heading", "heading"
+        ),
+        FLOATING_GHOST_ID: WorkItem(FLOATING_GHOST_ID, "Ghost type", "not_a_real_type"),
+        CHILD_REQ_ID: WorkItem(
+            CHILD_REQ_ID, "Child requirement", "systemrequirement", module_id=MODULE_ID
+        ),
+        UNCOVERED_REQ_ID: WorkItem(
+            UNCOVERED_REQ_ID,
+            "Uncovered requirement",
+            "systemrequirement",
+            module_id=MODULE_ID,
+        ),
+        PARENT_REQ_ID: WorkItem(
+            PARENT_REQ_ID,
+            "Parent requirement",
+            "systemrequirement",
+            module_id=PARENT_MODULE_ID,
+        ),
+        TESTCASE_ID: WorkItem(TESTCASE_ID, "Coverage test case", "systemtestcase"),
+    },
+    documents={
+        DOC: Document(
+            name=DOC,
+            title="Fake Doc",
+            body_html=(
+                '<h1 id="h-1">Fake Doc</h1>'
+                f'<p id="{DOC_INTRO_PARAGRAPH_ID}">Fake intro paragraph.</p>'
+            ),
+            # Section A heading (positional-move anchor) -> one work-item part.
+            parts=[
+                DocumentPart("heading", DOC_HEADING_ID, level=1),
+                DocumentPart("workitem", CHILD_REQ_ID),
+            ],
+            # Root + one reply; resolving the root resolves the whole thread.
+            comments=[
+                Comment(ROOT_COMMENT_ID, "fake root comment"),
+                Comment(
+                    REPLY_COMMENT_ID, "fake reply comment", parent_id=ROOT_COMMENT_ID
+                ),
+            ],
+        ),
+        PARENT_DOC: Document(
+            name=PARENT_DOC,
+            title="Fake Parent Doc",
+            body_html='<h1 id="ph-1">Fake Parent Doc</h1>',
+        ),
+    },
+    # Forward (outgoing) work-item links: source short id -> [(role, target short
+    # id)]. CHILD_REQ has a parent + a test case; UNCOVERED_REQ deliberately none.
+    links={
+        CHILD_REQ_ID: [("satisfies", PARENT_REQ_ID), ("verifies", TESTCASE_ID)],
+    },
+    # (resource, field_id) -> enum option ids (+ which is the default).
+    enums={
+        ("workitems", "type"): [
+            ("systemrequirement", False),
+            ("softwarerequirement", False),
+            ("systemtestcase", False),
+            ("softwaretestcase", False),
+            ("risk", False),
+            ("release", False),
+            ("workpackage", False),
+            ("task", True),
+            ("changerequest", False),
+            ("issue", False),
+            ("testcase", False),
+            ("unittestcase", False),
+        ],
+        ("workitems", "severity"): [
+            ("must_have", False),
+            ("should_have", True),
+            ("nice_to_have", False),
+            ("will_not_have", False),
+        ],
+        ("workitems", "status"): [
+            ("open", True),
+            ("inProgress", False),
+            ("done", False),
+            ("reopened", False),
+        ],
+        ("workitems", "priority"): [
+            ("90.0", False),
+            ("50.0", True),
+            ("10.0", False),
+        ],
+        ("documents", "type"): [
+            ("systemRequirementSpecification", True),
+            ("softwareRequirementSpecification", False),
+        ],
+        ("documents", "status"): [
+            ("draft", True),
+            ("inReview", False),
+            ("approved", False),
+        ],
+    },
+    # Project-level enums (``/enumerations/~/{name}/~``) -- dict-shaped ``data``
+    # with ``attributes.options[].id``, unlike getAvailableOptions' list.
+    project_enums={
+        "hyperlink-role": ["ref_int", "ref_ext"],
+        "workitem-link-role": ["relates_to", "parent", "satisfies", "verifies"],
+    },
+)

--- a/evals/harness/fixtures.py
+++ b/evals/harness/fixtures.py
@@ -7,6 +7,7 @@ serves resources built from ``SEEDS``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 POLARION_HOST = "https://polarion.example.com"
 API_PREFIX = "/polarion/rest/v1"
@@ -75,7 +76,7 @@ class DocumentPart:
     as ``{kind}_{work_item_id}``; ``nextPart`` links are derived from order.
     """
 
-    kind: str  # "heading" | "workitem"
+    kind: Literal["heading", "workitem"]
     work_item_id: str
     level: int = 1  # heading level; ignored for workitem parts
 

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -20,7 +20,8 @@ from strands_evals.types import TaskOutput
 import mcp_server_polarion.core.client as _client_mod
 from mcp_server_polarion.server import mcp
 
-from .fake_polarion import POLARION_HOST, PROJECT, FakePolarion
+from .fake_polarion import FakePolarion
+from .fixtures import POLARION_HOST, PROJECT
 from .mcp_bridge import TrajectoryRecorder, build_agent_tools
 from .model import build_model
 

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -9,8 +9,8 @@ from typing import Any
 
 import httpx
 
-from evals.harness.fake_polarion import (
-    _WORK_ITEMS,
+from evals.harness.fake_polarion import FakePolarion
+from evals.harness.fixtures import (
     API_PREFIX,
     CHILD_REQ_ID,
     DOC,
@@ -24,9 +24,9 @@ from evals.harness.fake_polarion import (
     POLARION_HOST,
     PROJECT,
     SECTION_A_PART_ID,
+    SEEDS,
     SPACE,
     TESTCASE_ID,
-    FakePolarion,
 )
 
 _BASE = f"{POLARION_HOST}{API_PREFIX}"
@@ -82,7 +82,7 @@ class TestReadRouting:
     def test_work_item_list_returns_all(self) -> None:
         response = _get(FakePolarion(), f"/projects/{PROJECT}/workitems")
         assert response.status_code == 200
-        assert _json(response)["meta"]["totalCount"] == len(_WORK_ITEMS)
+        assert _json(response)["meta"]["totalCount"] == len(SEEDS.work_items)
 
     def test_work_item_list_filters_headings(self) -> None:
         response = _get(

--- a/tests/evals/harness/test_fixtures.py
+++ b/tests/evals/harness/test_fixtures.py
@@ -1,0 +1,42 @@
+"""Referential-integrity checks on ``SEEDS``: a broken cross-reference would
+otherwise surface as a late ``KeyError`` deep in ``FakePolarion`` only when a
+case happens to hit the affected entity. Catching it at the data layer keeps
+the "add an entity = one table entry" workflow safe.
+"""
+
+from __future__ import annotations
+
+from evals.harness.fixtures import PROJECT, SEEDS, SPACE
+
+
+def test_document_keys_match_names() -> None:
+    for key, doc in SEEDS.documents.items():
+        assert key == doc.name
+
+
+def test_parts_reference_existing_work_items() -> None:
+    for doc in SEEDS.documents.values():
+        for part in doc.parts:
+            assert part.work_item_id in SEEDS.work_items
+
+
+def test_links_reference_existing_work_items() -> None:
+    for source, targets in SEEDS.links.items():
+        assert source in SEEDS.work_items
+        for _role, target in targets:
+            assert target in SEEDS.work_items
+
+
+def test_comment_parents_reference_sibling_comments() -> None:
+    for doc in SEEDS.documents.values():
+        ids = {c.comment_id for c in doc.comments}
+        for comment in doc.comments:
+            if comment.parent_id is not None:
+                assert comment.parent_id in ids
+
+
+def test_work_item_modules_reference_existing_documents() -> None:
+    module_ids = {f"{PROJECT}/{SPACE}/{doc.name}" for doc in SEEDS.documents.values()}
+    for wi in SEEDS.work_items.values():
+        if wi.module_id:
+            assert wi.module_id in module_ids


### PR DESCRIPTION
## Summary

`evals/harness/fake_polarion.py` mixed 23 module-level constants and four seed tables with the HTTP dispatch logic, and documents/parts/comments were hard-coded inside dispatch methods with per-doc `if`/membership-tuple branching. Adding a new fake document meant editing four methods.

This splits the data out into `evals/harness/fixtures.py` and models documents as seed data, so a new entity is one table entry: `FakePolarion` serves it with no per-entity branching.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- fake_polarion.py mixed globals + seed tables with HTTP dispatch; adding a document needed per-doc branching edits
- move ids/seeds to fixtures.py; model docs in SEEDS so FakePolarion serves them data-driven via injectable seeds field

## Testing

`ruff check .` + `ruff format --check .` + `mypy src/` + `pytest` (1227 passed). Pure move + reference swap; harness routing tests (`tests/evals/harness/test_fake_polarion.py`) pin behavior parity. New `Document`/`DocumentPart`/`Comment` seed model verified against the existing two-doc fixture.

## Notes for Reviewers

- `WorkItem`/`Seeds` made public (dropped leading underscore) and joined by new `Document`/`DocumentPart`/`Comment`: a reusable fixture API.
- `FakePolarion` gains a `seeds: Seeds = SEEDS` field (default = global), so a case can inject an isolated seed set; existing no-arg construction unchanged.
- Comments are now keyed by document name (regex-extracted) instead of returning the same thread for any `/comments` path: more correct, parity preserved since only `FakeDoc` seeds a thread.