### PR TITLE
docs(meta): condense CLAUDE.md and evals README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-MCP server: AI read/write access to Polarion ALM. FastMCP 3.0, strict async, fully typed.
+MCP server: AI read/write Polarion ALM. FastMCP 3.0, strict async, fully typed.
 
 ## Commands
 
@@ -17,10 +17,10 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 
 ## Architecture
 
-- `core/` — `client.py` (async httpx, retries 429/5xx, maps to `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only). Loggers: `logging.getLogger("mcp_server_polarion.<module>")`.
-- `tools/` — domain modules; `_build_*_payload` helpers = unit-test seam. Import in `tools/__init__.py` registers `@mcp.tool`s. `tools/_shared/`: `helpers.py` (client/string/path/lucene), `parse.py` (JSON:API→models), `pagination.py` (`make_page`), `fields.py`/`custom_fields.py` (sparse-fieldset constants + custom-field policy), `cache.py` (`TTLCache`), `guard.py` (write guards), `sql.py` (query recipes). `tools/guides/` = on-demand data.
-- `utils/html.py` — Markdown ↔ HTML, `stamp_block_ids`, `first_anchorless_block`.
-- `models/` — Pydantic v2, re-exported from `models/__init__.py`. `PaginatedResult[T]` wraps all list responses.
+- `core/` — `client.py` (async httpx, retries 429/5xx → `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only; loggers `mcp_server_polarion.<module>`).
+- `tools/` — domain modules; `_build_*_payload` = unit-test seam; `tools/__init__.py` import registers `@mcp.tool`s. `_shared/`: `helpers.py`, `parse.py` (JSON:API→models), `pagination.py` (`make_page`), `fields.py`/`custom_fields.py` (sparse-fieldset + custom-field policy), `cache.py` (`TTLCache`), `guard.py` (write guards), `sql.py` (recipes). `tools/guides/` = on-demand data.
+- `utils/html.py` — Markdown↔HTML, `stamp_block_ids`, `first_anchorless_block`.
+- `models/` — Pydantic v2, re-exported from `models/__init__.py`; `PaginatedResult[T]` wraps list responses.
 - `server.py` — FastMCP instance; lifespan owns `PolarionClient`.
 
 ## Non-Negotiable Rules
@@ -31,64 +31,43 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 - Body fields asymmetric by tool purpose:
   - Round-trip: `get_*(include_*_html=True)` returns raw Polarion HTML; `update_*(*_html=...)` accepts verbatim — no sanitize/convert.
   - Greenfield create (Markdown): `markdown_to_html` + `sanitize_html`. Post-create edits = raw-HTML round-trip; formats never mix.
