### PR TITLE
fix(deps): bump joserfc to 1.7.1 (CVE fix)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1098,14 +1098,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.5"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

osv-scanner flags joserfc 1.6.5 (GHSA-wphv-vfrh-23q5, CVSS 5.3) in the security-scan `audit` job, so the gate fails on every PR. joserfc is a transitive dependency (authlib -> fastmcp), so this is a lockfile-only bump to 1.7.1 (past the 1.6.7 fix); pyproject is unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- joserfc 1.6.5 flagged by osv-scanner GHSA-wphv-vfrh-23q5 (medium), failing the security-scan audit on every PR
- Transitive bump via uv lock --upgrade-package joserfc to 1.7.1 (>=1.6.7 fix); lockfile-only, no pyproject change

## Testing

- uv lock resolves 148 packages clean; joserfc 1.6.5 -> 1.7.1, no other package moves (uv.lock diff is 3 lines).
- Confirmed 1.7.1 satisfies authlib's joserfc constraint; runtime-requirements export will now carry the fixed version, clearing the osv-scanner audit.

## Notes for Reviewers

- Pre-existing on main, not introduced by any feature branch; split out so the CVE fix lands under a fix(deps) label instead of being buried in an unrelated squash.
