### PR TITLE
feat(tool): add list_work_item_comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Applies to ALL comments/docstrings incl. CLAUDE.md.
 - Link ids composite `<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`. Bulk tools cap at `MAX_BULK_ITEMS` (50). Link-create POST atomic — 4xx rolls back batch; re-query `list_work_item_links` before retry.
 - `PATCH /workitems` needs ≥1 `attributes`/`relationships` entry. `changeTypeTo` resets `status` to new type's initial state.
 - `update_document_comment`: root comments only (replies 400); resolving root resolves whole thread.
+- Comment ids: work item comments 3-segment (`<proj>/<wi>/<cmt>`), document comments 4-segment. `list_work_item_comments`/`list_document_comments` share the `Comment` model + `build_comment` parser; work item comments add `title` (own `WORK_ITEM_COMMENT_LIST_FIELDS`), documents send none.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Applies to ALL comments/docstrings incl. CLAUDE.md.
 - Link ids composite `<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`. Bulk tools cap at `MAX_BULK_ITEMS` (50). Link-create POST atomic — 4xx rolls back batch; re-query `list_work_item_links` before retry.
 - `PATCH /workitems` needs ≥1 `attributes`/`relationships` entry. `changeTypeTo` resets `status` to new type's initial state.
 - `update_document_comment`: root comments only (replies 400); resolving root resolves whole thread.
-- Comment ids: work item comments 3-segment (`<proj>/<wi>/<cmt>`), document comments 4-segment. `list_work_item_comments`/`list_document_comments` share the `Comment` model + `build_comment` parser; work item comments add `title` (own `WORK_ITEM_COMMENT_LIST_FIELDS`), documents send none.
+- Comment ids: work item comments 3-segment (`<proj>/<wi>/<cmt>`), document comments 4-segment. `list_work_item_comments`/`list_document_comments` share the `Comment` model + `build_comments_page` parser; work item comments add `title` (own `WORK_ITEM_COMMENT_LIST_FIELDS`), documents send none.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **P
 
 ## Features
 
-- **24 tools** covering read and write across documents, work items, traceability links, and comments.
+- **25 tools** covering read and write across documents, work items, traceability links, and comments.
 - **Read** — render documents as Markdown, search with Lucene or SQL, walk incoming/outgoing links, resolve enum options.
 - **Write** — create and update work items and documents, manage links, reorganize document structure, post comments.
 - **Safe writes** — every write tool supports `dry_run`, and pre-write guards validate fields, enum values, and link targets before hitting Polarion.
@@ -166,6 +166,7 @@ claude mcp add mcp-server-polarion \
 | `read_work_item` | Get work item details with the body as Markdown |
 | `list_work_item_links` | List a work item's outgoing or incoming links |
 | `list_document_comments` | List a document's comments with thread relationships |
