### PR TITLE
test(meta): harden eval gate soundness/coverage

### DIFF
--- a/evals/cases/efficiency.py
+++ b/evals/cases/efficiency.py
@@ -1,9 +1,8 @@
 """Efficiency cases: the correct answer must be reached without waste.
 
-The behaviour under test is economy — the short, correct path (one bulk call,
-direct lookup by known id, no redundant identical reads, the right query
-mechanism). ``min_pass_rate = 0.8``: occasional waste tolerated, systematic
-waste blocks.
+The short path: one bulk call, direct id lookup, no redundant reads, right
+query mechanism. ``min_pass_rate = 0.8`` — occasional waste tolerated,
+systematic waste blocks.
 """
 
 from __future__ import annotations
@@ -67,8 +66,8 @@ CASES: list[Case] = [
         "Create two tasks: 'Fake delta' with severity must_have and "
         "'Fake epsilon' with severity nice_to_have.",
         "no_duplicate_reads",
-        intent="Stable enum options are fetched once; re-fetching the same "
-        "options fails.",
+        intent="If enum options are fetched, they are fetched once; re-fetching "
+        "identical options fails.",
         covers=["list_work_item_enum_options", "create_work_items"],
     ),
     _case(
@@ -77,8 +76,9 @@ CASES: list[Case] = [
         f"in space '{SPACE}'.",
         "scoped_query_uses_sql",
         intent="Document scoping uses SQL:(...) or read_document_parts; a Lucene "
-        "module term fails.",
-        covers=["list_work_items"],
+        "module term fails. A SQL query must be recipe-sourced (get_sql_query_recipes "
+        "first).",
+        covers=["list_work_items", "get_sql_query_recipes"],
     ),
     _case(
         "EFF-DETACH-NOOP",

--- a/evals/cases/orchestration.py
+++ b/evals/cases/orchestration.py
@@ -1,16 +1,13 @@
 """Orchestration cases: a multi-step task must walk the correct ordered tool
 sequence and thread ids between steps.
 
-Each case asserts an ordered tool subsequence (other calls may interleave) plus
-id threading via the single ``ordered_trajectory`` check; the sequence lives in
-``metadata["params"]["steps"]``. ``min_pass_rate = 0.8`` — ordered + observed-id
-is flaky on weak models, so occasional waste is tolerated, systematic
-mis-orchestration fails.
+``ordered_trajectory`` asserts an ordered tool subsequence (interleaving OK) plus
+id threading; the sequence lives in ``metadata["params"]["steps"]``.
+``min_pass_rate = 0.8`` — ordered + observed-id is flaky on weak models.
 
-Groups: W = document authoring (write), R = traceability/analysis (read-only),
-M = read-then-write (gated). Design principle: enumerating a document's work
-items uses ``list_work_items`` (SQL), never ``read_document_parts`` — the latter
-appears only to fetch a part-id anchor for a positional move.
+Groups: W = authoring (write), R = traceability (read-only), M = read-then-write
+(gated). Enumerating a doc's work items uses ``list_work_items`` (SQL), never
+``read_document_parts`` — the latter only fetches a part-id anchor for a move.
 """
 
 from __future__ import annotations
@@ -26,9 +23,8 @@ from evals.harness.fixtures import (
 
 MIN_PASS_RATE = 0.8
 
-# Reused step fragments. The move must run after the create (needs the new id)
-# and after read_document_parts (the anchor) -- the latter is enforced by the
-# observed-id source, the former by ``after``.
+# Reused step fragments. Move runs after create (new id, via ``after``) and
+# after read_document_parts (anchor, via observed-id source).
 _READ_PARTS = {"tool": "read_document_parts", "match": {"document_name": DOC}}
 _MOVE_ANCHORED = {
     "tool": "move_work_item_to_document",
@@ -67,7 +63,7 @@ def _case(name: str, prompt: str, *, intent: str, **params: object) -> Case:
 
 
 CASES: list[Case] = [
-    # --- W: document authoring ----------------------------------------------
+    # W: document authoring
     _case(
         "ORCH-SPEC-INTO-DOC",
         f"In the document '{DOC}' in space '{SPACE}', add a new requirement work "
@@ -86,9 +82,7 @@ CASES: list[Case] = [
         f"In the document '{DOC}' in space '{SPACE}', first add a new 'Performance' "
         f"section heading with a one-sentence intro. Then add a requirement work "
         f"item titled 'p95 latency under 200ms' into the document under that heading.",
-        # Crux is the split: prose/heading via update_document, the spec via
-        # create + move (not everything through one tool). No anchored move --
-        # the fresh heading isn't in the static fake parts.
+        # No anchored move -- the fresh heading isn't in the static fake parts.
         intent="Prose/heading via update_document, spec via create + move — the "
         "two write paths must not collapse into one tool.",
         steps=[
@@ -133,15 +127,14 @@ CASES: list[Case] = [
             },
         ],
     ),
-    # --- R: traceability / analysis (read-only) -----------------------------
+    # R: traceability / analysis (read-only)
     _case(
         "ORCH-CONSISTENCY",
         f"Check the consistency between the document '{DOC}' in space '{SPACE}' and "
         f"its parent document: for a requirement in '{DOC}' that links to a parent "
         f"requirement, compare their contents.",
-        # Enumerate the doc's reqs, follow a link, read the linked parent's
-        # content. Enumeration and the target read each accept the equivalent
-        # tools the model picks; "SQL vs read_document_parts" is owned by efficiency.
+        # Enumeration and target read accept equivalent tools; SQL-vs-parts
+        # choice is owned by efficiency.
         intent="Enumerate doc reqs -> follow a link -> read the linked parent "
         "(target id observed from the link); read-only.",
         steps=[
@@ -160,8 +153,8 @@ CASES: list[Case] = [
         "ORCH-IMPACT-ANALYSIS",
         f"For each work item linked to {CHILD_REQ_ID}, give a short summary of its "
         f"description.",
-        # The link summary already carries title/type/status, so a description
-        # summary forces a follow-up read of each linked target.
+        # Link summary carries title/type/status, so a description summary forces
+        # a follow-up read of each target.
         intent="List links from a known req -> read each linked target (ids "
         "observed from the link list); read-only.",
         steps=[
@@ -182,8 +175,7 @@ CASES: list[Case] = [
         "ORCH-COVERAGE-GAP",
         f"Which requirements in the document '{DOC}' in space '{SPACE}' have no "
         f"linked test case?",
-        # Enumerate the doc's reqs, then inspect each one's links. Enumeration
-        # accepts the equivalent tools the model picks.
+        # Enumeration accepts the equivalent tools the model picks.
         intent="Enumerate doc reqs -> inspect each req's links; read-only.",
         steps=[
             {"tool": ["list_work_items", "read_document_parts"]},
@@ -191,11 +183,32 @@ CASES: list[Case] = [
         ],
         read_only=True,
     ),
-    # --- M: read -> decide -> write (gated) ---------------------------------
+    _case(
+        "ORCH-DOC-COMMENT-DISCOVERY",
+        "I don't remember the exact name of our requirements specification "
+        "document in this project -- list all comments on it.",
+        # Only the one spec doc is surfaced by the heading-scan; no project step
+        # (project id is ambient).
+        intent="Discover the spec doc via list_documents -> read its comments "
+        "(document_name observed from the listing); read-only.",
+        steps=[
+            {"tool": "list_documents"},
+            {
+                "tool": "list_document_comments",
+                "observed_arg": "document_name",
+                "observed_in": "list_documents",
+                "observed_path": "items[].document_name",
+            },
+        ],
+        read_only=True,
+    ),
+    # M: read -> decide -> write (gated)
     _case(
         "ORCH-CONDITIONAL-UPDATE",
         f"If work item {FLOATING_TASK_ID} is still open, raise its priority by one "
         f"level.",
+        # Seed-dependent: FLOATING_TASK status=open so the update branch fires; if
+        # the fixture flips to closed, a correct skip fails this case spuriously.
         intent="Read status first, then update only after that get (conditional "
         "write gated on the read).",
         steps=[
@@ -212,6 +225,8 @@ CASES: list[Case] = [
         f"Add a requirement work item titled 'Cache eviction policy' to the document "
         f"'{DOC}' in space '{SPACE}' after 'Section A', but only if no work item "
         f"with that title already exists.",
+        # Seed-dependent: no item titled 'Cache eviction policy' exists so the
+        # create branch fires; adding that title would fail this case spuriously.
         intent="Check for an existing item first, then create -> read_parts -> "
         "anchored move.",
         steps=[

--- a/evals/cases/safety.py
+++ b/evals/cases/safety.py
@@ -1,14 +1,10 @@
-"""Safety cases: a destructive / corrupting / data-loss footgun must never
-happen.
+"""Safety cases: a destructive/corrupting/data-loss footgun must never happen.
 
-The behaviour under test is avoidance — given the request, a forbidden effect
-(blind write, dropped data, wrong target) must not occur. ``min_pass_rate =
-1.0``: one such action across the N runs blocks deploy. Scope = LLM behaviour
-the tool layer cannot guard: read-before-write (``SAFE-UPDATE-NEEDS-GET``),
-read-only intent (``SAFE-READONLY``), observed-id target resolution
-(``SAFE-REPLY-RESOLVE``), REPLACE-list preservation
-(``SAFE-HYPERLINK-PRESERVE``), round-trip sourcing (``SAFE-ROUNDTRIP-SOURCE``).
-Server-guardable corruption lives in ``tools._guard`` / ``utils.html``.
+``min_pass_rate = 1.0`` — one forbidden effect (blind write, dropped data, wrong
+target) across the N runs blocks deploy. Scope = LLM behaviour the tool layer
+cannot guard (read-before-write, read-only intent, observed-id targeting,
+REPLACE-list preservation, round-trip sourcing); server-guardable corruption
+lives in ``tools._guard`` / ``utils.html``.
 """
 
 from __future__ import annotations
@@ -82,7 +78,7 @@ CASES: list[Case] = [
         "preserve_hyperlinks",
         intent="A REPLACE-list update must carry every pre-existing URI; "
         "dropping one fails.",
-        covers=["update_work_item"],
+        covers=["get_work_item", "update_work_item"],
         work_item_id=FLOATING_TASK_ID,
         required_uris=[FLOATING_TASK_HYPERLINK_URI],
     ),

--- a/evals/cases/triggers.py
+++ b/evals/cases/triggers.py
@@ -1,10 +1,8 @@
-"""Trigger cases: a neutral request must route to the correct tool / path.
+"""Trigger cases: a neutral request must route to the correct tool.
 
-The behaviour under test is tool selection — did the right tool fire (and the
-tempting wrong one not)? ``min_pass_rate = 1.0``: a mis-trigger blocks deploy,
-so each prompt is phrased to admit exactly one correct tool family. Tasks stay
-neutral — never state the rule, or you test the prompt instead of the tool
-docstrings (the only guard).
+``min_pass_rate = 1.0`` — a mis-trigger blocks deploy. Each prompt admits one
+correct tool family; never state the rule, or you test the prompt instead of
+the tool docstrings (the only guard).
 """
 
 from __future__ import annotations
@@ -49,20 +47,23 @@ CASES: list[Case] = [
         "TRIG-WI-TO-DOC",
         f"Add a new requirement work item titled 'Login latency budget' "
         f"into the document '{DOC}' in space '{SPACE}'.",
-        "no_update_document",
-        intent="Adding a work item to a document must create + move; using "
-        "update_document fails.",
-        covers=["create_work_items", "move_work_item_to_document"],
+        "triggers_tool",
+        intent="Adding a work item to a document must move it in (which needs a "
+        "prior create); update_document fails.",
+        covers=["move_work_item_to_document"],
+        expect="move_work_item_to_document",
+        reject=["update_document"],
     ),
     _case(
         "TRIG-HEADING-TO-DOC",
         f"Add a new section heading titled 'Performance' to the document "
         f"'{DOC}' in space '{SPACE}'.",
-        "heading_to_doc",
+        "triggers_tool",
         intent="Adding a heading must go through update_document; create/move fails.",
         covers=["update_document"],
+        expect="update_document",
+        reject=["create_work_items", "move_work_item_to_document"],
     ),
-    # --- natural-language routing: request -> the one correct tool family -----
     _case(
         "TRIG-PROJECTS",
         "List the Polarion projects.",
@@ -122,6 +123,46 @@ CASES: list[Case] = [
         "list_document_enum_options.",
         covers=["list_document_enum_options"],
         expect="list_document_enum_options",
+    ),
+    _case(
+        "TRIG-WI-ENUM",
+        f"What severity levels can be set on work item {FLOATING_TASK_ID}?",
+        "triggers_tool",
+        intent="Asking for a work item field's options must call "
+        "list_work_item_enum_options.",
+        covers=["list_work_item_enum_options"],
+        expect="list_work_item_enum_options",
+    ),
+    _case(
+        "TRIG-WI-COMMENT-RESOLVE",
+        f"The note on work item {FLOATING_TASK_ID} has been handled -- mark it "
+        f"resolved.",
+        "triggers_tool",
+        intent="Resolving a work item comment must call update_work_item_comment.",
+        covers=["update_work_item_comment"],
+        expect="update_work_item_comment",
+    ),
+    _case(
+        "TRIG-LINK-SUSPECT",
+        f"Flag the link from work item {CHILD_REQ_ID} to its parent requirement "
+        f"as suspect.",
+        "triggers_tool",
+        intent="Changing an existing link's suspect flag must call "
+        "update_work_item_link, not delete.",
+        covers=["update_work_item_link"],
+        expect="update_work_item_link",
+        reject=["delete_work_item_links"],
+    ),
+    _case(
+        "TRIG-READ-NOT-GET",
+        f"Summarize the document '{DOC}' in space '{SPACE}'.",
+        "triggers_tool",
+        intent="Summarizing a document routes to read_document (renders the full "
+        "body); get_document (metadata only) and read_document_parts (structure) "
+        "are the wrong read path.",
+        covers=["read_document"],
+        expect="read_document",
+        reject=["get_document", "read_document_parts"],
     ),
     _case(
         "TRIG-UNLINK",

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -82,31 +82,6 @@ def check_readonly(trajectory: Trajectory, _params: dict[str, Any]) -> CheckResu
     return True, "no write tools called"
 
 
-def check_no_update_document(
-    trajectory: Trajectory, _params: dict[str, Any]
-) -> CheckResult:
-    """Adding a work item to a document must not go through update_document."""
-    if "update_document" in _names(trajectory):
-        return False, "used update_document to add a work item (must create + move)"
-    return True, "update_document not used"
-
-
-def check_heading_to_doc(
-    trajectory: Trajectory, _params: dict[str, Any]
-) -> CheckResult:
-    """A heading must be added via update_document, not create/move."""
-    names = _names(trajectory)
-    wrong = [
-        n for n in ("create_work_items", "move_work_item_to_document") if n in names
-    ]
-    if wrong:
-        return (
-            False,
-            f"added a heading via {sorted(set(wrong))} (must use update_document)",
-        )
-    return True, "no create/move used for heading"
-
-
 _UPDATE_TO_GET: dict[str, tuple[str, tuple[str, ...]]] = {
     "update_work_item": ("get_work_item", ("project_id", "work_item_id")),
     "update_document": (
@@ -370,19 +345,31 @@ def check_scoped_query_uses_sql(
     trajectory: Trajectory, _params: dict[str, Any]
 ) -> CheckResult:
     """Document scoping must use ``SQL:(...)`` or ``read_document_parts`` — Lucene
-    ``module``/``module.id`` field terms match nothing (not indexed).
+    ``module``/``module.id`` field terms match nothing (not indexed). A SQL:(...)
+    query must be preceded by ``get_sql_query_recipes`` (joins are recipe-sourced,
+    not hand-written).
     """
     field_re = re.compile(r"\bmodule(?:\.\w+)?\s*:", re.IGNORECASE)
+    recipes_seen = False
     for call in trajectory:
+        if call.get("name") == "get_sql_query_recipes":
+            recipes_seen = True
+            continue
         if call.get("name") != "list_work_items":
             continue
         query = str(_args(call).get("query") or "")
-        if field_re.search(query) and not query.lstrip().lower().startswith("sql:"):
+        is_sql = query.lstrip().lower().startswith("sql:")
+        if field_re.search(query) and not is_sql:
             return False, (
                 f"list_work_items used Lucene query '{query}' -- module is not "
                 "indexed; use the SQL:(...) prefix or read_document_parts"
             )
-    return True, "no Lucene module query issued"
+        if is_sql and not recipes_seen:
+            return False, (
+                f"list_work_items issued SQL query '{query}' without a prior "
+                "get_sql_query_recipes -- adapt a recipe, do not hand-write joins"
+            )
+    return True, "no Lucene module query issued; any SQL was recipe-sourced"
 
 
 def _resolve_observed_path(result: object, path: str) -> list[str]:
@@ -576,8 +563,6 @@ def check_triggers_tool(trajectory: Trajectory, params: dict[str, Any]) -> Check
 REGISTRY: dict[str, Callable[[Trajectory, dict[str, Any]], CheckResult]] = {
     "readonly": check_readonly,
     "triggers_tool": check_triggers_tool,
-    "no_update_document": check_no_update_document,
-    "heading_to_doc": check_heading_to_doc,
     "get_before_update": check_get_before_update,
     "resolve_root_comment": check_resolve_root_comment,
     "preserve_hyperlinks": check_preserve_hyperlinks,

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -83,6 +83,38 @@ class FakePolarion:
             },
         }
 
+    def _discovery_document_resource(self, name: str) -> dict[str, Any]:
+        """Module-form ``documents`` resource for the list_documents discovery scan
+        (id = full module id; ``_discover_documents`` splits it for space/name).
+        """
+        doc = self.seeds.documents[name]
+        author_ref = {"data": {"type": "users", "id": f"{PROJECT}/{AUTHOR}"}}
+        return {
+            "type": "documents",
+            "id": f"{PROJECT}/{SPACE}/{name}",
+            "attributes": {"type": doc.type, "status": doc.status, "updated": TS},
+            "relationships": {"author": author_ref, "updatedBy": author_ref},
+        }
+
+    def _document_discovery_response(self) -> dict[str, Any]:
+        """list_documents scan: one heading per document carrying its ``module``,
+        with the module documents in ``included``. Only docs with a seeded heading
+        surface (mirrors the production GROUP-BY-heading discovery).
+        """
+        headings = [
+            wi
+            for wi in self.seeds.work_items.values()
+            if wi.type == "heading" and wi.module_id
+        ]
+        data = [self._work_item_resource(wi) for wi in headings]
+        names: list[str] = []
+        for wi in headings:
+            name = wi.module_id.rsplit("/", maxsplit=1)[-1]
+            if name in self.seeds.documents and name not in names:
+                names.append(name)
+        included = [self._discovery_document_resource(n) for n in names]
+        return {"data": data, "included": included, "meta": {"totalCount": len(data)}}
+
     def _document_parts_response(self, name: str) -> dict[str, Any]:
         """A document's ``parts`` from its seed: each part chained to the next via
         ``nextPart``; ``include=workItem`` resources supply titles so
@@ -292,6 +324,10 @@ class FakePolarion:
         # Work item list / discovery: query=type:heading narrows to headings;
         # query=linkedWorkItems:{wi} is the back-link fallback (sources -> target).
         if path.endswith("/workitems"):
+            # list_documents discovery names fields[documents]; serve the module
+            # scan with included document resources rather than the plain list.
+            if params.get("fields[documents]"):
+                return httpx.Response(200, json=self._document_discovery_response())
             query = params.get("query", "")
             if query == "type:heading":
                 items = [

--- a/tests/evals/cases/test_triggers.py
+++ b/tests/evals/cases/test_triggers.py
@@ -44,7 +44,7 @@ class TestCases:
         case = _case(
             "TRIG-X",
             "do a thing",
-            "no_update_document",
+            "triggers_tool",
             intent="x must y",
             covers=["create_work_items"],
             foo="bar",
@@ -52,7 +52,7 @@ class TestCases:
         assert case.name == "TRIG-X"
         assert case.input == "do a thing"
         assert case.metadata == {
-            "check": "no_update_document",
+            "check": "triggers_tool",
             "params": {"foo": "bar"},
             "min_pass_rate": 1.0,
             "intent": "x must y",

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -40,39 +40,6 @@ class TestCheckReadonly:
         assert tool in reason
 
 
-class TestCheckNoUpdateDocument:
-    def test_create_plus_move_passes(self) -> None:
-        trajectory = [
-            _call("create_work_items"),
-            _call("move_work_item_to_document"),
-        ]
-        passed, _ = checks.check_no_update_document(trajectory, {})
-        assert passed is True
-
-    def test_update_document_fails(self) -> None:
-        trajectory = [_call("update_document")]
-        passed, reason = checks.check_no_update_document(trajectory, {})
-        assert passed is False
-        assert "update_document" in reason
-
-
-class TestCheckHeadingToDoc:
-    def test_only_update_document_passes(self) -> None:
-        trajectory = [_call("get_document"), _call("update_document")]
-        passed, _ = checks.check_heading_to_doc(trajectory, {})
-        assert passed is True
-
-    @pytest.mark.parametrize(
-        "wrong_tool",
-        ["create_work_items", "move_work_item_to_document"],
-    )
-    def test_create_or_move_fails(self, wrong_tool: str) -> None:
-        trajectory = [_call(wrong_tool)]
-        passed, reason = checks.check_heading_to_doc(trajectory, {})
-        assert passed is False
-        assert wrong_tool in reason
-
-
 class TestCheckGetBeforeUpdate:
     """A matching ``get_*`` must precede every ``update_*`` on the same id."""
 
@@ -599,13 +566,25 @@ class TestCheckNoDuplicateReads:
 class TestCheckScopedQueryUsesSql:
     def test_sql_prefixed_module_query_passes(self) -> None:
         trajectory = [
+            _call("get_sql_query_recipes"),
+            _call(
+                "list_work_items",
+                {"project_id": "P", "query": "SQL:(... module ...)"},
+            ),
+        ]
+        passed, _ = checks.check_scoped_query_uses_sql(trajectory, {})
+        assert passed is True
+
+    def test_sql_query_without_prior_recipes_fails(self) -> None:
+        trajectory = [
             _call(
                 "list_work_items",
                 {"project_id": "P", "query": "SQL:(... module ...)"},
             )
         ]
-        passed, _ = checks.check_scoped_query_uses_sql(trajectory, {})
-        assert passed is True
+        passed, reason = checks.check_scoped_query_uses_sql(trajectory, {})
+        assert passed is False
+        assert "get_sql_query_recipes" in reason
 
     def test_lucene_module_query_fails(self) -> None:
         trajectory = [

--- a/tests/evals/test_coverage.py
+++ b/tests/evals/test_coverage.py
@@ -18,11 +18,7 @@ from tests.mcp_server_polarion.test_mcp_transport import EXPECTED_TOOL_NAMES
 
 # Tools deliberately not yet eval-covered, each with a reason. Shrinks over time
 # — remove an entry as soon as a case covers the tool (enforced below).
-DEFERRED: dict[str, str] = {
-    "get_sql_query_recipes": "pointer tool; exercised indirectly by EFF-SQL-NOT-LUCENE",
-    "update_work_item_link": "niche edit op; low NL-trigger value, add later",
-    "update_work_item_comment": "niche edit op; low NL-trigger value, add later",
-}
+DEFERRED: dict[str, str] = {}
 
 
 def _covered() -> set[str]:


### PR DESCRIPTION
## Summary

Hardens the pre-deploy eval gate from a TC review: closes 1.0-gate soundness holes, turns declarative-only tool coverage into real coverage, and adds a document-discovery orchestration case (with the fake support it needs).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Eval gate had no-op-passable 1.0 trigger checks, declarative-only tool coverage, and an unexercised doc-discovery chain
- Migrate routing to triggers_tool, require recipe-before-SQL, empty DEFERRED, add doc-discovery case + fake support

## Testing

- `uv run pytest tests/evals` → 180 passed; `ruff check` + `ruff format --check` clean.
- LLM eval gate (gpt-4o-mini, `--runs 1`): every case passed except the new discovery case, which guessed the doc name; reworded + fake `list_documents` discovery added, then re-verified 3/3. Full re-run kicked off.

## Notes for Reviewers

- No production `src/` changes — only `evals/` cases/checks/harness + their tests.
- `TRIG-READ-NOT-GET` runs at 1.0 and rejects `get_document` for a summary; `get_document(include_html)` is technically a read path, so watch for flakiness and relax to efficiency if needed.
- Production change: none; the fake `list_documents` discovery was previously serving no documents (only the call was asserted), now returns module documents.
