### PR TITLE
feat(tools): add list_test_runs read tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,56 +15,56 @@ uv run pytest --cov=src/mcp_server_polarion --cov=evals --cov-report=xml \
 uv run mcp-server-polarion                               # run server (stdio)
 ```
 
-CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-under=90`) → `diff-cover` (every changed line ≥90%). Each PR line needs a test — incl. parser defensive branches and `evals/harness` request handlers, not only `src/`. Run the `diff-cover` command above before pushing.
+CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-under=90`) → `diff-cover` (every changed line ≥90%). Each PR line needs test — incl parser defensive branches + `evals/harness` request handlers, not only `src/`. Run `diff-cover` command above before push.
 
 ## Architecture
 
 - `core/` — `client.py` (async httpx, retries 429/5xx → `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only; loggers `mcp_server_polarion.<module>`).
 - `tools/` — domain modules; `_build_*_payload` = unit-test seam; `tools/__init__.py` import registers `@mcp.tool`s. `_shared/`: `helpers.py`, `parse.py` (JSON:API→models), `pagination.py` (`make_page`), `fields.py`/`custom_fields.py` (sparse-fieldset + custom-field policy), `cache.py` (`TTLCache`), `guard.py` (write guards), `sql.py` (recipes). `tools/guides/` = on-demand data.
 - `utils/html.py` — Markdown↔HTML, `stamp_block_ids`, `first_anchorless_block`.
-- `models/` — Pydantic v2, re-exported from `models/__init__.py`; `PaginatedResult[T]` wraps list responses.
+- `models/` — Pydantic v2, re-exported from `models/__init__.py`; `PaginatedResult[T]` wrap list responses.
 - `server.py` — FastMCP instance; lifespan owns `PolarionClient`.
 
 ## Non-Negotiable Rules
 
-- NEVER `print()` — stdout is MCP JSON-RPC; log to stderr.
+- NEVER `print()` — stdout = MCP JSON-RPC; log to stderr.
 - NEVER `typing.Any` — concrete types or `object`.
-- All functions: full annotations + `from __future__ import annotations`. Tool functions: `async def` returning Pydantic model.
+- All functions: full annotations + `from __future__ import annotations`. Tool functions: `async def` return Pydantic model.
 - Body fields asymmetric by tool purpose:
-  - Round-trip: `get_*(include_*_html=True)` returns raw Polarion HTML; `update_*(*_html=...)` accepts verbatim — no sanitize/convert.
+  - Round-trip: `get_*(include_*_html=True)` return raw Polarion HTML; `update_*(*_html=...)` accept verbatim — no sanitize/convert.
   - Greenfield create (Markdown): `markdown_to_html` + `sanitize_html`. Post-create edits = raw-HTML round-trip; formats never mix.
