### PR TITLE
feat(tool): add create_work_item_comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ Applies to ALL comments/docstrings incl. CLAUDE.md.
 - `PATCH /workitems` needs ≥1 `attributes`/`relationships` entry. `changeTypeTo` resets `status` to new type's initial state.
 - `update_document_comment`/`update_work_item_comment`: root comments only (replies 400). Document resolve cascades to whole thread; work item resolve flips only that comment (no cascade).
 - Comment ids: work item comments 3-segment (`<proj>/<wi>/<cmt>`), document comments 4-segment. `list_work_item_comments`/`list_document_comments` share the `Comment` model + `build_comments_page` parser; work item comments add `title` (own `WORK_ITEM_COMMENT_LIST_FIELDS`), documents send none.
+- `create_document_comments`/`create_work_item_comments` share the `CommentSpec` input + `_comment_create_payload` helper; `title` honored only for work item comments (document create drops it). No `MAX_BULK_ITEMS` cap on either.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Applies to ALL comments/docstrings incl. CLAUDE.md.
 - `PATCH /workitems` needs ≥1 `attributes`/`relationships` entry. `changeTypeTo` resets `status` to new type's initial state.
 - `update_document_comment`/`update_work_item_comment`: root comments only (replies 400). Document resolve cascades to whole thread; work item resolve flips only that comment (no cascade).
 - Comment ids: work item comments 3-segment (`<proj>/<wi>/<cmt>`), document comments 4-segment. `list_work_item_comments`/`list_document_comments` share the `Comment` model + `build_comments_page` parser; work item comments add `title` (own `WORK_ITEM_COMMENT_LIST_FIELDS`), documents send none.
-- `create_document_comments`/`create_work_item_comments` share the `CommentSpec` input + `_comment_create_payload` helper; `title` honored only for work item comments (document create drops it). No `MAX_BULK_ITEMS` cap on either.
+- `create_document_comments`/`create_work_item_comments` share the `_comment_create_payload` helper; document takes base `CommentSpec` (no `title`), work item takes `WorkItemCommentSpec` (subclass adds `title`). Helper emits `title` only when the spec carries one. No `MAX_BULK_ITEMS` cap on either.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | `move_work_item_to_document` | Attach a work item to a document at a chosen position |
 | `move_work_item_from_document` | Detach a work item from its document |
 | `create_document_comments` | Add one or more comments or replies to a document |
