### PR TITLE
refactor(meta): rename eval evaluator to dispatch

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -40,7 +40,7 @@ to the real provider while **no request ever reaches a real Polarion**. Every
 mutating request is recorded but has no effect.
 
 The agent's tool calls are captured by `TrajectoryRecorder`; the
-`ForbiddenBehaviorEvaluator` dispatches on `Case.metadata["check"]` to a pure
+`CheckDispatchEvaluator` dispatches on `Case.metadata["check"]` to a pure
 check in [`evaluators/checks.py`](evaluators/checks.py) plus cross-cutting global
 checks (e.g. every `update_document` body block must carry a non-empty `id`).
 

--- a/evals/evaluators/__init__.py
+++ b/evals/evaluators/__init__.py
@@ -1,1 +1,1 @@
-"""Deterministic Tier-1 evaluators."""
+"""Deterministic check dispatch + pure trajectory checks."""

--- a/evals/evaluators/dispatch.py
+++ b/evals/evaluators/dispatch.py
@@ -1,5 +1,6 @@
-"""Tier-1 evaluator: dispatches on ``Case.metadata["check"]`` to the matching
-pure check in ``checks.py``.
+"""Generic check dispatcher: routes ``Case.metadata["check"]`` to the matching
+pure check in ``checks.py``. One evaluator serves every category — categories
+are a property of cases, not evaluators.
 """
 
 from __future__ import annotations
@@ -12,8 +13,8 @@ from strands_evals.types.evaluation import EvaluationData, EvaluationOutput
 from . import checks
 
 
-class ForbiddenBehaviorEvaluator(Evaluator[Any, Any]):
-    """Deterministic gate: 1.0 if no forbidden action was taken, else 0.0."""
+class CheckDispatchEvaluator(Evaluator[Any, Any]):
+    """Deterministic gate: 1.0 if the case's check passes, else 0.0."""
 
     def evaluate(
         self, evaluation_case: EvaluationData[Any, Any]
@@ -24,7 +25,7 @@ class ForbiddenBehaviorEvaluator(Evaluator[Any, Any]):
 
         trajectory = evaluation_case.actual_trajectory
         if not isinstance(trajectory, list) or not trajectory:
-            # Empty trajectory = agent never engaged; "no forbidden action" is
+            # Empty trajectory = agent never engaged; a "passing" verdict would be
             # vacuous, so fail closed.
             return [
                 EvaluationOutput(
@@ -58,7 +59,7 @@ class ForbiddenBehaviorEvaluator(Evaluator[Any, Any]):
             EvaluationOutput(
                 score=1.0,
                 test_pass=True,
-                reason="no forbidden action observed",
+                reason=f"check '{check_name}' passed",
                 label=check_name,
             )
         ]

--- a/evals/run.py
+++ b/evals/run.py
@@ -28,7 +28,7 @@ from strands_evals.types.evaluation import EvaluationData
 from evals.cases.tier1_prohibitions import CASES as TIER1_CASES
 from evals.cases.tier2_efficiency import CASES as TIER2_CASES
 from evals.cases.tier3_orchestration import CASES as TIER3_CASES
-from evals.evaluators.tier1 import ForbiddenBehaviorEvaluator
+from evals.evaluators.dispatch import CheckDispatchEvaluator
 from evals.harness.model import resolve_model_id
 from evals.harness.runner import AGENT_ERROR_PREFIX, run_case
 
@@ -61,9 +61,7 @@ def _git_sha() -> str:
         return "unknown"
 
 
-def _evaluate_once(
-    case: Case, evaluator: ForbiddenBehaviorEvaluator
-) -> tuple[bool, str]:
+def _evaluate_once(case: Case, evaluator: CheckDispatchEvaluator) -> tuple[bool, str]:
     task_output = run_case(case)
     output = task_output.get("output")
     if isinstance(output, str) and output.startswith(AGENT_ERROR_PREFIX):
@@ -81,7 +79,7 @@ def _evaluate_once(
 
 
 def _run_case_n_times(
-    case: Case, runs: int, evaluator: ForbiddenBehaviorEvaluator
+    case: Case, runs: int, evaluator: CheckDispatchEvaluator
 ) -> dict[str, Any]:
     min_rate = float((case.metadata or {}).get("min_pass_rate", 1.0))
     passes = 0
@@ -129,7 +127,7 @@ def main() -> int:
             print(f"no case named '{args.case}'", file=sys.stderr)
             return 2
 
-    evaluator = ForbiddenBehaviorEvaluator()
+    evaluator = CheckDispatchEvaluator()
     model = resolve_model_id()
     print(
         f"Eval gate · tier={args.tier} · model={model} · "

--- a/tests/evals/evaluators/test_dispatch.py
+++ b/tests/evals/evaluators/test_dispatch.py
@@ -1,4 +1,4 @@
-"""``ForbiddenBehaviorEvaluator`` tests: metadata dispatch, fail-closed on
+"""``CheckDispatchEvaluator`` tests: metadata dispatch, fail-closed on
 empty/non-list trajectory, delegation to the named check. No LLM, no I/O.
 """
 
@@ -12,7 +12,7 @@ pytest.importorskip("strands_evals")
 
 from strands_evals.types.evaluation import EvaluationData
 
-from evals.evaluators.tier1 import ForbiddenBehaviorEvaluator
+from evals.evaluators.dispatch import CheckDispatchEvaluator
 
 
 def _call(name: str, args: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -39,42 +39,42 @@ def _data(
     )
 
 
-class TestForbiddenBehaviorEvaluator:
+class TestCheckDispatchEvaluator:
     def test_empty_trajectory_fails_closed(self) -> None:
-        result = ForbiddenBehaviorEvaluator().evaluate(_data([]))[0]
+        result = CheckDispatchEvaluator().evaluate(_data([]))[0]
         assert result.test_pass is False
         assert result.score == 0.0
         assert "no tool-call trajectory" in (result.reason or "")
 
     def test_unknown_check_fails_closed(self) -> None:
         data = _data([_call("get_document")], check="does_not_exist")
-        result = ForbiddenBehaviorEvaluator().evaluate(data)[0]
+        result = CheckDispatchEvaluator().evaluate(data)[0]
         assert result.test_pass is False
         assert "does_not_exist" in (result.reason or "")
 
     def test_missing_check_name_fails_closed(self) -> None:
         data = _data([_call("get_document")], check=None)
-        result = ForbiddenBehaviorEvaluator().evaluate(data)[0]
+        result = CheckDispatchEvaluator().evaluate(data)[0]
         assert result.test_pass is False
 
     def test_registered_check_passing_scores_one(self) -> None:
         data = _data([_call("get_document")], check="readonly")
-        result = ForbiddenBehaviorEvaluator().evaluate(data)[0]
+        result = CheckDispatchEvaluator().evaluate(data)[0]
         assert result.test_pass is True
         assert result.score == 1.0
         assert result.label == "readonly"
 
     def test_registered_check_failing_scores_zero_with_reason(self) -> None:
         data = _data([_call("create_work_items")], check="readonly")
-        result = ForbiddenBehaviorEvaluator().evaluate(data)[0]
+        result = CheckDispatchEvaluator().evaluate(data)[0]
         assert result.test_pass is False
         assert result.score == 0.0
         assert "create_work_items" in (result.reason or "")
 
     async def test_evaluate_async_delegates(self) -> None:
         data = _data([_call("get_document")], check="readonly")
-        sync = ForbiddenBehaviorEvaluator().evaluate(data)[0]
-        asy = (await ForbiddenBehaviorEvaluator().evaluate_async(data))[0]
+        sync = CheckDispatchEvaluator().evaluate(data)[0]
+        asy = (await CheckDispatchEvaluator().evaluate_async(data))[0]
         assert (asy.test_pass, asy.score, asy.label) == (
             sync.test_pass,
             sync.score,


### PR DESCRIPTION
## Summary

Rename the single eval evaluator so its name no longer implies per-tier evaluators. A reviewer asked "why only `evaluators/tier1.py`, where are tier2/tier3?" — the answer is that one generic evaluator dispatches `Case.metadata["check"]` to a pure check and serves every tier; the `tier1` name was misleading. Pure rename, no behaviour change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- one evaluator serves every tier; the `tier1` name implied per-tier evaluators that never existed
- rename `evaluators/tier1.py`->`dispatch.py` and `ForbiddenBehaviorEvaluator`->`CheckDispatchEvaluator`

## Testing

`ruff check` / `ruff format --check` / `mypy src/` clean; `pytest tests/evals tests/mcp_server_polarion/test_mcp_transport.py` green (227 passed).

## Notes for Reviewers

First of a 3-PR stack: rename (this) -> case restructure -> NL triggers + coverage gate. Base = `main`.
