### PR TITLE
feat(tool): add update_work_item_comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Applies to ALL comments/docstrings incl. CLAUDE.md.
 
 - Link ids composite `<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`. Bulk tools cap at `MAX_BULK_ITEMS` (50). Link-create POST atomic — 4xx rolls back batch; re-query `list_work_item_links` before retry.
 - `PATCH /workitems` needs ≥1 `attributes`/`relationships` entry. `changeTypeTo` resets `status` to new type's initial state.
-- `update_document_comment`: root comments only (replies 400); resolving root resolves whole thread.
+- `update_document_comment`/`update_work_item_comment`: root comments only (replies 400). Document resolve cascades to whole thread; work item resolve flips only that comment (no cascade).
 - Comment ids: work item comments 3-segment (`<proj>/<wi>/<cmt>`), document comments 4-segment. `list_work_item_comments`/`list_document_comments` share the `Comment` model + `build_comments_page` parser; work item comments add `title` (own `WORK_ITEM_COMMENT_LIST_FIELDS`), documents send none.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **P
 
 ## Features
 
-- **25 tools** covering read and write across documents, work items, traceability links, and comments.
+- **26 tools** covering read and write across documents, work items, traceability links, and comments.
 - **Read** — render documents as Markdown, search with Lucene or SQL, walk incoming/outgoing links, resolve enum options.
 - **Write** — create and update work items and documents, manage links, reorganize document structure, post comments.
 - **Safe writes** — every write tool supports `dry_run`, and pre-write guards validate fields, enum values, and link targets before hitting Polarion.
@@ -187,6 +187,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | `move_work_item_from_document` | Detach a work item from its document |
 | `create_document_comments` | Add one or more comments or replies to a document |
 | `update_document_comment` | Resolve or re-open a document comment |