+| `create_work_item_comments` | Add one or more comments or replies to a work item |
 | `update_document_comment` | Resolve or re-open a document comment |
 | `update_work_item_comment` | Resolve or re-open a work item comment |
 

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -10,6 +10,7 @@ from mcp_server_polarion.models.comments import (
     CommentsCreateResult,
     CommentSpec,
     CommentUpdateResult,
+    WorkItemCommentSpec,
 )
 from mcp_server_polarion.models.common import (
     MAX_BODY_HTML_LEN,
@@ -65,6 +66,7 @@ __all__: list[str] = [
     "PaginatedResult",
     "ProjectSummary",
     "SqlRecipeGallery",
+    "WorkItemCommentSpec",
     "WorkItemCreateSpec",
     "WorkItemDetail",
     "WorkItemLink",

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from mcp_server_polarion.models.comments import (
     Comment,
+    CommentsCreateResult,
+    CommentSpec,
     CommentUpdateResult,
-    DocumentCommentsCreateResult,
-    DocumentCommentSpec,
 )
 from mcp_server_polarion.models.common import (
     MAX_BODY_HTML_LEN,
@@ -50,9 +50,9 @@ from mcp_server_polarion.models.work_items import (
 __all__: list[str] = [
     "MAX_BODY_HTML_LEN",
     "Comment",
+    "CommentSpec",
     "CommentUpdateResult",
-    "DocumentCommentSpec",
-    "DocumentCommentsCreateResult",
+    "CommentsCreateResult",
     "DocumentCreateResult",
     "DocumentDetail",
     "DocumentPart",

--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -29,7 +29,7 @@ class CommentSpec(BaseModel):
     text_format: Literal["text/html", "text/plain"] = "text/plain"
     title: str | None = Field(
         default=None,
-        description="Comment title -- work item comments only; ignored for documents.",
+        description="Comment title; ignored only for document comments.",
     )
     resolved: bool | None = None
     author_id: str | None = None

--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -22,18 +22,22 @@ class Comment(BaseModel):
     child_comment_ids: list[str] = Field(default_factory=list)
 
 
-class DocumentCommentSpec(BaseModel):
-    """One comment to create via ``create_document_comments``."""
+class CommentSpec(BaseModel):
+    """A comment to create via the comment-create tools."""
 
     text: str = Field(min_length=1)
     text_format: Literal["text/html", "text/plain"] = "text/plain"
+    title: str | None = Field(
+        default=None,
+        description="Comment title -- work item comments only; ignored for documents.",
+    )
     resolved: bool | None = None
     author_id: str | None = None
     parent_comment_id: str | None = None
 
 
-class DocumentCommentsCreateResult(BaseModel):
-    """Result of a ``create_document_comments`` operation."""
+class CommentsCreateResult(BaseModel):
+    """Result of a comment-create operation."""
 
     created: bool
     dry_run: bool

--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -23,17 +23,19 @@ class Comment(BaseModel):
 
 
 class CommentSpec(BaseModel):
-    """A comment to create via the comment-create tools."""
+    """Common fields for a comment to create; base for type-specific specs."""
 
     text: str = Field(min_length=1)
     text_format: Literal["text/html", "text/plain"] = "text/plain"
-    title: str | None = Field(
-        default=None,
-        description="Comment title; ignored only for document comments.",
-    )
     resolved: bool | None = None
     author_id: str | None = None
     parent_comment_id: str | None = None
+
+
+class WorkItemCommentSpec(CommentSpec):
+    """Work item comment to create; adds ``title`` (document comments have none)."""
+
+    title: str | None = Field(default=None, description="Comment heading.")
 
 
 class CommentsCreateResult(BaseModel):

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -38,16 +38,16 @@ from mcp_server_polarion.tools._shared.helpers import (
 logger = logging.getLogger("mcp_server_polarion.tools.comments")
 
 
-def _comment_create_payload(
+def _build_comment_create_payload(
     *,
     specs: Sequence[CommentSpec],
     comment_type: str,
     parent_prefix: str,
 ) -> dict[str, JsonValue]:
-    """JSON:API POST body (``data`` list); ``None`` fields omitted, short
+    """JSON:API POST body (``data`` list); ``None``/empty fields omitted, short
     ``parent_comment_id`` expanded to the full path the API requires. ``title``
-    emitted only when the spec carries one (WorkItemCommentSpec); base
-    CommentSpec has no title, so document comments never send it.
+    emitted only when the spec carries a non-empty one (WorkItemCommentSpec);
+    base CommentSpec has no title, so document comments never send it.
     """
     items: list[JsonValue] = []
     for spec in specs:
@@ -55,7 +55,7 @@ def _comment_create_payload(
             "text": {"type": spec.text_format, "value": spec.text},
         }
         title = getattr(spec, "title", None)
-        if title is not None:
+        if title:
             attributes["title"] = title
         if spec.resolved is not None:
             attributes["resolved"] = spec.resolved
@@ -90,7 +90,7 @@ def _build_document_comments_payload(
     document_name: str,
 ) -> dict[str, JsonValue]:
     """POST body for .../documents/{d}/comments; parent ids are 4-segment."""
-    return _comment_create_payload(
+    return _build_comment_create_payload(
         specs=specs,
         comment_type="document_comments",
         parent_prefix=f"{project_id}/{space_id}/{document_name}",
@@ -104,11 +104,24 @@ def _build_work_item_comments_payload(
     work_item_id: str,
 ) -> dict[str, JsonValue]:
     """POST body for .../workitems/{wi}/comments; parent ids are 3-segment."""
-    return _comment_create_payload(
+    return _build_comment_create_payload(
         specs=specs,
         comment_type="workitem_comments",
         parent_prefix=f"{project_id}/{work_item_id}",
     )
+
+
+def _extract_created_comment_ids(response: object) -> list[str]:
+    """Short ids from a comment-create POST response (``data`` list)."""
+    raw_data = response.get("data", []) if isinstance(response, dict) else []
+    comment_ids: list[str] = []
+    if isinstance(raw_data, list):
+        for entry in raw_data:
+            if isinstance(entry, dict):
+                full_id = safe_str(entry.get("id", ""))
+                if full_id:
+                    comment_ids.append(extract_short_id(full_id))
+    return comment_ids
 
 
 def _comment_update_payload(
@@ -346,15 +359,7 @@ async def create_document_comments(  # noqa: PLR0913
             f"Failed to create document comments: {exc.message}"
         ) from exc
 
-    raw_data = response.get("data", []) if isinstance(response, dict) else []
-    comment_ids: list[str] = []
-    if isinstance(raw_data, list):
-        for entry in raw_data:
-            if isinstance(entry, dict):
-                full_id = safe_str(entry.get("id", ""))
-                if full_id:
-                    comment_ids.append(extract_short_id(full_id))
-
+    comment_ids = _extract_created_comment_ids(response)
     if not comment_ids:
         raise RuntimeError(
             "Polarion returned no comment IDs after creation."
@@ -439,15 +444,7 @@ async def create_work_item_comments(
             f"Failed to create work item comments: {exc.message}"
         ) from exc
 
-    raw_data = response.get("data", []) if isinstance(response, dict) else []
-    comment_ids: list[str] = []
-    if isinstance(raw_data, list):
-        for entry in raw_data:
-            if isinstance(entry, dict):
-                full_id = safe_str(entry.get("id", ""))
-                if full_id:
-                    comment_ids.append(extract_short_id(full_id))
-
+    comment_ids = _extract_created_comment_ids(response)
     if not comment_ids:
         raise RuntimeError(
             "Polarion returned no comment IDs after creation."

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -15,9 +15,9 @@ from mcp_server_polarion.core.exceptions import (
 )
 from mcp_server_polarion.models import (
     Comment,
+    CommentsCreateResult,
+    CommentSpec,
     CommentUpdateResult,
-    DocumentCommentsCreateResult,
-    DocumentCommentSpec,
     JsonValue,
     PaginatedResult,
 )
@@ -36,22 +36,24 @@ from mcp_server_polarion.tools._shared.helpers import (
 logger = logging.getLogger("mcp_server_polarion.tools.comments")
 
 
-def _build_document_comments_payload(
+def _comment_create_payload(
     *,
-    specs: list[DocumentCommentSpec],
-    project_id: str,
-    space_id: str,
-    document_name: str,
+    specs: list[CommentSpec],
+    comment_type: str,
+    parent_prefix: str,
+    include_title: bool,
 ) -> dict[str, JsonValue]:
-    """JSON:API POST body for .../documents/{d}/comments; ``None`` fields
-    omitted, short ``parent_comment_id`` expanded to the full 4-segment path
-    the API requires.
+    """JSON:API POST body (``data`` list); ``None`` fields omitted, short
+    ``parent_comment_id`` expanded to the full path the API requires. ``title``
+    only emitted when supported by the comment type.
     """
     items: list[JsonValue] = []
     for spec in specs:
         attributes: dict[str, JsonValue] = {
             "text": {"type": spec.text_format, "value": spec.text},
         }
+        if include_title and spec.title is not None:
+            attributes["title"] = spec.title
         if spec.resolved is not None:
             attributes["resolved"] = spec.resolved
 
@@ -59,15 +61,15 @@ def _build_document_comments_payload(
         if spec.author_id is not None:
             relationships["author"] = {"data": {"id": spec.author_id, "type": "users"}}
         if spec.parent_comment_id is not None:
-            full_parent = (
-                f"{project_id}/{space_id}/{document_name}/{spec.parent_comment_id}"
-            )
             relationships["parentComment"] = {
-                "data": {"id": full_parent, "type": "document_comments"}
+                "data": {
+                    "id": f"{parent_prefix}/{spec.parent_comment_id}",
+                    "type": comment_type,
+                }
             }
 
         item: dict[str, JsonValue] = {
-            "type": "document_comments",
+            "type": comment_type,
             "attributes": attributes,
         }
         if relationships:
@@ -75,6 +77,39 @@ def _build_document_comments_payload(
         items.append(item)
 
     return {"data": items}
+
+
+def _build_document_comments_payload(
+    *,
+    specs: list[CommentSpec],
+    project_id: str,
+    space_id: str,
+    document_name: str,
+) -> dict[str, JsonValue]:
+    """POST body for .../documents/{d}/comments; parent ids are 4-segment.
+    Document comments have no title, so ``title`` is dropped.
+    """
+    return _comment_create_payload(
+        specs=specs,
+        comment_type="document_comments",
+        parent_prefix=f"{project_id}/{space_id}/{document_name}",
+        include_title=False,
+    )
+
+
+def _build_work_item_comments_payload(
+    *,
+    specs: list[CommentSpec],
+    project_id: str,
+    work_item_id: str,
+) -> dict[str, JsonValue]:
+    """POST body for .../workitems/{wi}/comments; parent ids are 3-segment."""
+    return _comment_create_payload(
+        specs=specs,
+        comment_type="workitem_comments",
+        parent_prefix=f"{project_id}/{work_item_id}",
+        include_title=True,
+    )
 
 
 def _comment_update_payload(
@@ -258,7 +293,7 @@ async def create_document_comments(  # noqa: PLR0913
         min_length=1,
         description="Document name within ``space_id``.",
     ),
-    comments: list[DocumentCommentSpec] = Field(  # noqa: B008
+    comments: list[CommentSpec] = Field(  # noqa: B008
         min_length=1,
         description="Comments to create in one request.",
     ),
@@ -266,12 +301,13 @@ async def create_document_comments(  # noqa: PLR0913
         default=False,
         description="Preview payload without calling Polarion.",
     ),
-) -> DocumentCommentsCreateResult:
+) -> CommentsCreateResult:
     """Create one or more comments on a document in a single request.
 
     Reply: set parent_comment_id to a short ID from list_document_comments
     (None = top-level). 'text/html' text is sent unsanitized; omit author_id
-    for the token's user. NOT idempotent — a retry duplicates.
+    for the token's user. title is ignored for documents. NOT idempotent — a
+    retry duplicates.
     """
     payload = _build_document_comments_payload(
         specs=comments,
@@ -281,7 +317,7 @@ async def create_document_comments(  # noqa: PLR0913
     )
 
     if dry_run:
-        return DocumentCommentsCreateResult(
+        return CommentsCreateResult(
             created=False,
             dry_run=True,
             comment_ids=[],
@@ -327,7 +363,100 @@ async def create_document_comments(  # noqa: PLR0913
             " The POST may have succeeded — verify with `list_document_comments`."
         )
 
-    return DocumentCommentsCreateResult(
+    return CommentsCreateResult(
+        created=True,
+        dry_run=False,
+        comment_ids=comment_ids,
+        payload_preview=None,
+    )
+
+
+@mcp.tool(
+    tags={"write"},
+    timeout=60.0,
+    annotations={
+        # Additive: non-destructive, but non-idempotent (a retry duplicates comments).
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+async def create_work_item_comments(
+    ctx: Context,
+    project_id: str = Field(min_length=1, description="Polarion project ID."),
+    work_item_id: str = Field(
+        min_length=1,
+        description="Work item ID, e.g. 'MCPT-001'.",
+    ),
+    comments: list[CommentSpec] = Field(  # noqa: B008
+        min_length=1,
+        description="Comments to create in one request.",
+    ),
+    dry_run: bool = Field(
+        default=False,
+        description="Preview payload without calling Polarion.",
+    ),
+) -> CommentsCreateResult:
+    """Create one or more comments on a work item in a single request.
+
+    Reply: set parent_comment_id to a short ID from list_work_item_comments
+    (None = top-level). Optional title sets the comment heading. 'text/html'
+    text is sent unsanitized; omit author_id for the token's user. NOT
+    idempotent — a retry duplicates.
+    """
+    payload = _build_work_item_comments_payload(
+        specs=comments,
+        project_id=project_id,
+        work_item_id=work_item_id,
+    )
+
+    if dry_run:
+        return CommentsCreateResult(
+            created=False,
+            dry_run=True,
+            comment_ids=[],
+            payload_preview=payload,
+        )
+
+    client = get_client(ctx)
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/workitems/{encode_path_segment(work_item_id)}"
+        "/comments"
+    )
+    try:
+        response = await client.post(path, json=cast(dict[str, object], payload))
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot create work item comments -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Work item '{work_item_id}' (project '{project_id}') not found."
+            " Use `list_work_items` to discover valid IDs."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to create work item comments: {exc.message}"
+        ) from exc
+
+    raw_data = response.get("data", []) if isinstance(response, dict) else []
+    comment_ids: list[str] = []
+    if isinstance(raw_data, list):
+        for entry in raw_data:
+            if isinstance(entry, dict):
+                full_id = safe_str(entry.get("id", ""))
+                if full_id:
+                    comment_ids.append(extract_short_id(full_id))
+
+    if not comment_ids:
+        raise RuntimeError(
+            "Polarion returned no comment IDs after creation."
+            " The POST may have succeeded — verify with `list_work_item_comments`."
+        )
+
+    return CommentsCreateResult(
         created=True,
         dry_run=False,
         comment_ids=comment_ids,

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -54,7 +54,7 @@ def _build_comment_create_payload(
         attributes: dict[str, JsonValue] = {
             "text": {"type": spec.text_format, "value": spec.text},
         }
-        title = getattr(spec, "title", None)
+        title = spec.title if isinstance(spec, WorkItemCommentSpec) else None
         if title:
             attributes["title"] = title
         if spec.resolved is not None:

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import cast
 
 from fastmcp import Context
@@ -20,6 +21,7 @@ from mcp_server_polarion.models import (
     CommentUpdateResult,
     JsonValue,
     PaginatedResult,
+    WorkItemCommentSpec,
 )
 from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools._shared.helpers import (
@@ -38,22 +40,23 @@ logger = logging.getLogger("mcp_server_polarion.tools.comments")
 
 def _comment_create_payload(
     *,
-    specs: list[CommentSpec],
+    specs: Sequence[CommentSpec],
     comment_type: str,
     parent_prefix: str,
-    include_title: bool,
 ) -> dict[str, JsonValue]:
     """JSON:API POST body (``data`` list); ``None`` fields omitted, short
     ``parent_comment_id`` expanded to the full path the API requires. ``title``
-    only emitted when supported by the comment type.
+    emitted only when the spec carries one (WorkItemCommentSpec); base
+    CommentSpec has no title, so document comments never send it.
     """
     items: list[JsonValue] = []
     for spec in specs:
         attributes: dict[str, JsonValue] = {
             "text": {"type": spec.text_format, "value": spec.text},
         }
-        if include_title and spec.title is not None:
-            attributes["title"] = spec.title
+        title = getattr(spec, "title", None)
+        if title is not None:
+            attributes["title"] = title
         if spec.resolved is not None:
             attributes["resolved"] = spec.resolved
 
@@ -86,20 +89,17 @@ def _build_document_comments_payload(
     space_id: str,
     document_name: str,
 ) -> dict[str, JsonValue]:
-    """POST body for .../documents/{d}/comments; parent ids are 4-segment.
-    Document comments have no title, so ``title`` is dropped.
-    """
+    """POST body for .../documents/{d}/comments; parent ids are 4-segment."""
     return _comment_create_payload(
         specs=specs,
         comment_type="document_comments",
         parent_prefix=f"{project_id}/{space_id}/{document_name}",
-        include_title=False,
     )
 
 
 def _build_work_item_comments_payload(
     *,
-    specs: list[CommentSpec],
+    specs: list[WorkItemCommentSpec],
     project_id: str,
     work_item_id: str,
 ) -> dict[str, JsonValue]:
@@ -108,7 +108,6 @@ def _build_work_item_comments_payload(
         specs=specs,
         comment_type="workitem_comments",
         parent_prefix=f"{project_id}/{work_item_id}",
-        include_title=True,
     )
 
 
@@ -306,8 +305,7 @@ async def create_document_comments(  # noqa: PLR0913
 
     Reply: set parent_comment_id to a short ID from list_document_comments
     (None = top-level). 'text/html' text is sent unsanitized; omit author_id
-    for the token's user. title is ignored for documents. NOT idempotent — a
-    retry duplicates.
+    for the token's user. NOT idempotent — a retry duplicates.
     """
     payload = _build_document_comments_payload(
         specs=comments,
@@ -389,7 +387,7 @@ async def create_work_item_comments(
         min_length=1,
         description="Work item ID, e.g. 'MCPT-001'.",
     ),
-    comments: list[CommentSpec] = Field(  # noqa: B008
+    comments: list[WorkItemCommentSpec] = Field(  # noqa: B008
         min_length=1,
         description="Comments to create in one request.",
     ),

--- a/tests/mcp_server_polarion/models/test_comments.py
+++ b/tests/mcp_server_polarion/models/test_comments.py
@@ -10,6 +10,7 @@ from mcp_server_polarion.models import (
     CommentsCreateResult,
     CommentSpec,
     CommentUpdateResult,
+    WorkItemCommentSpec,
 )
 
 
@@ -39,17 +40,32 @@ class TestCommentSpec:
         spec = CommentSpec(text="hello")
         assert spec.text == "hello"
         assert spec.text_format == "text/plain"
-        assert spec.title is None
         assert spec.resolved is None
         assert spec.parent_comment_id is None
 
-    def test_title(self):
-        spec = CommentSpec(text="hello", title="Heads up")
-        assert spec.title == "Heads up"
+    def test_no_title_field(self):
+        """Base spec (document comments) has no title field at all."""
+        assert not hasattr(CommentSpec(text="hello"), "title")
 
     def test_empty_text_rejected(self):
         with pytest.raises(ValidationError):
             CommentSpec(text="")
+
+
+class TestWorkItemCommentSpec:
+    def test_inherits_base_fields(self):
+        spec = WorkItemCommentSpec(text="hello")
+        assert spec.text == "hello"
+        assert spec.text_format == "text/plain"
+        assert spec.title is None
+
+    def test_title(self):
+        spec = WorkItemCommentSpec(text="hello", title="Heads up")
+        assert spec.title == "Heads up"
+
+    def test_empty_text_rejected(self):
+        with pytest.raises(ValidationError):
+            WorkItemCommentSpec(text="")
 
 
 class TestCommentsCreateResult:

--- a/tests/mcp_server_polarion/models/test_comments.py
+++ b/tests/mcp_server_polarion/models/test_comments.py
@@ -7,9 +7,9 @@ from pydantic import ValidationError
 
 from mcp_server_polarion.models import (
     Comment,
+    CommentsCreateResult,
+    CommentSpec,
     CommentUpdateResult,
-    DocumentCommentsCreateResult,
-    DocumentCommentSpec,
 )
 
 
@@ -34,26 +34,31 @@ class TestComment:
         assert c.child_comment_ids == ["c3", "c4"]
 
 
-class TestDocumentCommentSpec:
+class TestCommentSpec:
     def test_minimal(self):
-        spec = DocumentCommentSpec(text="hello")
+        spec = CommentSpec(text="hello")
         assert spec.text == "hello"
         assert spec.text_format == "text/plain"
+        assert spec.title is None
         assert spec.resolved is None
         assert spec.parent_comment_id is None
 
+    def test_title(self):
+        spec = CommentSpec(text="hello", title="Heads up")
+        assert spec.title == "Heads up"
+
     def test_empty_text_rejected(self):
         with pytest.raises(ValidationError):
-            DocumentCommentSpec(text="")
+            CommentSpec(text="")
 
 
-class TestDocumentCommentsCreateResult:
+class TestCommentsCreateResult:
     def test_dry_run(self):
-        result = DocumentCommentsCreateResult(
+        result = CommentsCreateResult(
             created=False,
             dry_run=True,
             comment_ids=[],
-            payload_preview={"data": [{"type": "document_comments"}]},
+            payload_preview={"data": [{"type": "workitem_comments"}]},
         )
         assert result.dry_run is True
         assert result.comment_ids == []

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -51,6 +51,7 @@ _WRITE_TOOL_NAMES: frozenset[str] = frozenset(
         "create_document",
         "update_document",
         "create_document_comments",
+        "create_work_item_comments",
         "update_document_comment",
         "update_work_item_comment",
     }

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -16,15 +16,17 @@ from mcp_server_polarion.core.exceptions import (
 )
 from mcp_server_polarion.models import (
     Comment,
+    CommentSpec,
     CommentUpdateResult,
-    DocumentCommentSpec,
     PaginatedResult,
 )
 from mcp_server_polarion.tools.comments import (
     _build_document_comment_update_payload,
     _build_document_comments_payload,
     _build_work_item_comment_update_payload,
+    _build_work_item_comments_payload,
     create_document_comments,
+    create_work_item_comments,
     list_document_comments,
     list_work_item_comments,
     update_document_comment,
@@ -652,7 +654,7 @@ class TestBuildDocumentCommentsPayload:
 
     def test_single_plain_text_spec(self) -> None:
         payload = _build_document_comments_payload(
-            specs=[DocumentCommentSpec(text="hello")],
+            specs=[CommentSpec(text="hello")],
             project_id="Proj",
             space_id="Space",
             document_name="Doc",
@@ -672,8 +674,8 @@ class TestBuildDocumentCommentsPayload:
     def test_multiple_specs_produce_multiple_items(self) -> None:
         payload = _build_document_comments_payload(
             specs=[
-                DocumentCommentSpec(text="first"),
-                DocumentCommentSpec(text="second"),
+                CommentSpec(text="first"),
+                CommentSpec(text="second"),
             ],
             project_id="P",
             space_id="S",
@@ -683,7 +685,7 @@ class TestBuildDocumentCommentsPayload:
 
     def test_resolved_true_in_attributes(self) -> None:
         payload = _build_document_comments_payload(
-            specs=[DocumentCommentSpec(text="t", resolved=True)],
+            specs=[CommentSpec(text="t", resolved=True)],
             project_id="P",
             space_id="S",
             document_name="D",
@@ -694,7 +696,7 @@ class TestBuildDocumentCommentsPayload:
     def test_resolved_false_in_attributes(self) -> None:
         """Explicit False must be sent, not silently omitted like None."""
         payload = _build_document_comments_payload(
-            specs=[DocumentCommentSpec(text="t", resolved=False)],
+            specs=[CommentSpec(text="t", resolved=False)],
             project_id="P",
             space_id="S",
             document_name="D",
@@ -704,7 +706,7 @@ class TestBuildDocumentCommentsPayload:
 
     def test_resolved_none_omits_key(self) -> None:
         payload = _build_document_comments_payload(
-            specs=[DocumentCommentSpec(text="t", resolved=None)],
+            specs=[CommentSpec(text="t", resolved=None)],
             project_id="P",
             space_id="S",
             document_name="D",
@@ -714,7 +716,7 @@ class TestBuildDocumentCommentsPayload:
 
     def test_author_relationship(self) -> None:
         payload = _build_document_comments_payload(
-            specs=[DocumentCommentSpec(text="t", author_id="alice")],
+            specs=[CommentSpec(text="t", author_id="alice")],
             project_id="P",
             space_id="S",
             document_name="D",
@@ -728,7 +730,7 @@ class TestBuildDocumentCommentsPayload:
     def test_parent_comment_full_path_composed(self) -> None:
         """Short parent_comment_id is expanded to the full 4-segment path."""
         payload = _build_document_comments_payload(
-            specs=[DocumentCommentSpec(text="t", parent_comment_id="c1")],
+            specs=[CommentSpec(text="t", parent_comment_id="c1")],
             project_id="Proj",
             space_id="Space",
             document_name="Doc",
@@ -740,9 +742,7 @@ class TestBuildDocumentCommentsPayload:
 
     def test_both_relationships_present(self) -> None:
         payload = _build_document_comments_payload(
-            specs=[
-                DocumentCommentSpec(text="t", author_id="bob", parent_comment_id="c5")
-            ],
+            specs=[CommentSpec(text="t", author_id="bob", parent_comment_id="c5")],
             project_id="P",
             space_id="S",
             document_name="D",
@@ -755,7 +755,7 @@ class TestBuildDocumentCommentsPayload:
 
     def test_html_format_preserved(self) -> None:
         payload = _build_document_comments_payload(
-            specs=[DocumentCommentSpec(text="<b>bold</b>", text_format="text/html")],
+            specs=[CommentSpec(text="<b>bold</b>", text_format="text/html")],
             project_id="P",
             space_id="S",
             document_name="D",
@@ -765,13 +765,24 @@ class TestBuildDocumentCommentsPayload:
 
     def test_payload_wrapped_in_array(self) -> None:
         payload = _build_document_comments_payload(
-            specs=[DocumentCommentSpec(text="t")],
+            specs=[CommentSpec(text="t")],
             project_id="P",
             space_id="S",
             document_name="D",
         )
         assert isinstance(payload["data"], list)
         assert len(payload["data"]) == 1  # type: ignore[arg-type]
+
+    def test_title_dropped_for_documents(self) -> None:
+        """Document comments have no title — it must not reach attributes."""
+        payload = _build_document_comments_payload(
+            specs=[CommentSpec(text="t", title="ignored")],
+            project_id="P",
+            space_id="S",
+            document_name="D",
+        )
+        attrs = payload["data"][0]["attributes"]  # type: ignore[index]
+        assert "title" not in attrs  # type: ignore[operator]
 
 
 class TestCreateDocumentCommentsDryRun:
@@ -785,7 +796,7 @@ class TestCreateDocumentCommentsDryRun:
             project_id="P",
             space_id="S",
             document_name="D",
-            comments=[DocumentCommentSpec(text="hello")],
+            comments=[CommentSpec(text="hello")],
             dry_run=True,
         )
         mock_client.post.assert_not_called()
@@ -802,8 +813,8 @@ class TestCreateDocumentCommentsDryRun:
             space_id="S",
             document_name="D",
             comments=[
-                DocumentCommentSpec(text="first"),
-                DocumentCommentSpec(text="second"),
+                CommentSpec(text="first"),
+                CommentSpec(text="second"),
             ],
             dry_run=True,
         )
@@ -820,9 +831,7 @@ class TestCreateDocumentCommentsDryRun:
             space_id="S",
             document_name="D",
             comments=[
-                DocumentCommentSpec(
-                    text="reply", author_id="bob", parent_comment_id="c5"
-                )
+                CommentSpec(text="reply", author_id="bob", parent_comment_id="c5")
             ],
             dry_run=True,
         )
@@ -851,8 +860,8 @@ class TestCreateDocumentCommentsHappyPath:
             space_id="s",
             document_name="d",
             comments=[
-                DocumentCommentSpec(text="first"),
-                DocumentCommentSpec(text="second"),
+                CommentSpec(text="first"),
+                CommentSpec(text="second"),
             ],
             dry_run=False,
         )
@@ -872,7 +881,7 @@ class TestCreateDocumentCommentsHappyPath:
             project_id="Proj",
             space_id="_default",
             document_name="Doc",
-            comments=[DocumentCommentSpec(text="hello")],
+            comments=[CommentSpec(text="hello")],
             dry_run=False,
         )
         call_args = mock_client.post.call_args
@@ -890,7 +899,7 @@ class TestCreateDocumentCommentsHappyPath:
             project_id="P",
             space_id="My Space",
             document_name="My Doc",
-            comments=[DocumentCommentSpec(text="hi")],
+            comments=[CommentSpec(text="hi")],
             dry_run=False,
         )
         call_args = mock_client.post.call_args
@@ -912,8 +921,8 @@ class TestCreateDocumentCommentsHappyPath:
             space_id="S",
             document_name="D",
             comments=[
-                DocumentCommentSpec(text="one"),
-                DocumentCommentSpec(text="two"),
+                CommentSpec(text="one"),
+                CommentSpec(text="two"),
             ],
             dry_run=False,
         )
@@ -931,7 +940,7 @@ class TestCreateDocumentCommentsHappyPath:
             project_id="P",
             space_id="S",
             document_name="D",
-            comments=[DocumentCommentSpec(text="done", resolved=True)],
+            comments=[CommentSpec(text="done", resolved=True)],
             dry_run=False,
         )
         body = mock_client.post.call_args[1]["json"]
@@ -951,7 +960,7 @@ class TestCreateDocumentCommentsErrors:
                 project_id="P",
                 space_id="S",
                 document_name="D",
-                comments=[DocumentCommentSpec(text="hi")],
+                comments=[CommentSpec(text="hi")],
                 dry_run=False,
             )
 
@@ -967,7 +976,7 @@ class TestCreateDocumentCommentsErrors:
                 project_id="P",
                 space_id="S",
                 document_name="D",
-                comments=[DocumentCommentSpec(text="hi")],
+                comments=[CommentSpec(text="hi")],
                 dry_run=False,
             )
 
@@ -981,7 +990,7 @@ class TestCreateDocumentCommentsErrors:
                 project_id="P",
                 space_id="S",
                 document_name="D",
-                comments=[DocumentCommentSpec(text="hi")],
+                comments=[CommentSpec(text="hi")],
                 dry_run=False,
             )
 
@@ -996,13 +1005,13 @@ class TestCreateDocumentCommentsErrors:
                 project_id="P",
                 space_id="S",
                 document_name="D",
-                comments=[DocumentCommentSpec(text="hi")],
+                comments=[CommentSpec(text="hi")],
                 dry_run=False,
             )
 
 
 class TestCreateDocumentCommentsFieldValidation:
-    """Field constraints on create_document_comments / DocumentCommentSpec — direct
+    """Field constraints on create_document_comments / CommentSpec — direct
     calls bypass FastMCP's JSON Schema gate, so rebuild a ``TypeAdapter`` per
     parameter to prove the constraint is wired.
     """
@@ -1030,14 +1039,14 @@ class TestCreateDocumentCommentsFieldValidation:
 
     def test_spec_text_rejects_empty(self) -> None:
         with pytest.raises(ValidationError):
-            DocumentCommentSpec(text="")
+            CommentSpec(text="")
 
     def test_spec_text_accepts_non_empty(self) -> None:
-        spec = DocumentCommentSpec(text="hello")
+        spec = CommentSpec(text="hello")
         assert spec.text == "hello"
 
     def test_spec_default_text_format_is_plain(self) -> None:
-        spec = DocumentCommentSpec(text="hello")
+        spec = CommentSpec(text="hello")
         assert spec.text_format == "text/plain"
 
     def test_comments_rejects_empty_list(self) -> None:
@@ -1047,6 +1056,287 @@ class TestCreateDocumentCommentsFieldValidation:
     def test_comments_accepts_non_empty_list(self) -> None:
         specs = [{"text": "hello"}]
         result = self._adapter_for("comments").validate_python(specs)
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+
+class TestBuildWorkItemCommentsPayload:
+    """Unit tests for the private ``_build_work_item_comments_payload`` helper."""
+
+    def test_single_plain_text_spec(self) -> None:
+        payload = _build_work_item_comments_payload(
+            specs=[CommentSpec(text="hello")],
+            project_id="Proj",
+            work_item_id="MCPT-1",
+        )
+        data = payload["data"]
+        assert isinstance(data, list)
+        assert len(data) == 1
+        item = data[0]
+        assert isinstance(item, dict)
+        assert item["type"] == "workitem_comments"
+        attrs = item["attributes"]
+        assert isinstance(attrs, dict)
+        assert attrs["text"] == {"type": "text/plain", "value": "hello"}
+        assert "title" not in attrs
+        assert "resolved" not in attrs
+        assert "relationships" not in item
+
+    def test_title_in_attributes(self) -> None:
+        payload = _build_work_item_comments_payload(
+            specs=[CommentSpec(text="t", title="Heads up")],
+            project_id="P",
+            work_item_id="MCPT-1",
+        )
+        attrs = payload["data"][0]["attributes"]  # type: ignore[index]
+        assert attrs["title"] == "Heads up"  # type: ignore[index]
+
+    def test_resolved_false_in_attributes(self) -> None:
+        """Explicit False must be sent, not silently omitted like None."""
+        payload = _build_work_item_comments_payload(
+            specs=[CommentSpec(text="t", resolved=False)],
+            project_id="P",
+            work_item_id="MCPT-1",
+        )
+        attrs = payload["data"][0]["attributes"]  # type: ignore[index]
+        assert attrs["resolved"] is False  # type: ignore[index]
+
+    def test_resolved_none_omits_key(self) -> None:
+        payload = _build_work_item_comments_payload(
+            specs=[CommentSpec(text="t", resolved=None)],
+            project_id="P",
+            work_item_id="MCPT-1",
+        )
+        attrs = payload["data"][0]["attributes"]  # type: ignore[index]
+        assert "resolved" not in attrs  # type: ignore[operator]
+
+    def test_author_relationship(self) -> None:
+        payload = _build_work_item_comments_payload(
+            specs=[CommentSpec(text="t", author_id="alice")],
+            project_id="P",
+            work_item_id="MCPT-1",
+        )
+        item = payload["data"][0]  # type: ignore[index]
+        assert isinstance(item, dict)
+        assert item["relationships"]["author"] == {  # type: ignore[index]
+            "data": {"id": "alice", "type": "users"}
+        }
+
+    def test_parent_comment_full_path_composed(self) -> None:
+        """Short parent_comment_id is expanded to the full 3-segment path."""
+        payload = _build_work_item_comments_payload(
+            specs=[CommentSpec(text="t", parent_comment_id="c1")],
+            project_id="Proj",
+            work_item_id="MCPT-1",
+        )
+        item = payload["data"][0]  # type: ignore[index]
+        assert isinstance(item, dict)
+        rel = item["relationships"]["parentComment"]  # type: ignore[index]
+        assert rel == {"data": {"id": "Proj/MCPT-1/c1", "type": "workitem_comments"}}
+
+    def test_multiple_specs_produce_multiple_items(self) -> None:
+        payload = _build_work_item_comments_payload(
+            specs=[CommentSpec(text="first"), CommentSpec(text="second")],
+            project_id="P",
+            work_item_id="MCPT-1",
+        )
+        assert len(payload["data"]) == 2  # type: ignore[arg-type]
+
+
+class TestCreateWorkItemCommentsDryRun:
+    """Verify dry_run returns preview without calling Polarion."""
+
+    async def test_dry_run_no_post_call(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_work_item_comments(
+            mock_ctx,
+            project_id="P",
+            work_item_id="MCPT-1",
+            comments=[CommentSpec(text="hello")],
+            dry_run=True,
+        )
+        mock_client.post.assert_not_called()
+        assert result.dry_run is True
+        assert result.created is False
+        assert result.comment_ids == []
+
+    async def test_dry_run_payload_preview_populated(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_work_item_comments(
+            mock_ctx,
+            project_id="P",
+            work_item_id="MCPT-1",
+            comments=[CommentSpec(text="first", title="T"), CommentSpec(text="second")],
+            dry_run=True,
+        )
+        assert result.payload_preview is not None
+        assert isinstance(result.payload_preview["data"], list)
+        assert len(result.payload_preview["data"]) == 2  # type: ignore[arg-type]
+
+
+class TestCreateWorkItemCommentsHappyPath:
+    """Verify successful creation extracts and returns short comment IDs."""
+
+    async def test_returns_short_comment_ids(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [
+                {"type": "workitem_comments", "id": "p/MCPT-1/c42"},
+                {"type": "workitem_comments", "id": "p/MCPT-1/c43"},
+            ]
+        }
+        result = await create_work_item_comments(
+            mock_ctx,
+            project_id="p",
+            work_item_id="MCPT-1",
+            comments=[CommentSpec(text="first"), CommentSpec(text="second")],
+            dry_run=False,
+        )
+        assert result.created is True
+        assert result.dry_run is False
+        assert result.comment_ids == ["c42", "c43"]
+        assert result.payload_preview is None
+
+    async def test_post_called_with_correct_path(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "workitem_comments", "id": "Proj/MCPT-1/c1"}]
+        }
+        await create_work_item_comments(
+            mock_ctx,
+            project_id="Proj",
+            work_item_id="MCPT-1",
+            comments=[CommentSpec(text="hello")],
+            dry_run=False,
+        )
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "/projects/Proj/workitems/MCPT-1/comments"
+
+    async def test_path_url_encodes_special_chars(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "workitem_comments", "id": "P/MY%20WI/c1"}]
+        }
+        await create_work_item_comments(
+            mock_ctx,
+            project_id="P",
+            work_item_id="MY WI",
+            comments=[CommentSpec(text="hi")],
+            dry_run=False,
+        )
+        assert "MY%20WI" in mock_client.post.call_args[0][0]
+
+    async def test_title_sent_in_payload(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "workitem_comments", "id": "P/MCPT-1/c1"}]
+        }
+        await create_work_item_comments(
+            mock_ctx,
+            project_id="P",
+            work_item_id="MCPT-1",
+            comments=[CommentSpec(text="t", title="Heads up")],
+            dry_run=False,
+        )
+        body = mock_client.post.call_args[1]["json"]
+        assert body["data"][0]["attributes"]["title"] == "Heads up"
+
+
+class TestCreateWorkItemCommentsErrors:
+    """Verify domain exceptions map to the correct public exceptions."""
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionAuthError("auth", status_code=401)
+        with pytest.raises(PermissionError, match="POLARION_TOKEN"):
+            await create_work_item_comments(
+                mock_ctx,
+                project_id="P",
+                work_item_id="MCPT-1",
+                comments=[CommentSpec(text="hi")],
+                dry_run=False,
+            )
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionNotFoundError(
+            "not found", status_code=404
+        )
+        with pytest.raises(ValueError, match="list_work_items"):
+            await create_work_item_comments(
+                mock_ctx,
+                project_id="P",
+                work_item_id="MCPT-1",
+                comments=[CommentSpec(text="hi")],
+                dry_run=False,
+            )
+
+    async def test_other_polarion_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionError("boom", status_code=500)
+        with pytest.raises(RuntimeError, match="boom"):
+            await create_work_item_comments(
+                mock_ctx,
+                project_id="P",
+                work_item_id="MCPT-1",
+                comments=[CommentSpec(text="hi")],
+                dry_run=False,
+            )
+
+    async def test_empty_response_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """201 with no IDs must raise rather than silently return created=True."""
+        mock_client.post.return_value = {}
+        with pytest.raises(RuntimeError, match="no comment IDs"):
+            await create_work_item_comments(
+                mock_ctx,
+                project_id="P",
+                work_item_id="MCPT-1",
+                comments=[CommentSpec(text="hi")],
+                dry_run=False,
+            )
+
+
+class TestCreateWorkItemCommentsFieldValidation:
+    """Field constraints on create_work_item_comments — direct calls bypass
+    FastMCP's JSON Schema gate, so rebuild a ``TypeAdapter`` per parameter to
+    prove the constraint is wired.
+    """
+
+    @staticmethod
+    def _adapter_for(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(create_work_item_comments)
+        sig = inspect.signature(create_work_item_comments)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_project_id_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("project_id").validate_python("")
+
+    def test_work_item_id_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("work_item_id").validate_python("")
+
+    def test_work_item_id_accepts_non_empty(self) -> None:
+        assert self._adapter_for("work_item_id").validate_python("MCPT-1") == "MCPT-1"
+
+    def test_comments_rejects_empty_list(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter_for("comments").validate_python([])
+
+    def test_comments_accepts_non_empty_list(self) -> None:
+        result = self._adapter_for("comments").validate_python([{"text": "hello"}])
         assert isinstance(result, list)
         assert len(result) == 1
 

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -19,6 +19,7 @@ from mcp_server_polarion.models import (
     CommentSpec,
     CommentUpdateResult,
     PaginatedResult,
+    WorkItemCommentSpec,
 )
 from mcp_server_polarion.tools.comments import (
     _build_document_comment_update_payload,
@@ -773,10 +774,12 @@ class TestBuildDocumentCommentsPayload:
         assert isinstance(payload["data"], list)
         assert len(payload["data"]) == 1  # type: ignore[arg-type]
 
-    def test_title_dropped_for_documents(self) -> None:
-        """Document comments have no title — it must not reach attributes."""
+    def test_no_title_for_documents(self) -> None:
+        """Base CommentSpec has no title field, so it never reaches attributes."""
+        spec = CommentSpec(text="t")
+        assert not hasattr(spec, "title")
         payload = _build_document_comments_payload(
-            specs=[CommentSpec(text="t", title="ignored")],
+            specs=[spec],
             project_id="P",
             space_id="S",
             document_name="D",
@@ -1065,7 +1068,7 @@ class TestBuildWorkItemCommentsPayload:
 
     def test_single_plain_text_spec(self) -> None:
         payload = _build_work_item_comments_payload(
-            specs=[CommentSpec(text="hello")],
+            specs=[WorkItemCommentSpec(text="hello")],
             project_id="Proj",
             work_item_id="MCPT-1",
         )
@@ -1084,7 +1087,7 @@ class TestBuildWorkItemCommentsPayload:
 
     def test_title_in_attributes(self) -> None:
         payload = _build_work_item_comments_payload(
-            specs=[CommentSpec(text="t", title="Heads up")],
+            specs=[WorkItemCommentSpec(text="t", title="Heads up")],
             project_id="P",
             work_item_id="MCPT-1",
         )
@@ -1094,7 +1097,7 @@ class TestBuildWorkItemCommentsPayload:
     def test_resolved_false_in_attributes(self) -> None:
         """Explicit False must be sent, not silently omitted like None."""
         payload = _build_work_item_comments_payload(
-            specs=[CommentSpec(text="t", resolved=False)],
+            specs=[WorkItemCommentSpec(text="t", resolved=False)],
             project_id="P",
             work_item_id="MCPT-1",
         )
@@ -1103,7 +1106,7 @@ class TestBuildWorkItemCommentsPayload:
 
     def test_resolved_none_omits_key(self) -> None:
         payload = _build_work_item_comments_payload(
-            specs=[CommentSpec(text="t", resolved=None)],
+            specs=[WorkItemCommentSpec(text="t", resolved=None)],
             project_id="P",
             work_item_id="MCPT-1",
         )
@@ -1112,7 +1115,7 @@ class TestBuildWorkItemCommentsPayload:
 
     def test_author_relationship(self) -> None:
         payload = _build_work_item_comments_payload(
-            specs=[CommentSpec(text="t", author_id="alice")],
+            specs=[WorkItemCommentSpec(text="t", author_id="alice")],
             project_id="P",
             work_item_id="MCPT-1",
         )
@@ -1125,7 +1128,7 @@ class TestBuildWorkItemCommentsPayload:
     def test_parent_comment_full_path_composed(self) -> None:
         """Short parent_comment_id is expanded to the full 3-segment path."""
         payload = _build_work_item_comments_payload(
-            specs=[CommentSpec(text="t", parent_comment_id="c1")],
+            specs=[WorkItemCommentSpec(text="t", parent_comment_id="c1")],
             project_id="Proj",
             work_item_id="MCPT-1",
         )
@@ -1136,7 +1139,10 @@ class TestBuildWorkItemCommentsPayload:
 
     def test_multiple_specs_produce_multiple_items(self) -> None:
         payload = _build_work_item_comments_payload(
-            specs=[CommentSpec(text="first"), CommentSpec(text="second")],
+            specs=[
+                WorkItemCommentSpec(text="first"),
+                WorkItemCommentSpec(text="second"),
+            ],
             project_id="P",
             work_item_id="MCPT-1",
         )
@@ -1153,7 +1159,7 @@ class TestCreateWorkItemCommentsDryRun:
             mock_ctx,
             project_id="P",
             work_item_id="MCPT-1",
-            comments=[CommentSpec(text="hello")],
+            comments=[WorkItemCommentSpec(text="hello")],
             dry_run=True,
         )
         mock_client.post.assert_not_called()
@@ -1168,7 +1174,10 @@ class TestCreateWorkItemCommentsDryRun:
             mock_ctx,
             project_id="P",
             work_item_id="MCPT-1",
-            comments=[CommentSpec(text="first", title="T"), CommentSpec(text="second")],
+            comments=[
+                WorkItemCommentSpec(text="first", title="T"),
+                WorkItemCommentSpec(text="second"),
+            ],
             dry_run=True,
         )
         assert result.payload_preview is not None
@@ -1192,7 +1201,10 @@ class TestCreateWorkItemCommentsHappyPath:
             mock_ctx,
             project_id="p",
             work_item_id="MCPT-1",
-            comments=[CommentSpec(text="first"), CommentSpec(text="second")],
+            comments=[
+                WorkItemCommentSpec(text="first"),
+                WorkItemCommentSpec(text="second"),
+            ],
             dry_run=False,
         )
         assert result.created is True
@@ -1210,7 +1222,7 @@ class TestCreateWorkItemCommentsHappyPath:
             mock_ctx,
             project_id="Proj",
             work_item_id="MCPT-1",
-            comments=[CommentSpec(text="hello")],
+            comments=[WorkItemCommentSpec(text="hello")],
             dry_run=False,
         )
         call_args = mock_client.post.call_args
@@ -1226,7 +1238,7 @@ class TestCreateWorkItemCommentsHappyPath:
             mock_ctx,
             project_id="P",
             work_item_id="MY WI",
-            comments=[CommentSpec(text="hi")],
+            comments=[WorkItemCommentSpec(text="hi")],
             dry_run=False,
         )
         assert "MY%20WI" in mock_client.post.call_args[0][0]
@@ -1241,7 +1253,7 @@ class TestCreateWorkItemCommentsHappyPath:
             mock_ctx,
             project_id="P",
             work_item_id="MCPT-1",
-            comments=[CommentSpec(text="t", title="Heads up")],
+            comments=[WorkItemCommentSpec(text="t", title="Heads up")],
             dry_run=False,
         )
         body = mock_client.post.call_args[1]["json"]
@@ -1260,7 +1272,7 @@ class TestCreateWorkItemCommentsErrors:
                 mock_ctx,
                 project_id="P",
                 work_item_id="MCPT-1",
-                comments=[CommentSpec(text="hi")],
+                comments=[WorkItemCommentSpec(text="hi")],
                 dry_run=False,
             )
 
@@ -1275,7 +1287,7 @@ class TestCreateWorkItemCommentsErrors:
                 mock_ctx,
                 project_id="P",
                 work_item_id="MCPT-1",
-                comments=[CommentSpec(text="hi")],
+                comments=[WorkItemCommentSpec(text="hi")],
                 dry_run=False,
             )
 
@@ -1288,7 +1300,7 @@ class TestCreateWorkItemCommentsErrors:
                 mock_ctx,
                 project_id="P",
                 work_item_id="MCPT-1",
-                comments=[CommentSpec(text="hi")],
+                comments=[WorkItemCommentSpec(text="hi")],
                 dry_run=False,
             )
 
@@ -1302,7 +1314,7 @@ class TestCreateWorkItemCommentsErrors:
                 mock_ctx,
                 project_id="P",
                 work_item_id="MCPT-1",
-                comments=[CommentSpec(text="hi")],
+                comments=[WorkItemCommentSpec(text="hi")],
                 dry_run=False,
             )
 

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -1094,6 +1094,16 @@ class TestBuildWorkItemCommentsPayload:
         attrs = payload["data"][0]["attributes"]  # type: ignore[index]
         assert attrs["title"] == "Heads up"  # type: ignore[index]
 
+    def test_empty_title_omitted(self) -> None:
+        """Empty title is dropped, not sent as a blank heading."""
+        payload = _build_work_item_comments_payload(
+            specs=[WorkItemCommentSpec(text="t", title="")],
+            project_id="P",
+            work_item_id="MCPT-1",
+        )
+        attrs = payload["data"][0]["attributes"]  # type: ignore[index]
+        assert "title" not in attrs  # type: ignore[operator]
+
     def test_resolved_false_in_attributes(self) -> None:
         """Explicit False must be sent, not silently omitted like None."""
         payload = _build_work_item_comments_payload(

--- a/tests/mcp_server_polarion/tools/test_tool_annotations.py
+++ b/tests/mcp_server_polarion/tools/test_tool_annotations.py
@@ -88,6 +88,15 @@ class TestWriteToolAnnotations:
                 },
             ),
             (
+                "create_work_item_comments",
+                {
+                    "readOnlyHint": False,
+                    "destructiveHint": False,
+                    "idempotentHint": False,
+                    "openWorldHint": True,
+                },
+            ),
+            (
                 "update_document_comment",
                 {
                     "readOnlyHint": False,


### PR DESCRIPTION
## Summary

Adds `create_work_item_comments` -- post one or more comments (or threaded replies) to a Polarion work item via `POST /projects/{projectId}/workitems/{workItemId}/comments`. Mirrors `create_document_comments`.

Comment-create input is unified on a shared `CommentSpec` (+ `CommentsCreateResult`), following the shared `CommentUpdateResult` pattern from #115. A `WorkItemCommentSpec` subclass adds an optional `title`; the base `CommentSpec` (document create) has no `title` field, so document comments never send one.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- work item comments were read/resolve-only; no MCP path to post new comments or replies
- add the tool; unify create input on shared CommentSpec + CommentsCreateResult; title honored only for work items

## Testing

- CI gate green locally: `ruff check` + `ruff format --check` + `mypy src/` + `pytest` (1292 passed)
- New unit tests: work item payload builder (type `workitem_comments`, 3-segment parent, title in attrs), dry_run, happy path, error mapping, field validation; plus a doc-builder `title`-dropped case
- Live Polarion (testdrive `MCP_Test_Project/Design/Software Requirement Specification`): created a document comment with a stray `title` set -- Polarion returned 201, title silently dropped, comment created (verified via `list_document_comments`)

## Notes for Reviewers

- `DocumentCommentSpec`/`DocumentCommentsCreateResult` renamed to shared `CommentSpec`/`CommentsCreateResult` -- touches existing document comment code + tests
- No `MAX_BULK_ITEMS` cap on comment creation (matches `create_document_comments`)