+| `list_work_item_comments` | List a work item's comments with thread relationships |
 | `list_document_enum_options` | Resolve valid enum ids for a document field |
 | `list_work_item_enum_options` | Resolve valid enum ids for a work item field |
 

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -6,7 +6,7 @@ in the JSON Schema — omit a description when name + type say everything.
 from __future__ import annotations
 
 from mcp_server_polarion.models.comments import (
-    DocumentComment,
+    Comment,
     DocumentCommentsCreateResult,
     DocumentCommentSpec,
     DocumentCommentUpdateResult,
@@ -49,7 +49,7 @@ from mcp_server_polarion.models.work_items import (
 
 __all__: list[str] = [
     "MAX_BODY_HTML_LEN",
-    "DocumentComment",
+    "Comment",
     "DocumentCommentSpec",
     "DocumentCommentUpdateResult",
     "DocumentCommentsCreateResult",

--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -1,4 +1,4 @@
-"""Document comment models — comment views, create specs, and write results."""
+"""Comment models — shared comment view, document create specs, and write results."""
 
 from __future__ import annotations
 
@@ -8,12 +8,13 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
-class DocumentComment(BaseModel):
-    """A single document comment returned by ``list_document_comments``."""
+class Comment(BaseModel):
+    """A single comment returned by the comment list tools."""
 
     id: str
     created: str
     resolved: bool = False
+    title: str = ""
     text: str = ""
     text_format: Literal["text/html", "text/plain"] = "text/html"
     author_id: str | None = None

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -17,6 +17,7 @@ from mcp_server_polarion.models import (
     EnumOption,
     Hyperlink,
     JsonValue,
+    PaginatedResult,
     WorkItemDetail,
     WorkItemLink,
     WorkItemSummary,
@@ -451,7 +452,7 @@ def parse_work_item_summaries(
     return items
 
 
-def build_comment(item: dict[str, object]) -> Comment:
+def _build_comment(item: dict[str, object]) -> Comment:
     """Build a ``Comment`` from a JSON:API resource (short relationship IDs)."""
     attributes_raw = item.get("attributes")
     attributes: dict[str, object] = (
@@ -487,6 +488,37 @@ def build_comment(item: dict[str, object]) -> Comment:
     )
 
 
+def build_comments_page(
+    response: dict[str, object], page_number: int, page_size: int
+) -> PaginatedResult[Comment]:
+    """Parse a JSON:API comments response into a ``PaginatedResult`` page.
+
+    Shared by the document- and work-item comment list tools; ``total`` falls
+    back to an offset estimate when Polarion omits ``meta.totalCount``.
+    """
+    raw_data = response.get("data", [])
+    comment_items: list[Comment] = []
+    if isinstance(raw_data, list):
+        for entry in raw_data:
+            if isinstance(entry, dict):
+                comment_items.append(_build_comment(entry))
+
+    raw_total = extract_total_count(response)
+    total = raw_total
+    if total <= 0 and comment_items:
+        total = (page_number - 1) * page_size + len(comment_items)
+
+    return PaginatedResult[Comment](
+        items=comment_items,
+        total_count=total,
+        page=page_number,
+        page_size=page_size,
+        has_more=compute_has_more(
+            response, raw_total, page_number, page_size, len(comment_items)
+        ),
+    )
+
+
 def build_enum_option(entry: dict[str, object]) -> EnumOption:
     def _bool(key: str) -> bool:
         value = entry.get(key)
@@ -514,7 +546,7 @@ __all__: list[str] = [
     "WORK_ITEM_DETAIL_FIELDS",
     "WORK_ITEM_LIST_FIELDS",
     "WORK_ITEM_PART_FIELDS",
-    "build_comment",
+    "build_comments_page",
     "build_enum_option",
     "build_included_user_name_map",
     "build_included_work_item_map",

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -13,7 +13,7 @@ from fastmcp import Context
 
 from mcp_server_polarion.core.client import PolarionClient
 from mcp_server_polarion.models import (
-    DocumentComment,
+    Comment,
     EnumOption,
     Hyperlink,
     JsonValue,
@@ -56,6 +56,10 @@ DOCUMENT_DETAIL_FIELDS: Final[str] = "@all"
 # Sparse fieldset filters relationships too — name them explicitly.
 DOCUMENT_COMMENT_LIST_FIELDS: Final[str] = (
     "created,resolved,text,author,parentComment,childComments"
+)
+# Work item comments add ``title``; document comments have none.
+WORK_ITEM_COMMENT_LIST_FIELDS: Final[str] = (
+    "created,resolved,title,text,author,parentComment,childComments"
 )
 
 # Standard-attribute allowlist (REST OpenAPI schema); anything outside is
@@ -447,8 +451,8 @@ def parse_work_item_summaries(
     return items
 
 
-def build_document_comment(item: dict[str, object]) -> DocumentComment:
-    """Build a ``DocumentComment`` from a JSON:API resource (short relationship IDs)."""
+def build_comment(item: dict[str, object]) -> Comment:
+    """Build a ``Comment`` from a JSON:API resource (short relationship IDs)."""
     attributes_raw = item.get("attributes")
     attributes: dict[str, object] = (
         attributes_raw if isinstance(attributes_raw, dict) else {}
@@ -470,10 +474,11 @@ def build_document_comment(item: dict[str, object]) -> DocumentComment:
     parent_full = extract_relationship_id(relationships, "parentComment")
     child_full = extract_relationship_ids(relationships, "childComments")
 
-    return DocumentComment(
+    return Comment(
         id=extract_short_id(safe_str(item.get("id", ""))),
         created=safe_str(attributes.get("created", "")),
         resolved=bool(attributes.get("resolved", False)),
+        title=safe_str(attributes.get("title", "")),
         text=text_value,
         text_format=text_format,
         author_id=extract_short_id(author_full) or None,
@@ -505,10 +510,11 @@ __all__: list[str] = [
     "OPTION_LIST_LIMIT",
     "STANDARD_DOCUMENT_ATTRIBUTES",
     "STANDARD_WORK_ITEM_ATTRIBUTES",
+    "WORK_ITEM_COMMENT_LIST_FIELDS",
     "WORK_ITEM_DETAIL_FIELDS",
     "WORK_ITEM_LIST_FIELDS",
     "WORK_ITEM_PART_FIELDS",
-    "build_document_comment",
+    "build_comment",
     "build_enum_option",
     "build_included_user_name_map",
     "build_included_work_item_map",

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -26,11 +26,9 @@ from mcp_server_polarion.tools._shared.helpers import (
     DEFAULT_PAGE_SIZE,
     DOCUMENT_COMMENT_LIST_FIELDS,
     WORK_ITEM_COMMENT_LIST_FIELDS,
-    build_comment,
-    compute_has_more,
+    build_comments_page,
     encode_path_segment,
     extract_short_id,
-    extract_total_count,
     get_client,
     safe_str,
 )
@@ -153,27 +151,7 @@ async def list_document_comments(  # noqa: PLR0913
             f"Failed to list comments for '{space_id}/{document_name}': {exc.message}"
         ) from exc
 
-    raw_data = response.get("data", []) if isinstance(response, dict) else []
-    comment_items: list[Comment] = []
-    if isinstance(raw_data, list):
-        for entry in raw_data:
-            if isinstance(entry, dict):
-                comment_items.append(build_comment(entry))
-
-    raw_total = extract_total_count(response)
-    total = raw_total
-    if total <= 0 and comment_items:
-        total = (page_number - 1) * page_size + len(comment_items)
-
-    return PaginatedResult[Comment](
-        items=comment_items,
-        total_count=total,
-        page=page_number,
-        page_size=page_size,
-        has_more=compute_has_more(
-            response, raw_total, page_number, page_size, len(comment_items)
-        ),
-    )
+    return build_comments_page(response, page_number, page_size)
 
 
 @mcp.tool(
@@ -225,27 +203,7 @@ async def list_work_item_comments(
             f"Failed to list comments for '{work_item_id}': {exc.message}"
         ) from exc
 
-    raw_data = response.get("data", []) if isinstance(response, dict) else []
-    comment_items: list[Comment] = []
-    if isinstance(raw_data, list):
-        for entry in raw_data:
-            if isinstance(entry, dict):
-                comment_items.append(build_comment(entry))
-
-    raw_total = extract_total_count(response)
-    total = raw_total
-    if total <= 0 and comment_items:
-        total = (page_number - 1) * page_size + len(comment_items)
-
-    return PaginatedResult[Comment](
-        items=comment_items,
-        total_count=total,
-        page=page_number,
-        page_size=page_size,
-        has_more=compute_has_more(
-            response, raw_total, page_number, page_size, len(comment_items)
-        ),
-    )
+    return build_comments_page(response, page_number, page_size)
 
 
 @mcp.tool(

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -1,4 +1,4 @@
-"""Document comment tools — list, create, and update comments."""
+"""Comment tools — list document/work-item comments; create/update document comments."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
-    DocumentComment,
+    Comment,
     DocumentCommentsCreateResult,
     DocumentCommentSpec,
     DocumentCommentUpdateResult,
@@ -25,7 +25,8 @@ from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools._shared.helpers import (
     DEFAULT_PAGE_SIZE,
     DOCUMENT_COMMENT_LIST_FIELDS,
-    build_document_comment,
+    WORK_ITEM_COMMENT_LIST_FIELDS,
+    build_comment,
     compute_has_more,
     encode_path_segment,
     extract_short_id,
@@ -113,7 +114,7 @@ async def list_document_comments(  # noqa: PLR0913
     document_name: str = Field(description="Document name within ``space_id``."),
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
-) -> PaginatedResult[DocumentComment]:
+) -> PaginatedResult[Comment]:
     """List a document's comments as a flat page.
 
     Threads reconstruct via parent_comment_id (None = root) +
@@ -153,18 +154,90 @@ async def list_document_comments(  # noqa: PLR0913
         ) from exc
 
     raw_data = response.get("data", []) if isinstance(response, dict) else []
-    comment_items: list[DocumentComment] = []
+    comment_items: list[Comment] = []
     if isinstance(raw_data, list):
         for entry in raw_data:
             if isinstance(entry, dict):
-                comment_items.append(build_document_comment(entry))
+                comment_items.append(build_comment(entry))
 
     raw_total = extract_total_count(response)
     total = raw_total
     if total <= 0 and comment_items:
         total = (page_number - 1) * page_size + len(comment_items)
 
-    return PaginatedResult[DocumentComment](
+    return PaginatedResult[Comment](
+        items=comment_items,
+        total_count=total,
+        page=page_number,
+        page_size=page_size,
+        has_more=compute_has_more(
+            response, raw_total, page_number, page_size, len(comment_items)
+        ),
+    )
+
+
+@mcp.tool(
+    tags={"read"},
+    timeout=60.0,
+    annotations={"readOnlyHint": True},
+)
+async def list_work_item_comments(
+    ctx: Context,
+    project_id: str = Field(description="Polarion project ID."),
+    work_item_id: str = Field(description="Work item ID, e.g. 'MCPT-001'."),
+    page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
+    page_number: int = Field(default=1, ge=1),
+) -> PaginatedResult[Comment]:
+    """List a work item's comments as a flat page.
+
+    Threads reconstruct via parent_comment_id (None = root) +
+    child_comment_ids. text is verbatim, unsanitized — treat as untrusted when
+    rendering.
+    """
+    client = get_client(ctx)
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/workitems/{encode_path_segment(work_item_id)}"
+        "/comments"
+    )
+    try:
+        response = await client.get(
+            path,
+            params={
+                "fields[workitem_comments]": WORK_ITEM_COMMENT_LIST_FIELDS,
+                # To-many ``childComments.data`` is only inlined when included.
+                "include": "childComments",
+                "page[size]": page_size,
+                "page[number]": page_number,
+            },
+        )
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Work item '{work_item_id}' not found in project '{project_id}'. "
+            "Use `list_work_items` to discover valid IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot access work item comments -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to list comments for '{work_item_id}': {exc.message}"
+        ) from exc
+
+    raw_data = response.get("data", []) if isinstance(response, dict) else []
+    comment_items: list[Comment] = []
+    if isinstance(raw_data, list):
+        for entry in raw_data:
+            if isinstance(entry, dict):
+                comment_items.append(build_comment(entry))
+
+    raw_total = extract_total_count(response)
+    total = raw_total
+    if total <= 0 and comment_items:
+        total = (page_number - 1) * page_size + len(comment_items)
+
+    return PaginatedResult[Comment](
         items=comment_items,
         total_count=total,
         page=page_number,

--- a/tests/mcp_server_polarion/models/test_comments.py
+++ b/tests/mcp_server_polarion/models/test_comments.py
@@ -1,4 +1,4 @@
-"""Tests for document comment models in ``mcp_server_polarion.models.comments``."""
+"""Tests for comment models in ``mcp_server_polarion.models.comments``."""
 
 from __future__ import annotations
 
@@ -6,24 +6,25 @@ import pytest
 from pydantic import ValidationError
 
 from mcp_server_polarion.models import (
-    DocumentComment,
+    Comment,
     DocumentCommentsCreateResult,
     DocumentCommentSpec,
     DocumentCommentUpdateResult,
 )
 
 
-class TestDocumentComment:
+class TestComment:
     def test_top_level_defaults(self):
-        c = DocumentComment(id="c1", created="2026-01-01T00:00:00Z")
+        c = Comment(id="c1", created="2026-01-01T00:00:00Z")
         assert c.resolved is False
+        assert c.title == ""
         assert c.text == ""
         assert c.text_format == "text/html"
         assert c.parent_comment_id is None
         assert c.child_comment_ids == []
 
     def test_reply_with_children(self):
-        c = DocumentComment(
+        c = Comment(
             id="c2",
             created="2026-01-01T00:00:00Z",
             parent_comment_id="c1",

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -36,6 +36,7 @@ _READ_TOOL_NAMES: frozenset[str] = frozenset(
         "read_work_item",
         "list_work_item_links",
         "list_document_comments",
+        "list_work_item_comments",
     }
 )
 _WRITE_TOOL_NAMES: frozenset[str] = frozenset(

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -1,4 +1,4 @@
-"""Tests for the document comment tools."""
+"""Tests for the comment tools."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
-    DocumentComment,
+    Comment,
     DocumentCommentSpec,
     DocumentCommentUpdateResult,
     PaginatedResult,
@@ -25,6 +25,7 @@ from mcp_server_polarion.tools.comments import (
     _build_document_comments_payload,
     create_document_comments,
     list_document_comments,
+    list_work_item_comments,
     update_document_comment,
 )
 
@@ -73,7 +74,7 @@ class TestListDocumentComments:
         assert len(result.items) == 1
 
         comment = result.items[0]
-        assert isinstance(comment, DocumentComment)
+        assert isinstance(comment, Comment)
         assert comment.id == "cmt-1"
         assert comment.created == "2026-04-01T12:00:00Z"
         assert comment.resolved is False
@@ -337,6 +338,308 @@ class TestListDocumentComments:
                 project_id="proj1",
                 space_id="Design",
                 document_name="SRS",
+                page_size=100,
+                page_number=1,
+            )
+
+
+class TestListWorkItemComments:
+    """Tests for the ``list_work_item_comments`` tool."""
+
+    async def test_returns_paginated_result(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "workitem_comments",
+                    "id": "proj1/MCPT-1/cmt-1",
+                    "attributes": {
+                        "id": "cmt-1",
+                        "created": "2026-04-01T12:00:00Z",
+                        "resolved": False,
+                        "title": "Needs review",
+                        "text": {"type": "text/html", "value": "<p>Review me</p>"},
+                    },
+                    "relationships": {
+                        "author": {
+                            "data": {"type": "users", "id": "alice"},
+                        },
+                    },
+                },
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_work_item_comments(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-1",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert result.total_count == 1
+        assert result.page == 1
+        assert result.page_size == 100
+        assert result.has_more is False
+        assert len(result.items) == 1
+
+        comment = result.items[0]
+        assert isinstance(comment, Comment)
+        assert comment.id == "cmt-1"
+        assert comment.created == "2026-04-01T12:00:00Z"
+        assert comment.resolved is False
+        assert comment.title == "Needs review"
+        assert comment.text == "<p>Review me</p>"
+        assert comment.text_format == "text/html"
+        assert comment.author_id == "alice"
+        assert comment.parent_comment_id is None
+        assert comment.child_comment_ids == []
+
+    async def test_extracts_thread_relationships(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "workitem_comments",
+                    "id": "proj1/MCPT-1/cmt-reply",
+                    "attributes": {
+                        "id": "cmt-reply",
+                        "created": "2026-04-02T09:00:00Z",
+                        "resolved": True,
+                        "text": {"type": "text/html", "value": "<p>thanks</p>"},
+                    },
+                    "relationships": {
+                        "author": {"data": {"type": "users", "id": "bob"}},
+                        "parentComment": {
+                            "data": {
+                                "type": "workitem_comments",
+                                "id": "proj1/MCPT-1/cmt-root",
+                            },
+                        },
+                        "childComments": {
+                            "data": [
+                                {
+                                    "type": "workitem_comments",
+                                    "id": "proj1/MCPT-1/cmt-grand-1",
+                                },
+                                {
+                                    "type": "workitem_comments",
+                                    "id": "proj1/MCPT-1/cmt-grand-2",
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_work_item_comments(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-1",
+            page_size=100,
+            page_number=1,
+        )
+
+        comment = result.items[0]
+        assert comment.resolved is True
+        assert comment.parent_comment_id == "cmt-root"
+        assert comment.child_comment_ids == ["cmt-grand-1", "cmt-grand-2"]
+
+    async def test_handles_plain_text_format(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "workitem_comments",
+                    "id": "proj1/MCPT-1/cmt-plain",
+                    "attributes": {
+                        "id": "cmt-plain",
+                        "created": "2026-04-03T00:00:00Z",
+                        "resolved": False,
+                        "text": {
+                            "type": "text/plain",
+                            "value": "raw <not html> text",
+                        },
+                    },
+                    "relationships": {},
+                },
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_work_item_comments(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-1",
+            page_size=100,
+            page_number=1,
+        )
+
+        comment = result.items[0]
+        assert comment.text_format == "text/plain"
+        assert comment.text == "raw <not html> text"
+
+    async def test_missing_relationships_default_to_none(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "workitem_comments",
+                    "id": "proj1/MCPT-1/cmt-empty",
+                    "attributes": {
+                        "id": "cmt-empty",
+                        "created": "2026-04-04T00:00:00Z",
+                        "resolved": False,
+                    },
+                },
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_work_item_comments(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-1",
+            page_size=100,
+            page_number=1,
+        )
+
+        comment = result.items[0]
+        assert comment.author_id is None
+        assert comment.parent_comment_id is None
+        assert comment.child_comment_ids == []
+        assert comment.title == ""
+        assert comment.text == ""
+        assert comment.text_format == "text/html"
+
+    async def test_signals_has_more_when_total_exceeds_page(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "workitem_comments",
+                    "id": f"proj1/MCPT-1/cmt-{i}",
+                    "attributes": {
+                        "id": f"cmt-{i}",
+                        "created": "2026-04-01T00:00:00Z",
+                        "resolved": False,
+                        "text": {"type": "text/html", "value": "<p>x</p>"},
+                    },
+                    "relationships": {},
+                }
+                for i in range(2)
+            ],
+            "meta": {"totalCount": 5},
+        }
+
+        result = await list_work_item_comments(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-1",
+            page_size=2,
+            page_number=1,
+        )
+
+        assert result.total_count == 5
+        assert result.has_more is True
+        assert len(result.items) == 2
+
+    async def test_passes_pagination_and_fieldset_params(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": []}
+
+        await list_work_item_comments(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT-1",
+            page_size=25,
+            page_number=3,
+        )
+
+        calls = mock_client.get.call_args_list
+        assert len(calls) == 1
+        assert calls[0][0][0] == "/projects/proj1/workitems/MCPT-1/comments"
+        params = calls[0][1]["params"]
+        assert params["fields[workitem_comments]"] == (
+            "created,resolved,title,text,author,parentComment,childComments"
+        )
+        assert params["include"] == "childComments"
+        assert params["page[size]"] == 25
+        assert params["page[number]"] == 3
+
+    async def test_url_encodes_work_item_id(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": []}
+
+        await list_work_item_comments(
+            mock_ctx,
+            project_id="proj1",
+            work_item_id="MCPT 1/2",
+            page_size=100,
+            page_number=1,
+        )
+
+        path = mock_client.get.call_args_list[0][0][0]
+        assert path == "/projects/proj1/workitems/MCPT%201%2F2/comments"
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found",
+            status_code=404,
+        )
+
+        with pytest.raises(ValueError, match="MCPT-1"):
+            await list_work_item_comments(
+                mock_ctx,
+                project_id="proj1",
+                work_item_id="MCPT-1",
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError(
+            "Forbidden",
+            status_code=403,
+        )
+
+        with pytest.raises(PermissionError, match="POLARION_TOKEN"):
+            await list_work_item_comments(
+                mock_ctx,
+                project_id="proj1",
+                work_item_id="MCPT-1",
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_polarion_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError(
+            "Boom",
+            status_code=500,
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to list comments"):
+            await list_work_item_comments(
+                mock_ctx,
+                project_id="proj1",
+                work_item_id="MCPT-1",
                 page_size=100,
                 page_number=1,
             )


### PR DESCRIPTION
## Summary

Adds `list_work_item_comments`, the work-item analogue of `list_document_comments`, so an LLM can read a work item's comment thread via `GET /projects/{p}/workitems/{wi}/comments`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Polarion exposes work-item comments but no MCP tool surfaced them
- Add read-only list_work_item_comments; rename DocumentComment to Comment (now with title) reused by both lists

## Testing

CI gate green locally: `ruff check` + `ruff format --check` + `mypy src/` clean; `pytest` 1245 passed. New `TestListWorkItemComments` mirrors the document-comment cases (paginated parse, thread relationships, text-format, defaults, has_more, fieldset/path params, URL-encoding, the three error mappings) and asserts the new `title` field.

## Notes for Reviewers

- Work-item comments carry a `title` attribute document comments lack, so they use their own `WORK_ITEM_COMMENT_LIST_FIELDS` (includes `title`); the document fieldset is untouched to avoid a 400 on a field docs don't have.
- Read-only scope only — no create/update of work-item comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
