### PR TITLE
docs(meta): add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security issues privately — do not open a public issue.
+
+- Open a private advisory: [Report a vulnerability](https://github.com/devemberx/mcp-server-polarion/security/advisories/new)
+- Or email: devemberx@gmail.com
+
+We aim to acknowledge reports within 72 hours and will keep you informed
+of remediation progress. Please include reproduction steps and affected
+versions where possible.
+
+## Supported Versions
+
+Only the latest released version on PyPI receives security fixes.


### PR DESCRIPTION
## Summary

Add `SECURITY.md` documenting how to report vulnerabilities. Required for the docker/mcp-registry submission checklist (Security Contact).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- registry submission requires a documented security reporting method
- add SECURITY.md pointing to private GitHub advisory or maintainer email

## Testing

Docs-only change; no code paths touched.

## Notes for Reviewers

After merge, enable Settings > Security > Private vulnerability reporting so the advisory link in SECURITY.md is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)