### PR TITLE
docs(meta): add contributor onboarding docs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at devemberx@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,181 +1,147 @@
-# Contributing Guide
+# Contributing to mcp-server-polarion
 
-Thanks for contributing to `mcp-server-polarion`. This document describes the **branch strategy**, **commit message rules**, and **pull request workflow** used in this repository. For codebase architecture and engineering rules, see [CLAUDE.md](../CLAUDE.md).
+Thanks for taking the time to contribute. Every bug report, doc fix, and pull request helps.
 
----
+This guide walks you through the contributor's path: **find something to work on → set up your
+environment → make the change → open a pull request.** For the codebase architecture, tool-design
+conventions, and Polarion API gotchas, see [CLAUDE.md](../CLAUDE.md) — read it before touching
+`tools/` or `core/`.
 
-## 1. Branch Strategy
-
-We use a lightweight trunk-based flow: `main` is always releasable, and all work happens on short-lived topic branches.
-
-### Branch naming
-
-Format: `<type>/<short-kebab-summary>`
-
-| Type        | When to use                                                    | Example                       |
-| ----------- | -------------------------------------------------------------- | ----------------------------- |
-| `feature/`  | New tool, capability, or user-visible behavior                 | `feature/read-fidelity`       |
-| `fix/`      | Bug fix on existing behavior                                   | `fix/utils-html-attachments`  |
-| `refactor/` | Internal restructuring with no functional change               | `refactor/tools`              |
-| `test/`     | Test-only changes (unit tests, eval cases, fixtures)           | `test/tier2-efficiency-evals` |
-| `docs/`     | Documentation-only changes                                     | `docs/contributing`           |
-| `chore/`    | Dependency bumps, build tooling, repository housekeeping       | `chore/bump-fastmcp`          |
-| `ci/`       | GitHub Actions / workflow / release-pipeline changes           | `ci/cache-uv-deps`            |
-
-Rules:
-
-- Use **lowercase kebab-case** for the summary segment.
-- Keep the summary short (≤4 words). The PR title carries the full description.
-- One topic per branch. Split unrelated changes into separate branches.
-- Branch off the latest `main`; rebase (do not merge) `main` into the branch before opening a PR.
-- **Branch prefixes use the long form (`feature/`, `refactor/`); commit types use the short Conventional Commits form (`feat`, `refactor`).** The asymmetry is intentional — branch names read as English nouns, commit types follow the Conventional Commits spec.
-
-### Protection rules
-
-- `main` is protected. Direct pushes are not allowed — every change must go through a PR.
-- **Force push to `main` is forbidden.** Force push to your own feature branch is allowed only after explicit reviewer authorization (e.g. after `git rebase -i` cleanup).
+> **The best first step is often an issue.** A clear bug report or a short design proposal lets us
+> agree on the approach before anyone writes code — that saves you from reworking a PR later.
 
 ---
 
-## 2. Commit Message Rules
+## Ways to contribute
 
