### PR TITLE
fix(deps): pin litellm <1.89 for tier3 gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # 1.89.x regresses gpt-4o-mini tool-calling and breaks the Tier-3 eval
+      # gate; held at <1.89 in pyproject. Drop this once upstream is fixed.
+      - dependency-name: "litellm"
+        versions: [">=1.89"]
     groups:
       production:
         dependency-type: "production"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ dev = [
 evals = [
     "strands-agents[litellm]",
     "strands-agents-evals",
-    "litellm>=1.83.10",
+    # 1.89.x regresses gpt-4o-mini tool-calling: the agent skips
+    # read_document_parts and loops past the cycle cap, breaking Tier-3
+    # orchestration cases (T3-DEDUP-BEFORE-CREATE, T3-BULK-SPEC-INTO-DOC).
+    "litellm>=1.83.10,<1.89",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.89.1"
+version = "1.88.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1146,9 +1146,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/1b/de398e6cef46d4cbc4395c895330f30eab05439bf6d0c5c53b0203661eeb/litellm-1.89.1.tar.gz", hash = "sha256:eb9292f90afe46dcce4bfef6bbeaa54494945813763e1c0917f4e9a1c584c1a4", size = 14071586, upload-time = "2026-06-16T03:12:52.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/2b/26e8a66113e55aacb432ede26df64a9ae6c3c4fe3083bd3ab297554ed1b1/litellm-1.88.2.tar.gz", hash = "sha256:8ce5013f4d23093807eddb07700b18af482b3c8e48a8c812637d815e6c0fae4d", size = 13895106, upload-time = "2026-06-14T02:32:50.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/24/81f03088876a13b628fdbaf746ee746e1dff127d63f339ef72f1a3801c91/litellm-1.89.1-py3-none-any.whl", hash = "sha256:a52a67625d89cb1787ef48c4b3c1ab9c2574ea304f56900bc631844297a13bd4", size = 15484855, upload-time = "2026-06-16T03:12:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/01/90/c93eb77a3e26af75fdc97f7e533ad65c12b9a34e7966bf5e13c9bc5d3b70/litellm-1.88.2-py3-none-any.whl", hash = "sha256:076809ad7baf792f015da3a41b552767aa61473f35cc3edec98a10c7a9ccf31e", size = 15287619, upload-time = "2026-06-14T02:32:48.204Z" },
 ]
 
 [[package]]
@@ -1301,7 +1301,7 @@ dev = [
     { name = "ruff", specifier = ">=0.15" },
 ]
 evals = [
-    { name = "litellm", specifier = ">=1.83.10" },
+    { name = "litellm", specifier = ">=1.83.10,<1.89" },
     { name = "strands-agents", extras = ["litellm"] },
     { name = "strands-agents-evals" },
 ]


### PR DESCRIPTION
## Summary

The v1.3.1 publish was blocked at the Tier-3 eval gate. Root cause is **litellm 1.89.1** (introduced by dependabot #108), which regresses gpt-4o-mini tool-calling: the eval agent skips `read_document_parts` and loops past the cycle cap, dropping `T3-DEDUP-BEFORE-CREATE` and `T3-BULK-SPEC-INTO-DOC` from 10/10 to 0–6/10. litellm is only in the `evals` dependency-group, so this has zero runtime impact on the shipped server.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- litellm 1.89.1 regressed gpt-4o-mini tool-calling: Tier-3 DEDUP/BULK skip read_document_parts and loop, blocks publish
- cap litellm <1.89 in evals group, re-lock to 1.88.2, ignore 1.89.x in dependabot until upstream fixes it

## Testing

Reproduced and verified locally on the locked version (litellm 1.88.2):
- T3-DEDUP-BEFORE-CREATE: 10/10 (was 0–5/10 on 1.89.1)
- T3-BULK-SPEC-INTO-DOC: 10/10 (was 6/10 on 1.89.1)
- ruff check + ruff format --check + mypy: clean; pytest: 1233 passed

## Notes for Reviewers

Drop the `<1.89` cap and the dependabot `ignore` once litellm fixes the tool-calling regression upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
