### PR TITLE
feat(documents): outline numbering + autoSuspect

### DIFF
--- a/src/mcp_server_polarion/models/documents.py
+++ b/src/mcp_server_polarion/models/documents.py
@@ -32,7 +32,6 @@ class DocumentDetail(BaseModel):
     content_html: str = ""
     auto_suspect: bool = False
     uses_outline_numbering: bool = False
-    outline_numbering_prefix: str = ""
     custom_fields: dict[str, object] = Field(default_factory=dict)
 
 

--- a/src/mcp_server_polarion/models/documents.py
+++ b/src/mcp_server_polarion/models/documents.py
@@ -30,6 +30,9 @@ class DocumentDetail(BaseModel):
     author: str = ""
     last_updated_by: str = ""
     content_html: str = ""
+    auto_suspect: bool = False
+    uses_outline_numbering: bool = False
+    outline_numbering_prefix: str = ""
     custom_fields: dict[str, object] = Field(default_factory=dict)
 
 

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -431,6 +431,9 @@ def _build_update_document_payload(  # noqa: PLR0913
     status: str | None,
     type: str | None,
     home_page_content_html: str | None = None,
+    auto_suspect: bool | None = None,
+    uses_outline_numbering: bool | None = None,
+    outline_numbering_prefix: str | None = None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
     """JSON:API PATCH body for ``.../documents/{d}``; skips unset.
@@ -448,6 +451,12 @@ def _build_update_document_payload(  # noqa: PLR0913
             "type": "text/html",
             "value": home_page_content_html,
         }
+    if auto_suspect is not None:
+        attributes["autoSuspect"] = auto_suspect
+    if uses_outline_numbering is not None:
+        attributes["usesOutlineNumbering"] = uses_outline_numbering
+    if outline_numbering_prefix is not None:
+        attributes["outlineNumbering"] = {"prefix": outline_numbering_prefix}
     merge_custom_fields(attributes, custom_fields, STANDARD_DOCUMENT_ATTRIBUTES)
 
     item: dict[str, JsonValue] = {
@@ -467,6 +476,9 @@ def _build_create_document_payload(  # noqa: PLR0913
     type: str,
     home_page_content_html: str,
     status: str | None,
+    auto_suspect: bool | None = None,
+    uses_outline_numbering: bool | None = None,
+    outline_numbering_prefix: str | None = None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
     """JSON:API POST body for ``.../spaces/{s}/documents``; skips unset."""
@@ -482,6 +494,12 @@ def _build_create_document_payload(  # noqa: PLR0913
             "type": "text/html",
             "value": home_page_content_html,
         }
+    if auto_suspect is not None:
+        attributes["autoSuspect"] = auto_suspect
+    if uses_outline_numbering is not None:
+        attributes["usesOutlineNumbering"] = uses_outline_numbering
+    if outline_numbering_prefix is not None:
+        attributes["outlineNumbering"] = {"prefix": outline_numbering_prefix}
     merge_custom_fields(attributes, custom_fields, STANDARD_DOCUMENT_ATTRIBUTES)
 
     item: dict[str, JsonValue] = {
@@ -575,6 +593,8 @@ async def get_document(
 ) -> DocumentDetail:
     """Get a document's metadata: title/type/status/editors/custom fields.
 
+    Also returns auto_suspect, uses_outline_numbering, and
+    outline_numbering_prefix (feed back to update_document to round-trip).
     author / last_updated_by are display names (creator, last editor); updated
     is the last-modified timestamp.
 
@@ -635,6 +655,11 @@ async def get_document(
         if isinstance(content_obj, dict):
             content_html = safe_str(content_obj.get("value", ""))
 
+    outline_obj = attributes.get("outlineNumbering")
+    outline_prefix = (
+        safe_str(outline_obj.get("prefix", "")) if isinstance(outline_obj, dict) else ""
+    )
+
     detail = DocumentDetail(
         title=safe_str(attributes.get("title", "")),
         type=safe_str(attributes.get("type", "")),
@@ -645,6 +670,9 @@ async def get_document(
             extract_relationship_id(relationships, "updatedBy"), ""
         ),
         content_html=content_html,
+        auto_suspect=bool(attributes.get("autoSuspect", False)),
+        uses_outline_numbering=bool(attributes.get("usesOutlineNumbering", False)),
+        outline_numbering_prefix=outline_prefix,
         custom_fields=extract_custom_fields(attributes, STANDARD_DOCUMENT_ATTRIBUTES),
     )
     return detail
@@ -834,6 +862,18 @@ async def update_document(  # noqa: PLR0913
             "anchorless blocks get id= auto-stamped."
         ),
     ),
+    auto_suspect: bool | None = Field(
+        default=None,
+        description="Flag linked work items suspect on change.",
+    ),
+    uses_outline_numbering: bool | None = Field(
+        default=None,
+        description="Enable auto outline numbers (1, 1.1, ...).",
+    ),
+    outline_numbering_prefix: str | None = Field(
+        default=None,
+        description="Outline number prefix; needs uses_outline_numbering=True.",
+    ),
     custom_fields: dict[str, object] | None = Field(  # noqa: B008
         default=None,
         description="Partial; rich-text values as {'type':'text/html','value':...}.",
@@ -864,6 +904,8 @@ async def update_document(  # noqa: PLR0913
     - A polarion_wiki macro name=module-workitem <div> leaves the work item's
       module unset — attach via move_work_item_to_document.
 
+    outline_numbering_prefix only renders when uses_outline_numbering=True.
+
     workflow_action must pair with ≥1 attribute (else 400). Unknown status/type
     raise ValueError; custom_fields keys outside the document type's schema are
     rejected, values NOT validated — resolve via list_document_enum_options
@@ -889,19 +931,24 @@ async def update_document(  # noqa: PLR0913
         or status is not None
         or type is not None
         or home_page_content_html is not None
+        or auto_suspect is not None
+        or uses_outline_numbering is not None
+        or outline_numbering_prefix is not None
         or bool(custom_fields)
     )
     if not has_attrs and not workflow_action:
         raise ValueError(
             "update_document requires at least one of: title, status, "
-            "type, home_page_content_html, custom_fields, or "
-            "workflow_action."
+            "type, home_page_content_html, auto_suspect, "
+            "uses_outline_numbering, outline_numbering_prefix, "
+            "custom_fields, or workflow_action."
         )
     if not has_attrs and workflow_action:
         raise ValueError(
             "workflow_action alone is not supported -- Polarion rejects "
             "PATCH bodies with no attributes. Pair workflow_action with "
             "at least one of title, status, type, home_page_content_html, "
+            "auto_suspect, uses_outline_numbering, outline_numbering_prefix, "
             "or custom_fields."
         )
 
@@ -924,6 +971,9 @@ async def update_document(  # noqa: PLR0913
         status=status,
         type=type,
         home_page_content_html=home_page_content_html,
+        auto_suspect=auto_suspect,
+        uses_outline_numbering=uses_outline_numbering,
+        outline_numbering_prefix=outline_numbering_prefix,
         custom_fields=custom_fields,
     )
     # A type change keys the custom-field schema on the new type, else current.
@@ -1016,6 +1066,18 @@ async def create_document(  # noqa: PLR0913
         max_length=MAX_BODY_HTML_LEN,
         description="Markdown body; converted to sanitized HTML.",
     ),
+    auto_suspect: bool | None = Field(
+        default=None,
+        description="Flag linked work items suspect on change.",
+    ),
+    uses_outline_numbering: bool | None = Field(
+        default=None,
+        description="Enable auto outline numbers (1, 1.1, ...).",
+    ),
+    outline_numbering_prefix: str | None = Field(
+        default=None,
+        description="Outline number prefix; needs uses_outline_numbering=True.",
+    ),
     custom_fields: dict[str, object] | None = Field(  # noqa: B008
         default=None,
         description=(
@@ -1038,6 +1100,8 @@ async def create_document(  # noqa: PLR0913
     unique ids. Post-create edits round-trip raw HTML via
     get_document(include_homepage_content_html=True) ↔ update_document; add work
     items via move_work_item_to_document.
+
+    outline_numbering_prefix only renders when uses_outline_numbering=True.
     """
     client = get_client(ctx)
     await guard_document_enums(
@@ -1066,6 +1130,9 @@ async def create_document(  # noqa: PLR0913
         type=type,
         home_page_content_html=home_page_content_html,
         status=status,
+        auto_suspect=auto_suspect,
+        uses_outline_numbering=uses_outline_numbering,
+        outline_numbering_prefix=outline_numbering_prefix,
         custom_fields=custom_fields,
     )
 

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -594,7 +594,7 @@ async def get_document(
     """Get a document's metadata: title/type/status/editors/custom fields.
 
     Also returns auto_suspect, uses_outline_numbering, and
-    outline_numbering_prefix (feed back to update_document to round-trip).
+    outline_numbering_prefix (round-trip via update_document).
     author / last_updated_by are display names (creator, last editor); updated
     is the last-modified timestamp.
 
@@ -904,8 +904,6 @@ async def update_document(  # noqa: PLR0913
     - A polarion_wiki macro name=module-workitem <div> leaves the work item's
       module unset — attach via move_work_item_to_document.
 
-    outline_numbering_prefix only renders when uses_outline_numbering=True.
-
     workflow_action must pair with ≥1 attribute (else 400). Unknown status/type
     raise ValueError; custom_fields keys outside the document type's schema are
     rejected, values NOT validated — resolve via list_document_enum_options
@@ -1100,8 +1098,6 @@ async def create_document(  # noqa: PLR0913
     unique ids. Post-create edits round-trip raw HTML via
     get_document(include_homepage_content_html=True) ↔ update_document; add work
     items via move_work_item_to_document.
-
-    outline_numbering_prefix only renders when uses_outline_numbering=True.
     """
     client = get_client(ctx)
     await guard_document_enums(

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -593,8 +593,7 @@ async def get_document(
 ) -> DocumentDetail:
     """Get a document's metadata: title/type/status/editors/custom fields.
 
-    Also returns auto_suspect, uses_outline_numbering, and
-    outline_numbering_prefix (round-trip via update_document).
+    Also returns outline numbering + autoSuspect (round-trip via update_document).
     author / last_updated_by are display names (creator, last editor); updated
     is the last-modified timestamp.
 

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -433,7 +433,6 @@ def _build_update_document_payload(  # noqa: PLR0913
     home_page_content_html: str | None = None,
     auto_suspect: bool | None = None,
     uses_outline_numbering: bool | None = None,
-    outline_numbering_prefix: str | None = None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
     """JSON:API PATCH body for ``.../documents/{d}``; skips unset.
@@ -455,8 +454,6 @@ def _build_update_document_payload(  # noqa: PLR0913
         attributes["autoSuspect"] = auto_suspect
     if uses_outline_numbering is not None:
         attributes["usesOutlineNumbering"] = uses_outline_numbering
-    if outline_numbering_prefix is not None:
-        attributes["outlineNumbering"] = {"prefix": outline_numbering_prefix}
     merge_custom_fields(attributes, custom_fields, STANDARD_DOCUMENT_ATTRIBUTES)
 
     item: dict[str, JsonValue] = {
@@ -478,7 +475,6 @@ def _build_create_document_payload(  # noqa: PLR0913
     status: str | None,
     auto_suspect: bool | None = None,
     uses_outline_numbering: bool | None = None,
-    outline_numbering_prefix: str | None = None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
     """JSON:API POST body for ``.../spaces/{s}/documents``; skips unset."""
@@ -498,8 +494,6 @@ def _build_create_document_payload(  # noqa: PLR0913
         attributes["autoSuspect"] = auto_suspect
     if uses_outline_numbering is not None:
         attributes["usesOutlineNumbering"] = uses_outline_numbering
-    if outline_numbering_prefix is not None:
-        attributes["outlineNumbering"] = {"prefix": outline_numbering_prefix}
     merge_custom_fields(attributes, custom_fields, STANDARD_DOCUMENT_ATTRIBUTES)
 
     item: dict[str, JsonValue] = {
@@ -654,11 +648,6 @@ async def get_document(
         if isinstance(content_obj, dict):
             content_html = safe_str(content_obj.get("value", ""))
 
-    outline_obj = attributes.get("outlineNumbering")
-    outline_prefix = (
-        safe_str(outline_obj.get("prefix", "")) if isinstance(outline_obj, dict) else ""
-    )
-
     detail = DocumentDetail(
         title=safe_str(attributes.get("title", "")),
         type=safe_str(attributes.get("type", "")),
@@ -671,7 +660,6 @@ async def get_document(
         content_html=content_html,
         auto_suspect=bool(attributes.get("autoSuspect", False)),
         uses_outline_numbering=bool(attributes.get("usesOutlineNumbering", False)),
-        outline_numbering_prefix=outline_prefix,
         custom_fields=extract_custom_fields(attributes, STANDARD_DOCUMENT_ATTRIBUTES),
     )
     return detail
@@ -869,10 +857,6 @@ async def update_document(  # noqa: PLR0913
         default=None,
         description="Enable auto outline numbers (1, 1.1, ...).",
     ),
-    outline_numbering_prefix: str | None = Field(
-        default=None,
-        description="Outline number prefix; needs uses_outline_numbering=True.",
-    ),
     custom_fields: dict[str, object] | None = Field(  # noqa: B008
         default=None,
         description="Partial; rich-text values as {'type':'text/html','value':...}.",
@@ -930,23 +914,20 @@ async def update_document(  # noqa: PLR0913
         or home_page_content_html is not None
         or auto_suspect is not None
         or uses_outline_numbering is not None
-        or outline_numbering_prefix is not None
         or bool(custom_fields)
     )
     if not has_attrs and not workflow_action:
         raise ValueError(
             "update_document requires at least one of: title, status, "
             "type, home_page_content_html, auto_suspect, "
-            "uses_outline_numbering, outline_numbering_prefix, "
-            "custom_fields, or workflow_action."
+            "uses_outline_numbering, custom_fields, or workflow_action."
         )
     if not has_attrs and workflow_action:
         raise ValueError(
             "workflow_action alone is not supported -- Polarion rejects "
             "PATCH bodies with no attributes. Pair workflow_action with "
             "at least one of title, status, type, home_page_content_html, "
-            "auto_suspect, uses_outline_numbering, outline_numbering_prefix, "
-            "or custom_fields."
+            "auto_suspect, uses_outline_numbering, or custom_fields."
         )
 
     client = get_client(ctx)
@@ -970,7 +951,6 @@ async def update_document(  # noqa: PLR0913
         home_page_content_html=home_page_content_html,
         auto_suspect=auto_suspect,
         uses_outline_numbering=uses_outline_numbering,
-        outline_numbering_prefix=outline_numbering_prefix,
         custom_fields=custom_fields,
     )
     # A type change keys the custom-field schema on the new type, else current.
@@ -1071,10 +1051,6 @@ async def create_document(  # noqa: PLR0913
         default=None,
         description="Enable auto outline numbers (1, 1.1, ...).",
     ),
-    outline_numbering_prefix: str | None = Field(
-        default=None,
-        description="Outline number prefix; needs uses_outline_numbering=True.",
-    ),
     custom_fields: dict[str, object] | None = Field(  # noqa: B008
         default=None,
         description=(
@@ -1127,7 +1103,6 @@ async def create_document(  # noqa: PLR0913
         status=status,
         auto_suspect=auto_suspect,
         uses_outline_numbering=uses_outline_numbering,
-        outline_numbering_prefix=outline_numbering_prefix,
         custom_fields=custom_fields,
     )
 

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -675,6 +675,48 @@ class TestGetDocument:
         assert result.author == ""
         assert result.last_updated_by == ""
 
+    async def test_outline_and_autosuspect_parsed(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "attributes": {
+                    "title": "Doc",
+                    "type": "generic",
+                    "status": "draft",
+                    "autoSuspect": True,
+                    "usesOutlineNumbering": True,
+                    "outlineNumbering": {"prefix": "REQ"},
+                },
+            },
+        }
+
+        result = await get_document(
+            mock_ctx, project_id="proj1", space_id="_default", document_name="Doc"
+        )
+
+        assert result.auto_suspect is True
+        assert result.uses_outline_numbering is True
+        assert result.outline_numbering_prefix == "REQ"
+        # Standard attrs never leak into custom_fields.
+        assert result.custom_fields == {}
+
+    async def test_outline_and_autosuspect_default_when_absent(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Missing outlineNumbering / autoSuspect → safe defaults."""
+        mock_client.get.return_value = {
+            "data": {"attributes": {"title": "Doc", "type": "generic"}},
+        }
+
+        result = await get_document(
+            mock_ctx, project_id="proj1", space_id="_default", document_name="Doc"
+        )
+
+        assert result.auto_suspect is False
+        assert result.uses_outline_numbering is False
+        assert result.outline_numbering_prefix == ""
+
     async def test_include_homepage_content_html_false_omits_content(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
@@ -2152,6 +2194,63 @@ class TestBuildUpdateDocumentPayload:
                 custom_fields={"moduleFolder": "Other"},
             )
 
+    def test_outline_and_autosuspect_serialised_when_set(self) -> None:
+        payload = _build_update_document_payload(
+            project_id="MyProj",
+            space_id="S",
+            document_name="D",
+            title=None,
+            status=None,
+            type=None,
+            auto_suspect=True,
+            uses_outline_numbering=True,
+            outline_numbering_prefix="ABC",
+        )
+
+        data = cast(dict[str, object], payload["data"])
+        attributes = cast(dict[str, object], data["attributes"])
+        assert attributes == {
+            "autoSuspect": True,
+            "usesOutlineNumbering": True,
+            "outlineNumbering": {"prefix": "ABC"},
+        }
+
+    def test_outline_and_autosuspect_omitted_when_none(self) -> None:
+        payload = _build_update_document_payload(
+            project_id="MyProj",
+            space_id="S",
+            document_name="D",
+            title="T",
+            status=None,
+            type=None,
+        )
+        body_str = repr(payload)
+        assert "autoSuspect" not in body_str
+        assert "usesOutlineNumbering" not in body_str
+        assert "outlineNumbering" not in body_str
+
+    def test_false_and_empty_prefix_are_serialised(self) -> None:
+        # False bool and "" prefix (unlike None) clear the values server-side.
+        payload = _build_update_document_payload(
+            project_id="MyProj",
+            space_id="S",
+            document_name="D",
+            title=None,
+            status=None,
+            type=None,
+            auto_suspect=False,
+            uses_outline_numbering=False,
+            outline_numbering_prefix="",
+        )
+
+        data = cast(dict[str, object], payload["data"])
+        attributes = cast(dict[str, object], data["attributes"])
+        assert attributes == {
+            "autoSuspect": False,
+            "usesOutlineNumbering": False,
+            "outlineNumbering": {"prefix": ""},
+        }
+
 
 class TestUpdateDocumentValidation:
     """Tool-layer validation that protects against empty / no-op PATCHes."""
@@ -2169,6 +2268,9 @@ class TestUpdateDocumentValidation:
                 status=None,
                 type=None,
                 home_page_content_html=None,
+                auto_suspect=None,
+                uses_outline_numbering=None,
+                outline_numbering_prefix=None,
                 custom_fields=None,
                 workflow_action=None,
                 dry_run=True,
@@ -2188,6 +2290,9 @@ class TestUpdateDocumentValidation:
                 status=None,
                 type=None,
                 home_page_content_html=None,
+                auto_suspect=None,
+                uses_outline_numbering=None,
+                outline_numbering_prefix=None,
                 custom_fields=None,
                 workflow_action="approve",
                 dry_run=True,
@@ -2378,6 +2483,9 @@ class TestUpdateDocumentDryRun:
             status=None,
             type=None,
             home_page_content_html=None,
+            auto_suspect=None,
+            uses_outline_numbering=None,
+            outline_numbering_prefix=None,
             custom_fields=None,
             workflow_action=None,
             dry_run=True,
@@ -2435,6 +2543,9 @@ class TestUpdateDocumentHappyPath:
             status=None,
             type=None,
             home_page_content_html=None,
+            auto_suspect=None,
+            uses_outline_numbering=None,
+            outline_numbering_prefix=None,
             custom_fields=None,
             workflow_action=None,
             dry_run=False,
@@ -2491,6 +2602,9 @@ class TestUpdateDocumentHappyPath:
             status=None,
             type=None,
             home_page_content_html=raw,
+            auto_suspect=None,
+            uses_outline_numbering=None,
+            outline_numbering_prefix=None,
             custom_fields=None,
             workflow_action=None,
             dry_run=False,
@@ -2589,6 +2703,31 @@ class TestUpdateDocumentHappyPath:
         )
         assert result.dry_run is True
 
+    async def test_outline_param_alone_passes_has_attrs_guard(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """An outline/suspect param alone satisfies the has_attrs guard."""
+        result = await update_document(
+            mock_ctx,
+            project_id="MyProj",
+            space_id="S",
+            document_name="D",
+            title=None,
+            status=None,
+            type=None,
+            home_page_content_html=None,
+            auto_suspect=None,
+            uses_outline_numbering=True,
+            outline_numbering_prefix=None,
+            custom_fields=None,
+            workflow_action=None,
+            dry_run=True,
+        )
+        assert result.dry_run is True
+        data = cast(dict[str, object], result.payload_preview["data"])  # type: ignore[index]
+        attributes = cast(dict[str, object], data["attributes"])
+        assert attributes == {"usesOutlineNumbering": True}
+
     async def test_explicit_empty_title_is_serialized(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
@@ -2604,6 +2743,9 @@ class TestUpdateDocumentHappyPath:
             status=None,
             type=None,
             home_page_content_html=None,
+            auto_suspect=None,
+            uses_outline_numbering=None,
+            outline_numbering_prefix=None,
             custom_fields=None,
             workflow_action=None,
             dry_run=False,
@@ -2886,6 +3028,55 @@ class TestBuildCreateDocumentPayload:
                 custom_fields={"title": "duplicate"},
             )
 
+    def test_outline_and_autosuspect_attached_when_set(self) -> None:
+        payload = _build_create_document_payload(
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            home_page_content_html="",
+            status=None,
+            auto_suspect=True,
+            uses_outline_numbering=True,
+            outline_numbering_prefix="X",
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attributes = cast(dict[str, object], item["attributes"])
+        assert attributes["autoSuspect"] is True
+        assert attributes["usesOutlineNumbering"] is True
+        assert attributes["outlineNumbering"] == {"prefix": "X"}
+
+    def test_outline_and_autosuspect_omitted_when_none(self) -> None:
+        payload = _build_create_document_payload(
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            home_page_content_html="",
+            status=None,
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attributes = cast(dict[str, object], item["attributes"])
+        assert set(attributes.keys()) == {"moduleName", "title", "type"}
+
+    def test_false_and_empty_prefix_serialised(self) -> None:
+        payload = _build_create_document_payload(
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            home_page_content_html="",
+            status=None,
+            auto_suspect=False,
+            uses_outline_numbering=False,
+            outline_numbering_prefix="",
+        )
+
+        item = cast(list[dict[str, object]], payload["data"])[0]
+        attributes = cast(dict[str, object], item["attributes"])
+        assert attributes["autoSuspect"] is False
+        assert attributes["usesOutlineNumbering"] is False
+        assert attributes["outlineNumbering"] == {"prefix": ""}
+
 
 class TestCreateDocumentDryRun:
     """Tests for ``create_document`` with ``dry_run=True``."""
@@ -2902,6 +3093,9 @@ class TestCreateDocumentDryRun:
             type="req_specification",
             status=None,
             home_page_content=None,
+            auto_suspect=None,
+            uses_outline_numbering=None,
+            outline_numbering_prefix=None,
             custom_fields=None,
             dry_run=True,
         )

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -686,7 +686,6 @@ class TestGetDocument:
                     "status": "draft",
                     "autoSuspect": True,
                     "usesOutlineNumbering": True,
-                    "outlineNumbering": {"prefix": "REQ"},
                 },
             },
         }
@@ -697,14 +696,13 @@ class TestGetDocument:
 
         assert result.auto_suspect is True
         assert result.uses_outline_numbering is True
-        assert result.outline_numbering_prefix == "REQ"
         # Standard attrs never leak into custom_fields.
         assert result.custom_fields == {}
 
     async def test_outline_and_autosuspect_default_when_absent(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Missing outlineNumbering / autoSuspect → safe defaults."""
+        """Missing usesOutlineNumbering / autoSuspect → safe defaults."""
         mock_client.get.return_value = {
             "data": {"attributes": {"title": "Doc", "type": "generic"}},
         }
@@ -715,7 +713,6 @@ class TestGetDocument:
 
         assert result.auto_suspect is False
         assert result.uses_outline_numbering is False
-        assert result.outline_numbering_prefix == ""
 
     async def test_include_homepage_content_html_false_omits_content(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -2204,7 +2201,6 @@ class TestBuildUpdateDocumentPayload:
             type=None,
             auto_suspect=True,
             uses_outline_numbering=True,
-            outline_numbering_prefix="ABC",
         )
 
         data = cast(dict[str, object], payload["data"])
@@ -2212,7 +2208,6 @@ class TestBuildUpdateDocumentPayload:
         assert attributes == {
             "autoSuspect": True,
             "usesOutlineNumbering": True,
-            "outlineNumbering": {"prefix": "ABC"},
         }
 
     def test_outline_and_autosuspect_omitted_when_none(self) -> None:
@@ -2227,10 +2222,9 @@ class TestBuildUpdateDocumentPayload:
         body_str = repr(payload)
         assert "autoSuspect" not in body_str
         assert "usesOutlineNumbering" not in body_str
-        assert "outlineNumbering" not in body_str
 
-    def test_false_and_empty_prefix_are_serialised(self) -> None:
-        # False bool and "" prefix (unlike None) clear the values server-side.
+    def test_false_autosuspect_and_outline_are_serialised(self) -> None:
+        # False (unlike None) clears the values server-side.
         payload = _build_update_document_payload(
             project_id="MyProj",
             space_id="S",
@@ -2240,7 +2234,6 @@ class TestBuildUpdateDocumentPayload:
             type=None,
             auto_suspect=False,
             uses_outline_numbering=False,
-            outline_numbering_prefix="",
         )
 
         data = cast(dict[str, object], payload["data"])
@@ -2248,7 +2241,6 @@ class TestBuildUpdateDocumentPayload:
         assert attributes == {
             "autoSuspect": False,
             "usesOutlineNumbering": False,
-            "outlineNumbering": {"prefix": ""},
         }
 
 
@@ -2270,7 +2262,6 @@ class TestUpdateDocumentValidation:
                 home_page_content_html=None,
                 auto_suspect=None,
                 uses_outline_numbering=None,
-                outline_numbering_prefix=None,
                 custom_fields=None,
                 workflow_action=None,
                 dry_run=True,
@@ -2292,7 +2283,6 @@ class TestUpdateDocumentValidation:
                 home_page_content_html=None,
                 auto_suspect=None,
                 uses_outline_numbering=None,
-                outline_numbering_prefix=None,
                 custom_fields=None,
                 workflow_action="approve",
                 dry_run=True,
@@ -2485,7 +2475,6 @@ class TestUpdateDocumentDryRun:
             home_page_content_html=None,
             auto_suspect=None,
             uses_outline_numbering=None,
-            outline_numbering_prefix=None,
             custom_fields=None,
             workflow_action=None,
             dry_run=True,
@@ -2545,7 +2534,6 @@ class TestUpdateDocumentHappyPath:
             home_page_content_html=None,
             auto_suspect=None,
             uses_outline_numbering=None,
-            outline_numbering_prefix=None,
             custom_fields=None,
             workflow_action=None,
             dry_run=False,
@@ -2604,7 +2592,6 @@ class TestUpdateDocumentHappyPath:
             home_page_content_html=raw,
             auto_suspect=None,
             uses_outline_numbering=None,
-            outline_numbering_prefix=None,
             custom_fields=None,
             workflow_action=None,
             dry_run=False,
@@ -2718,7 +2705,6 @@ class TestUpdateDocumentHappyPath:
             home_page_content_html=None,
             auto_suspect=None,
             uses_outline_numbering=True,
-            outline_numbering_prefix=None,
             custom_fields=None,
             workflow_action=None,
             dry_run=True,
@@ -2745,7 +2731,6 @@ class TestUpdateDocumentHappyPath:
             home_page_content_html=None,
             auto_suspect=None,
             uses_outline_numbering=None,
-            outline_numbering_prefix=None,
             custom_fields=None,
             workflow_action=None,
             dry_run=False,
@@ -3037,14 +3022,12 @@ class TestBuildCreateDocumentPayload:
             status=None,
             auto_suspect=True,
             uses_outline_numbering=True,
-            outline_numbering_prefix="X",
         )
 
         item = cast(list[dict[str, object]], payload["data"])[0]
         attributes = cast(dict[str, object], item["attributes"])
         assert attributes["autoSuspect"] is True
         assert attributes["usesOutlineNumbering"] is True
-        assert attributes["outlineNumbering"] == {"prefix": "X"}
 
     def test_outline_and_autosuspect_omitted_when_none(self) -> None:
         payload = _build_create_document_payload(
@@ -3059,7 +3042,7 @@ class TestBuildCreateDocumentPayload:
         attributes = cast(dict[str, object], item["attributes"])
         assert set(attributes.keys()) == {"moduleName", "title", "type"}
 
-    def test_false_and_empty_prefix_serialised(self) -> None:
+    def test_false_autosuspect_and_outline_serialised(self) -> None:
         payload = _build_create_document_payload(
             module_name="MySpec",
             title="t",
@@ -3068,14 +3051,12 @@ class TestBuildCreateDocumentPayload:
             status=None,
             auto_suspect=False,
             uses_outline_numbering=False,
-            outline_numbering_prefix="",
         )
 
         item = cast(list[dict[str, object]], payload["data"])[0]
         attributes = cast(dict[str, object], item["attributes"])
         assert attributes["autoSuspect"] is False
         assert attributes["usesOutlineNumbering"] is False
-        assert attributes["outlineNumbering"] == {"prefix": ""}
 
 
 class TestCreateDocumentDryRun:
@@ -3095,7 +3076,6 @@ class TestCreateDocumentDryRun:
             home_page_content=None,
             auto_suspect=None,
             uses_outline_numbering=None,
-            outline_numbering_prefix=None,
             custom_fields=None,
             dry_run=True,
         )


### PR DESCRIPTION
## Summary

Polarion documents carry `autoSuspect` and `usesOutlineNumbering`, but the MCP server never exposed them: `create_document`/`update_document` had no parameters for them and `get_document` did not return them, so these document settings were uncontrollable. This adds read + write support across all three tools with symmetric param/field names.

The `outlineNumbering` (`{prefix}`) setting was scoped out: the prefix only relabels exported/printed work-item outline numbers (e.g. `REQ-2-1`) and never touches heading section numbers, so it is niche with little real use. `usesOutlineNumbering=True` alone yields plain numbering (`1`, `1.1`, `2-1`), verified live.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- create/update had no autoSuspect/outline params; get_document never returned them, settings uncontrollable.
- Add auto_suspect / uses_outline_numbering to create/update; surface them in get_document for round-trip.

## Testing

`ruff check` + `ruff format` + `mypy src/` clean. `pytest` 1430 passed. New unit tests cover both payload builders (set / omitted / `False` cases), the `has_attrs` guard for an outline param alone, and `get_document` parsing (present + absent to defaults). E2E verified live against testdrive.polarion.com: write accepted (no 400), round-trip read, `False`/empty clears, restored to original.

## Notes for Reviewers

New write params use `bool | None` with `is not None` semantics so `False` is an explicit clear, not a no-op. No enum guard added: these are booleans, not enums; both already live in `STANDARD_DOCUMENT_ATTRIBUTES` so no custom-field collision. `outlineNumbering` stays in `STANDARD_DOCUMENT_ATTRIBUTES` (pre-existing) to keep it from leaking into custom_fields on read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)