### PR TITLE
docs(skills): refine and compress skill suite

### DIFF
--- a/.claude/skills/compress-code-comments/SKILL.md
+++ b/.claude/skills/compress-code-comments/SKILL.md
@@ -1,17 +1,16 @@
----
 name: compress-code-comments
-description: Compress verbose developer code comments and dev docstrings in .py files, Google-style — keep the why, drop the what, one line per point; gated on a comment-only AST diff. Use when asked to tidy/shrink/clean up code comments, cut comment verbosity, or trim over-explained docstrings. NOT for `@mcp.tool` docstrings or `Field(description=...)` (LLM-facing — use shrink-mcp-tool-docs). Triggers on `/compress-code-comments`.
+description: Compress verbose developer code comments and dev docstrings in .py files, Google-style — keep why, drop what, one line per point; gated on comment-only AST diff. Use when asked to tidy/shrink/clean up code comments, cut comment verbosity, or trim over-explained docstrings. NOT for `@mcp.tool` docstrings or `Field(description=...)` (LLM-facing — use shrink-mcp-tool-docs). Triggers on `/compress-code-comments`.
 ---
 
-# Tidy Comments
+# Self-Documenting Code: Comment Compression
 
-Goal: raise the **information density** of developer-facing comments across the codebase. Verbose narration → tight, "why"-first lines. Redundant "what" comments → deleted. The code keeps doing exactly what it did — only comments and dev docstrings change.
+Over-commenting costs: every "what" comment needs re-sync on each code edit (or rots into lie), narration drags reading. Goal: raise **information density** of developer-facing comments across codebase. Verbose narration → tight "why"-first lines. Redundant "what" comments → deleted. Code keeps doing same — only comments and dev docstrings change.
 
-Work **one file at a time** and report what you cut and why. The diff must be comment-only: no executable line moves, no string literal changes, no behavior change. The gate below proves it.
+Work **one file at a time**, report what cut and why. Diff must be comment-only: no executable line moves, no string literal changes, no behavior change. Gate below proves it.
 
 ## Boundary vs shrink-mcp-tool-docs (read first)
 
-This skill and `shrink-mcp-tool-docs` edit different surfaces. Do not cross the line:
+This skill and `shrink-mcp-tool-docs` edit different surfaces. Don't cross line:
 
 | Surface | Owner | This skill |
 |---|---|---|
@@ -21,59 +20,61 @@ This skill and `shrink-mcp-tool-docs` edit different surfaces. Do not cross the 
 | `@mcp.tool` function docstrings | shrink-mcp-tool-docs | **skip — never touch** |
 | `Field(description=...)` strings | shrink-mcp-tool-docs | **skip — never touch** |
 
-A function decorated with `@mcp.tool` ships its whole docstring to the client LLM; that text is eval-gated by the other skill. Leave it byte-for-byte unchanged. Same for every `Field(description=...)`. You may still tidy `#` comments *inside the body* of an `@mcp.tool` function — just not its docstring.
+Function decorated `@mcp.tool` ships whole docstring to client LLM; that text eval-gated by other skill. Leave byte-for-byte unchanged. Same for every `Field(description=...)`. Can still tidy `#` comments *inside the body* of an `@mcp.tool` function — just not its docstring.
 
 ## Scope
 
-Every `.py` file in the repo except `.venv/` and other vendored trees: `src/`, `tests/`, `evals/`, `.github/scripts/`, `.claude/hooks/`, `scripts/`. CLAUDE.md and other `*.md` are out of scope (this skill is code comments only).
+Every `.py` file in repo except `.venv/` and other vendored trees: `src/`, `tests/`, `evals/`, `.github/scripts/`, `.claude/hooks/`, `scripts/`. CLAUDE.md and other `*.md` out of scope (this skill code comments only).
 
-House style is already written down in CLAUDE.md → **Comment & Docstring Style**; this skill applies it Google-style across files that drifted from it. When the repo rule and a Google guideline disagree, the repo rule wins.
+House style already in CLAUDE.md → **Non-Negotiable Rules** (comment/docstring bullets); this skill applies it Google-style across files that drifted. When repo rule and Google guideline disagree, repo rule wins.
 
 ## Never touch — functional pseudo-comments
 
-These look like comments but drive tooling/runtime. Deleting or rewording them breaks the build. Preserve verbatim, including position on the line:
+These look like comments but drive tooling/runtime. Deleting or rewording breaks build. Preserve verbatim, including position on line:
 
-- `# noqa` / `# noqa: E501` (ruff suppressions — this repo uses many)
+- `# noqa` / `# noqa: E501` (ruff suppressions — repo uses many)
 - `# type: ignore[...]` (mypy)
 - `# pragma: no cover` (coverage)
 - `# fmt: off` / `# fmt: on` / `# ruff: noqa` / `# isort:` directives
 - `#!` shebang lines, `# -*- coding: -*-` encoding lines, license/SPDX headers
-- A `#`-comment that is the load-bearing reason a line reads oddly (e.g. explains a `# noqa`)
+- A `#`-comment that is load-bearing reason a line reads oddly (e.g. explains a `# noqa`)
 
-If a comment *combines* a directive with prose (`x = f()  # noqa: E501  legacy: drop after migration`), keep the directive; you may tighten only the prose after it.
+Comment *combines* directive with prose (`x = f()  # noqa: E501  legacy: drop after migration`): keep directive; tighten only prose after it.
 
 ## Compression principles (Google-style)
 
 1. **Density.** Narrative sentences → keyword/noun-phrase fragments. *"This is here in order to retry the request when the server returns a 429 so that we don't fail"* → *"Retry on 429 (rate limit)."*
-2. **Why, not what.** Delete any comment a competent reader gets from the code itself. Keep only intent, rationale, non-obvious constraint, gotcha. `i += 1  # increment i` → delete. `i += 1  # skip the sentinel row` → keep.
-3. **No step-by-step narration.** Inline "now we do X, then Y" comments tracking each statement → delete. If one fact is genuinely load-bearing, lift a single summary line to the top of the function/block (or its docstring) instead of scattering it.
-4. **One line per point.** No multi-sentence paragraphs restating the same idea. No dev-narrative ("we tried X then switched to Y"). No `WARNING:`/`NOTE:`/banner-divider prefixes — state the fact plainly.
-5. **TODOs → Google format.** `# TODO(username): concrete action`. Add an owner if the surrounding context names one; otherwise keep it ownerless but still concrete (`# TODO: drop after Polarion 2410`). Never invent an owner.
-6. **Field/param doc lines** in dev docstrings: one line; drop entirely when the name + type already say it.
+2. **Why, not what.** Delete any comment competent reader gets from code itself. Keep only intent, rationale, non-obvious constraint, gotcha. `i += 1  # increment i` → delete. `i += 1  # skip the sentinel row` → keep.
+3. **No step-by-step narration.** Inline "now we do X, then Y" comments tracking each statement → delete. If one fact genuinely load-bearing, lift single summary line to top of function/block (or its docstring) instead of scattering.
+4. **One line per point.** No multi-sentence paragraphs restating same idea. No dev-narrative ("we tried X then switched to Y"). No `WARNING:`/`NOTE:`/banner-divider prefixes (`# ====`, `# ----`) — state fact plainly.
+5. **TODOs → Google format.** `# TODO(username): concrete action`. Add owner if surrounding context names one; else keep ownerless but still concrete (`# TODO: drop after Polarion 2410`). Prefer issue number or milestone over guessed name when one exists (`# TODO(#142): ...`). Never invent owner.
+6. **Field/param doc lines** in dev docstrings: one line; drop entirely when name + type already say it.
 