+| `update_work_item_comment` | Resolve or re-open a work item comment |
 
 ## Example Prompts
 

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from mcp_server_polarion.models.comments import (
     Comment,
+    CommentUpdateResult,
     DocumentCommentsCreateResult,
     DocumentCommentSpec,
-    DocumentCommentUpdateResult,
 )
 from mcp_server_polarion.models.common import (
     MAX_BODY_HTML_LEN,
@@ -50,8 +50,8 @@ from mcp_server_polarion.models.work_items import (
 __all__: list[str] = [
     "MAX_BODY_HTML_LEN",
     "Comment",
+    "CommentUpdateResult",
     "DocumentCommentSpec",
-    "DocumentCommentUpdateResult",
     "DocumentCommentsCreateResult",
     "DocumentCreateResult",
     "DocumentDetail",

--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -1,4 +1,4 @@
-"""Comment models — shared comment view, document create specs, and write results."""
+"""Comment models — shared comment view, create specs, and update results."""
 
 from __future__ import annotations
 
@@ -41,8 +41,8 @@ class DocumentCommentsCreateResult(BaseModel):
     payload_preview: Mapping[str, object] | None
 
 
-class DocumentCommentUpdateResult(BaseModel):
-    """Result of an ``update_document_comment`` operation."""
+class CommentUpdateResult(BaseModel):
+    """Shared result of a comment-resolve update, across all comment types."""
 
     updated: bool
     dry_run: bool

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -1,4 +1,4 @@
-"""Comment tools — list document/work-item comments; create/update document comments."""
+"""Comment tools — list comments, create + resolve them."""
 
 from __future__ import annotations
 
@@ -15,9 +15,9 @@ from mcp_server_polarion.core.exceptions import (
 )
 from mcp_server_polarion.models import (
     Comment,
+    CommentUpdateResult,
     DocumentCommentsCreateResult,
     DocumentCommentSpec,
-    DocumentCommentUpdateResult,
     JsonValue,
     PaginatedResult,
 )
@@ -77,6 +77,26 @@ def _build_document_comments_payload(
     return {"data": items}
 
 
+def _comment_update_payload(
+    *,
+    full_id: str,
+    comment_type: str,
+    resolved: bool,
+) -> dict[str, JsonValue]:
+    """Single-resource PATCH body (``data`` dict, not list). Only ``resolved``
+    is patchable; ``id`` is the full resource path the API expects.
+    """
+    return {
+        "data": {
+            "type": comment_type,
+            "id": full_id,
+            "attributes": {
+                "resolved": resolved,
+            },
+        }
+    }
+
+
 def _build_document_comment_update_payload(
     *,
     project_id: str,
@@ -85,19 +105,29 @@ def _build_document_comment_update_payload(
     comment_id: str,
     resolved: bool,
 ) -> dict[str, JsonValue]:
-    """Single-resource PATCH body (``data`` dict, not list); ``id`` is the
-    full 4-segment path. Only ``resolved`` is patchable.
-    """
+    """PATCH body for a document comment; ``id`` is the full 4-segment path."""
     full_id = f"{project_id}/{space_id}/{document_name}/{comment_id}"
-    return {
-        "data": {
-            "type": "document_comments",
-            "id": full_id,
-            "attributes": {
-                "resolved": resolved,
-            },
-        }
-    }
+    return _comment_update_payload(
+        full_id=full_id,
+        comment_type="document_comments",
+        resolved=resolved,
+    )
+
+
+def _build_work_item_comment_update_payload(
+    *,
+    project_id: str,
+    work_item_id: str,
+    comment_id: str,
+    resolved: bool,
+) -> dict[str, JsonValue]:
+    """PATCH body for a work item comment; ``id`` is the full 3-segment path."""
+    full_id = f"{project_id}/{work_item_id}/{comment_id}"
+    return _comment_update_payload(
+        full_id=full_id,
+        comment_type="workitem_comments",
+        resolved=resolved,
+    )
 
 
 @mcp.tool(
@@ -335,7 +365,7 @@ async def update_document_comment(  # noqa: PLR0913
         default=False,
         description="Preview payload without calling Polarion.",
     ),
-) -> DocumentCommentUpdateResult:
+) -> CommentUpdateResult:
     """Resolve or re-open one document comment thread.
 
     Root comments only (a reply 400s) — pick a root id (parent_comment_id=None)
@@ -351,7 +381,7 @@ async def update_document_comment(  # noqa: PLR0913
     )
 
     if dry_run:
-        return DocumentCommentUpdateResult(
+        return CommentUpdateResult(
             updated=False,
             dry_run=True,
             comment_id=None,
@@ -381,7 +411,88 @@ async def update_document_comment(  # noqa: PLR0913
     except PolarionError as exc:
         raise RuntimeError(f"Failed to update document comment: {exc.message}") from exc
 
-    return DocumentCommentUpdateResult(
+    return CommentUpdateResult(
+        updated=True,
+        dry_run=False,
+        comment_id=comment_id,
+        resolved=resolved,
+        payload_preview=None,
+    )
+
+
+@mcp.tool(
+    tags={"write"},
+    timeout=60.0,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+async def update_work_item_comment(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(min_length=1, description="Polarion project ID."),
+    work_item_id: str = Field(
+        min_length=1,
+        description="Work item ID, e.g. 'MCPT-001'.",
+    ),
+    comment_id: str = Field(
+        min_length=1,
+        description="Short comment ID (e.g. 'c42' from list_work_item_comments).",
+    ),
+    resolved: bool = Field(description="New resolved state."),
+    dry_run: bool = Field(
+        default=False,
+        description="Preview payload without calling Polarion.",
+    ),
+) -> CommentUpdateResult:
+    """Resolve or re-open one work item comment.
+
+    Root comments only (a reply 400s) — pick a root id (parent_comment_id=None)
+    from list_work_item_comments; resolving a root flips only that comment.
+    Idempotent.
+    """
+    payload = _build_work_item_comment_update_payload(
+        project_id=project_id,
+        work_item_id=work_item_id,
+        comment_id=comment_id,
+        resolved=resolved,
+    )
+
+    if dry_run:
+        return CommentUpdateResult(
+            updated=False,
+            dry_run=True,
+            comment_id=None,
+            resolved=resolved,
+            payload_preview=payload,
+        )
+
+    client = get_client(ctx)
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/workitems/{encode_path_segment(work_item_id)}"
+        f"/comments/{encode_path_segment(comment_id)}"
+    )
+    try:
+        await client.patch(path, json=cast(dict[str, object], payload))
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot update work item comment -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Comment '{comment_id}' on work item '{work_item_id}'"
+            f" (project '{project_id}') not found."
+            " Use `list_work_item_comments` to discover valid comment IDs."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to update work item comment: {exc.message}"
+        ) from exc
+
+    return CommentUpdateResult(
         updated=True,
         dry_run=False,
         comment_id=comment_id,

--- a/tests/mcp_server_polarion/models/test_comments.py
+++ b/tests/mcp_server_polarion/models/test_comments.py
@@ -7,9 +7,9 @@ from pydantic import ValidationError
 
 from mcp_server_polarion.models import (
     Comment,
+    CommentUpdateResult,
     DocumentCommentsCreateResult,
     DocumentCommentSpec,
-    DocumentCommentUpdateResult,
 )
 
 
@@ -60,9 +60,9 @@ class TestDocumentCommentsCreateResult:
         assert result.payload_preview is not None
 
 
-class TestDocumentCommentUpdateResult:
+class TestCommentUpdateResult:
     def test_resolve(self):
-        result = DocumentCommentUpdateResult(
+        result = CommentUpdateResult(
             updated=True,
             dry_run=False,
             comment_id="proj/space/doc/c1",
@@ -71,3 +71,14 @@ class TestDocumentCommentUpdateResult:
         )
         assert result.comment_id == "proj/space/doc/c1"
         assert result.resolved is True
+
+    def test_resolve_work_item_three_segment_id(self):
+        result = CommentUpdateResult(
+            updated=True,
+            dry_run=False,
+            comment_id="c1",
+            resolved=False,
+            payload_preview=None,
+        )
+        assert result.comment_id == "c1"
+        assert result.resolved is False

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -52,6 +52,7 @@ _WRITE_TOOL_NAMES: frozenset[str] = frozenset(
         "update_document",
         "create_document_comments",
         "update_document_comment",
+        "update_work_item_comment",
     }
 )
 EXPECTED_TOOL_NAMES: frozenset[str] = _READ_TOOL_NAMES | _WRITE_TOOL_NAMES

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -16,17 +16,19 @@ from mcp_server_polarion.core.exceptions import (
 )
 from mcp_server_polarion.models import (
     Comment,
+    CommentUpdateResult,
     DocumentCommentSpec,
-    DocumentCommentUpdateResult,
     PaginatedResult,
 )
 from mcp_server_polarion.tools.comments import (
     _build_document_comment_update_payload,
     _build_document_comments_payload,
+    _build_work_item_comment_update_payload,
     create_document_comments,
     list_document_comments,
     list_work_item_comments,
     update_document_comment,
+    update_work_item_comment,
 )
 
 
@@ -1129,7 +1131,7 @@ class TestUpdateDocumentCommentDryRun:
             resolved=True,
             dry_run=True,
         )
-        assert isinstance(result, DocumentCommentUpdateResult)
+        assert isinstance(result, CommentUpdateResult)
         assert result.dry_run is True
         assert result.updated is False
 
@@ -1258,7 +1260,7 @@ class TestUpdateDocumentCommentHappyPath:
             resolved=True,
             dry_run=False,
         )
-        assert isinstance(result, DocumentCommentUpdateResult)
+        assert isinstance(result, CommentUpdateResult)
         assert result.updated is True
         assert result.dry_run is False
         assert result.comment_id == "c42"
@@ -1330,6 +1332,231 @@ class TestUpdateDocumentCommentErrors:
                 project_id="Proj",
                 space_id="Space",
                 document_name="Doc",
+                comment_id="c42",
+                resolved=True,
+                dry_run=False,
+            )
+
+
+class TestBuildWorkItemCommentUpdatePayload:
+    """Unit tests for _build_work_item_comment_update_payload (no I/O)."""
+
+    def _build(
+        self,
+        *,
+        project_id: str = "Proj",
+        work_item_id: str = "MCPT-001",
+        comment_id: str = "c42",
+        resolved: bool = True,
+    ) -> dict:  # type: ignore[type-arg]
+        return _build_work_item_comment_update_payload(
+            project_id=project_id,
+            work_item_id=work_item_id,
+            comment_id=comment_id,
+            resolved=resolved,
+        )
+
+    def test_payload_is_dict_not_list(self) -> None:
+        payload = self._build()
+        assert isinstance(payload["data"], dict)
+        assert not isinstance(payload["data"], list)
+
+    def test_type_is_workitem_comments(self) -> None:
+        payload = self._build()
+        assert payload["data"]["type"] == "workitem_comments"  # type: ignore[index]
+
+    def test_resolved_true_included(self) -> None:
+        payload = self._build(resolved=True)
+        assert payload["data"]["attributes"]["resolved"] is True  # type: ignore[index]
+
+    def test_resolved_false_included(self) -> None:
+        payload = self._build(resolved=False)
+        assert payload["data"]["attributes"]["resolved"] is False  # type: ignore[index]
+
+    def test_full_id_composed_from_three_segments(self) -> None:
+        payload = self._build(
+            project_id="P",
+            work_item_id="W",
+            comment_id="c42",
+        )
+        assert payload["data"]["id"] == "P/W/c42"  # type: ignore[index]
+
+
+class TestUpdateWorkItemCommentDryRun:
+    """Dry-run path must not call client.patch."""
+
+    async def test_dry_run_skips_patch(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        await update_work_item_comment(
+            mock_ctx,
+            project_id="Proj",
+            work_item_id="MCPT-001",
+            comment_id="c42",
+            resolved=True,
+            dry_run=True,
+        )
+        mock_client.patch.assert_not_called()
+
+    async def test_dry_run_result_flags(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await update_work_item_comment(
+            mock_ctx,
+            project_id="Proj",
+            work_item_id="MCPT-001",
+            comment_id="c42",
+            resolved=True,
+            dry_run=True,
+        )
+        assert isinstance(result, CommentUpdateResult)
+        assert result.dry_run is True
+        assert result.updated is False
+
+    async def test_dry_run_comment_id_is_none(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await update_work_item_comment(
+            mock_ctx,
+            project_id="Proj",
+            work_item_id="MCPT-001",
+            comment_id="c42",
+            resolved=True,
+            dry_run=True,
+        )
+        assert result.comment_id is None
+
+    async def test_dry_run_payload_preview_populated(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await update_work_item_comment(
+            mock_ctx,
+            project_id="Proj",
+            work_item_id="MCPT-001",
+            comment_id="c42",
+            resolved=True,
+            dry_run=True,
+        )
+        assert result.payload_preview is not None
+        data = result.payload_preview["data"]
+        assert data["type"] == "workitem_comments"  # type: ignore[index]
+        assert data["attributes"]["resolved"] is True  # type: ignore[index]
+        assert data["id"] == "Proj/MCPT-001/c42"  # type: ignore[index]
+
+
+class TestUpdateWorkItemCommentHappyPath:
+    """Successful PATCH path (204 No Content)."""
+
+    async def test_patch_called_with_correct_path(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        await update_work_item_comment(
+            mock_ctx,
+            project_id="Proj",
+            work_item_id="MCPT-001",
+            comment_id="c42",
+            resolved=True,
+            dry_run=False,
+        )
+        path = mock_client.patch.call_args[0][0]
+        assert path == "/projects/Proj/workitems/MCPT-001/comments/c42"
+
+    async def test_patch_body_three_segment_id_and_type(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        await update_work_item_comment(
+            mock_ctx,
+            project_id="Proj",
+            work_item_id="MCPT-001",
+            comment_id="c42",
+            resolved=True,
+            dry_run=False,
+        )
+        body = mock_client.patch.call_args[1]["json"]
+        assert body["data"]["id"] == "Proj/MCPT-001/c42"
+        assert body["data"]["type"] == "workitem_comments"
+
+    async def test_returns_updated_true(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        result = await update_work_item_comment(
+            mock_ctx,
+            project_id="Proj",
+            work_item_id="MCPT-001",
+            comment_id="c42",
+            resolved=False,
+            dry_run=False,
+        )
+        assert isinstance(result, CommentUpdateResult)
+        assert result.updated is True
+        assert result.dry_run is False
+        assert result.comment_id == "c42"
+        assert result.resolved is False
+        assert result.payload_preview is None
+
+    async def test_path_url_encodes_segments(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+        await update_work_item_comment(
+            mock_ctx,
+            project_id="My Proj",
+            work_item_id="WI 1",
+            comment_id="c 1",
+            resolved=True,
+            dry_run=False,
+        )
+        path = mock_client.patch.call_args[0][0]
+        assert "My%20Proj" in path
+        assert "WI%201" in path
+        assert "c%201" in path
+
+
+class TestUpdateWorkItemCommentErrors:
+    """Exception mapping for PATCH failures."""
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.side_effect = PolarionAuthError("auth", status_code=401)
+        with pytest.raises(PermissionError, match="POLARION_TOKEN"):
+            await update_work_item_comment(
+                mock_ctx,
+                project_id="Proj",
+                work_item_id="MCPT-001",
+                comment_id="c42",
+                resolved=True,
+                dry_run=False,
+            )
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.side_effect = PolarionNotFoundError(
+            "not found", status_code=404
+        )
+        with pytest.raises(ValueError, match="list_work_item_comments"):
+            await update_work_item_comment(
+                mock_ctx,
+                project_id="Proj",
+                work_item_id="MCPT-001",
+                comment_id="c42",
+                resolved=True,
+                dry_run=False,
+            )
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.side_effect = PolarionError("boom", status_code=500)
+        with pytest.raises(RuntimeError, match="boom"):
+            await update_work_item_comment(
+                mock_ctx,
+                project_id="Proj",
+                work_item_id="MCPT-001",
                 comment_id="c42",
                 resolved=True,
                 dry_run=False,

--- a/tests/mcp_server_polarion/tools/test_tool_annotations.py
+++ b/tests/mcp_server_polarion/tools/test_tool_annotations.py
@@ -96,6 +96,15 @@ class TestWriteToolAnnotations:
                     "openWorldHint": True,
                 },
             ),
+            (
+                "update_work_item_comment",
+                {
+                    "readOnlyHint": False,
+                    "destructiveHint": False,
+                    "idempotentHint": True,
+                    "openWorldHint": True,
+                },
+            ),
         ],
     )
     async def test_write_tool_annotation(


### PR DESCRIPTION
## Summary

Adds `update_work_item_comment` — resolve/re-open a single work item comment via
`PATCH /projects/{p}/workitems/{wi}/comments/{c}`. Mirrors `update_document_comment`,
reusing models and helpers: the result model is renamed `DocumentCommentUpdateResult`
→ `CommentUpdateResult` and shared by both tools, and a shared `_comment_update_payload`
core backs both document (4-seg id, `document_comments`) and work item (3-seg id,
`workitem_comments`) payload builders.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- work item comments had no resolve/re-open tool; only document comment threads were writable
- add update_work_item_comment; share CommentUpdateResult + payload core with the document tool

## Testing

- Full local gate green: `ruff check` + `ruff format --check` + `mypy src/` + `pytest` (1265 passed).
- New unit tests cover the payload seam (3-seg id, `workitem_comments` type), dry-run, happy path, and error mapping.
- E2E against live Polarion (MCPT-557): dry_run payload verified; resolving the root comment flips
  only that comment (no thread cascade, unlike documents); resolving a reply returns
  `400 Resolved field can be set only for root comments`. Docstring reflects this. Test state restored.

## Notes for Reviewers

- `CommentUpdateResult` is intentionally generic (no tool names in its docstring) for reuse by future
  comment types (e.g. test-run comments).
- Open follow-up: optionally add a CLAUDE.md gotcha noting work item resolve is root-only with no thread cascade.
