### PR TITLE
ci(deps): auto-merge non-major dependabot prs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,8 +17,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge for patch and minor updates
-        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+      # indirect deps report a null update-type (fetch-metadata lacks the previous version),
+      # so gate on "not major" to auto-merge those too while still flagging real majors below.
+      - name: Enable auto-merge for non-major updates
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

Dependabot auto-merge never fired for #105 (`aiohttp` 3.14.0 -> 3.14.1). `aiohttp` is an **indirect** dep, so `fetch-metadata` got no previous version and emitted `update-type: null`. The merge step gated on `update-type == patch || minor`, which null never matches -- step skipped, PR left open despite being CLEAN/MERGEABLE.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- Indirect deps yield a null `update-type`, so the patch/minor gate never matched and #105 stalled
- Gate on "not `semver-major`" so indirect + patch/minor updates auto-merge; majors still labeled and assigned

## Testing

YAML-only change; no test suite touched. Auto-merge stays gated by branch protection required checks (`check`, `security-scan / scan`, `security-scan / audit`, `CodeQL`, strict), so a failing or vulnerable bump still cannot merge. Will confirm against the next Dependabot PR.

## Notes for Reviewers

Trade-off: a green major bump of an **indirect** dep can now auto-merge (its `update-type` is null too, indistinguishable from patch/minor). Required checks remain the real gate. Direct-dep majors still report `semver-major` -> `major-update` label + reviewer request, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)