-Don't over-cut. A comment that survives explains something the code cannot. When unsure whether a comment is load-bearing, keep it — density is the goal, amnesia is not.
+Don't over-cut. Surviving comment explains something code cannot. Unsure if comment load-bearing → keep it — density is goal, amnesia not.
+
+A bare triple-quoted string that isn't a docstring (not first statement of module/class/function) is string literal, not comment — gate protects it exactly like `Field(...)`. Don't compress it; touching it fails gate.
 
 ## Workflow
 
-Run on a branch off `main` (e.g. `chore/compress-code-comments`), never directly on `main`.
+Run on branch off `main` (e.g. `chore/compress-code-comments`), never directly on `main`.
 
-1. **Baseline gates green.** Confirm a clean tree, then `uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest -q`. If any is already red, stop and report — you need a green baseline to attribute a later failure to your cuts.
-2. **Build the file list** (scope above), e.g. `git ls-files '*.py' | grep -vE '^\.venv/'`. Put it in your todo list and walk it top to bottom — one file in `in_progress` at a time.
+1. **Baseline gates green.** Confirm clean tree, then `uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest -q`. If any already red, stop and report — need green baseline to attribute later failure to your cuts.
+2. **Build the file list.** User named specific files/dirs → restrict to those. No scope given → confirm before starting; don't silently sweep whole repo; offer full scope above or ask which subset. Then build list (e.g. `git ls-files '*.py' | grep -vE '^\.venv/'`), put in todo list, walk top to bottom — one file in `in_progress` at a time.
 3. **Per file:**
    a. Read it. Identify `@mcp.tool` docstrings and `Field(description=...)` → mark off-limits. Identify functional pseudo-comments → mark off-limits.
-   b. Apply the compression principles to the remaining comments/dev-docstrings via `Edit`.
-   c. **Comment-only gate:** `python .claude/skills/compress-code-comments/scripts/assert_comment_only.py <file>` — compares the working file against `HEAD` with comments stripped and docstrings normalized; nonzero exit ⇒ you changed code or a non-docstring literal ⇒ revert that edit. (First run of the loop commits a green baseline so `HEAD` is the pre-tidy state; or pass `--against <ref>`.)
-   d. Record the file's cuts for the summary (count + one-line rationale).
-4. **After a batch (or all files):** run the full gate again — `uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest -q`. Green ⇒ keep. A new ruff/mypy failure almost always means you deleted a `# noqa`/`# type: ignore` — restore it. Red pytest on a comment-only diff is near-impossible; if it happens, your diff wasn't comment-only — re-check with the script.
-5. **Stop** when the list is exhausted or the user scopes you to a subset. Final state = all four gates green.
+   b. Apply compression principles to remaining comments/dev-docstrings via `Edit`.
+   c. **Comment-only gate:** `python .claude/skills/compress-code-comments/scripts/assert_comment_only.py <file>` — compares working file against `HEAD` with comments stripped and docstrings normalized; nonzero exit ⇒ you changed code or non-docstring literal ⇒ revert that edit. Step 1's clean tree makes `HEAD` pre-tidy baseline; don't commit mid-loop, so every per-file check compares working file against original (pass `--against <ref>` only if need different baseline).
+   d. Record file's cuts for summary (count + one-line rationale).
+4. **After a batch (or all files):** run full gate again — `uv run ruff check . && uv run ruff format --check . && uv run mypy src/ && uv run pytest -q`. Green ⇒ keep. New ruff/mypy failure almost always means you deleted a `# noqa`/`# type: ignore` — restore it. Red pytest on comment-only diff near-impossible; if it happens, your diff wasn't comment-only — re-check with script.
+5. **Stop** when list exhausted or user scopes you to subset. Final state = all four gates green.
 
-The `assert_comment_only.py` script is the cheap per-file check; the four-command gate is the authoritative one. Use the script to fail fast, the gate to confirm.
+`assert_comment_only.py` script is cheap per-file check; four-command gate is authoritative one. Use script to fail fast, gate to confirm.
 
 ## Output format
 
-1. **Per file** (only files you changed): `path` — N comments removed, M compressed, plus a one-line rationale for any non-obvious cut. Show the diff for the first couple of files so the user can calibrate, then summarize the rest.
-2. **Preserved-on-purpose:** note any verbose-looking comment you deliberately kept and why (load-bearing), and confirm `@mcp.tool` docstrings / `Field(description=...)` / functional comments were untouched.
-3. **Final gates:** the four green commands.
+1. **Per file** (only files you changed): `path` — N comments removed, M compressed, plus one-line rationale for any non-obvious cut. Show diff for first couple files so user can calibrate, then summarize rest.
+2. **Preserved-on-purpose:** note any verbose-looking comment you deliberately kept and why (load-bearing), confirm `@mcp.tool` docstrings / `Field(description=...)` / functional comments untouched.
+3. **Final gates:** four green commands.
 4. **Totals:** files touched, comments removed, comments compressed, net lines/chars saved.
 
 See `references/google-comment-style.md` for worked before/after examples covering each principle.

--- a/.claude/skills/compress-code-comments/references/google-comment-style.md
+++ b/.claude/skills/compress-code-comments/references/google-comment-style.md
@@ -1,7 +1,7 @@
 # Google-Style Comment Compression — Worked Examples
 
-Reference for the six principles in SKILL.md. Each shows a before → after on Python.
-"Keep" = the comment earns its line. "Cut" = delete entirely.
+Reference for six principles in SKILL.md. Each show before → after on Python.
+"Keep" = comment earn line. "Cut" = delete entirely.
 
 ## 1. Density — narrative → keyword fragments
 
@@ -18,7 +18,7 @@ await asyncio.sleep(POST_MUTATION_DELAY)
 await asyncio.sleep(POST_MUTATION_DELAY)
 ```
 
-Drop "We need to", "here", "because", "in order to". Lead with the noun phrase.
+Drop "We need to", "here", "because", "in order to". Lead with noun phrase.
 
 ## 2. Why, not what — delete code-restating comments
 
@@ -36,7 +36,7 @@ if user is None:         # anonymous comment author resolves to None here
     return
 ```
 
-If deleting the comment loses nothing a reader couldn't get from the line, delete it.
+Deleting comment lose nothing reader couldn't get from line? Delete it.
 
 ## 3. No step-by-step narration — lift one summary line
 
@@ -57,23 +57,26 @@ def _build_payload(item):
     return {"data": {"type": "workitems", "attributes": attrs}}
 ```
 
-The envelope line and the copy line were "what" — gone. The one non-obvious fact
-(why None is filtered) survives as a single line.
+Envelope line and copy line were "what" — gone. One non-obvious fact (why None
+filtered) survive as single line.
 
 ## 4. One line per point — no paragraphs, no banner prefixes
 
 ```python
 # Before
-# NOTE: This is important!!! The link id is composite. It is made up of five
-# segments joined by slashes. Do NOT try to parse it yourself. Always derive
-# the target from the relationships block instead. This has bitten us before.
+# ============================================================
+# WARNING: IMPORTANT!!! READ BEFORE TOUCHING THE LINK ID
+# ============================================================
+# The link id is composite. It is made up of five segments joined by
+# slashes. Do NOT try to parse it yourself. Always derive the target from
+# the relationships block instead. This has bitten us before.
 
 # After
 # Link id is composite (5 slash-joined segments) — derive target from
 # relationships, never parse.
 ```
 
-No `NOTE:`/`WARNING:`, no "this has bitten us before" dev-narrative, no `!!!`.
+No banner dividers (`# ====` or `# ----`), no `NOTE:`/`WARNING:`, no "this has bitten us before" dev-narrative, no `!!!`.
 
 ## 5. TODOs — Google format
 
@@ -82,11 +85,13 @@ No `NOTE:`/`WARNING:`, no "this has bitten us before" dev-narrative, no `!!!`.
 # todo: this is kind of hacky, should probably fix the retry logic at some point
 
 # After
