### PR TITLE
feat(client): pace reads to <=3 req/s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
 - JSON:API v1. HTML stored as `{"type": "text/html", "value": "..."}`.
 - Linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse. Module ids = 3 segments, doc names may contain `/` — use `split_module_id`.
 - Lucene: trailing wildcards OK, leading 400. `module`/`description` not indexed — use `query="SQL:(...)"`; recipes via `get_sql_query_recipes`.
-- Server limits: ≤3 req/s, no concurrency. Client retries 429/5xx, does NOT serialize client-side.
+- Server limits: ≤3 req/s, no concurrency. Client serializes via lock + paces every request to ≤3 req/s (start-based min-interval, so slow requests add no extra wait); writes also add a 1.5s post-delay; retries 429/5xx.
 - Sparse fieldset drops `relationships` block — list relationship names explicitly. To-many need `include=`; nested dot-path drops intermediate resource (`module,module.author`, not `module.author` alone).
 - `/backlinkedworkitems` unsupported — back direction via `query=linkedWorkItems:{wi}`, so back results have `role=None`.
 - Polarion validates neither custom-field ids (unknown keys persist; wrong-type 400), nor enum values, nor link targets/roles — `guard.py` validates pre-write. `getAvailableOptions` = only key→enum-options API (non-enum/unknown → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (`data` is dict, not list).

--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -32,6 +32,9 @@ _RETRYABLE_STATUS_CODES: Final[frozenset[int]] = frozenset({429, 500, 502, 503, 
 
 # Pause after each mutation (Polarion forbids concurrent writes).
 _WRITE_DELAY_SECONDS: Final[float] = 1.5
+# Min gap between request starts → ≤3 req/s cap; start-based, so a slow
+# request's own latency counts and adds no extra wait.
+_MIN_REQUEST_INTERVAL_SECONDS: Final[float] = 1.0 / 3.0
 _DEFAULT_TIMEOUT_SECONDS: Final[float] = 30.0
 
 _HTTP_NO_CONTENT: Final[int] = 204
@@ -80,9 +83,13 @@ class PolarionClient:
         config: PolarionConfig,
         *,
         write_delay: float = _WRITE_DELAY_SECONDS,
+        min_interval: float = _MIN_REQUEST_INTERVAL_SECONDS,
     ) -> None:
         self.base_url: str = config.base_api_url
         self._write_delay = write_delay
+        self._min_interval = min_interval
+        # -inf so the first request never waits, whatever the monotonic clock's epoch.
+        self._last_request_monotonic: float = float("-inf")
         self._client = httpx.AsyncClient(
             base_url=self.base_url,
             headers={
@@ -101,6 +108,18 @@ class PolarionClient:
         if self._request_lock is None:
             self._request_lock = asyncio.Lock()
         return self._request_lock
+
+    async def _pace(self) -> None:
+        """Sleep until ``_min_interval`` has elapsed since the previous request
+        was issued, then stamp this request's issue time. Caller holds the lock.
+        """
+        loop = asyncio.get_running_loop()
+        wait = self._min_interval - (loop.time() - self._last_request_monotonic)
+        if wait > 0:
+            await asyncio.sleep(wait)
+        # Stamp after the sleep: the real issue time the next request spaces from.
+        # Before the sleep would under-space (a fast follower reads a stale value).
+        self._last_request_monotonic = loop.time()
 
     async def __aenter__(self) -> PolarionClient:
         return self
@@ -188,6 +207,8 @@ class PolarionClient:
         """
         # Lock held across retries — releasing mid-backoff would let another
         # caller slip in and hit the same 429.
+        # Pace to ≤3 req/s before the first attempt; retry backoffs only widen the gap.
+        await self._pace()
         last_exception: PolarionError | None = None
         backoff = _INITIAL_BACKOFF_SECONDS
 

--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -110,16 +110,14 @@ class PolarionClient:
         return self._request_lock
 
     async def _pace(self) -> None:
-        """Sleep until ``_min_interval`` has elapsed since the previous request
-        was issued, then stamp this request's issue time. Caller holds the lock.
+        """Block until ``_min_interval`` has elapsed since the previous request
+        was issued. Caller holds the lock; :meth:`_request` stamps each attempt's
+        issue time, so the next request paces from the last one actually sent.
         """
         loop = asyncio.get_running_loop()
         wait = self._min_interval - (loop.time() - self._last_request_monotonic)
         if wait > 0:
             await asyncio.sleep(wait)
-        # Stamp after the sleep: the real issue time the next request spaces from.
-        # Before the sleep would under-space (a fast follower reads a stale value).
-        self._last_request_monotonic = loop.time()
 
     async def __aenter__(self) -> PolarionClient:
         return self
@@ -211,8 +209,12 @@ class PolarionClient:
         await self._pace()
         last_exception: PolarionError | None = None
         backoff = _INITIAL_BACKOFF_SECONDS
+        loop = asyncio.get_running_loop()
 
         for attempt in range(_MAX_RETRIES + 1):
+            # Stamp each attempt's issue time so the next request spaces from the
+            # last one actually sent, not the stale first-attempt time after retries.
+            self._last_request_monotonic = loop.time()
             try:
                 response = await self._client.request(
                     method,

--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -32,8 +32,8 @@ _RETRYABLE_STATUS_CODES: Final[frozenset[int]] = frozenset({429, 500, 502, 503, 
 
 # Pause after each mutation (Polarion forbids concurrent writes).
 _WRITE_DELAY_SECONDS: Final[float] = 1.5
-# Min gap between request starts → ≤3 req/s cap; start-based, so a slow
-# request's own latency counts and adds no extra wait.
+# Min gap between request starts → ≤3 req/s; start-based, so slow
+# requests add no extra wait.
 _MIN_REQUEST_INTERVAL_SECONDS: Final[float] = 1.0 / 3.0
 _DEFAULT_TIMEOUT_SECONDS: Final[float] = 30.0
 
@@ -88,7 +88,7 @@ class PolarionClient:
         self.base_url: str = config.base_api_url
         self._write_delay = write_delay
         self._min_interval = min_interval
-        # -inf so the first request never waits, whatever the monotonic clock's epoch.
+        # -inf: first request never waits, whatever the clock epoch.
         self._last_request_monotonic: float = float("-inf")
         self._client = httpx.AsyncClient(
             base_url=self.base_url,
@@ -100,8 +100,8 @@ class PolarionClient:
             timeout=httpx.Timeout(_DEFAULT_TIMEOUT_SECONDS),
             verify=config.polarion_verify_ssl,
         )
-        # Lazily bound to the running loop; serializes all calls (Polarion
-        # forbids concurrency); not reentrant.
+        # Lazily bound to running loop; serializes all calls
+        # (no concurrency); not reentrant.
         self._request_lock: asyncio.Lock | None = None
 
     def _get_request_lock(self) -> asyncio.Lock:
@@ -110,9 +110,8 @@ class PolarionClient:
         return self._request_lock
 
     async def _pace(self) -> None:
-        """Block until ``_min_interval`` has elapsed since the previous request
-        was issued. Caller holds the lock; :meth:`_request` stamps each attempt's
-        issue time, so the next request paces from the last one actually sent.
+        """Block until ``_min_interval`` since the previous request issued. Caller
+        holds the lock; :meth:`_request` stamps each attempt's issue time.
         """
         loop = asyncio.get_running_loop()
         wait = self._min_interval - (loop.time() - self._last_request_monotonic)
@@ -203,17 +202,16 @@ class PolarionClient:
         """Execute with error mapping; retries 429/5xx up to ``_MAX_RETRIES``
         with exponential backoff, other errors raise immediately.
         """
-        # Lock held across retries — releasing mid-backoff would let another
-        # caller slip in and hit the same 429.
-        # Pace to ≤3 req/s before the first attempt; retry backoffs only widen the gap.
+        # Lock held across retries — releasing mid-backoff would let another caller
+        # slip in and hit the same 429. Pace before first attempt; backoffs widen gap.
         await self._pace()
         last_exception: PolarionError | None = None
         backoff = _INITIAL_BACKOFF_SECONDS
         loop = asyncio.get_running_loop()
 
         for attempt in range(_MAX_RETRIES + 1):
-            # Stamp each attempt's issue time so the next request spaces from the
-            # last one actually sent, not the stale first-attempt time after retries.
+            # Stamp per attempt so the next request paces from the last one
+            # sent, not the stale first.
             self._last_request_monotonic = loop.time()
             try:
                 response = await self._client.request(
@@ -259,7 +257,6 @@ class PolarionClient:
         if last_exception is not None:
             raise last_exception
 
-        # Defensive: should never be reached.
         raise PolarionError(  # pragma: no cover
             "Unexpected retry loop exit",
             status_code=0,

--- a/tests/mcp_server_polarion/core/test_client.py
+++ b/tests/mcp_server_polarion/core/test_client.py
@@ -41,7 +41,9 @@ class TestAuthentication:
                 return_value=httpx.Response(200, json={"data": []}),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 await client.get("/projects")
 
             assert route.called
@@ -55,7 +57,9 @@ class TestAuthentication:
                 return_value=httpx.Response(200, json={"data": []}),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 await client.get("/projects")
 
             request = route.calls.last.request
@@ -77,7 +81,9 @@ class TestSuccessfulResponses:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 result = await client.get("/projects")
 
             assert result["data"] == [{"id": "proj1"}]
@@ -88,7 +94,9 @@ class TestSuccessfulResponses:
                 return_value=httpx.Response(200, json={"data": []}),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 await client.get(
                     "/projects/P1/workitems",
                     params={"fields[workitems]": "title", "page[size]": 10},
@@ -106,7 +114,9 @@ class TestSuccessfulResponses:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 result = await client.post(
                     "/projects/P1/workitems",
                     json={
@@ -125,7 +135,9 @@ class TestSuccessfulResponses:
                 return_value=httpx.Response(204),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 result = await client.patch(
                     "/projects/P1/workitems/WI-001",
                     json={"data": {"attributes": {"title": "Updated"}}},
@@ -140,7 +152,9 @@ class TestSuccessfulResponses:
                 return_value=httpx.Response(204),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 result = await client.delete(
                     "/projects/P1/workitems/WI-001/linkedworkitems",
                     json={
@@ -163,7 +177,9 @@ class TestSuccessfulResponses:
                 return_value=httpx.Response(204)
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 await client.delete(
                     "/projects/P1/workitems/WI-001/linkedworkitems",
                     json={
@@ -194,7 +210,9 @@ class TestSuccessfulResponses:
                 return_value=httpx.Response(200, json=[1, 2, 3]),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 result = await client.get("/some/list")
 
             assert result == {"data": [1, 2, 3]}
@@ -212,7 +230,9 @@ class TestErrorMapping:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionAuthError) as exc_info:
                     await client.get("/projects")
 
@@ -227,7 +247,9 @@ class TestErrorMapping:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionAuthError) as exc_info:
                     await client.get("/projects")
 
@@ -242,7 +264,9 @@ class TestErrorMapping:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionNotFoundError) as exc_info:
                     await client.get("/projects/MISSING/workitems/WI-999")
 
@@ -257,7 +281,9 @@ class TestErrorMapping:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionNotFoundError) as exc_info:
                     await client.delete(
                         "/projects/P1/workitems/WI-001/linkedworkitems",
@@ -282,7 +308,9 @@ class TestErrorMapping:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionError) as exc_info:
                     await client.post(
                         "/projects/P1/workitems",
@@ -302,7 +330,9 @@ class TestErrorMapping:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionError, match="Internal"):
                     await client.get("/projects")
 
@@ -316,7 +346,9 @@ class TestErrorMapping:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionAuthError, match="Unauthorized"):
                     await client.get("/projects")
 
@@ -330,7 +362,9 @@ class TestErrorMapping:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionError) as exc_info:
                     await client.get("/projects")
 
@@ -349,7 +383,9 @@ class TestErrorMapping:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionError) as exc_info:
                     await client.get("/projects")
 
@@ -368,7 +404,9 @@ class TestTransportErrors:
                 side_effect=httpx.ConnectError("refused"),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionError, match="transport error"):
                     await client.get("/projects")
 
@@ -378,7 +416,9 @@ class TestTransportErrors:
                 side_effect=httpx.ReadTimeout("timed out"),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionError, match="transport error"):
                     await client.get("/projects")
 
@@ -396,7 +436,9 @@ class TestRetry:
                 ],
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 result = await client.get("/projects")
 
             assert result == {"data": []}
@@ -411,7 +453,9 @@ class TestRetry:
                 ],
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 result = await client.get("/projects")
 
             assert result == {"data": ["ok"]}
@@ -428,7 +472,9 @@ class TestRetry:
                 ],
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionError) as exc_info:
                     await client.get("/projects")
 
@@ -445,7 +491,9 @@ class TestRetry:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionError):
                     await client.get("/projects")
 
@@ -461,7 +509,9 @@ class TestRetry:
                 ),
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 with pytest.raises(PolarionAuthError):
                     await client.get("/projects")
 
@@ -478,7 +528,9 @@ class TestRetry:
                 ],
             )
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 result = await client.get("/projects")
 
             assert result == {"data": "ok"}
@@ -505,7 +557,9 @@ class TestSerialization:
         with respx.mock(base_url=BASE) as mock:
             route = mock.get("/projects").mock(side_effect=_record)
 
-            async with PolarionClient(_config(), write_delay=0) as client:
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=0
+            ) as client:
                 await asyncio.gather(
                     client.get("/projects"),
                     client.get("/projects"),
@@ -535,7 +589,9 @@ class TestSerialization:
             mock.post("/projects/p/workitems").mock(side_effect=_on_post)
             mock.get("/projects").mock(side_effect=_on_get)
 
-            async with PolarionClient(_config(), write_delay=write_delay) as client:
+            async with PolarionClient(
+                _config(), write_delay=write_delay, min_interval=0
+            ) as client:
                 await asyncio.gather(
                     client.post("/projects/p/workitems", json={}),
                     client.get("/projects"),
@@ -548,13 +604,78 @@ class TestSerialization:
             f"expected ≥ {write_delay * 0.9:.3f}s (write_delay held by lock)."
         )
 
+    async def test_read_requests_paced_to_min_interval(self) -> None:
+        """Two back-to-back GETs are spaced by at least ``min_interval`` — the
+        ≤3 req/s cap applies to reads, not just writes.
+        """
+        get_start: list[float] = []
+
+        async def _on_get(request: httpx.Request) -> httpx.Response:
+            get_start.append(asyncio.get_running_loop().time())
+            return httpx.Response(200, json={"data": []})
+
+        min_interval = 0.2
+
+        with respx.mock(base_url=BASE) as mock:
+            mock.get("/projects").mock(side_effect=_on_get)
+
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=min_interval
+            ) as client:
+                await client.get("/projects")
+                await client.get("/projects")
+
+        assert len(get_start) == 2
+        # 0.9 slack absorbs scheduler jitter (sleep may wake slightly early).
+        assert get_start[1] - get_start[0] >= min_interval * 0.9, (
+            f"second GET started {get_start[1] - get_start[0]:.3f}s after first; "
+            f"expected ≥ {min_interval * 0.9:.3f}s (read pacing)."
+        )
+
+    async def test_slow_request_adds_no_extra_pacing(self) -> None:
+        """A request slower than ``min_interval`` consumes the interval itself, so
+        the next request issues immediately — pacing is start-based, not additive.
+        """
+        request_time = 0.4
+        min_interval = 0.2
+        first_end: list[float] = []
+        second_start: list[float] = []
+        call = 0
+
+        async def _on_get(request: httpx.Request) -> httpx.Response:
+            nonlocal call
+            call += 1
+            if call == 1:
+                await asyncio.sleep(request_time)
+                first_end.append(asyncio.get_running_loop().time())
+            else:
+                second_start.append(asyncio.get_running_loop().time())
+            return httpx.Response(200, json={"data": []})
+
+        with respx.mock(base_url=BASE) as mock:
+            mock.get("/projects").mock(side_effect=_on_get)
+
+            async with PolarionClient(
+                _config(), write_delay=0, min_interval=min_interval
+            ) as client:
+                await client.get("/projects")
+                await client.get("/projects")
+
+        assert first_end and second_start
+        # request_time (0.4s) already exceeds min_interval, so the second GET
+        # starts right after the first ends — no added pacing sleep.
+        assert second_start[0] - first_end[0] < min_interval, (
+            f"second GET started {second_start[0] - first_end[0]:.3f}s after the "
+            f"first ended; expected < {min_interval:.3f}s (no extra pacing)."
+        )
+
 
 class TestContextManager:
     """Verify async context-manager protocol."""
 
     async def test_context_manager_closes_client(self) -> None:
         """``async with`` should call ``close()`` on exit."""
-        async with PolarionClient(_config(), write_delay=0) as client:
+        async with PolarionClient(_config(), write_delay=0, min_interval=0) as client:
             assert client.base_url.endswith("/polarion/rest/v1")
 
         # After closing, the underlying httpx client is closed.
@@ -562,7 +683,7 @@ class TestContextManager:
 
     async def test_manual_close(self) -> None:
         """Calling ``close()`` directly also shuts down the client."""
-        client = PolarionClient(_config(), write_delay=0)
+        client = PolarionClient(_config(), write_delay=0, min_interval=0)
         await client.close()
         assert client.is_closed
 

--- a/tests/mcp_server_polarion/core/test_client.py
+++ b/tests/mcp_server_polarion/core/test_client.py
@@ -143,7 +143,6 @@ class TestSuccessfulResponses:
                     json={"data": {"attributes": {"title": "Updated"}}},
                 )
 
-            # 204 No Content → empty dict
             assert result == {}
 
     async def test_delete_returns_empty_on_204(self) -> None:
@@ -167,7 +166,6 @@ class TestSuccessfulResponses:
                     },
                 )
 
-            # 204 No Content → empty dict
             assert result == {}
 
     async def test_delete_sends_json_body(self) -> None:
@@ -389,7 +387,6 @@ class TestErrorMapping:
                 with pytest.raises(PolarionError) as exc_info:
                     await client.get("/projects")
 
-        # The error detail portion must not exceed the configured limit.
         status_prefix = "Polarion API error 400 Bad Request: "
         detail_part = str(exc_info.value)[len(status_prefix) :]
         assert len(detail_part) <= _MAX_ERROR_DETAIL_LEN
@@ -605,9 +602,7 @@ class TestSerialization:
         )
 
     async def test_read_requests_paced_to_min_interval(self) -> None:
-        """Two back-to-back GETs are spaced by at least ``min_interval`` — the
-        ≤3 req/s cap applies to reads, not just writes.
-        """
+        """Reads obey the ≤3 req/s cap: two GETs spaced by ``min_interval``."""
         get_start: list[float] = []
 
         async def _on_get(request: httpx.Request) -> httpx.Response:
@@ -633,9 +628,7 @@ class TestSerialization:
         )
 
     async def test_slow_request_adds_no_extra_pacing(self) -> None:
-        """A request slower than ``min_interval`` consumes the interval itself, so
-        the next request issues immediately — pacing is start-based, not additive.
-        """
+        """Start-based pacing: a request slower than ``min_interval`` adds no wait."""
         request_time = 0.4
         min_interval = 0.2
         first_end: list[float] = []
@@ -662,17 +655,14 @@ class TestSerialization:
                 await client.get("/projects")
 
         assert first_end and second_start
-        # request_time (0.4s) already exceeds min_interval, so the second GET
-        # starts right after the first ends — no added pacing sleep.
+        # request_time > min_interval, so the second GET adds no extra sleep.
         assert second_start[0] - first_end[0] < min_interval, (
             f"second GET started {second_start[0] - first_end[0]:.3f}s after the "
             f"first ended; expected < {min_interval:.3f}s (no extra pacing)."
         )
 
     async def test_retry_restamps_pacing(self) -> None:
-        """A retried request stamps each attempt, so the next request paces from
-        the last attempt sent — not from the original (now-stale) start time.
-        """
+        """After a retry, pacing tracks the last attempt sent, not the stale start."""
         starts: list[float] = []
 
         async def _on_get(request: httpx.Request) -> httpx.Response:
@@ -686,19 +676,16 @@ class TestSerialization:
         with respx.mock(base_url=BASE) as mock:
             mock.get("/projects").mock(side_effect=_on_get)
 
-            # Small but non-zero backoff so the retry attempt lands measurably
-            # after the first — exposing pacing that spaces from the stale start.
+            # Non-zero backoff so the retry attempt lands measurably after the first.
             with patch("mcp_server_polarion.core.client._INITIAL_BACKOFF_SECONDS", 0.1):
                 async with PolarionClient(
                     _config(), write_delay=0, min_interval=min_interval
                 ) as client:
                     await client.get("/projects")  # 429 → retried → 200
-                    await client.get("/projects")  # follow-up
+                    await client.get("/projects")
 
-        # Attempts: first 429, retry 200, follow-up 200.
-        assert len(starts) == 3
-        # The follow-up must space from the retry attempt (starts[1]), not the
-        # original start (starts[0]); 0.9 slack absorbs scheduler jitter.
+        assert len(starts) == 3  # first 429, retry 200, follow-up 200
+        # Follow-up spaces from the retry attempt (starts[1]), not stale starts[0].
         assert starts[2] - starts[1] >= min_interval * 0.9, (
             f"follow-up GET started {starts[2] - starts[1]:.3f}s after the retry "
             f"attempt; expected ≥ {min_interval * 0.9:.3f}s (re-stamped pacing)."
@@ -713,7 +700,6 @@ class TestContextManager:
         async with PolarionClient(_config(), write_delay=0, min_interval=0) as client:
             assert client.base_url.endswith("/polarion/rest/v1")
 
-        # After closing, the underlying httpx client is closed.
         assert client.is_closed
 
     async def test_manual_close(self) -> None:

--- a/tests/mcp_server_polarion/core/test_client.py
+++ b/tests/mcp_server_polarion/core/test_client.py
@@ -669,6 +669,41 @@ class TestSerialization:
             f"first ended; expected < {min_interval:.3f}s (no extra pacing)."
         )
 
+    async def test_retry_restamps_pacing(self) -> None:
+        """A retried request stamps each attempt, so the next request paces from
+        the last attempt sent — not from the original (now-stale) start time.
+        """
+        starts: list[float] = []
+
+        async def _on_get(request: httpx.Request) -> httpx.Response:
+            starts.append(asyncio.get_running_loop().time())
+            if len(starts) == 1:
+                return httpx.Response(429, json={"error": "Too Many Requests"})
+            return httpx.Response(200, json={"data": []})
+
+        min_interval = 0.2
+
+        with respx.mock(base_url=BASE) as mock:
+            mock.get("/projects").mock(side_effect=_on_get)
+
+            # Small but non-zero backoff so the retry attempt lands measurably
+            # after the first — exposing pacing that spaces from the stale start.
+            with patch("mcp_server_polarion.core.client._INITIAL_BACKOFF_SECONDS", 0.1):
+                async with PolarionClient(
+                    _config(), write_delay=0, min_interval=min_interval
+                ) as client:
+                    await client.get("/projects")  # 429 → retried → 200
+                    await client.get("/projects")  # follow-up
+
+        # Attempts: first 429, retry 200, follow-up 200.
+        assert len(starts) == 3
+        # The follow-up must space from the retry attempt (starts[1]), not the
+        # original start (starts[0]); 0.9 slack absorbs scheduler jitter.
+        assert starts[2] - starts[1] >= min_interval * 0.9, (
+            f"follow-up GET started {starts[2] - starts[1]:.3f}s after the retry "
+            f"attempt; expected ≥ {min_interval * 0.9:.3f}s (re-stamped pacing)."
+        )
+
 
 class TestContextManager:
     """Verify async context-manager protocol."""


### PR DESCRIPTION
## Summary

Polarion caps clients at ≤3 req/s. The client serialized requests with a lock and added a 1.5s post-write delay, but read (GET) traffic had no rate cap — fast back-to-back reads could exceed 3 req/s and trip 429s, recovered only by retry. This adds deterministic client-side pacing to all requests.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- GETs had no rate cap; fast back-to-back reads tripped Polarion 429s
- Add start-based min-interval pacing in `_request` (no dep, burst-free)

## Testing

- `uv run pytest` — 1396 passed, including 2 new pacing tests
- `uv run ruff check . && uv run ruff format --check . && uv run mypy src/` — all green

New tests in `tests/.../core/test_client.py`:
- `test_read_requests_paced_to_min_interval` — two GETs spaced ≥ `min_interval`
- `test_slow_request_adds_no_extra_pacing` — a request slower than the interval adds no extra wait (pacing is start-based, not additive)

`min_interval` is injectable (defaults to 1/3 s); tests pass `min_interval=0` to stay instant. Chose min-spacing over a token bucket / `aiolimiter`: even drip is the lowest-peak load for a single-threaded server, and needs no new dependency.

## Notes for Reviewers

Writes are unaffected — the existing 1.5s `write_delay` already exceeds the 1/3 s interval, so pacing adds nothing on top of writes.