-  - Synthesis (READ-ONLY): `read_*` tools convert HTML→Markdown; feeding output back to writes loses Polarion markup.
+  - Synthesis (READ-ONLY): `read_*` convert HTML→Markdown; feeding output back to writes loses Polarion markup.
 - Write payloads skip `None`/empty (Polarion reads empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
 - Every list tool: `page_size` (max 100) + `page_number` → `PaginatedResult[T]` with `has_more`.
 - Every write tool: `dry_run: bool = False` — return payload without hitting Polarion.
-- Tool docstrings = LLM's manual, Google-style. Only prose above `Args:` ships to clients; keep tight. Return-field bullets in sync with Pydantic model.
 - Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`.
 - Guards fail closed: validation GET error blocks write; only successful empty option set defers to Polarion.
-
-## Comment & Docstring Style
-
-Applies to ALL comments/docstrings incl. CLAUDE.md.
-
-- Field descriptions one line; skip when name + type say all.
-- No `WARNING:`/`NOTE:` prefixes, no dev-narrative, no banner dividers.
-- CLAUDE.md is dev-only; anything an MCP-user LLM needs must live in the `@mcp.tool` docstring, even if duplicated here.
-- Module docstrings = why module exists; timing/sizing constraints inline next to what they constrain.
+- Docstrings = LLM manual, Google-style; only prose above `Args:` ships — keep tight; return-field bullets in sync with model. Field descriptions one line, skip when name + type say all.
+- No `WARNING:`/`NOTE:` prefixes, no dev-narrative, no banner dividers. CLAUDE.md dev-only — MCP-user info lives in `@mcp.tool` docstring. Module docstrings = why module exists; constraints inline next to what they constrain.
+- Comments: one line, explain why not what; never restate self-evident code. No dead code, no stray `TODO`s; keep comments in sync when code changes.
 
 ## Polarion API Gotchas
 
+- Baseline: Polarion REST API v2506 — assume that version's behavior.
 - JSON:API v1. HTML stored as `{"type": "text/html", "value": "..."}`.
-- Linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse. Module ids = 3 segments, document names may contain `/` — use `split_module_id`.
+- Linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse. Module ids = 3 segments, doc names may contain `/` — use `split_module_id`.
 - Lucene: trailing wildcards OK, leading 400. `module`/`description` not indexed — use `query="SQL:(...)"`; recipes via `get_sql_query_recipes`.
 - Server limits: ≤3 req/s, no concurrency. Client retries 429/5xx, does NOT serialize client-side.
-- Sparse fieldset drops `relationships` block — list relationship names explicitly. To-many relationships need `include=`; nested dot-path drops intermediate resource (`module,module.author`, not `module.author` alone).
+- Sparse fieldset drops `relationships` block — list relationship names explicitly. To-many need `include=`; nested dot-path drops intermediate resource (`module,module.author`, not `module.author` alone).
 - `/backlinkedworkitems` unsupported — back direction via `query=linkedWorkItems:{wi}`, so back results have `role=None`.
-- Polarion validates neither custom-field ids (unknown keys persist silently; wrong-type 400), nor enum values, nor link targets/roles — `guard.py` validates pre-write. `getAvailableOptions` = only key→enum-options API (non-enum/unknown field → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (response `data` is dict, not list). Guard TTL caches in `tools/_shared/cache.py`; tests drive expiry by patching `tools._shared.cache._now`.
+- Polarion validates neither custom-field ids (unknown keys persist; wrong-type 400), nor enum values, nor link targets/roles — `guard.py` validates pre-write. `getAvailableOptions` = only key→enum-options API (non-enum/unknown → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (`data` is dict, not list).
 - Custom fields inline under `attributes` (no `customFields` container; `@all` tokens dropped). `GET /projects/{p}/documents` absent on some builds.
-
-### Document writes
-
-- Body edits via `homePageContent` PATCH, not `/parts` (rejects heading-type items). Empty `home_page_content_html` rejected (would orphan headings).
-- Anchorless `<p>`/`<ul>`/`<ol>`/`<table>`/`<div>`/`<blockquote>`/`<pre>` break `/parts` (PATCH 200, next GET 500) — each needs unique non-empty `id=`; `create_document`/`update_document` run `stamp_block_ids` + `first_anchorless_block` guard. For body text, prefer `create_work_items` + `move_work_item_to_document`.
-- `module` settable only via `move_work_item_to_document` / `move_work_item_from_document`. `create_work_item` doesn't expose `module` (would land in recycle bin) — create free-floating, then move. `moveFromDocument` not idempotent (400 if detached). `moveToDocument` auto-creates link to enclosing heading; later same-role `create_work_item_links` 201s but isn't persisted.
-
-### Work item & comment quirks
-
-- Link ids composite `<srcProj>/<srcWI>/<role>/<tgtProj>/<tgtWI>`. Bulk tools cap at `MAX_BULK_ITEMS` (50). Link-create POST atomic — 4xx rolls back batch; re-query `list_work_item_links` before retry.
-- `PATCH /workitems` needs ≥1 `attributes`/`relationships` entry. `changeTypeTo` resets `status` to new type's initial state.
-- `update_document_comment`/`update_work_item_comment`: root comments only (replies 400). Document resolve cascades to whole thread; work item resolve flips only that comment (no cascade).
-- Comment ids: work item comments 3-segment (`<proj>/<wi>/<cmt>`), document comments 4-segment. `list_work_item_comments`/`list_document_comments` share the `Comment` model + `build_comments_page` parser; work item comments add `title` (own `WORK_ITEM_COMMENT_LIST_FIELDS`), documents send none.
-- `create_document_comments`/`create_work_item_comments` share the `_comment_create_payload` helper; document takes base `CommentSpec` (no `title`), work item takes `WorkItemCommentSpec` (subclass adds `title`). Helper emits `title` only when the spec carries one. No `MAX_BULK_ITEMS` cap on either.
 
 ## Testing
 
-- `tests/` mirrors source tree one-to-one; shared fixtures in `tests/` root `conftest.py`; `mock_client`/`mock_ctx` + autouse guard-cache reset in `tests/mcp_server_polarion/tools/conftest.py`.
+- `tests/` mirrors source one-to-one; shared fixtures in `tests/` `conftest.py`; `mock_client`/`mock_ctx` + autouse guard-cache reset in `tools/conftest.py`.
 - `pytest-asyncio` `mode=auto`. Tool tests call functions directly (`@mcp.tool` returns original); client tests use `respx`. Pydantic `Field` constraints bypass JSON Schema on direct calls — verify via `TypeAdapter` reconstruction.
 - New `@mcp.tool` requires updating `EXPECTED_TOOL_NAMES` in `test_mcp_transport.py`.
-- `tests/evals/` opens with `pytest.importorskip` (`evals` dependency group; CI syncs `--group evals`).
+- `tests/evals/` opens with `pytest.importorskip` (`evals` group; CI syncs `--group evals`).
 
 ## Evals — deploy gate
 
-`evals/` drives real LLM through in-memory server against mocked Polarion; deterministic checks, no judge. Hard gate before PyPI publish. Cases grouped by behaviour (file = category): `triggers`/`safety` (`min_pass_rate=1.0`), `efficiency`/`orchestration` (`0.8`); one `CheckDispatchEvaluator` dispatches `metadata["check"]` to a pure check. New case: check in `evals/evaluators/checks.py::REGISTRY` + `Case` in the matching `cases/<category>.py` with `intent` + `covers`; phrase task neutrally. `tests/evals/test_coverage.py` enforces every tool is covered or deferred. Detail: [evals/README.md](evals/README.md).
+`evals/` drives real LLM through in-memory server against mocked Polarion; deterministic checks, no judge. Hard gate before PyPI publish (`triggers`/`safety` min_pass_rate 1.0; `efficiency`/`orchestration` 0.8). New-case + coverage rules in [evals/README.md](evals/README.md); `tests/evals/test_coverage.py` enforces every tool covered or deferred.
 
 ## Repo Conventions
 
 Full rules in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md); enforced by `.githooks/commit-msg` + `.claude/hooks/`.
 
-- Branches: `<type>/<short-kebab-summary>` off `main`. Types: `feature|fix|refactor|test|docs|chore|ci`.
-- Commits: `type(scope): summary` ≤50 chars, lowercase imperative, no period. Types: `feat|fix|docs|refactor|perf|test|ci|chore`. Scopes: `tool|server|transport|config|deps|utils|model|project|meta|git`. Body: blank line + exactly 2 bullets (motivation, then change), ≤120 chars each.
-- PR template checklist: flip `[ ]`→`[x]`; don't delete unchecked options.
+- Branches off `main`: `<type>/<short-kebab-summary>`. Commits: `type(scope): summary` ≤50 chars + 2-bullet body (motivation, change).
+- PR checklist: flip `[ ]`→`[x]`; don't delete unchecked options.
 - Squash merge only; NEVER `--subject` to `gh pr merge`. Force-push feature branches only with explicit authorization; never `main`.

--- a/evals/README.md
+++ b/evals/README.md
@@ -2,42 +2,27 @@
 
 Drives an LLM agent through the **real** in-memory MCP server against a
 **mocked** Polarion backend, then deterministically asserts the agent's
-behaviour. Runs as a hard gate ahead of the PyPI publish jobs in
-[`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
+behaviour. Hard gate ahead of the PyPI publish jobs in
+[`publish.yml`](../.github/workflows/publish.yml). No LLM judge — every verdict
+is a pure function of the tool-call trajectory, so the only model cost is the
+agent under test.
 
-Cases are organised by the **behaviour** they test (one file per category),
-sharing the same harness and the one evaluator; `min_pass_rate` is a per-case
-property, not a per-category one:
+## Categories
 
-- **triggers** ([`cases/triggers.py`](cases/triggers.py)): the request must route
-  to the **correct tool / path** — did the right tool fire (and the tempting
-  wrong one not)? `min_pass_rate = 1.0` — a single mis-trigger blocks release, so
-  each prompt admits exactly one correct tool family.
-- **safety** ([`cases/safety.py`](cases/safety.py)): a destructive / corrupting /
-  data-loss **footgun must never happen** (read-before-write, read-only intent,
-  REPLACE-list preservation, round-trip sourcing, right comment target).
-  `min_pass_rate = 1.0`.
-- **efficiency** ([`cases/efficiency.py`](cases/efficiency.py)): the correct answer
-  must be reached **without waste** (one bulk call, direct get by known id, no
-  redundant identical reads, right query mechanism). `min_pass_rate = 0.8` —
-  occasional waste tolerated, systematic waste blocks.
-- **orchestration** ([`cases/orchestration.py`](cases/orchestration.py)):
-  multi-step tasks must walk the correct ordered tool sequence and thread ids
-  between steps (e.g. `create_work_items → read_document_parts →
-  move_work_item_to_document` with the move's part-id observed from the read).
-  One generic `ordered_trajectory` check; cases are data. `min_pass_rate = 0.8`.
+One file per behaviour; all share the harness and the one evaluator.
+`min_pass_rate` is per-case, not per-category.
 
-The number-based `tier0/1/2/3` split is gone: it conflated *behaviour* with
-*gate strictness*. Category = behaviour (the file); strictness = each case's
-`min_pass_rate`.
+| Category | Asserts | `min_pass_rate` |
+| --- | --- | --- |
+| [triggers](cases/triggers.py) | right tool / path fires (and the tempting wrong one doesn't) | 1.0 |
+| [safety](cases/safety.py) | destructive / data-loss footgun never happens | 1.0 |
+| [efficiency](cases/efficiency.py) | correct answer reached without waste | 0.8 |
+| [orchestration](cases/orchestration.py) | multi-step tasks walk the correct ordered sequence, threading ids between steps | 0.8 |
 
 Every case carries an `intent` (one line: what passes vs. fails) and a `covers`
-list (the tools it exercises) in its metadata. `uv run python -m evals.run
---list` prints the catalog; `tests/evals/test_coverage.py` fails if any
-registered tool has no `covers` entry and is not explicitly deferred.
-
-No category needs an **LLM judge**: every verdict is a pure function of the
-tool-call trajectory. The only model cost is the agent under test.
+list (tools it exercises). `uv run python -m evals.run --list` prints the
+catalog; [`tests/evals/test_coverage.py`](../tests/evals/test_coverage.py) fails
+if a registered tool has no `covers` entry and is not explicitly deferred.
 
 ## How it works
 
@@ -49,131 +34,93 @@ Strands Agent (LiteLLM)
   → respx → FakePolarion  (structure of MCP_Test_Project, synthetic content)
 ```
 
-Everything runs in one process so respx intercepts Polarion HTTP. The router is
-created with `assert_all_mocked=False`, so the agent's LLM traffic falls through
-to the real provider while **no request ever reaches a real Polarion**. Every
-mutating request is recorded but has no effect.
-
-The agent's tool calls are captured by `TrajectoryRecorder`; the
-`CheckDispatchEvaluator` dispatches on `Case.metadata["check"]` to a pure
-check in [`evaluators/checks.py`](evaluators/checks.py) plus cross-cutting global
-checks (e.g. every `update_document` body block must carry a non-empty `id`).
-All categories share this one evaluator — there is deliberately no per-category
-evaluator (the check, named in case metadata, is what varies).
+One process, so respx intercepts Polarion HTTP. The router runs with
+`assert_all_mocked=False` — agent LLM traffic hits the real provider while no
+request reaches a real Polarion; mutations are recorded but never applied.
+`TrajectoryRecorder` captures the tool calls; `CheckDispatchEvaluator` dispatches
+on `Case.metadata["check"]` to a pure check in
+[`evaluators/checks.py`](evaluators/checks.py), plus cross-cutting global checks
+(e.g. every `update_document` block must carry a non-empty `id`).
 
 ## Running
 
 ```bash
 uv sync --group evals
 
-# Full gate (all cases, EVAL_RUNS times each; default 10)
-uv run python -m evals.run
-uv run python evals/run.py        # equivalent
-
-# Print the case catalog (name/category/check/covers/intent); no model cost
-uv run python -m evals.run --list
-uv run python -m evals.run --category triggers --list
-
-# One case, once (fast smoke)
-uv run python -m evals.run --case SAFE-READONLY --runs 1
+uv run python -m evals.run                                  # full gate (each case EVAL_RUNS times, default 10)
+uv run python -m evals.run --list                           # case catalog, no model cost
+uv run python -m evals.run --case SAFE-READONLY --runs 1    # one case, once (smoke)
 ```
 
-Each case runs N times and passes only at its `min_pass_rate`
-(triggers/safety: 1.0, efficiency/orchestration: 0.8). The gate fails (exit 1)
-if any case falls short. A JSON report is written to
-`evals/reports/gate-<sha>-<model>.json` (gitignored).
+The gate fails (exit 1) if any case falls below its `min_pass_rate`. A JSON
+report is written to `evals/reports/gate-<sha>-<model>.json` (gitignored).
 
-## Choosing the model
+## Model
 
-A single LiteLLM adapter serves cloud and local — switch with `EVAL_MODEL`:
+Switch with `EVAL_MODEL` (one LiteLLM adapter serves cloud and local):
 
 ```bash
-# Cloud (CI default) — needs OPENAI_API_KEY
-EVAL_MODEL=openai/gpt-4o-mini uv run python -m evals.run
-
-# Local via Ollama — free, no key
-EVAL_MODEL=ollama_chat/qwen3.5:9b-mlx uv run python -m evals.run
-# (set EVAL_MODEL_BASE_URL if Ollama is not on localhost:11434)
+EVAL_MODEL=openai/gpt-4o-mini uv run python -m evals.run         # cloud (CI default), needs OPENAI_API_KEY
+EVAL_MODEL=ollama_chat/qwen3.5:9b-mlx uv run python -m evals.run # local, free; set EVAL_MODEL_BASE_URL if not localhost:11434
 ```
 
-`temperature` is pinned to 0 and `parallel_tool_calls` off (gpt-4o-mini can
-emit the same tool call twice in one parallel block) to keep the
-zero-tolerance gate stable.
+`temperature` is pinned to 0 and `parallel_tool_calls` off (gpt-4o-mini can emit
+the same call twice in one parallel block) to keep the gate stable.
 
-## Runaway protection
+## Limits
 
-Local models can loop indefinitely without producing a final answer, and
-cloud providers can return 429 when TPM/RPM is exhausted. Each case is
-bounded by case-level limits (fail-closed via `<agent-error: ...>`), and a
-single model call retries transient 429 / network errors with exponential
-backoff (handled by the OpenAI SDK underneath LiteLLM) before giving up.
+Local models can loop; cloud providers return 429 when TPM/RPM is exhausted.
+Each case is bounded fail-closed (via `<agent-error: ...>`).
 
-| Env var             | Default | Cap                                                                              |
-| ------------------- | ------- | -------------------------------------------------------------------------------- |
-| `EVAL_MAX_CYCLES`   | `10`    | Model calls per case (`BeforeModelCallEvent` hook count).                        |
-| `EVAL_CASE_TIMEOUT` | `120`   | Wall-clock seconds (`asyncio.wait_for`).                                         |
-| `EVAL_NUM_RETRIES`  | `10`    | LiteLLM `num_retries`; OpenAI SDK sleeps `min(0.5·2ⁿ, 8)s` with ±25 % jitter, or honours `Retry-After` if present. |
-| `EVAL_LLM_TIMEOUT`  | `60`    | Wall-clock seconds for one model call (LiteLLM `timeout`).                       |
+| Env var | Default | Cap |
+| --- | --- | --- |
+| `EVAL_MAX_CYCLES` | `10` | Model calls per case. |
+| `EVAL_CASE_TIMEOUT` | `120` | Wall-clock seconds per case. |
+| `EVAL_NUM_RETRIES` | `10` | LiteLLM retries; OpenAI SDK sleeps `min(0.5·2ⁿ, 8)s` ±25 % jitter, or honours `Retry-After`. |
+| `EVAL_LLM_TIMEOUT` | `60` | Wall-clock seconds per model call. |
 
-`EVAL_LLM_TIMEOUT` is per attempt — worst-case wall-clock for one model
-call is `EVAL_NUM_RETRIES × EVAL_LLM_TIMEOUT` when every attempt times out
-without a fast 429 response. Raise `EVAL_CASE_TIMEOUT` in lockstep when
-bumping either, or the case fail-closes via `asyncio.wait_for` before the
-retry budget is exhausted.
-
-For slow CPU inference raise `EVAL_CASE_TIMEOUT`:
-
-```bash
-EVAL_MAX_CYCLES=10 EVAL_CASE_TIMEOUT=600 \
-  EVAL_MODEL=ollama_chat/gemma4:e4b uv run python -m evals.run
-```
+`EVAL_LLM_TIMEOUT` is per attempt, so worst-case per model call is
+`EVAL_NUM_RETRIES × EVAL_LLM_TIMEOUT`. Raise `EVAL_CASE_TIMEOUT` in lockstep when
+bumping either (and for slow CPU inference), or the case fail-closes first.
 
 ## Release pipeline
 
-- **Hard gate** — the `gate` job in
-  [`publish.yml`](../.github/workflows/publish.yml) calls the reusable
-  [`publish-gate.yml`](../.github/workflows/publish-gate.yml) (triggers ->
-  safety -> efficiency -> orchestration) on tag push, and every later publish
-  job depends on it, so a failing gate blocks the release.
-- **On-demand run** — the
-  [`Evals (on-demand)`](../.github/workflows/evals-on-demand.yml) workflow is
-  `workflow_dispatch`: trigger it from the Actions tab with a chosen `model`
-  and `runs` to review results before deciding to tag.
+- **Hard gate** — the `gate` job in [`publish.yml`](../.github/workflows/publish.yml)
+  calls [`publish-gate.yml`](../.github/workflows/publish-gate.yml) on tag push;
+  every later publish job depends on it.
+- **On-demand** — [`evals-on-demand.yml`](../.github/workflows/evals-on-demand.yml)
+  is `workflow_dispatch`: pick a `model` and `runs` from the Actions tab before tagging.
 
-Both read the **`OPENAI_API_KEY` repository secret**. If it is missing, the
-job fails and the release is blocked (fail-closed) — add the secret before the
-first tagged release.
+Both read the **`OPENAI_API_KEY` repository secret**; if it is missing the job
+fails and the release is blocked (fail-closed).
 
 ## Adding a case
 
-1. Add a pure check to `evaluators/checks.py` and register it in `REGISTRY`
-   (or reuse an existing one). Keep it a function of the trajectory only.
-2. Add a `Case` to the file for the behaviour it tests — `cases/triggers.py`
-   (right tool fires, `1.0`), `cases/safety.py` (footgun avoided, `1.0`),
-   `cases/efficiency.py` (no waste, `0.8`), or `cases/orchestration.py`
-   (multi-step, `0.8`); `run.py` loads all four lists. Give every case an
-   `intent` (one line) and a `covers` list (tools it exercises) — an
+1. Add a pure check to [`evaluators/checks.py`](evaluators/checks.py) and register
+   it in `REGISTRY` (or reuse one). Keep it a function of the trajectory only.
+2. Add a `Case` to the behaviour file — triggers/safety (`1.0`),
+   efficiency/orchestration (`0.8`). Give it an `intent` and a `covers` list. An
    orchestration case derives `covers` from its steps and usually reuses the
-   `ordered_trajectory` check, just declaring its step sequence in `params`.
+   `ordered_trajectory` check, declaring its step sequence in `params`.
 3. Phrase the task neutrally — never state the rule, or you test the prompt
    instead of the tool docstrings (the only guard).
-4. If the case exercises a previously-uncovered tool, drop it from the
-   `DEFERRED` map in `tests/evals/test_coverage.py`.
+4. If the case covers a previously-uncovered tool, drop it from the `DEFERRED`
+   map in [`tests/evals/test_coverage.py`](../tests/evals/test_coverage.py).
 
-Seed entities (project `MCP_Test_Project`, doc `FakeDoc` with an anchored
-intro paragraph, free-floating `MCPT-200` task carrying
-`custom_fields={"acceptance_criteria_id": "AC-1"}` and one `ref_ext`
-hyperlink, `MCPT-201` heading, `MCPT-202` ghost-typed task, comment thread
-`1`→`2`, project enum `hyperlink-role`) live in
-[`harness/fixtures.py`](harness/fixtures.py) as `SEEDS`;
+## Fixtures
+
+Seeds live in [`harness/fixtures.py`](harness/fixtures.py) (`SEEDS`);
 [`harness/fake_polarion.py`](harness/fake_polarion.py) serves them. Mirror the
-real server's *structure* there; keep all content synthetic. Bulk POSTs echo one
-id per submitted entry, so bulk cases exercise the tools' count-match rule.
+real server's *structure*; keep content synthetic. Bulk POSTs echo one id per
+submitted entry, so bulk cases exercise the count-match rule.
 
-Orchestration adds: a second document `FakeParentDoc`; requirements `MCPT-300` (in
-`FakeDoc`, links `satisfies`→`MCPT-400` and `verifies`→`MCPT-500`), `MCPT-301`
-(in `FakeDoc`, no test-case link — coverage-gap signal), `MCPT-400` (parent, in
-`FakeParentDoc`), test case `MCPT-500`; a `FakeDoc` `/parts` response with the
-`Section A` heading part (`heading_MCPT-100`, the positional-move anchor); and
-project enum `workitem-link-role`. Forward links come from `SEEDS.links`; the back
-direction is served via `list_work_items` `query=linkedWorkItems:{wi}`.
+- Project `MCP_Test_Project`, doc `FakeDoc` (anchored intro paragraph).
+- `MCPT-200` free-floating task (`custom_fields={"acceptance_criteria_id": "AC-1"}`,
+  one `ref_ext` hyperlink), `MCPT-201` heading, `MCPT-202` ghost-typed task;
+  comment thread `1`→`2`; enum `hyperlink-role`.
+- Orchestration adds doc `FakeParentDoc`; `MCPT-300` (in `FakeDoc`, links
+  `satisfies`→`MCPT-400` and `verifies`→`MCPT-500`), `MCPT-301` (no test-case link
+  — coverage-gap signal), `MCPT-400` (parent, in `FakeParentDoc`), test case
+  `MCPT-500`; a `FakeDoc` `/parts` `Section A` heading (`heading_MCPT-100`, the
+  positional-move anchor); enum `workitem-link-role`. Forward links from
+  `SEEDS.links`; back direction via `query=linkedWorkItems:{wi}`.


### PR DESCRIPTION
## Summary

Condense the two developer-facing docs (CLAUDE.md and evals/README.md). No behavior change — prose only.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- cut redundant dev-doc prose and merge the comment/docstring-style rules into the non-negotiables
- table-ify eval categories and limits, trim the run examples to one line each

## Testing

Docs-only; no code touched. CI ruff/mypy/pytest unaffected.