-# TODO(devemberx): replace ad-hoc retry with backoff helper
+# TODO: replace ad-hoc retry with a backoff helper
 ```
 
-Concrete action, owner if context names one. Never invent an owner — ownerless is
-fine if still concrete: `# TODO: drop after Polarion 2410 ships`.
+Before name no owner, so don't invent one — keep ownerless with concrete action.
+Use `# TODO(owner):` or `# TODO(#142):` only when context actually supply owner
+or issue. Ownerless fine if still concrete: `# TODO: drop after
+Polarion 2410 ships`.
 
 ## 6. Dev docstrings — one line per field, drop the obvious
 
@@ -108,15 +113,45 @@ def _split_module_id(module_id):
     """Split a module id (project/space/name); document name may contain '/'."""
 ```
 
-The one fact worth keeping (the name can contain `/`, so you can't naive-split) is
-now the whole docstring. The rest restated the signature.
+One fact worth keeping (name can contain `/`, so can't naive-split) now whole
+docstring. Rest restated signature.
 
 ## What NOT to cut
 
-- Anything explaining a workaround, a gotcha, or a non-obvious constraint.
+- Anything explaining workaround, gotcha, or non-obvious constraint.
 - Functional pseudo-comments: `# noqa`, `# type: ignore[...]`, `# pragma: no cover`,
   `# fmt: off`, shebangs, encoding lines. These drive tooling — preserve verbatim.
 - `@mcp.tool` docstrings and `Field(description=...)` — owned by
   shrink-mcp-tool-docs; out of scope here.
 
-When unsure whether a comment is load-bearing, keep it. Goal is density, not amnesia.
+Unsure if comment load-bearing? Keep it. Goal density, not amnesia.
+
+## Boundary in practice — cut the body comment, preserve everything protected
+
+Inside `@mcp.tool` function you may still tidy `#` comments in body — but
+docstring, every `Field(description=...)`, and functional pseudo-comments stay
+byte-identical. Gate fails if any move.
+
+```python
+# Before
+@mcp.tool
+async def get_work_item(
+    work_item_id: str = Field(description="Verbose id description shipped to the LLM."),
+) -> WorkItem:
+    """Long verbose tool docstring that ships to the client LLM."""
+    raw = await client.get(url)  # noqa: E501
+    # First we parse the raw json into our model object and then we return it
+    # back to the calling function for further processing.
+    return parse(raw)
+
+# After
+@mcp.tool
+async def get_work_item(
+    work_item_id: str = Field(description="Verbose id description shipped to the LLM."),
+) -> WorkItem:
+    """Long verbose tool docstring that ships to the client LLM."""
+    raw = await client.get(url)  # noqa: E501
+    return parse(raw)
+```
+
+Only body "what"-comment cut. Docstring, `Field(...)`, and `# noqa: E501` untouched.

--- a/.claude/skills/compress-code-comments/scripts/assert_comment_only.py
+++ b/.claude/skills/compress-code-comments/scripts/assert_comment_only.py
@@ -61,9 +61,8 @@ def _dump(src: str) -> str:
 
 
 def _git_show(ref: str, path: str) -> str:
-    # git resolves <ref>:<path> from the repo root, not CWD — normalize to a
-    # repo-root-relative path so a subdir or absolute path still hits the right
-    # blob. A path mismatch must not masquerade as "new file" and pass the gate.
+    # git resolves <ref>:<path> from repo root (not CWD); normalize to repo-root-
+    # relative so subdir/absolute paths hit the right blob, not a false "new file".
     root = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
         capture_output=True,
@@ -75,6 +74,10 @@ def _git_show(ref: str, path: str) -> str:
     rel = os.path.relpath(Path(path).resolve(), root.stdout.strip()).replace(
         os.sep, "/"
     )