-  - Synthesis (READ-ONLY): `read_*` convert HTML→Markdown; feeding output back to writes loses Polarion markup.
-- Write payloads skip `None`/empty (Polarion reads empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
+  - Synthesis (READ-ONLY): `read_*` convert HTML→Markdown; feed output back to writes lose Polarion markup.
+- Write payloads skip `None`/empty (Polarion read empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
 - Every list tool: `page_size` (max 100) + `page_number` → `PaginatedResult[T]` with `has_more`.
-- Every write tool: `dry_run: bool = False` — return payload without hitting Polarion.
+- Every write tool: `dry_run: bool = False` — return payload, no hit Polarion.
 - Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`.
-- Guards fail closed: validation GET error blocks write; only successful empty option set defers to Polarion.
-- Docstrings = LLM manual, Google-style; only prose above `Args:` ships — keep tight; return-field bullets in sync with model. Field descriptions one line, skip when name + type say all.
-- No `WARNING:`/`NOTE:` prefixes, no dev-narrative, no banner dividers. CLAUDE.md dev-only — MCP-user info lives in `@mcp.tool` docstring. Module docstrings = why module exists; constraints inline next to what they constrain.
-- Comments: one line, explain why not what; never restate self-evident code. No dead code, no stray `TODO`s; keep comments in sync when code changes.
+- Guards fail closed: validation GET error block write; only successful empty option set defer to Polarion.
+- Docstrings = LLM manual, Google-style; only prose above `Args:` ship — keep tight; return-field bullets sync with model. Field descriptions one line, skip when name + type say all.
+- No `WARNING:`/`NOTE:` prefixes, no dev-narrative, no banner dividers. CLAUDE.md dev-only — MCP-user info live in `@mcp.tool` docstring. Module docstrings = why module exists; constraints inline next to what they constrain.
+- Comments: one line, explain why not what; never restate self-evident code. No dead code, no stray `TODO`s; keep comments sync when code change.
 
 ## Polarion API Gotchas
 
-- Baseline: Polarion REST API v2506 — assume that version's behavior.
+- Baseline: Polarion REST API v2506 — assume that version behavior.
 - JSON:API v1. HTML stored as `{"type": "text/html", "value": "..."}`.
 - Linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse. Module ids = 3 segments, doc names may contain `/` — use `split_module_id`.
 - Lucene: trailing wildcards OK, leading 400. `module`/`description` not indexed — use `query="SQL:(...)"`; recipes via `get_sql_query_recipes`.
-- Server limits: ≤3 req/s, no concurrency. Client serializes via lock + paces every request to ≤3 req/s (start-based min-interval, so slow requests add no extra wait); writes also add a 1.5s post-delay; retries 429/5xx.
-- Sparse fieldset drops `relationships` block — list relationship names explicitly. To-many need `include=`; nested dot-path drops intermediate resource (`module,module.author`, not `module.author` alone).
+- Server limits: ≤3 req/s, no concurrency. Client serialize via lock + pace every request to ≤3 req/s (start-based min-interval, so slow request add no extra wait); writes add 1.5s post-delay; retries 429/5xx.
+- Sparse fieldset drop `relationships` block — list relationship names explicit. To-many need `include=`; nested dot-path drop intermediate resource (`module,module.author`, not `module.author` alone).
 - `/backlinkedworkitems` unsupported — back direction via `query=linkedWorkItems:{wi}`, so back results have `role=None`.
-- Polarion validates neither custom-field ids (unknown keys persist; wrong-type 400), nor enum values, nor link targets/roles — `guard.py` validates pre-write. `getAvailableOptions` = only key→enum-options API (non-enum/unknown → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (`data` is dict, not list).
+- Polarion validate neither custom-field ids (unknown keys persist; wrong-type 400), nor enum values, nor link targets/roles — `guard.py` validate pre-write. `getAvailableOptions` = only key→enum-options API (non-enum/unknown → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (`data` = dict, not list).
 - Custom fields inline under `attributes` (no `customFields` container; `@all` tokens dropped). `GET /projects/{p}/documents` absent on some builds.
 
 ## Testing
 
-- `tests/` mirrors source one-to-one; shared fixtures in `tests/` `conftest.py`; `mock_client`/`mock_ctx` + autouse guard-cache reset in `tools/conftest.py`.
-- `pytest-asyncio` `mode=auto`. Tool tests call functions directly (`@mcp.tool` returns original); client tests use `respx`. Pydantic `Field` constraints bypass JSON Schema on direct calls — verify via `TypeAdapter` reconstruction.
-- New `@mcp.tool` requires updating `EXPECTED_TOOL_NAMES` in `test_mcp_transport.py`.
-- `tests/evals/` opens with `pytest.importorskip` (`evals` group; CI syncs `--group evals`).
+- `tests/` mirror source one-to-one; shared fixtures in `tests/` `conftest.py`; `mock_client`/`mock_ctx` + autouse guard-cache reset in `tools/conftest.py`.
+- `pytest-asyncio` `mode=auto`. Tool tests call functions directly (`@mcp.tool` return original); client tests use `respx`. Pydantic `Field` constraints bypass JSON Schema on direct call — verify via `TypeAdapter` reconstruction.
+- New `@mcp.tool` needs update `EXPECTED_TOOL_NAMES` in `test_mcp_transport.py`.
+- `tests/evals/` open with `pytest.importorskip` (`evals` group; CI sync `--group evals`).
 
 ## Evals — deploy gate
 
-`evals/` drives real LLM through in-memory server against mocked Polarion; deterministic checks, no judge. Hard gate before PyPI publish (`triggers`/`safety` min_pass_rate 1.0; `efficiency`/`orchestration` 0.8). New-case + coverage rules in [evals/README.md](evals/README.md); `tests/evals/test_coverage.py` enforces every tool covered or deferred.
+`evals/` drive real LLM through in-memory server against mocked Polarion; deterministic checks, no judge. Hard gate before PyPI publish (`triggers`/`safety` min_pass_rate 1.0; `efficiency`/`orchestration` 0.8). New-case + coverage rules in [evals/README.md](evals/README.md); `tests/evals/test_coverage.py` enforce every tool covered or deferred.
 
 ## Repo Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,12 @@ uv run pytest                                            # all tests
 uv run pytest --cov --cov-report=term-missing            # tests + uncovered lines
 uv run pytest --cov --cov-report=html                    # htmlcov/index.html (visual)
 uv run ruff check . && uv run ruff format . && uv run mypy src/  # lint + format + types
+uv run pytest --cov=src/mcp_server_polarion --cov=evals --cov-report=xml \
+  && uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90  # changed-line gate
 uv run mcp-server-polarion                               # run server (stdio)
 ```
 
-CI: `ruff check` → `ruff format --check` → `mypy` → `pytest`.
+CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-under=90`) → `diff-cover` (every changed line ≥90%). Each PR line needs a test — incl. parser defensive branches and `evals/harness` request handlers, not only `src/`. Run the `diff-cover` command above before pushing.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **P
 
 ## Features
 
-- **27 tools** covering read and write across documents, work items, traceability links, and comments.
+- **28 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
 - **Read** — render documents as Markdown, search with Lucene or SQL, walk incoming/outgoing links, resolve enum options.
 - **Write** — create and update work items and documents, manage links, reorganize document structure, post comments.
 - **Safe writes** — every write tool supports `dry_run`, and pre-write guards validate fields, enum values, and link targets before hitting Polarion.
@@ -158,6 +158,7 @@ claude mcp add mcp-server-polarion \
 | `list_projects` | List accessible projects |
 | `list_documents` | List documents in a project |
 | `list_work_items` | Search work items with Lucene or SQL queries |
+| `list_test_runs` | List test runs in a project (Lucene/SQL query, templates filter) |
 | `get_sql_query_recipes` | Fetch copy-paste SQL recipes for advanced queries |
 | `get_document` | Get document metadata, optionally with the raw body HTML |
 | `read_document` | Render a document end-to-end as Markdown |

--- a/evals/cases/triggers.py
+++ b/evals/cases/triggers.py
@@ -14,6 +14,7 @@ from evals.harness.fixtures import (
     DOC,
     FLOATING_TASK_ID,
     PARENT_REQ_ID,
+    PROJECT,
     SPACE,
 )
 
@@ -173,5 +174,14 @@ CASES: list[Case] = [
         covers=["delete_work_item_links"],
         expect="delete_work_item_links",
         reject=["update_work_item_link"],
+    ),
+    _case(
+        "TRIG-LIST-TEST-RUNS",
+        f"List the test runs in project '{PROJECT}'.",
+        "triggers_tool",
+        intent="Listing test runs must call list_test_runs, not list_work_items.",
+        covers=["list_test_runs"],
+        expect="list_test_runs",
+        reject=["list_work_items"],
     ),
 ]

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -27,6 +27,7 @@ from .fixtures import (
     TS,
     Comment,
     Seeds,
+    TestRun,
     WorkItem,
 )
 
@@ -65,6 +66,23 @@ class FakePolarion:
                 **wi.custom_fields,
             },
             "relationships": relationships,
+        }
+
+    def _test_run_resource(self, tr: TestRun) -> dict[str, Any]:
+        return {
+            "type": "testruns",
+            "id": f"{PROJECT}/{tr.short_id}",
+            "attributes": {
+                "title": tr.title,
+                "type": tr.type,
+                "status": tr.status,
+                "finishedOn": tr.finished_on,
+                "updated": TS,
+                "isTemplate": tr.is_template,
+            },
+            "relationships": {
+                "author": {"data": {"type": "users", "id": f"{PROJECT}/{AUTHOR}"}},
+            },
         }
 
     def _document_resource(self, name: str) -> dict[str, Any]:
@@ -345,6 +363,36 @@ class FakePolarion:
             data = [self._work_item_resource(w) for w in items]
             return httpx.Response(
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
+            )
+
+        # Test runs: templates=true returns blueprints, else actual instances.
+        # author resolves to a display name via the included users resource.
+        if path.endswith("/testruns"):
+            want_templates = params.get("templates", "").lower() == "true"
+            runs = [
+                tr
+                for tr in self.seeds.test_runs.values()
+                if tr.is_template == want_templates
+            ]
+            data = [self._test_run_resource(tr) for tr in runs]
+            included = (
+                [
+                    {
+                        "type": "users",
+                        "id": f"{PROJECT}/{AUTHOR}",
+                        "attributes": {"name": "Fake Author"},
+                    }
+                ]
+                if data
+                else []
+            )
+            return httpx.Response(
+                200,
+                json={
+                    "data": data,
+                    "included": included,
+                    "meta": {"totalCount": len(data)},
+                },
             )
 
         # Parts derive from the document's seed; unseeded/absent docs stay empty.

--- a/evals/harness/fixtures.py
+++ b/evals/harness/fixtures.py
@@ -50,6 +50,9 @@ TESTCASE_ID = "MCPT-500"  # test case linked from CHILD_REQ_ID
 # Section A heading part id served by read_document_parts; anchors positional moves.
 SECTION_A_PART_ID = f"heading_{DOC_HEADING_ID}"
 
+# Test run instance served by list_test_runs (TRIG-LIST-TEST-RUNS).
+TEST_RUN_ID = "Fake-TR-001"
+
 TS = "2026-01-01T00:00:00.000Z"
 
 
@@ -96,6 +99,20 @@ class Comment:
 
 
 @dataclass
+class TestRun:
+    """A test run. ``is_template`` splits template blueprints from actual run
+    instances (the ``templates`` query param filters on it).
+    """
+
+    short_id: str
+    title: str
+    type: str = "manual"
+    status: str = "open"
+    finished_on: str = ""
+    is_template: bool = False
+
+
+@dataclass
 class Document:
     name: str
     title: str
@@ -116,6 +133,7 @@ class Seeds:
 
     work_items: dict[str, WorkItem]
     documents: dict[str, Document]
+    test_runs: dict[str, TestRun]
     links: dict[str, list[tuple[str, str]]]
     enums: dict[tuple[str, str], list[tuple[str, bool]]]
     project_enums: dict[str, list[str]]
@@ -187,6 +205,15 @@ SEEDS = Seeds(
             name=PARENT_DOC,
             title="Fake Parent Doc",
             body_html='<h1 id="ph-1">Fake Parent Doc</h1>',
+        ),
+    },
+    test_runs={
+        TEST_RUN_ID: TestRun(
+            TEST_RUN_ID,
+            "Fake Regression Run",
+            type="manual",
+            status="open",
+            finished_on=TS,
         ),
     },
     # Forward (outgoing) work-item links: source short id -> [(role, target short

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -36,6 +36,7 @@ from mcp_server_polarion.models.links import (
     WorkItemLinkUpdateSpec,
 )
 from mcp_server_polarion.models.projects import ProjectSummary
+from mcp_server_polarion.models.test_runs import TestRunSummary
 from mcp_server_polarion.models.work_items import (
     Hyperlink,
     SqlRecipeGallery,
@@ -66,6 +67,7 @@ __all__: list[str] = [
     "PaginatedResult",
     "ProjectSummary",
     "SqlRecipeGallery",
+    "TestRunSummary",
     "WorkItemCommentSpec",
     "WorkItemCreateSpec",
     "WorkItemDetail",

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -1,0 +1,18 @@
+"""Test run models — compact summaries for list results."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class TestRunSummary(BaseModel):
+    """Compact test-run representation for list results."""
+
+    id: str
+    title: str
+    type: str
+    status: str
+    finished_on: str = ""
+    updated: str = ""
+    author_name: str = ""
+    is_template: bool = False

--- a/src/mcp_server_polarion/tools/__init__.py
+++ b/src/mcp_server_polarion/tools/__init__.py
@@ -11,6 +11,7 @@ import mcp_server_polarion.tools.enum
 import mcp_server_polarion.tools.links
 import mcp_server_polarion.tools.moves
 import mcp_server_polarion.tools.projects
+import mcp_server_polarion.tools.test_runs
 import mcp_server_polarion.tools.work_items  # noqa: F401
 
 # Intentionally empty: tools register via import side effect, not by name export.

--- a/src/mcp_server_polarion/tools/_shared/fields.py
+++ b/src/mcp_server_polarion/tools/_shared/fields.py
@@ -11,6 +11,11 @@ MAX_BULK_ITEMS: Final[int] = 50
 WORK_ITEM_LIST_FIELDS: Final[str] = "title,type,status,priority,updated,module,assignee"
 WORK_ITEM_DETAIL_FIELDS: Final[str] = "@all"
 WORK_ITEM_PART_FIELDS: Final[str] = "title,type,status,description,outlineNumber"
+# camelCase finishedOn/isTemplate are Polarion attr names; author keeps the
+# relationship block alive under the sparse fieldset.
+TEST_RUN_LIST_FIELDS: Final[str] = (
+    "title,type,status,finishedOn,updated,author,isTemplate"
+)
 DOCUMENT_DETAIL_FIELDS: Final[str] = "@all"
 # Sparse fieldset filters relationships too — name them explicitly.
 DOCUMENT_COMMENT_LIST_FIELDS: Final[str] = (
@@ -25,6 +30,7 @@ __all__: list[str] = [
     "DOCUMENT_COMMENT_LIST_FIELDS",
     "DOCUMENT_DETAIL_FIELDS",
     "MAX_BULK_ITEMS",
+    "TEST_RUN_LIST_FIELDS",
     "WORK_ITEM_COMMENT_LIST_FIELDS",
     "WORK_ITEM_DETAIL_FIELDS",
     "WORK_ITEM_LIST_FIELDS",

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -12,6 +12,7 @@ from mcp_server_polarion.models import (
     EnumOption,
     Hyperlink,
     PaginatedResult,
+    TestRunSummary,
     WorkItemDetail,
     WorkItemLink,
     WorkItemSummary,
@@ -244,6 +245,64 @@ def parse_work_item_summaries(
         if not isinstance(item, dict):
             continue
         items.append(WorkItemSummary(**parse_work_item_summary_kwargs(item)))
+    return items
+
+
+class TestRunSummaryKwargs(TypedDict):
+    """Kwargs shape produced by ``parse_test_run_summary_kwargs``."""
+
+    id: str
+    title: str
+    type: str
+    status: str
+    finished_on: str
+    updated: str
+    author_name: str
+    is_template: bool
+
+
+def parse_test_run_summary_kwargs(
+    item: dict[str, object],
+    user_names: dict[str, str],
+) -> TestRunSummaryKwargs:
+    """``TestRunSummary`` kwargs from a JSON:API resource; ``user_names`` maps the
+    full author id to a display name (from the response's included ``users``).
+    """
+    attributes = item.get("attributes", {})
+    if not isinstance(attributes, dict):
+        attributes = {}
+    relationships = item.get("relationships", {})
+    if not isinstance(relationships, dict):
+        relationships = {}
+
+    author_id = extract_relationship_id(relationships, "author")
+    return {
+        "id": extract_short_id(safe_str(item.get("id", ""))),
+        "title": safe_str(attributes.get("title", "")),
+        "type": safe_str(attributes.get("type", "")),
+        "status": safe_str(attributes.get("status", "")),
+        "finished_on": safe_str(attributes.get("finishedOn", "")),
+        "updated": safe_str(attributes.get("updated", "")),
+        "author_name": user_names.get(author_id, ""),
+        "is_template": bool(attributes.get("isTemplate", False)),
+    }
+
+
+def parse_test_run_summaries(response: dict[str, object]) -> list[TestRunSummary]:
+    """Parse a test-runs list response into ``TestRunSummary`` models. Takes the
+    whole response (not just ``data``) to resolve author display names from the
+    included ``users`` resources.
+    """
+    user_names = parse_included_user_name_map(response)
+    data = response.get("data", [])
+    items: list[TestRunSummary] = []
+    if not isinstance(data, list):
+        return items
+
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        items.append(TestRunSummary(**parse_test_run_summary_kwargs(item, user_names)))
     return items
 
 

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -1,0 +1,86 @@
+"""Test run tools — list and search test runs in a project."""
+
+from __future__ import annotations
+
+from fastmcp import Context
+from pydantic import Field
+
+from mcp_server_polarion.core.exceptions import (
+    PolarionAuthError,
+    PolarionError,
+    PolarionNotFoundError,
+)
+from mcp_server_polarion.models import PaginatedResult, TestRunSummary
+from mcp_server_polarion.server import mcp
+from mcp_server_polarion.tools._shared.fields import TEST_RUN_LIST_FIELDS
+from mcp_server_polarion.tools._shared.helpers import (
+    encode_path_segment,
+    get_client,
+)
+from mcp_server_polarion.tools._shared.pagination import (
+    DEFAULT_PAGE_SIZE,
+    make_page,
+)
+from mcp_server_polarion.tools._shared.parse import parse_test_run_summaries
+
+
+@mcp.tool(
+    tags={"read"},
+    timeout=60.0,
+    annotations={"readOnlyHint": True},
+)
+async def list_test_runs(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(description="Polarion project ID."),
+    query: str | None = Field(
+        default=None,
+        description=(
+            "Optional Lucene filter (e.g. 'status:open', 'author.id:devemberx') "
+            "OR a 'SQL:(...)' prefix for native SQL."
+        ),
+    ),
+    templates: bool = Field(
+        default=False,
+        description="List template blueprints instead of actual run instances.",
+    ),
+    page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
+    page_number: int = Field(default=1, ge=1),
+) -> PaginatedResult[TestRunSummary]:
+    """List / search test runs in a project.
+
+    Returns actual run instances by default; set templates=True for the reusable
+    template blueprints instead. Filter with a Lucene query (status:open,
+    type:manual, author.id:<userid>) or omit for all.
+    """
+    client = get_client(ctx)
+    params: dict[str, str | int] = {
+        "fields[testruns]": TEST_RUN_LIST_FIELDS,
+        "include": "author",
+        "fields[users]": "name",
+        "page[size]": page_size,
+        "page[number]": page_number,
+    }
+    if query is not None:
+        params["query"] = query
+    if templates:
+        params["templates"] = "true"
+    try:
+        response = await client.get(
+            f"/projects/{encode_path_segment(project_id)}/testruns",
+            params=params,
+        )
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Project '{project_id}' not found. "
+            "Use `list_projects` to discover valid project IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot list test runs -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(f"Failed to list test runs: {exc.message}") from exc
+
+    items = parse_test_run_summaries(response)
+
+    return make_page(items, response, page_number, page_size)

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -26,6 +26,7 @@ from evals.harness.fixtures import (
     SECTION_A_PART_ID,
     SEEDS,
     SPACE,
+    TEST_RUN_ID,
     TESTCASE_ID,
 )
 
@@ -172,6 +173,26 @@ class TestReadRouting:
             f"/projects/{PROJECT}/enumerations/~/not-a-real-enum/~",
         )
         assert response.status_code == 404
+
+
+class TestTestRunRouting:
+    def test_instances_carry_resource_and_author(self) -> None:
+        response = _get(FakePolarion(), f"/projects/{PROJECT}/testruns")
+        assert response.status_code == 200
+        payload = _json(response)
+        run = payload["data"][0]
+        assert run["type"] == "testruns"
+        assert run["id"].rsplit("/", 1)[-1] == TEST_RUN_ID
+        assert run["attributes"]["isTemplate"] is False
+        assert payload["included"][0]["attributes"]["name"] == "Fake Author"
+
+    def test_templates_filter_excludes_instances(self) -> None:
+        response = _get(
+            FakePolarion(), f"/projects/{PROJECT}/testruns", templates="true"
+        )
+        payload = _json(response)
+        assert payload["meta"]["totalCount"] == 0
+        assert payload["included"] == []
 
 
 class TestWorkItemResource:

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -31,6 +31,7 @@ _READ_TOOL_NAMES: frozenset[str] = frozenset(
         "read_document_parts",
         "read_document",
         "list_work_items",
+        "list_test_runs",
         "get_sql_query_recipes",
         "get_work_item",
         "read_work_item",
@@ -200,6 +201,52 @@ class TestEndToEndInvocation:
         assert body["has_more"] is False
         assert body["items"][0]["id"] == "P1"
         assert body["items"][0]["name"] == "Proj One"
+
+    async def test_list_test_runs_round_trip(self, mcp_client: _MCPClient) -> None:
+        with respx.mock(base_url=_BASE, assert_all_called=False) as mock:
+            mock.get("/projects/P1/testruns").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "data": [
+                            {
+                                "type": "testruns",
+                                "id": "P1/TR-1",
+                                "attributes": {
+                                    "title": "Regression",
+                                    "type": "manual",
+                                    "status": "open",
+                                    "isTemplate": False,
+                                },
+                                "relationships": {
+                                    "author": {
+                                        "data": {"type": "users", "id": "P1/devemberx"}
+                                    }
+                                },
+                            }
+                        ],
+                        "included": [
+                            {
+                                "type": "users",
+                                "id": "P1/devemberx",
+                                "attributes": {"name": "Devember X"},
+                            }
+                        ],
+                        "meta": {"totalCount": 1},
+                    },
+                )
+            )
+            result = await mcp_client.call_tool(
+                "list_test_runs",
+                {"project_id": "P1", "page_size": 100, "page_number": 1},
+            )
+
+        body = result.structured_content
+        assert body is not None
+        assert body["total_count"] == 1
+        assert body["has_more"] is False
+        assert body["items"][0]["id"] == "TR-1"
+        assert body["items"][0]["author_name"] == "Devember X"
 
     async def test_polarion_not_found_surfaces_as_tool_error(
         self, mcp_client: _MCPClient

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -16,6 +16,8 @@ from mcp_server_polarion.tools._shared.parse import (
     parse_hyperlinks,
     parse_included_user_name_map,
     parse_included_work_item_map,
+    parse_test_run_summaries,
+    parse_test_run_summary_kwargs,
     parse_work_item_detail,
     parse_work_item_summaries,
     parse_work_item_summary_kwargs,
@@ -259,6 +261,34 @@ class TestParseWorkItemSummaries:
             },
         ]
         assert [s.id for s in parse_work_item_summaries(data)] == ["MCPT-1"]
+
+
+class TestParseTestRunSummaries:
+    """Tests for `parse_test_run_summaries` and its kwargs helper."""
+
+    def test_non_dict_attributes_and_relationships_default_empty(self) -> None:
+        kwargs = parse_test_run_summary_kwargs(
+            {"id": "proj/TR-1", "attributes": [], "relationships": "nope"},
+            user_names={},
+        )
+        assert kwargs["id"] == "TR-1"
+        assert kwargs["title"] == ""
+        assert kwargs["author_name"] == ""
+
+    def test_non_list_data_is_empty(self) -> None:
+        assert parse_test_run_summaries({"data": None}) == []
+
+    def test_skips_non_dict_entries(self) -> None:
+        response = {
+            "data": [
+                "nope",
+                {
+                    "id": "proj/TR-2",
+                    "attributes": {"title": "A", "type": "t", "status": "s"},
+                },
+            ]
+        }
+        assert [s.id for s in parse_test_run_summaries(response)] == ["TR-2"]
 
 
 class TestParseComment:

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -1,0 +1,338 @@
+"""Tests for the ``list_test_runs`` tool."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Annotated, get_type_hints
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from mcp_server_polarion.core.exceptions import (
+    PolarionAuthError,
+    PolarionError,
+    PolarionNotFoundError,
+)
+from mcp_server_polarion.models import PaginatedResult
+from mcp_server_polarion.tools.test_runs import list_test_runs
+
+
+class TestListTestRuns:
+    """Tests for the ``list_test_runs`` tool."""
+
+    async def test_returns_test_runs(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "testruns",
+                    "id": "proj1/TR-001",
+                    "attributes": {
+                        "title": "Sprint 1 Regression",
+                        "type": "manual",
+                        "status": "open",
+                        "finishedOn": "2026-05-02T11:00:00Z",
+                        "updated": "2026-05-01T09:00:00Z",
+                        "isTemplate": False,
+                    },
+                    "relationships": {
+                        "author": {"data": {"type": "users", "id": "proj1/devemberx"}}
+                    },
+                },
+                {
+                    "type": "testruns",
+                    "id": "proj1/TR-002",
+                    "attributes": {
+                        "title": "Smoke Template",
+                        "type": "automated",
+                        "status": "finished",
+                        "isTemplate": True,
+                    },
+                    "relationships": {"author": {"data": None}},
+                },
+            ],
+            "included": [
+                {
+                    "type": "users",
+                    "id": "proj1/devemberx",
+                    "attributes": {"name": "Devember X"},
+                }
+            ],
+            "meta": {"totalCount": 2},
+        }
+
+        result = await list_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            query=None,
+            templates=False,
+            page_size=100,
+            page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert len(result.items) == 2
+        assert result.total_count == 2
+
+        first = result.items[0]
+        assert first.id == "TR-001"
+        assert first.title == "Sprint 1 Regression"
+        assert first.type == "manual"
+        assert first.status == "open"
+        assert first.finished_on == "2026-05-02T11:00:00Z"
+        assert first.updated == "2026-05-01T09:00:00Z"
+        assert first.author_name == "Devember X"
+        assert first.is_template is False
+
+        second = result.items[1]
+        assert second.id == "TR-002"
+        assert second.finished_on == ""
+        assert second.updated == ""
+        assert second.author_name == ""
+        assert second.is_template is True
+
+    async def test_missing_author_yields_empty_name(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "id": "proj1/TR-003",
+                    "attributes": {
+                        "title": "No Author",
+                        "type": "manual",
+                        "status": "open",
+                    },
+                    "relationships": {
+                        "author": {"data": {"type": "users", "id": "proj1/ghost"}}
+                    },
+                }
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            query=None,
+            templates=False,
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.items[0].author_name == ""
+
+    async def test_sparse_fieldset_and_includes_requested(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
+
+        await list_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            query=None,
+            templates=False,
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        params = kwargs["params"]
+        assert "fields[testruns]" in params
+        assert params["include"] == "author"
+        assert params["fields[users]"] == "name"
+
+    async def test_strips_project_prefix_from_id(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "id": "myproject/TR-100",
+                    "attributes": {
+                        "title": "Run",
+                        "type": "manual",
+                        "status": "open",
+                    },
+                }
+            ],
+            "meta": {"totalCount": 1},
+        }
+
+        result = await list_test_runs(
+            mock_ctx,
+            project_id="myproject",
+            query=None,
+            templates=False,
+            page_size=100,
+            page_number=1,
+        )
+
+        assert result.items[0].id == "TR-100"
+
+    async def test_query_param_forwarded(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
+
+        await list_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            query="author.id:devemberx",
+            templates=False,
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["query"] == "author.id:devemberx"
+
+    async def test_query_none_omits_param(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
+
+        await list_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            query=None,
+            templates=False,
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert "query" not in kwargs["params"]
+
+    async def test_sql_prefix_query_passed_verbatim(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        sql_query = (
+            "SQL:(SELECT tr.* FROM POLARION.TESTRUN tr WHERE tr.C_STATUS = 'open')"
+        )
+        mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
+
+        await list_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            query=sql_query,
+            templates=False,
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["query"] == sql_query
+
+    async def test_templates_true_adds_param(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
+
+        await list_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            query=None,
+            templates=True,
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["templates"] == "true"
+
+    async def test_templates_false_omits_param(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
+
+        await list_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            query=None,
+            templates=False,
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert "templates" not in kwargs["params"]
+
+    async def test_project_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await list_test_runs(
+                mock_ctx,
+                project_id="missing",
+                query=None,
+                templates=False,
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await list_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                query=None,
+                templates=False,
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError("boom", status_code=500)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await list_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                query=None,
+                templates=False,
+                page_size=100,
+                page_number=1,
+            )
+
+
+class TestListTestRunsFieldValidation:
+    """``page_size`` bounds — direct calls bypass JSON Schema; proven via
+    ``TypeAdapter`` rebuild from the signature.
+    """
+
+    @staticmethod
+    def _adapter(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(list_test_runs)
+        sig = inspect.signature(list_test_runs)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_page_size_boundaries_accepted(self) -> None:
+        adapter = self._adapter("page_size")
+        assert adapter.validate_python(1) == 1
+        assert adapter.validate_python(100) == 100
+
+    def test_page_size_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("page_size").validate_python(0)
+
+    def test_page_size_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("page_size").validate_python(101)
+
+    def test_page_number_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("page_number").validate_python(0)

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -1,4 +1,6 @@
-"""Tests for the ``list_test_runs`` tool."""
+"""Tests for the ``list_test_runs`` tool — response parsing, param forwarding,
+error mapping, and page-size field bounds.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Adds a `list_test_runs` read tool exposing Polarion Test Runs (`GET /projects/{projectId}/testruns`), modeled on `list_work_items`. Parses a deliberately token-light field subset; author surfaces as a display name (reusing the `list_documents` pattern), and Lucene/SQL queries pass through (e.g. `author.id:devemberx`).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Polarion has no Test Run access via MCP; LLMs cannot list or filter test runs.
- Add `list_test_runs` mirroring `list_work_items`: token-light summary, author name, `templates` filter.

## Testing

- `ruff check` / `ruff format --check` / `mypy src/` clean.
- Full `uv run pytest`: 1416 passed (16 new unit tests plus a transport respx round-trip E2E).
- Eval coverage gate (`tests/evals/test_coverage.py`) green: `list_test_runs` covered by new `TRIG-LIST-TEST-RUNS` triggers case (fake Polarion now serves `/testruns`); no `DEFERRED`.
- LLM eval case verified registered (`evals.run --list`); full agent run executes in the CI gate (local run blocked only by a missing model API key, not code).

## Notes for Reviewers

- Polarion wire format kept verbatim (endpoint `/testruns`, JSON:API type `testruns`, `fields[testruns]`); only Python identifiers use snake_case `test_run`.
- `TestRunSummary` intentionally drops `created`, `homePageContent`, and config/detail attrs to save tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)