### PR TITLE
chore(meta): add Docker container support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,16 @@
-# Environment variables — NEVER commit secrets
+# Environment variables — NEVER bake secrets into the image
 .env
+.env.*
+
+# Git
+.git
+.github
 
 # Python caches
 __pycache__/
 *.py[cod]
 *.pyo
 *.pyd
-.Python
 
 # Virtual environments
 .venv/
@@ -21,23 +25,20 @@ build/
 
 # Tool caches
 .mypy_cache/
-.dmypy.json
 .ruff_cache/
 .pytest_cache/
 .coverage
 htmlcov/
 
-# Eval gate reports (generated per run)
-evals/reports/
+# Not needed at runtime
+tests/
+evals/
 
 # Claude / MCP configuration
-.claude/*
-!.claude/skills/
-!.claude/hooks/
-!.claude/settings.json
+.claude/
 .mcp.json
 
 # Editor / OS
-.vscode/*
+.vscode/
 .DS_Store
 Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS build
+WORKDIR /app
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY src ./src
+RUN uv sync --frozen --no-dev --no-editable
+
+FROM python:3.13-slim
+LABEL org.opencontainers.image.title="mcp-server-polarion" \
+      org.opencontainers.image.description="MCP server for Polarion ALM — read and write documents and work items" \
+      org.opencontainers.image.source="https://github.com/devemberx/mcp-server-polarion" \
+      org.opencontainers.image.licenses="MIT"
+COPY --from=build /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+RUN useradd -r -u 1000 mcp
+USER mcp
+ENTRYPOINT ["mcp-server-polarion"]


### PR DESCRIPTION
## Summary

Add Docker containerization so the server can be built as a Docker image (groundwork for `docker/mcp-registry` submission and standalone container runs).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- Enable a Docker-built image for `docker/mcp-registry` submission and standalone container runs
- Add multi-stage Dockerfile + `.dockerignore`, reorganize `.gitignore` into grouped sections

## Testing

Static review only. Verified `uv.lock`, `README.md`, `LICENSE`, and `src/` are present so the `--frozen` build COPY targets resolve. `docker build` not run here (no Docker daemon in this environment); CI (ruff + mypy + pytest) unaffected as no source changed.

## Notes for Reviewers

`.dockerignore` excludes `.env*`, `.git`, `.github`, `tests/`, `evals/`, and `.claude/` so no secrets or non-runtime files enter the image. Image entrypoint is the stdio server; runtime needs `POLARION_URL` and `POLARION_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