+    # Outside the repo: git show would 404 and look like a "new file" pass — the
+    # masquerade this whole path-normalization exists to stop. Make it a usage error.
+    if rel == ".." or rel.startswith("../"):
+        raise RuntimeError(f"{path} is outside the repo at {root.stdout.strip()}")
     out = subprocess.run(
         ["git", "show", f"{ref}:{rel}"],
         capture_output=True,
@@ -92,8 +95,8 @@ def main() -> int:
     ap.add_argument("--against", default="HEAD")
     args = ap.parse_args()
 
-    # Read working file first so a bad path is a usage error (exit 2), not a
-    # silent "new file" pass; only then does a ref miss below mean a real new file.
+    # Read working file first: bad path → usage error (exit 2), not a silent
+    # "new file" pass; only then is a below ref-miss a genuine new file.
     try:
         with Path(args.path).open(encoding="utf-8") as fh:
             new = _dump(fh.read())

--- a/.claude/skills/compress-code-comments/scripts/assert_comment_only.py
+++ b/.claude/skills/compress-code-comments/scripts/assert_comment_only.py
@@ -9,13 +9,14 @@ fails the gate, enforcing the shrink-mcp-tool-docs boundary.
 Usage: assert_comment_only.py <path.py> [--against REF]
 
 Exit 0 = comment/docstring-only (or new file, no baseline). 1 = code/protected
-literal changed. 2 = usage error or unparseable source/baseline.
+literal changed. 2 = usage error, unparseable source/baseline, or not a git repo.
 """
 
 from __future__ import annotations
 
 import argparse
 import ast
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -60,14 +61,28 @@ def _dump(src: str) -> str:
 
 
 def _git_show(ref: str, path: str) -> str:
+    # git resolves <ref>:<path> from the repo root, not CWD — normalize to a
+    # repo-root-relative path so a subdir or absolute path still hits the right
+    # blob. A path mismatch must not masquerade as "new file" and pass the gate.
+    root = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if root.returncode != 0:
+        raise RuntimeError(root.stderr.strip() or "not a git repository")
+    rel = os.path.relpath(Path(path).resolve(), root.stdout.strip()).replace(
+        os.sep, "/"
+    )
     out = subprocess.run(
-        ["git", "show", f"{ref}:{path}"],
+        ["git", "show", f"{ref}:{rel}"],
         capture_output=True,
         text=True,
         check=False,
     )
     if out.returncode != 0:
-        raise FileNotFoundError(out.stderr.strip() or f"{ref}:{path} not in git")
+        raise FileNotFoundError(out.stderr.strip() or f"{ref}:{rel} not in git")
     return out.stdout
 
 
@@ -90,6 +105,9 @@ def main() -> int:
     except FileNotFoundError as exc:
         print(f"skip: new file, no baseline ({exc})", file=sys.stderr)
         return 0
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     except SyntaxError as exc:
         print(f"error: baseline does not parse: {exc}", file=sys.stderr)
         return 2

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: deploy
-description: Deployment skill for mcp-server-polarion. Automates version bump, tag creation, and PyPI publish. Triggers on `/deploy` or any release/version bump/tag request.
+description: Deploy skill for mcp-server-polarion. Automate version bump, tag create, PyPI publish. Triggers on `/deploy` or any release/version bump/tag request.
 ---
 
 # Deploy Skill
 
-You are orchestrating a production release. Be deliberate. Never skip hooks. Never push without explicit user confirmation.
+Orchestrate production release. Be deliberate. Never skip hooks. Never push without explicit user confirm.
 
 ## Step 1 — Pre-flight checks (abort on any failure)
 
@@ -18,11 +18,11 @@ git rev-list --count origin/main..HEAD  # MUST be 0
 git config core.hooksPath               # SHOULD be '.githooks'
 ```
 
-- Dirty tree → list offending files and stop. Do NOT auto-stash.
-- Branch != main → ask user to switch manually. Do NOT switch.
-- Behind origin → tell user to `git pull --ff-only`.
-- Ahead of origin → tell user to push or reset; release commit must sit on synced main.
-- `core.hooksPath` ≠ `.githooks` → WARN, ask user to run `git config core.hooksPath .githooks`. Step 4 only *prints* the 50/120 lengths for you to check by eye; with the hook missing nothing enforces them automatically, so restore the hook (the repo-wide net for every commit, not just this one) before committing.
+- Dirty tree → list offending files, stop. Do NOT auto-stash.
+- Branch != main → ask user switch manually. Do NOT switch.
+- Behind origin → tell user run `git pull --ff-only`.
+- Ahead of origin → tell user push or reset; release commit must sit on synced main.
+- `core.hooksPath` ≠ `.githooks` → WARN, ask user run `git config core.hooksPath .githooks`. Step 4 only *prints* 50/120 lengths for eye-check; with hook missing nothing enforces them, so restore hook (repo-wide net for every commit, not just this one) before commit.
 
 ## Step 2 — Determine new version (interactive)
 
@@ -37,19 +37,19 @@ Analyze commits since `$PREV_TAG`:
 - any `feat:` → recommend **minor**
 - only `fix:` / `chore:` / `docs:` → recommend **patch**
 
-Call **AskUserQuestion** with options `patch` / `minor` / `major` / `custom`, noting the recommendation in the question text. For `custom`, prompt for exact `X.Y.Z`.
+Call **AskUserQuestion** with options `patch` / `minor` / `major` / `custom`, note recommendation in question text. For `custom`, prompt exact `X.Y.Z`.
 
-Verify the tag does not already exist (Step 1's `--tags` fetch means this catches remote tags too, not just local):
+Verify tag does not already exist (Step 1's `--tags` fetch catches remote tags too, not just local):
 
 ```bash
 git rev-parse "v${NEW_VERSION}" 2>/dev/null && abort "tag exists" || true
 ```
 
-If it exists, abort and tell the user to pick a different version. A remote tag means that version already shipped (or is mid-publish) — never reuse it. A local-only tag is likely a stale leftover from an aborted prior run; the user can delete it manually (`git tag -d v${NEW_VERSION}`) after confirming it never reached origin.
+If exists, abort, tell user pick different version. Remote tag means version already shipped (or mid-publish) — never reuse. Local-only tag likely stale leftover from aborted prior run; user can delete manually (`git tag -d v${NEW_VERSION}`) after confirming it never reached origin.
 
 ## Step 3 — Bump version
 
-Edit the `^version = "..."` line near the top of `pyproject.toml` to `version = "X.Y.Z"` using the Edit tool (replace only that line).
+Edit `^version = "..."` line near top of `pyproject.toml` to `version = "X.Y.Z"` using Edit tool (replace only that line).
 
 ```bash
 uv lock                          # syncs uv.lock self-entry
@@ -62,7 +62,7 @@ Draft two body bullets:
 - **Bullet 1** (motivation/themes, ≤120 chars) — derive from commits since `$PREV_TAG`.
 - **Bullet 2** (mechanical, fixed) — "Bump project version from PREV to NEW in pyproject.toml and uv.lock."
 
-Show both bullets to the user via AskUserQuestion (`approve` / `edit` / `cancel`). On `edit`, accept replacement text and re-validate.
+Show both bullets to user via AskUserQuestion (`approve` / `edit` / `cancel`). On `edit`, accept replacement text, re-validate.
 
 Validate lengths before invoking git:
 
@@ -72,7 +72,7 @@ awk '{print length}' <<<"- ${BULLET1}"                                  # ≤120
 awk '{print length}' <<<"- ${BULLET2}"                                  # ≤120
 ```
 
-Commit (never `--no-verify`). For the co-author trailer use the model running this deploy session — substitute its name (e.g. `Opus 4.8`) for `<model>` below; never hardcode a fixed version, it goes stale as the model changes:
+Commit (never `--no-verify`). For co-author trailer use model running this deploy session — substitute its name (e.g. `Opus 4.8`) for `<model>` below; never hardcode fixed version, goes stale as model changes:
 
 ```bash
 git add pyproject.toml uv.lock
@@ -87,7 +87,7 @@ EOF
 )"
 ```
 
-On commit-msg hook rejection: surface the hook output, redo `git commit` with corrected message. **Never `--amend`** — hook rejection means no commit was made, so amending would mutate the previous (unrelated) commit and silently corrupt history.
+On commit-msg hook rejection: surface hook output, redo `git commit` with corrected message. **Never `--amend`** — hook rejection means no commit made, so amend would mutate previous (unrelated) commit and silently corrupt history.
 
 ## Step 5 — Push commit (confirm #1)
 
@@ -97,22 +97,22 @@ AskUserQuestion: "Push commit to origin/main? Makes the bump public but does NOT
 git push origin main
 ```
 
-No auto-retry on failure — surface error and let the user decide.
+No auto-retry on failure — surface error, let user decide.
 
 ## Step 6 — Create annotated tag with curated highlights (interactive)
 
-The tag message is the single source of truth for this release's curated highlights — kept in the tag itself, not a committed file, so the repo never accumulates per-release notes. Line 1 is the dated marker; everything after it is the curated bullet list that `build_release_notes.py` reads back from the tag object on push, wraps under a `## Highlights` heading, and prepends above GitHub's categorized PR list. (The full categorized list is generated by the workflow — never hand-write it into the tag.)
+Tag message = single source of truth for this release's curated highlights — kept in tag itself, not a committed file, so repo never accumulates per-release notes. Line 1 = dated marker; rest = curated bullet list that `build_release_notes.py` reads back from tag object on push, wraps under a `## Highlights` heading, prepends above GitHub's categorized PR list. (Full categorized list generated by workflow — never hand-write into tag.)
 
-From the commits since `$PREV_TAG`, draft a curated summary of what *matters* to a user — a few plain-language bullets (or short prose), not a restatement of PR titles. Show it via AskUserQuestion (`approve` / `edit` / `skip`). English only.
+From commits since `$PREV_TAG`, draft curated summary of what *matters* to user — few plain-language bullets (or short prose), not restatement of PR titles. Show via AskUserQuestion (`approve` / `edit` / `skip`). English only.
 
-On `skip`, create a date-only tag (release ships the category list alone):
+On `skip`, create date-only tag (release ships category list alone):
 
 ```bash
 RELEASE_DATE=$(date +%F)  # UTC release date
 git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION} (${RELEASE_DATE})"
 ```
 
-Otherwise compose the message as a curated **bullet list only** — no `## Highlights` heading in the tag (`build_release_notes.py` wraps the bullets under that heading when it renders the GitHub Release). Create the tag with `-F`:
+Otherwise compose message as curated **bullet list only** — no `## Highlights` heading in tag (`build_release_notes.py` wraps bullets under that heading when it renders GitHub Release). Create tag with `-F`:
 
 ```bash
 RELEASE_DATE=$(date +%F)
@@ -141,9 +141,9 @@ git push origin "v${NEW_VERSION}"
 
 On failure: local tag still exists; user can retry with `git push origin v${NEW_VERSION}` or delete locally via `git tag -d v${NEW_VERSION}`.
 
-On `cancel`: the version-bump commit is already on `main` (pushed in Step 5) and the tag exists locally, but no release ships — `main` sits one commit ahead of the last release. Nothing to clean up; finish later by pushing the tag (`git push origin v${NEW_VERSION}`), or just let the next deploy carry it forward.
+On `cancel`: version-bump commit already on `main` (pushed in Step 5) and tag exists locally, but no release ships — `main` sits one commit ahead of last release. Nothing to clean up; finish later by pushing tag (`git push origin v${NEW_VERSION}`), or let next deploy carry it forward.
 
-The GitHub Release is created automatically by the `release` job in `publish.yml` after PyPI succeeds: `build_release_notes.py` reads the Step 6 highlights back from the tag object and prepends them to GitHub's categorized notes, grouped per `.github/release.yml`. Do NOT create a release by hand here; a manual `gh release create` would collide with the workflow (`release already exists`). Categorization quality depends on each merged PR carrying the right label, which `.github/workflows/label-pr.yml` stamps from the PR's conventional-commit title.
+GitHub Release created automatically by `release` job in `publish.yml` after PyPI succeeds: `build_release_notes.py` reads Step 6 highlights back from tag object, prepends to GitHub's categorized notes, grouped per `.github/release.yml`. Do NOT create release by hand here; manual `gh release create` collides with workflow (`release already exists`). Categorization quality depends on each merged PR carrying right label, which `.github/workflows/label-pr.yml` stamps from PR's conventional-commit title.
 
 ## Step 8 — Post-push summary
 
@@ -162,5 +162,5 @@ echo "Watch: https://github.com/${OWNER_REPO}/actions"
 - NEVER `git commit --amend` after a hook rejection.
 - ALWAYS confirm before commit push AND tag push (2 separate confirms).
 - ALWAYS show diff / draft to user before destructive ops.
-- NEVER hand-write the categorized PR list into the tag — `publish.yml` generates that; the tag body holds only the dated marker (line 1) plus curated highlight bullets, no `## Highlights` heading (the release renderer adds it).
-- NEVER run `gh release create` by hand during deploy — the workflow owns it; a manual release collides with the workflow's `release` job.
+- NEVER hand-write categorized PR list into tag — `publish.yml` generates that; tag body holds only dated marker (line 1) plus curated highlight bullets, no `## Highlights` heading (release renderer adds it).
+- NEVER run `gh release create` by hand during deploy — workflow owns it; manual release collides with workflow's `release` job.

--- a/.claude/skills/shrink-mcp-tool-docs/SKILL.md
+++ b/.claude/skills/shrink-mcp-tool-docs/SKILL.md
@@ -1,73 +1,56 @@
 ---
 name: shrink-mcp-tool-docs
-description: Shrink LLM-facing MCP tool descriptions — `@mcp.tool` docstrings and `Field(description=...)` — to the eval-failure boundary via a compress→eval→compress loop with snapshot+rollback, all gates green. Use when asked to shrink/compress/optimize/token-diet tool descriptions, docstrings, or parameter descriptions. NOT for ordinary code comments (use compress-code-comments). Triggers on `/shrink-mcp-tool-docs`.
+description: Shrink LLM-facing MCP tool descriptions — `@mcp.tool` docstrings and `Field(description=...)` — to eval-failure boundary via compress→eval→compress loop with snapshot+rollback, all gates green. Use when asked shrink/compress/optimize/token-diet tool descriptions, docstrings, or param descriptions. NOT for ordinary code comments (use compress-code-comments). Triggers on `/shrink-mcp-tool-docs`.
 ---
 
 # Shrink Tool Descriptions
 
-Goal: minimize the characters (tokens) shipped to the client LLM through `@mcp.tool` descriptions — the tool `description` (the whole docstring) and the `Field(description=...)` param descriptions — pushing to the **failure boundary** while keeping the eval gate GREEN. Operate as a **compress → eval → compress** loop that probes the boundary and adopts the **last GREEN before it**. RED is never committed — RED only means "one cut too far."
+Goal: minimize chars (tokens) shipped to client LLM through `@mcp.tool` descriptions — tool `description` (whole docstring) and `Field(description=...)` param descriptions — push to **failure boundary** while keeping eval gate GREEN. Run as **compress → eval → compress** loop: probe boundary, adopt **last GREEN before it**. RED never committed — RED mean "one cut too far."
 
-Be deliberate. One tool at a time; each cut is a small delta from the current GREEN, never a jump to an absolute terse form. Snapshot before every cut. On RED, **bisect** the cut set — never full-revert to original (that is the net-zero trap). Reproduce a RED before trusting it (`min_pass_rate=1.0` makes a single RED possibly noise).
+Be deliberate. One tool at a time. Each cut small delta from current GREEN, never jump to absolute terse form. Snapshot before every cut. On RED, **bisect** cut set — never full-revert to original (net-zero trap). Reproduce RED before trusting it (`min_pass_rate=1.0` make single RED possibly noise).
 
 ## What actually ships to the LLM (reprove every run — Step 0)
 
-This repo does **not** use Google-style `Args:`/`Returns:` docstrings. Verified surfaces:
+Repo does **not** use Google-style `Args:`/`Returns:` docstrings. Verified surfaces:
 
-- **Tool `description` = the ENTIRE docstring.** No section is stripped — the whole prose ships. **Primary target; editing it is docstring-only.**
-- **Param descriptions = `Field(description=...)` in the signature, NOT the docstring.** They ship in the input schema (`properties[p].description`), but a docstring edit **cannot** touch them.
-- **No `Returns:`/`Raises:`/`Example:` blocks exist** to strip — there is no free text to delete there.
+- **Tool `description` = ENTIRE docstring.** No section stripped — whole prose ships. **Primary target; editing it docstring-only.**
+- **Param descriptions = `Field(description=...)` in signature, NOT docstring.** Ship in input schema (`properties[p].description`); docstring edit **cannot** touch them.
+- **No `Returns:`/`Raises:`/`Example:` blocks exist** to strip — no free text there to delete.
 
-Don't trust this list blind — reprove it with the Step-0 dump each run; a refactor or FastMCP change can move text between surfaces.
+Don't trust list blind — reprove with Step-0 dump each run; refactor or FastMCP change can move text between surfaces.
 
 ### Two scopes
 
-- **Scope A — docstring-only (default).** Compress the docstring prose → tool `description`. Signature untouched. Fully honors "signature/return/logic unchanged."
-- **Scope B — Field-description pass (opt-in; requires explicit operator go-ahead).** Also compress `Field(description=...)` strings. Touch **only** the `description=` string — never the type, `default`, `min_length`/`max_length`, or validators. Params are ~40% of LLM-facing chars (e.g. `update_work_item`: 705 of 1745 chars), so Scope B roughly doubles reachable savings.
+- **Scope A — docstring-only (default).** Compress docstring prose → tool `description`. Signature untouched. Fully honors "signature/return/logic unchanged."
+- **Scope B — Field-description pass (opt-in; needs explicit operator go-ahead).** Also compress `Field(description=...)` strings. Touch **only** `description=` string — never type, `default`, `min_length`/`max_length`, or validators. Params often big share of LLM-facing chars (~40% on param-heavy tools, per Step-0 dump), so Scope B roughly doubles reachable savings.
 
-If the operator has not opted into Scope B, **every `Field(description=...)` is a no-op for your edits** — exclude it from the reducible baseline and report it as such.
+If operator not opted into Scope B, **every `Field(description=...)` no-op for your edits** — exclude from reducible baseline, report as such.
 
 ## Step 0 — dump schema + record baseline (always first)
 
-Dump what reaches the client and confirm your edits change it. `mcp.list_tools()` is async and returns `list[FunctionTool]` with `.name`, `.description`, `.parameters`.
+Dump what reaches client, confirm edits change it. `mcp.list_tools()` async, returns `list[FunctionTool]` with `.name`, `.description`, `.parameters`.
 
 ```bash
 REPO=$(git rev-parse --show-toplevel)   # capture repo root before leaving it
-cd /tmp && uv run --project "$REPO" python - <<'PY'
-import asyncio
-from mcp_server_polarion.server import mcp
-async def go():
-    tools = sorted(await mcp.list_tools(), key=lambda t: t.name)
-    rows = []
-    for t in tools:
-        props = (t.parameters or {}).get("properties", {})
-        desc_n = len(t.description or "")
-        param_n = sum(len(s.get("description", "")) for s in props.values())
-        rows.append((t.name, desc_n, param_n, desc_n + param_n))
-    rows.sort(key=lambda r: -r[3])
-    total = sum(r[3] for r in rows)
-    print(f'{"tool":34}{"desc":>6}{"param":>7}{"total":>7}')
-    for name, d, p, tot in rows:
-        print(f"{name:34}{d:6}{p:7}{tot:7}")
-    print(f'{"TOTAL LLM-facing chars":34}{total:20}')
-asyncio.run(go())
-PY
+cd /tmp && uv run --project "$REPO" python \
+  "$REPO"/.claude/skills/shrink-mcp-tool-docs/scripts/dump_schema.py
 ```
 
-Run from `/tmp` so the repo `.env` is not auto-loaded (it poisons `PolarionConfig` if it ever holds an `OPENAI_API_KEY`). Record per tool: `desc` chars (Scope A target), `param` chars (Scope B target), `total`. Sort descending — long tools = biggest savings first. (Orientation: ~14k total across 24 tools at time of writing.) If a tokenizer (`tiktoken`) is available, also note token counts; else chars are the primary metric.
+Run from `/tmp` so repo `.env` not auto-loaded (poisons `PolarionConfig` if it holds `OPENAI_API_KEY`). Record per tool: `desc` chars (Scope A target), `param` chars (Scope B target), `total`. Sort descending — long tools = biggest savings first. Dump authoritative — never assume fixed tool count or total; set drifts. If tokenizer (`tiktoken`) available, also note token counts; else chars primary metric.
 
-For each param, confirm the schema description text matches what you intend to edit. A param whose text lives in `Field(description=...)` will not move under a Scope-A edit — flag it `no-op (Scope B)`.
+Per param, confirm schema description text matches what you intend to edit. Param whose text lives in `Field(description=...)` won't move under Scope-A edit — flag `no-op (Scope B)`.
 
 ## Compression principles (LLM-facing text only)
 
 **Prose (→ `description`, most important)**
 - "When to call / trigger" over "what it does." `"Updates a work item"` → `"Call to change fields on an existing work item; fetch it first."`
-- One **boundary** line vs the nearest sibling tool ("this tool for X; for Y use `other_tool`").
-- One **negative** line only if misuse is likely ("not for moving between documents — use `move_*`").
-- Keep **pointers to runtime tools** the LLM must chain to (`list_work_item_enum_options`, `get_sql_query_recipes`, `move_work_item_to_document`).
+- One **boundary** line vs nearest sibling tool ("this tool for X; for Y use `other_tool`").
+- One **negative** line only if misuse likely ("not for moving between documents — use `move_*`").
+- Keep **pointers to runtime tools** LLM must chain to (`list_work_item_enum_options`, `get_sql_query_recipes`, `move_work_item_to_document`).
 
 **Field descriptions (→ schema params; Scope B only)**
-- Keep: format/constraint (ID shape, date format, enum allowed values), and the **source** of a value that comes from another tool's output.
-- Drop: type/required already stated by the signature; descriptions self-evident from the name.
+- Keep: format/constraint (ID shape, date format, enum allowed values), and **source** of value from another tool's output.
+- Drop: type/required already stated by signature; descriptions self-evident from name.
 
 **Form**
 - One line each. No dev-narrative ("we tried X"). No `WARNING:`/`NOTE:` prefixes. No banner comments. Consistent tense/terms/format.
@@ -75,48 +58,48 @@ For each param, confirm the schema description text matches what you intend to e
 ## The optimization loop
 
 **Global prep**
-1. Work on a branch off `main` (e.g. `chore/shrink-mcp-tool-docs`) — never run the loop on `main`. Per-cut rollback uses a working-copy snapshot (`git stash` / file copy), not a commit; reserve commits for adopted GREEN baselines. The whole session lands as one squashed commit/PR.
-2. **Verify the eval gate actually runs**, then confirm all 3 gates are GREEN → that is your **GREEN baseline**; checkpoint it. The gate is the only signal that a cut is safe — if no eval model is reachable (`OPENAI_API_KEY` unset *and* ollama down), **STOP and report**. Do not cut without the gate; that ships unvalidated descriptions to clients.
+1. Work on branch off `main` (e.g. `chore/shrink-mcp-tool-docs`) — never run loop on `main`. Each adopted GREEN committed, so per-cut rollback just `git restore <file>` (or `git checkout -- <file>`) back to that commit — no stash juggling; working tree only ever holds in-flight cut. Whole session lands as one squashed commit/PR.
+2. **Match publish gate's model, or don't run.** Failure boundary model-specific, so optimize against *exact* model publish gate uses — `EVAL_MODEL`'s default `openai/gpt-4o-mini` (CI doesn't override). Needs `OPENAI_API_KEY`; if unset, **STOP and report** — never substitute local/ollama model, boundary found on different model REDs real gate. Then assume branch starts GREEN (released tip), run **one Fast gate** to confirm harness runs and green — not full Confirm; re-proving already-green tip with 10 runs wasted cost. Fast RED at entry = pre-existing breakage → STOP (not yours to fix here). That first GREEN your baseline; checkpoint it.
 3. Step-0 dump + baseline chars.
 4. Sort tools by LLM-facing chars **descending**.
 
-**Cut risk classes** (L1 safest → L4 riskiest; draw candidate cuts in this order, cheapest-risk first — these are a *risk ordering of edits*, not atomic rungs to jump to):
-- **L1** — bits restated by the signature / self-evident clauses / trivially redundant prose (Scope B: redundant param trims if opted in).
+**Cut risk classes** (L1 safest → L4 riskiest; draw candidate cuts in this order, cheapest-risk first — these *risk ordering of edits*, not atomic rungs to jump to):
+- **L1** — bits restated by signature / self-evident clauses / trivially redundant prose (Scope B: redundant param trims if opted in).
 - **L2** — rewrite prose what→when(trigger); compress boundary + negative to one line each.
 - **L3** — prose toward trigger line + boundary line; params (Scope B) toward format/constraint/source only.
 - **L4 (floor-adjacent)** — trigger line + only load-bearing enum/format/source. No further.
 
-**Per tool (incremental descent + bisection)** — each cut is a small delta from the *current GREEN*, never a jump to an absolute terse form; a RED is recovered by **bisecting the cut set**, never by reverting to the original (revert-to-original is the net-zero trap):
-1. Snapshot current GREEN (working-copy snapshot, cheap to revert).
-2. **First cut is always the gentlest** — L1 redundancy only. Gate → commit as the tool's first GREEN baseline **before** any rewrite. Guarantees ≥1 committed GREEN for every tool with slack, so a later overshoot can never zero the tool out.
-3. Build the next **candidate-cut set**: independent edits from the lowest unfinished risk class. Target ~15–20% of remaining reducible chars per step — a delta, not a leap to the floor.
-4. Apply the whole set, **Fast gate** → GREEN: go to 4-a. RED: go to 4-b.
+**Per tool (incremental descent + bisection)** — each cut small delta from *current GREEN*, never jump to absolute terse form; RED recovered by **bisecting cut set**, never reverting to original (revert-to-original net-zero trap):
+1. Last GREEN already committed (step 2 / 4-a), so to roll back any cut, `git restore <file>` returns file to that committed GREEN — no separate snapshot needed.
+2. **First cut always gentlest** — L1 redundancy only. Gate → commit as tool's first GREEN baseline **before** any rewrite. Guarantees ≥1 committed GREEN for every tool with slack, so later overshoot can never zero tool out.
+3. Build next **candidate-cut set**: independent edits from lowest unfinished risk class. Target ~15–20% of remaining reducible chars per step — delta, not leap to floor.
+4. Apply whole set, **Fast gate** → GREEN: go to 4-a. RED: go to 4-b.
 4-a. Fast GREEN → run **Confirm gate**:
-   - Confirm GREEN → commit as **new GREEN baseline**, refresh baseline chars, **re-sort**, build the next set (step 3).
+   - Confirm GREEN → commit as **new GREEN baseline**, refresh baseline chars, **re-sort**, build next set (step 3).
    - Confirm RED (variance or overfit) → revert to last GREEN, **lock** this tool, move to next tool.
-4-b. Fast RED — **bisect the candidate set, do NOT full-revert**:
-   - Split the set: safer half (L1 / redundant-param trims) vs riskier half (trigger/boundary/enum rewrites). Read the failing transcript to decide which cuts are riskier — **which tool was mis-selected or mis-parametrized, and why** (extended thinking on if available).
-   - Drop the riskier half, re-gate the safer half. GREEN → commit that subset, then re-attempt the dropped cuts **one at a time** (step 3). RED → recurse: bisect the still-applied set again.
-   - A single cut alone RED → that phrase is load-bearing → restore **only it**, keep the rest, lock it out of future sets.
-   - `min_pass_rate=1.0`: **reproduce a RED once** (re-run Fast) before calling a cut load-bearing — a lone RED can be noise.
-5. Repeat from 3 until the reducible set is exhausted or every remaining single cut is RED → **lock** at last GREEN.
+4-b. Fast RED — **bisect candidate set, do NOT full-revert**:
+   - Split set **mechanically by risk class**: safer half = lowest-Lx cuts (L1 / redundant-param trims), riskier half = higher-Lx ones (trigger/boundary/enum rewrites). If every cut same class, split by position into two equal halves (first vs second) — don't agonize over which *feels* riskier. Use failing transcript only to explain **why** a cut regressed (which tool mis-selected or mis-parametrized), not to choose split.
+   - Drop riskier half, re-gate safer half. GREEN → commit that subset, then re-attempt dropped cuts **one at a time** (step 3). RED → recurse: bisect still-applied set again.
+   - Single cut alone RED → that phrase load-bearing → restore **only it**, keep rest, lock out of future sets.
+   - `min_pass_rate=1.0`: **reproduce RED once** (re-run Fast) before calling cut load-bearing — lone RED can be noise.
+5. Repeat from 3 until reducible set exhausted or every remaining single cut RED → **lock** at last GREEN.
 
-**Invariant:** a RED discards only the last delta, never accumulated GREEN. Net-zero for a tool happens only if its very first L1 trim is RED — meaning it was already at floor.
+**Invariant:** RED discards only last delta, never accumulated GREEN. Net-zero for tool happens only if its very first L1 trim RED — meaning already at floor.
 
-**Confirm-gate cost:** smaller deltas mean more iterations, so don't run the (expensive) Confirm gate per delta far from the floor. For early L1 deltas, batch several Fast-GREEN deltas and Confirm once before switching risk class; near the boundary, Confirm per delta. A batched Confirm RED bisects the batch.
+**Confirm-gate cost:** smaller deltas mean more iterations, so don't run (expensive) Confirm gate per delta far from floor. For early L1 deltas, batch up to ~3–5 Fast-GREEN deltas (or one full risk-class pass, whichever first) and Confirm once before switching risk class; near boundary, Confirm per delta. Batched Confirm RED bisects batch.
 
-**Global stop:** all tools locked; or a full pass's cumulative saving < ~50 chars; or an operator-set iteration cap is hit. **On stop, re-run all 3 gates at the last GREEN baseline and confirm green.** Submission = last GREEN, never RED.
+**Global stop:** all tools locked; or full pass's cumulative saving < ~50 chars; or operator-set iteration cap hit. **On stop, re-run all gates at last GREEN baseline, confirm green.** Submission = last GREEN, never RED.
 
 ## Gates
 
-**Preconditions** (once): `uv sync --group evals` — `strands_evals` is not in the default env. The eval agent needs a model: `OPENAI_API_KEY` (cloud, CI default) or `EVAL_MODEL=ollama_chat/<model>` (local). Cloud is faster and more reliable at `min_pass_rate=1.0`; local ollama is slow, so lean on the Fast gate (`--runs 1`) for triage and raise runs only near the boundary. Run eval/pytest from a CWD outside the repo when the repo `.env` carries an `OPENAI_API_KEY` (it shadows `PolarionConfig`); `cd /tmp && uv run --project <repo> ...` avoids it.
+**Preconditions** (once): `uv sync --group evals` — `strands_evals` not in default env. Eval agent's model from `EVAL_MODEL` (default `openai/gpt-4o-mini`), publish gate uses that default — so **leave at default, provide `OPENAI_API_KEY`**. Optimizing against different model (e.g. local ollama) unsound vs gate (see Global prep 2). Run eval/pytest from CWD outside repo when repo `.env` carries `OPENAI_API_KEY` (shadows `PolarionConfig`); `cd /tmp && uv run --project <repo> ...` avoids it.
 
 **Fast gate** (cheap triage after each cut):
 ```bash
 uv run python -m evals.run --runs 1
 uv run pytest tests/mcp_server_polarion/test_mcp_transport.py -q
 ```
-- The gate runs **all behaviour categories**: `triggers`/`safety` (`min_pass_rate=1.0`) **and** `efficiency`/`orchestration` (`0.8`). Docstring cuts regress **both kinds** — a too-terse description can make the agent take a wasteful path (efficiency) even when it never does the forbidden action (safety). Read the gate summary, not just the exit code.
+- Gate runs **all behaviour categories**: `triggers`/`safety` (`min_pass_rate=1.0`) **and** `efficiency`/`orchestration` (`0.8`). Docstring cuts regress **both kinds** — too-terse description can make agent take wasteful path (efficiency) even when it never does forbidden action (safety). Read gate summary, not just exit code.
 - During diagnosis target one case: `uv run python -m evals.run --case <NAME> --runs 1` (browse case names + intents with `uv run python -m evals.run --list`).
 
 **Confirm gate** (before committing/locking a baseline — kills variance + overfit):
@@ -125,28 +108,35 @@ uv run python -m evals.run --runs 5     # raise toward boundary; full default = 
 uv run pytest
 uv run ruff check . && uv run ruff format . && uv run mypy src/
 ```
-- **Variance:** as cuts shrink, the effect size shrinks and noise vs real regression blurs → raise `--runs` near the boundary. GREEN/RED that flaps across runs = unstable cut → do **not** adopt it; keep the last stable GREEN.
-- **Overfit:** reserve a held-out subset of case names (pick a few via `--case`), **never run them during the loop**, run them only at Confirm. Held-out RED = overfit → revert that cut.
+- **Variance:** as cuts shrink, effect size shrinks and noise vs real regression blurs → raise `--runs` near boundary. GREEN/RED that flaps across runs = unstable cut → do **not** adopt; keep last stable GREEN.
+- **Overfit:** reserve held-out subset of case names (pick a few via `--case`), **never run during loop**, run only at Confirm. Held-out RED = overfit → revert that cut.
 
 ## Floor (never cut below — load-bearing)
 
-Trigger/when line · one sibling-boundary line when a near-duplicate tool exists · enum allowed-values and ID/date formats · the source of values that come from other tools' output · pointers to runtime-callable tools (`get_sql_query_recipes`, `list_*_enum_options`, `move_*`). The transport test asserts every `description` is **non-empty** — an empty description is a guaranteed RED.
+Trigger/when line · one sibling-boundary line when near-duplicate tool exists · enum allowed-values and ID/date formats · source of values from other tools' output · pointers to runtime-callable tools (`get_sql_query_recipes`, `list_*_enum_options`, `move_*`). Transport test asserts every `description` **non-empty** — empty description guaranteed RED.
+
+Keep constraint/format phrasings **byte-exact** — never abbreviate single character. Load-bearing because agent copies them verbatim into payloads:
+- ID shapes: `MCPT-123`, 5-segment link id, 3-segment module id form.
+- Date/time format: `YYYY-MM-DDThh:mm:ssZ`.
+- Enum allowed-value lists: `one of: open, inProgress, done`.
+
+Shortening any of these (e.g. `YYYY-MM-DD` → "a date") can make agent emit malformed value even when eval happens to pass on that run.
 
 ## Absolute rules
 
-1. **Final submission = the last GREEN baseline, with all 3 green:**
+1. **Final submission = last GREEN baseline, all gates green:**
    - `uv run python -m evals.run` (triggers/safety all pass at 1.0; efficiency/orchestration at 0.8)
    - `uv run pytest` (esp. `tests/mcp_server_polarion/test_mcp_transport.py` and `tests/evals/`)
    - `uv run ruff check . && uv run ruff format . && uv run mypy src/`
-2. **Scope A: docstring only.** Scope B (opt-in): only the `description=` string of `Field(...)`; never type/default/constraint/logic. Signatures, return types, behavior unchanged in both.
-3. Docstrings stay **self-contained** — but keep the runtime-tool pointers (`get_sql_query_recipes`, etc.).
-4. **Never commit/submit RED.** RED is a boundary signal; the adopted state is always the prior GREEN.
-5. Tool count is unchanged → leave `EXPECTED_TOOL_NAMES` alone. Don't touch the `get_sql_query_recipes` guide body (the transport test asserts its content).
+2. **Scope A: docstring only.** Scope B (opt-in): only `description=` string of `Field(...)`; never type/default/constraint/logic. Signatures, return types, behavior unchanged in both.
+3. Docstrings stay **self-contained** — but keep runtime-tool pointers (`get_sql_query_recipes`, etc.).
+4. **Never commit/submit RED.** RED boundary signal; adopted state always prior GREEN.
+5. Tool count unchanged → leave `EXPECTED_TOOL_NAMES` alone. Don't touch `get_sql_query_recipes` guide body (transport test asserts its content).
 
 ## Output format
 
-1. **Step-0 result:** which surface each string ships on, the Scope-B param list (the no-op-for-Scope-A set), and the baseline char table.
-2. **Per tool** (LLM-facing chars descending): before/after diff + one-line rationale ("what was cut and why") + adopted risk class (Lx) and final cut set (post-bisection) + char (and token, if available) savings.
-3. **Loop log:** one row per iteration `[tool | cut (Lx set / bisect-subset / single restore) | Fast | Confirm | decision (commit/bisect/lock)]`; each RED cut + its diagnosis (which tool mis-selected and why) + the bisection outcome on one line.
-4. **Final gate captures:** all 3 green at the last GREEN baseline.
+1. **Step-0 result:** which surface each string ships on, Scope-B param list (no-op-for-Scope-A set), baseline char table.
+2. **Per tool** (LLM-facing chars descending): before/after diff + one-line rationale ("what cut and why") + adopted risk class (Lx) and final cut set (post-bisection) + char (and token, if available) savings.
+3. **Loop log:** one row per iteration `[tool | cut (Lx set / bisect-subset / single restore) | Fast | Confirm | decision (commit/bisect/lock)]`; each RED cut + its diagnosis (which tool mis-selected and why) + bisection outcome on one line.
+4. **Final gate captures:** all gates green at last GREEN baseline.
 5. **Total LLM-facing savings:** summed chars (+ token estimate) + per-tool before→after table.

--- a/.claude/skills/shrink-mcp-tool-docs/scripts/dump_schema.py
+++ b/.claude/skills/shrink-mcp-tool-docs/scripts/dump_schema.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Dump each MCP tool's LLM-facing char counts: docstring (-> description) vs
+Field(description=...) params. Step 0 of shrink-mcp-tool-docs and the only
+authoritative baseline — never assume a fixed tool count or total, the set drifts.
+
+Run from outside the repo so the repo .env is not auto-loaded (a stray
+OPENAI_API_KEY there shadows PolarionConfig):
+
+    REPO=$(git rev-parse --show-toplevel)
+    cd /tmp && uv run --project "$REPO" python \
+      "$REPO"/.claude/skills/shrink-mcp-tool-docs/scripts/dump_schema.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from mcp_server_polarion.server import mcp
+
+
+async def go() -> None:
+    tools = sorted(await mcp.list_tools(), key=lambda t: t.name)
+    rows: list[tuple[str, int, int, int]] = []
+    for t in tools:
+        props = (t.parameters or {}).get("properties", {})
+        desc_n = len(t.description or "")
+        param_n = sum(len(s.get("description", "")) for s in props.values())
+        rows.append((t.name, desc_n, param_n, desc_n + param_n))
+    rows.sort(key=lambda r: -r[3])
+    total = sum(r[3] for r in rows)
+    print(f"{'tool':34}{'desc':>6}{'param':>7}{'total':>7}")
+    for name, d, p, tot in rows:
+        print(f"{name:34}{d:6}{p:7}{tot:7}")
+    print(f"{'TOTAL LLM-facing chars':34}{total:20}")
+
+
+if __name__ == "__main__":
+    asyncio.run(go())


### PR DESCRIPTION
## Summary

Refine the skill suite and then compress it. The earlier framing ("caveman-compress skill docs") undersold the work: alongside cutting per-load tokens, this hardens the skill rules, extracts a reusable helper script, and fixes a real bug in the comment-only gate. Prose is reworded into terse fragments only after the content was made correct; frontmatter and code blocks stay verbatim.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Skill guides needed firmer rules plus tooling, but the docs sold only compression and hid a comment-gate path bug
- Refine 4 skill guides, extract dump_schema.py, fix assert_comment_only repo-root path, then compress prose

## Details

- shrink-mcp-tool-docs: add the "match the publish gate's model" rule (optimize against gpt-4o-mini, never local ollama); switch rollback from git stash snapshots to git restore off committed GREEN baselines; add the byte-exact Floor section (ID/date/enum literals); split bisection mechanically by risk class; extract the inline Step-0 heredoc into scripts/dump_schema.py.
- compress-code-comments: expand the gate workflow (baseline-green precondition, file-list build, per-file vs full-gate cadence); add the @mcp.tool / non-docstring-literal boundary rules; broaden banner and TODO-owner guidance.
- google-comment-style.md: add the "Boundary in practice" section, banner-divider examples, and richer TODO-owner / what-not-to-cut guidance.
- deploy: tighten preflight, tag-existence, commit-hook, and release-notes (build_release_notes.py) guidance.
- assert_comment_only.py (bug fix): resolve the baseline blob against the repo root, not CWD, so a subdir or absolute path no longer misses the blob and silently passes the gate as a "new file"; add not-a-git-repo handling (exit 2).
- Compression: reword all prose into caveman-terse fragments; frontmatter name/description and fenced code blocks unchanged.

## Testing

- assert_comment_only.py run from a subdir and with an absolute path: baseline blob now resolves; not-a-repo path returns exit 2.
- dump_schema.py runs from /tmp against the in-memory server and prints the per-tool char table (matches the prior inline heredoc output).
- caveman-compress validator passed on all skill .md files (URLs, headings, code blocks, inline code preserved); frontmatter name and description intact, so triggering is unaffected.

## Notes for Reviewers

- No longer compression-only: the new rules in shrink-mcp-tool-docs (gate-model match, GREEN-baseline rollback, byte-exact Floor) and the assert_comment_only.py path fix change behavior; worth a close read.
- Net diff is roughly balanced: rule and example additions offset prose savings, so token reduction is modest by design.