-### Format
+- **Report a bug** — open a [bug report](https://github.com/devemberx/mcp-server-polarion/issues/new/choose).
+  Include your Polarion version, MCP client, and steps to reproduce.
+- **Request a feature** — open a [feature request](https://github.com/devemberx/mcp-server-polarion/issues/new/choose)
+  describing the problem first, then your proposed tool or behavior.
+- **Improve the docs** — fix a typo, clarify a tool docstring, or expand the README. Small docs PRs
+  are always welcome and need no prior discussion.
+- **Write code** — fix a bug or add a feature. Issues tagged **`good first issue`** are a friendly
+  starting point. For anything larger than a small fix, open an issue first so we can align.
 
-```
-<type>(<scope>): <subject>
+Security vulnerabilities go through [SECURITY.md](SECURITY.md), **not** public issues.
 
-- <motivation — why the change is needed>
-- <change — what concretely was done>
-```
+---
 
-### Type (Conventional Commits)
+## Development setup
 
-| Type       | Meaning                                                                |
-| ---------- | ---------------------------------------------------------------------- |
-| `feat`     | New feature (e.g. a new MCP tool, resource, or prompt)                 |
-| `fix`      | Bug fix (logic error, protocol non-compliance)                         |
-| `docs`     | Documentation-only change (README, docstrings, internal guides)        |
-| `refactor` | Code change that neither fixes a bug nor adds a feature                |
-| `perf`     | Performance improvement                                                |
-| `test`     | Adding missing tests or correcting existing tests                      |
-| `ci`       | CI configuration / GitHub Actions changes                              |
-| `chore`    | Build process, dependency updates, auxiliary tooling                   |
+### Prerequisites
 
-### Scope (never omit)
+- [**uv**](https://docs.astral.sh/uv/) — manages the Python toolchain and dependencies.
+- **Python 3.13+** (uv will fetch it if missing).
+- A live **Polarion 2506+** instance is **not** required to contribute — the test suite mocks
+  Polarion. You only need one to exercise the server end to end.
 
-| Scope       | Area                                                                                       |
-| ----------- | ------------------------------------------------------------------------------------------ |
-| `tool`      | Executable tool functions exposed to the LLM (e.g. `read.py`, `write.py`)                  |
-| `server`    | MCP server lifecycle, initialization, internal state                                       |
-| `transport` | Communication layer (stdio / sse / http)                                                   |
-| `config`    | Environment variables, `.env`, static settings                                             |
-| `deps`      | Python package management (`pyproject.toml`, lock files)                                   |
-| `utils`     | Shared helper modules (e.g. `utils/html.py`)                                               |
-| `model`     | Pydantic schemas in `models.py`                                                            |
-| `project`   | Cross-cutting changes touching multiple scopes simultaneously                              |
-| `meta`      | Repository maintenance (`.github/`, licenses, root-level configs)                          |
-| `git`       | Git-specific config (`.gitignore`, pre-commit hooks, commit templates)                     |
+### Get the code
 
-### Subject constraints
+1. **Fork** this repository (the **Fork** button on GitHub).
+2. **Clone** your fork and install dependencies:
 
-- Imperative, present tense (`add`, not `added` or `adds`).
-- Start with **lowercase**.
-- **No** trailing period.
-- **≤50 characters**, including `type(scope):` prefix.
+   ```bash
+   uv sync --dev
+   ```
 
-### Body constraints
+> Collaborators with write access may skip the fork and branch directly in this repo.
 
-- One blank line between subject and body.
-- **Exactly 2 bullets**, in this order: motivation first, then change.
-- Do **not** prefix bullets with literal `Why:` / `What:` — the order alone carries that meaning.
-- Each bullet is a **single line, ≤120 characters**. Longer rationale goes in the PR description.
-
-### Examples
-
-**Correct**
-
-```
-feat(tool): add description_html flag to get_work_item
-
-- Round-trip editing was lossy because Markdown conversion dropped Polarion macros.
-- Return raw HTML when description_html=True so update_work_item can re-apply it verbatim.
-```
-
-```
-fix(utils): preserve attachment imgs on read
-
-- Sanitizer stripped <img src="attachment:..."> tags, breaking image references in reads.
-- Allow attachment: scheme through the BeautifulSoup sanitization allowlist.
-```
-
-**Incorrect (and why)**
-
-| Bad                                              | Reason                                                  |
-| ------------------------------------------------ | ------------------------------------------------------- |
-| `feat: add new tool`                             | Missing scope                                           |
-| `feat(TOOL): Add new tool`                       | Scope and subject must be lowercase                     |
-| `fix(tool): Fixed the prompt injection bug.`     | Wrong tense + trailing period                           |
-| `feat(docs): add guide`                          | Never combine `feat` with documentation — use `docs`    |
-| `docs(git): update readme`                       | Missing mandatory blank line and 2-bullet body          |
-| `- Why: ...` / `- What: ...`                     | Drop the literal `Why:` / `What:` prefixes              |
-
-### Enforcement
-
-The repo ships a `commit-msg` hook in [`.githooks/`](../.githooks/commit-msg) that mechanically enforces the subject and bullet length limits. Enable it once per clone:
+Optionally enable the local commit-message helper (see [Commit messages](#commit-messages)):
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-The hook rejects any commit whose subject exceeds 50 chars or whose body does not contain exactly two bullets ≤120 chars each. Merge / revert / fixup / squash / amend autosquash subjects are skipped.
+---
+
+## Development workflow
+
+1. **Branch off the latest `main`.** Use the `<type>/<short-kebab-summary>` form:
+
+   | Prefix      | For                                          | Example                       |
+   | ----------- | -------------------------------------------- | ----------------------------- |
+   | `feature/`  | new tool or user-visible behavior            | `feature/read-fidelity`       |
+   | `fix/`      | bug fix on existing behavior                 | `fix/utils-html-attachments`  |
+   | `refactor/` | internal restructuring, no behavior change   | `refactor/tools`              |
+   | `test/`     | tests, eval cases, fixtures only             | `test/tier2-efficiency-evals` |
+   | `docs/`     | documentation only                           | `docs/contributing`           |
+   | `chore/`    | deps, build tooling, housekeeping            | `chore/bump-fastmcp`          |
+   | `ci/`       | GitHub Actions / release pipeline            | `ci/cache-uv-deps`            |
+
+   One topic per branch; split unrelated work apart.
+
+2. **Make your change.** Follow the rules in [CLAUDE.md](../CLAUDE.md) — strict async, full type
+   annotations, log to stderr (never `print()`), and keep tool docstrings in sync with their models.
+
+3. **Add tests.** `tests/` mirrors the source tree one-to-one. For write tools, verify the
+   `dry_run=True` path. New `@mcp.tool`s also need their name added to `EXPECTED_TOOL_NAMES`.
+
+4. **Run the checks locally** — the same gate CI runs:
+
+   ```bash
+   uv run ruff check . && uv run ruff format --check .
+   uv run mypy src/
+   uv run pytest
+   ```
+
+5. **Push to your fork** (`origin`) and open a pull request.
 
 ---
 
-## 3. Pull Request Guidelines
+## Commit messages
 
-### Before opening
+We **squash-merge** PRs, so the final commit is built from your **PR title** plus the **Changes**
+bullets — that's what follows the format. Your branch's "wip" commits don't matter; they vanish on
+squash.
 
-- Branch is rebased onto the latest `origin/main`.
-- All checks pass locally:
-  ```bash
-  uv run ruff check . && uv run ruff format --check .
-  uv run mypy src/
-  uv run pytest
-  ```
-- For write-tool changes: `dry_run=True` path verified.
-- Public-facing tool changes are reflected in the tool's docstring (the LLM-facing manual).
+```
+type(scope): summary       ← imperative, lowercase, no period, ≤50 chars
 
-### Opening the PR
+- why the change is needed  ← two bullets, ≤120 chars each
+- what changed
+```
 
-- **Title** follows the commit-subject format: `type(scope): summary`, ≤70 characters. Keep details for the body. Since the merge strategy is squash, the PR title becomes the squashed commit subject — if your title exceeds the 50-char commit-subject limit, shorten it (or edit the subject at squash time) before merging.
-- **Base branch**: `main`.
-- Use the [pull request template](PULL_REQUEST_TEMPLATE.md). It is auto-loaded by GitHub.
-- Fill every section: **Summary**, **Type of Change**, **Changes**, **Testing**.
-- In **Type of Change**, keep the full checkbox list as written — only flip `[ ]` → `[x]` for matching items. Do **not** delete unchecked options.
-- Link related issues with `Closes #<n>` or `Refs #<n>` in the Summary. Remove the placeholder line if there is no linked issue.
+- **type**: `feat` `fix` `docs` `refactor` `perf` `test` `ci` `chore`
+- **scope**: `tool` `server` `transport` `config` `deps` `utils` `model` `project` `meta` `git`
+
+Want it checked locally as you commit? Enable the optional hook:
+`git config core.hooksPath .githooks`.
+
+---
+
+## Pull requests
+
+- **Keep it small.** Small, focused PRs get reviewed fast; large ones sit in the queue. One concern
+  per PR.
+- **Open it against `devemberx/mcp-server-polarion:main`**, from your fork's branch.
+- **Use the [pull request template](PULL_REQUEST_TEMPLATE.md)** (auto-loaded). Fill every section —
+  Summary, Type of Change, Changes, Testing.
+- **Link issues** with `Closes #<n>` or `Refs #<n>` in the Summary.
+- **Make sure CI is green** — `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 
 ### Review and merge
 
-- At least one approving review is required.
-- CI must be green: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
-- Resolve conversations before merging; do not auto-resolve reviewer threads.
-- **Merge strategy: squash and merge.** The squashed commit message must follow the commit-message rules above (the PR title becomes the subject; the PR description supplies the 2-bullet body).
-- Delete the topic branch after merge.
-
-### Force push policy
-
-- Allowed on your own feature branch after explicit reviewer authorization (typically to clean up history before merge).
-- **Forbidden on `main`** under any circumstance.
+- At least one approving review is required; resolve review threads before merge.
+- Merge strategy is **squash and merge** — your PR title becomes the commit subject and the
+  *Changes* bullets become the body, so make them match the [commit format](#commit-messages).
+- Force-pushing your own fork branch is fine (e.g. to clean up history before merge).
 
 ---
 
-## 4. Development Quickstart
+## AI-assisted contributions
 
-```bash
-uv sync --dev                                            # install deps
-uv run pytest                                            # run all tests
-uv run ruff check . && uv run ruff format . && uv run mypy src/   # lint + format + types
-uv run mcp-server-polarion                               # run server (stdio)
-```
+Using an AI assistant to help write code or docs is welcome — this project is itself an MCP server.
+But the same bar applies to every line:
 
-Architectural rules, tool-design conventions, and Polarion API gotchas live in [CLAUDE.md](../CLAUDE.md). Read it before touching `tools/` or `core/`.
+- **You are the author.** Understand, and be able to explain, everything you submit. Review and test
+  AI-generated output before opening a PR; don't open unreviewed machine-generated PRs.
+- **Stay focused.** Don't let a tool expand the diff with unrelated refactors or boilerplate.
+- **Bug fixes start with a failing test** that passes after your change, AI-assisted or not.
+
+---
+
+## Code of Conduct & License
+
+This project follows a [Code of Conduct](CODE_OF_CONDUCT.md); by participating you agree to uphold it.
+Contributions are licensed under the project's [MIT License](../LICENSE).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
     id: server-version
     attributes:
       label: mcp-server-polarion version
-      placeholder: "e.g. 0.5.0 (from `uvx mcp-server-polarion --version` or PyPI)"
+      placeholder: "e.g. 1.3.1 (from `pip show mcp-server-polarion` or PyPI)"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Something doesn't work as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please don't include secrets (tokens, URLs) in logs.
+        For security vulnerabilities, use SECURITY.md instead of a public issue.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps (or the prompt you gave the assistant) that trigger the bug.
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: polarion-version
+    attributes:
+      label: Polarion version
+      description: Server requires Polarion 2506 or higher.
+      placeholder: "2506"
+    validations:
+      required: true
+  - type: dropdown
+    id: client
+    attributes:
+      label: MCP client
+      options:
+        - Claude Code
+        - Claude Desktop
+        - Cursor
+        - VS Code (GitHub Copilot)
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: server-version
+    attributes:
+      label: mcp-server-polarion version
+      placeholder: "e.g. 0.5.0 (from `uvx mcp-server-polarion --version` or PyPI)"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Server stderr output, if any. Redact tokens and instance URLs.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/devemberx/mcp-server-polarion/security/policy
+    about: Please report security issues privately per our security policy, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability
     url: https://github.com/devemberx/mcp-server-polarion/security/policy

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest a new tool, capability, or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem first — agreeing on the need makes the solution easier to design.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that you can't do today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed tool or behavior
+      description: What new tool, parameter, or behavior would solve it?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've thought about.
+    validations:
+      required: false

--- a/uv.lock
+++ b/uv.lock
@@ -1864,16 +1864,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The contributing guide read like a maintainer rulebook — it led with branch/commit tables, buried dev setup at the bottom, and gave newcomers no entry point. The repo also had no Code of Conduct and no issue templates, so the "open an issue first" flow had nowhere to land. This reworks the docs around the contributor's journey and adds the missing onboarding surface, modeled on the MCP python-sdk, pytest, and FastMCP guides.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Contributing guide read like a maintainer rulebook with setup buried and no entry point for new contributors.
- Rewrite it contributor-first, add a Code of Conduct, and add bug/feature issue templates.

## Testing

- No code changed — CI (ruff + mypy + pytest) is unaffected.
- Verified all three issue-template YAML files parse, all relative doc links resolve, and the commit-msg hook passed on every commit.

## Notes for Reviewers

- Commit rules are reframed around squash-merge: the PR title + Changes bullets are the final commit; branch commits can stay loose.
- Code of Conduct is the Contributor Covenant v2.1 (CC BY 4.0); attribution is retained, contact set to the maintainer email.
- The three commits squash into one on merge.
