### PR TITLE
feat(work-items): bulk update_work_items tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
   - Round-trip: `get_*(include_*_html=True)` return raw Polarion HTML; `update_*(*_html=...)` accept verbatim — no sanitize/convert.
   - Greenfield create (Markdown): `markdown_to_html` + `sanitize_html`. Post-create edits = raw-HTML round-trip; formats never mix.
   - Synthesis (READ-ONLY): `read_*` convert HTML→Markdown; feed output back to writes lose Polarion markup.
-- Write payloads skip `None`/empty (Polarion read empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
+- Write payloads skip `None`/empty (Polarion read empty as "clear default"). Resource POSTs + bulk PATCH `/workitems` wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
 - Every list tool: `page_size` (max 100) + `page_number` → `PaginatedResult[T]` with `has_more`.
 - Every write tool: `dry_run: bool = False` — return payload, no hit Polarion.
 - Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | Tool | Description |
 |---|---|
 | `create_work_items` | Create one or more work items in a single request |
-| `update_work_item` | Update an existing work item |
+| `update_work_items` | Update one or more work items in a single request |
 | `create_document` | Create a new document |
 | `update_document` | Update document metadata, body, or workflow status |
 | `create_test_runs` | Create one or more test runs, optionally from a template |

--- a/evals/cases/efficiency.py
+++ b/evals/cases/efficiency.py
@@ -9,7 +9,13 @@ from __future__ import annotations
 
 from strands_evals import Case
 
-from evals.harness.fixtures import DOC, FLOATING_TASK_ID, SPACE
+from evals.harness.fixtures import (
+    CHILD_REQ_ID,
+    DOC,
+    FLOATING_TASK_ID,
+    SPACE,
+    UNCOVERED_REQ_ID,
+)
 
 MIN_PASS_RATE = 0.8
 
@@ -44,6 +50,17 @@ CASES: list[Case] = [
         intent="Bulk-creatable items use one create call; splitting across calls "
         "fails.",
         covers=["create_work_items"],
+        min_items=3,
+    ),
+    _case(
+        "EFF-BULK-UPDATE",
+        f"Rename work item {CHILD_REQ_ID} to 'Renamed requirement A' and "
+        f"{UNCOVERED_REQ_ID} to 'Renamed requirement B'.",
+        "single_bulk_update",
+        intent="Attribute changes to several known items use one update call; "
+        "one call per item fails.",
+        covers=["update_work_items"],
+        min_items=2,
     ),
     _case(
         "EFF-DIRECT-GET",

--- a/evals/cases/orchestration.py
+++ b/evals/cases/orchestration.py
@@ -214,7 +214,7 @@ CASES: list[Case] = [
         steps=[
             {"tool": "get_work_item", "match": {"work_item_id": FLOATING_TASK_ID}},
             {
-                "tool": "update_work_item",
+                "tool": "update_work_items",
                 "match": {"work_item_id": FLOATING_TASK_ID},
                 "after": ["get_work_item"],
             },

--- a/evals/cases/safety.py
+++ b/evals/cases/safety.py
@@ -59,7 +59,7 @@ CASES: list[Case] = [
         "get_before_update",
         intent="An update must be preceded by a get on the same item; a blind "
         "update fails.",
-        covers=["get_work_item", "update_work_item"],
+        covers=["get_work_item", "update_work_items"],
     ),
     _case(
         "SAFE-REPLY-RESOLVE",
@@ -78,7 +78,7 @@ CASES: list[Case] = [
         "preserve_hyperlinks",
         intent="A REPLACE-list update must carry every pre-existing URI; "
         "dropping one fails.",
-        covers=["get_work_item", "update_work_item"],
+        covers=["get_work_item", "update_work_items"],
         work_item_id=FLOATING_TASK_ID,
         required_uris=[FLOATING_TASK_HYPERLINK_URI],
     ),

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -15,7 +15,7 @@ CheckResult = tuple[bool, str]
 WRITE_TOOLS: frozenset[str] = frozenset(
     {
         "create_work_items",
-        "update_work_item",
+        "update_work_items",
         "move_work_item_to_document",
         "move_work_item_from_document",
         "create_work_item_links",
@@ -74,6 +74,12 @@ def _errored(call: dict[str, Any]) -> bool:
     return isinstance(result, dict) and "error" in result
 
 
+def _update_items(call: dict[str, Any]) -> list[dict[str, Any]]:
+    """Per-item specs of a bulk ``update_work_items`` call (non-dicts dropped)."""
+    items = _args(call).get("items") or []
+    return [item for item in items if isinstance(item, dict)]
+
+
 def check_readonly(trajectory: Trajectory, _params: dict[str, Any]) -> CheckResult:
     """No write tool may be called on a read-only task."""
     used = [n for n in _names(trajectory) if n in WRITE_TOOLS]
@@ -83,7 +89,6 @@ def check_readonly(trajectory: Trajectory, _params: dict[str, Any]) -> CheckResu
 
 
 _UPDATE_TO_GET: dict[str, tuple[str, tuple[str, ...]]] = {
-    "update_work_item": ("get_work_item", ("project_id", "work_item_id")),
     "update_document": (
         "get_document",
         ("project_id", "space_id", "document_name"),
@@ -104,14 +109,40 @@ def _target_key(call: dict[str, Any], keys: tuple[str, ...]) -> tuple[object, ..
     )
 
 
+def _got_work_item_before(
+    trajectory: Trajectory, index: int, target: tuple[object, ...], *, flag: str = ""
+) -> bool:
+    """True when a ``get_work_item`` on ``target`` precedes ``trajectory[index]``
+    (with ``flag`` set truthy, when given)."""
+    id_keys = ("project_id", "work_item_id")
+    return any(
+        earlier.get("name") == "get_work_item"
+        and _target_key(earlier, id_keys) == target
+        and (not flag or bool(_args(earlier).get(flag)))
+        for earlier in trajectory[:index]
+    )
+
+
 def check_get_before_update(
     trajectory: Trajectory, _params: dict[str, Any]
 ) -> CheckResult:
     """Every ``update_*`` needs an earlier matching ``get_*`` — REPLACE-list and
-    partial-PATCH semantics make blind writes clobber silently.
+    partial-PATCH semantics make blind writes clobber silently. A bulk
+    ``update_work_items`` needs a prior ``get_work_item`` per targeted item.
     """
     for i, call in enumerate(trajectory):
         name = call.get("name", "")
+        if name == "update_work_items":
+            project = _args(call).get("project_id")
+            for item in _update_items(call):
+                target = (project, _short_id(item.get("work_item_id", "")))
+                if not _got_work_item_before(trajectory, i, target):
+                    return False, (
+                        f"called {name}({target}) without a prior "
+                        f"get_work_item({target}) -- update must observe "
+                        f"current state first"
+                    )
+            continue
         spec = _UPDATE_TO_GET.get(name)
         if spec is None:
             continue
@@ -182,21 +213,21 @@ def check_preserve_hyperlinks(
     target = _short_id(params.get("work_item_id", ""))
     required = [str(u) for u in params.get("required_uris", [])]
     for call in trajectory:
-        if call.get("name") != "update_work_item":
+        if call.get("name") != "update_work_items":
             continue
-        args = _args(call)
-        if _short_id(args.get("work_item_id", "")) != target:
-            continue
-        hyperlinks = args.get("hyperlinks")
-        if not hyperlinks:
-            continue
-        uris = {str(h.get("uri", "")) for h in hyperlinks if isinstance(h, dict)}
-        missing = [u for u in required if u not in uris]
-        if missing:
-            return False, (
-                f"update_work_item replaced hyperlinks on {target} without "
-                f"pre-existing URI(s) {missing} -- the full list must be passed"
-            )
+        for item in _update_items(call):
+            if _short_id(item.get("work_item_id", "")) != target:
+                continue
+            hyperlinks = item.get("hyperlinks")
+            if not hyperlinks:
+                continue
+            uris = {str(h.get("uri", "")) for h in hyperlinks if isinstance(h, dict)}
+            missing = [u for u in required if u not in uris]
+            if missing:
+                return False, (
+                    f"update_work_items replaced hyperlinks on {target} without "
+                    f"pre-existing URI(s) {missing} -- the full list must be passed"
+                )
     return True, "no hyperlink update dropped a pre-existing URI"
 
 
@@ -207,12 +238,6 @@ _BODY_WRITE_TO_SOURCE: dict[str, tuple[str, str, str, tuple[str, ...]]] = {
         "include_homepage_content_html",
         ("project_id", "space_id", "document_name"),
     ),
-    "update_work_item": (
-        "description_html",
-        "get_work_item",
-        "include_description_html",
-        ("project_id", "work_item_id"),
-    ),
 }
 
 
@@ -220,10 +245,28 @@ def check_round_trip_source(
     trajectory: Trajectory, _params: dict[str, Any]
 ) -> CheckResult:
     """Body writes must source from ``get_*(include_*_html=True)`` on the same
-    target — ``read_*`` synthesis Markdown collapses Polarion anchors.
+    target — ``read_*`` synthesis Markdown collapses Polarion anchors. For a
+    bulk ``update_work_items``, every item carrying ``description_html`` needs
+    its own flagged ``get_work_item``.
     """
     for i, call in enumerate(trajectory):
-        spec = _BODY_WRITE_TO_SOURCE.get(call.get("name", ""))
+        name = call.get("name", "")
+        if name == "update_work_items":
+            project = _args(call).get("project_id")
+            for item in _update_items(call):
+                if not item.get("description_html"):
+                    continue
+                target = (project, _short_id(item.get("work_item_id", "")))
+                if not _got_work_item_before(
+                    trajectory, i, target, flag="include_description_html"
+                ):
+                    return False, (
+                        f"{name}({target}) wrote description_html without a "
+                        f"prior get_work_item(include_description_html=True) "
+                        f"-- body was not round-trip sourced"
+                    )
+            continue
+        spec = _BODY_WRITE_TO_SOURCE.get(name)
         if spec is None:
             continue
         body_arg, get_name, flag_arg, id_keys = spec
@@ -398,10 +441,25 @@ def _resolve_observed_path(result: object, path: str) -> list[str]:
 
 
 def _args_match(args: dict[str, Any], match: dict[str, Any]) -> bool:
-    """All ``match`` entries equal the call's args (``*_id`` via ``_short_id``)."""
+    """All ``match`` entries equal the call's args (``*_id`` via ``_short_id``).
+
+    A ``work_item_id`` constraint on a bulk call (flat arg absent, ``items``
+    present) matches when any per-item id matches.
+    """
     for key, expected in match.items():
         actual = args.get(key)
-        if key.endswith("_id"):
+        if (
+            key == "work_item_id"
+            and actual is None
+            and isinstance(args.get("items"), list)
+        ):
+            if not any(
+                isinstance(item, dict)
+                and _short_id(item.get("work_item_id", "")) == _short_id(expected)
+                for item in args["items"]
+            ):
+                return False
+        elif key.endswith("_id"):
             if _short_id(actual) != _short_id(expected):
                 return False
         elif actual != expected:

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -74,9 +74,9 @@ def _errored(call: dict[str, Any]) -> bool:
     return isinstance(result, dict) and "error" in result
 
 
-def _update_items(call: dict[str, Any]) -> list[dict[str, Any]]:
-    """Per-item specs of a bulk ``update_work_items`` call (non-dicts dropped)."""
-    items = _args(call).get("items") or []
+def _bulk_items(call: dict[str, Any], items_key: str) -> list[dict[str, Any]]:
+    """Per-item dicts of a bulk call's ``args[items_key]`` (non-dicts dropped)."""
+    items = _args(call).get(items_key) or []
     return [item for item in items if isinstance(item, dict)]
 
 
@@ -88,11 +88,15 @@ def check_readonly(trajectory: Trajectory, _params: dict[str, Any]) -> CheckResu
     return True, "no write tools called"
 
 
-_UPDATE_TO_GET: dict[str, tuple[str, tuple[str, ...]]] = {
+# Last element = items_key: bulk tools read id_keys per-item from
+# ``args[items_key]``; ``None`` = flat call.
+_UPDATE_TO_GET: dict[str, tuple[str, tuple[str, ...], str | None]] = {
     "update_document": (
         "get_document",
         ("project_id", "space_id", "document_name"),
+        None,
     ),
+    "update_work_items": ("get_work_item", ("project_id", "work_item_id"), "items"),
 }
 
 
@@ -109,14 +113,42 @@ def _target_key(call: dict[str, Any], keys: tuple[str, ...]) -> tuple[object, ..
     )
 
 
-def _got_work_item_before(
-    trajectory: Trajectory, index: int, target: tuple[object, ...], *, flag: str = ""
+def _item_target_key(
+    args: dict[str, Any], item: dict[str, Any], keys: tuple[str, ...]
+) -> tuple[object, ...]:
+    """Identifier tuple for one bulk item: each key reads from ``item`` (the
+    per-item dict) when present, else falls back to the call's batch-level
+    ``args`` (e.g. ``project_id``); same normalization rule as ``_target_key``
+    so the tuples compare equal.
+    """
+    values = []
+    for k in keys:
+        v = item.get(k) if k in item else args.get(k)
+        values.append(_short_id(v) if k == "work_item_id" and v is not None else v)
+    return tuple(values)
+
+
+def _bulk_targets(
+    call: dict[str, Any], items_key: str, keys: tuple[str, ...]
+) -> list[tuple[object, ...]]:
+    """One target tuple per dict entry in ``call``'s ``args[items_key]`` list."""
+    args = _args(call)
+    return [_item_target_key(args, item, keys) for item in _bulk_items(call, items_key)]
+
+
+def _observed_before(
+    trajectory: Trajectory,
+    index: int,
+    get_name: str,
+    id_keys: tuple[str, ...],
+    target: tuple[object, ...],
+    *,
+    flag: str = "",
 ) -> bool:
-    """True when a ``get_work_item`` on ``target`` precedes ``trajectory[index]``
-    (with ``flag`` set truthy, when given)."""
-    id_keys = ("project_id", "work_item_id")
+    """True when a ``get_name`` call on ``target`` precedes ``trajectory[index]``
+    (with ``flag`` set truthy on that call, when given)."""
     return any(
-        earlier.get("name") == "get_work_item"
+        earlier.get("name") == get_name
         and _target_key(earlier, id_keys) == target
         and (not flag or bool(_args(earlier).get(flag)))
         for earlier in trajectory[:index]
@@ -132,34 +164,27 @@ def check_get_before_update(
     """
     for i, call in enumerate(trajectory):
         name = call.get("name", "")
-        if name == "update_work_items":
-            project = _args(call).get("project_id")
-            for item in _update_items(call):
-                target = (project, _short_id(item.get("work_item_id", "")))
-                if not _got_work_item_before(trajectory, i, target):
-                    return False, (
-                        f"called {name}({target}) without a prior "
-                        f"get_work_item({target}) -- update must observe "
-                        f"current state first"
-                    )
-            continue
         spec = _UPDATE_TO_GET.get(name)
         if spec is None:
             continue
-        get_name, id_keys = spec
-        target = _target_key(call, id_keys)
-        seen = False
-        for earlier in trajectory[:i]:
-            if earlier.get("name") != get_name:
-                continue
-            if _target_key(earlier, id_keys) == target:
-                seen = True
-                break
-        if not seen:
-            return False, (
-                f"called {name}({target}) without a prior {get_name}({target}) "
-                f"-- update must observe current state first"
-            )
+        get_name, id_keys, items_key = spec
+        if items_key:
+            targets = _bulk_targets(call, items_key, id_keys)
+            # Fail closed: a bulk write with no readable targets is still a
+            # blind write attempt, not a free pass.
+            if not targets:
+                return False, (
+                    f"called {name} with no valid entries in '{items_key}' -- "
+                    "cannot verify any target was observed first"
+                )
+        else:
+            targets = [_target_key(call, id_keys)]
+        for target in targets:
+            if not _observed_before(trajectory, i, get_name, id_keys, target):
+                return False, (
+                    f"called {name}({target}) without a prior {get_name}({target}) "
+                    f"-- update must observe current state first"
+                )
     return True, "every update_* was preceded by a matching get_*"
 
 
@@ -215,7 +240,7 @@ def check_preserve_hyperlinks(
     for call in trajectory:
         if call.get("name") != "update_work_items":
             continue
-        for item in _update_items(call):
+        for item in _bulk_items(call, "items"):
             if _short_id(item.get("work_item_id", "")) != target:
                 continue
             hyperlinks = item.get("hyperlinks")
@@ -231,12 +256,21 @@ def check_preserve_hyperlinks(
     return True, "no hyperlink update dropped a pre-existing URI"
 
 
-_BODY_WRITE_TO_SOURCE: dict[str, tuple[str, str, str, tuple[str, ...]]] = {
+# Last element = items_key, same convention as ``_UPDATE_TO_GET``.
+_BODY_WRITE_TO_SOURCE: dict[str, tuple[str, str, str, tuple[str, ...], str | None]] = {
     "update_document": (
         "home_page_content_html",
         "get_document",
         "include_homepage_content_html",
         ("project_id", "space_id", "document_name"),
+        None,
+    ),
+    "update_work_items": (
+        "description_html",
+        "get_work_item",
+        "include_description_html",
+        ("project_id", "work_item_id"),
+        "items",
     ),
 }
 
@@ -251,37 +285,34 @@ def check_round_trip_source(
     """
     for i, call in enumerate(trajectory):
         name = call.get("name", "")
-        if name == "update_work_items":
-            project = _args(call).get("project_id")
-            for item in _update_items(call):
-                if not item.get("description_html"):
-                    continue
-                target = (project, _short_id(item.get("work_item_id", "")))
-                if not _got_work_item_before(
-                    trajectory, i, target, flag="include_description_html"
-                ):
-                    return False, (
-                        f"{name}({target}) wrote description_html without a "
-                        f"prior get_work_item(include_description_html=True) "
-                        f"-- body was not round-trip sourced"
-                    )
-            continue
         spec = _BODY_WRITE_TO_SOURCE.get(name)
         if spec is None:
             continue
-        body_arg, get_name, flag_arg, id_keys = spec
-        if not _args(call).get(body_arg):
+        body_arg, get_name, flag_arg, id_keys, items_key = spec
+        args = _args(call)
+        if items_key:
+            for item in _bulk_items(call, items_key):
+                if not item.get(body_arg):
+                    continue
+                target = _item_target_key(args, item, id_keys)
+                if not _observed_before(
+                    trajectory, i, get_name, id_keys, target, flag=flag_arg
+                ):
+                    return False, (
+                        f"{name}({target}) wrote {body_arg} without a prior "
+                        f"{get_name}({flag_arg}=True) -- body was not "
+                        f"round-trip sourced"
+                    )
+            continue
+        if not args.get(body_arg):
             continue
         target = _target_key(call, id_keys)
-        sourced = any(
-            earlier.get("name") == get_name
-            and _target_key(earlier, id_keys) == target
-            and bool(_args(earlier).get(flag_arg))
-            for earlier in trajectory[:i]
+        sourced = _observed_before(
+            trajectory, i, get_name, id_keys, target, flag=flag_arg
         )
         if not sourced:
             return False, (
-                f"{call.get('name')}({target}) wrote {body_arg} without a prior "
+                f"{name}({target}) wrote {body_arg} without a prior "
                 f"{get_name}({flag_arg}=True) -- body was not round-trip sourced"
             )
     return True, "every body write was round-trip sourced"
@@ -443,27 +474,31 @@ def _resolve_observed_path(result: object, path: str) -> list[str]:
 def _args_match(args: dict[str, Any], match: dict[str, Any]) -> bool:
     """All ``match`` entries equal the call's args (``*_id`` via ``_short_id``).
 
-    A ``work_item_id`` constraint on a bulk call (flat arg absent, ``items``
-    present) matches when any per-item id matches.
+    ``*_id`` constraints missing from the flat args (bulk call, ``items``
+    present) must all be satisfied by ONE per-item dict -- generic over any
+    bulk tool's id field, and never stitched across different items.
     """
+    items = args.get("items")
+    item_keys: dict[str, Any] = {}
     for key, expected in match.items():
         actual = args.get(key)
-        if (
-            key == "work_item_id"
-            and actual is None
-            and isinstance(args.get("items"), list)
-        ):
-            if not any(
-                isinstance(item, dict)
-                and _short_id(item.get("work_item_id", "")) == _short_id(expected)
-                for item in args["items"]
-            ):
-                return False
+        if actual is None and isinstance(items, list) and key.endswith("_id"):
+            item_keys[key] = expected
         elif key.endswith("_id"):
             if _short_id(actual) != _short_id(expected):
                 return False
         elif actual != expected:
             return False
+    if item_keys:
+        # item_keys is only populated when ``items`` is a list.
+        return any(
+            isinstance(item, dict)
+            and all(
+                _short_id(item.get(key, "")) == _short_id(expected)
+                for key, expected in item_keys.items()
+            )
+            for item in items
+        )
     return True
 
 

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -342,28 +342,54 @@ def check_no_detach_retry_loop(
     return True, "no retry loop against a free-floating item"
 
 
-def check_single_bulk_create(
-    trajectory: Trajectory, params: dict[str, Any]
+def _single_bulk_call(
+    trajectory: Trajectory, tool: str, params: dict[str, Any]
 ) -> CheckResult:
-    """Items creatable in one bulk call must not be split across calls.
-
-    Counts committed ``create_work_items`` calls (``dry_run`` previews and
-    guard-rejected calls excluded). ``params["max_calls"]`` defaults to 1.
+    """Committed ``tool`` calls (``dry_run`` previews and guard-rejected calls
+    excluded) must not exceed ``params["max_calls"]`` (default 1), and their
+    batches must carry ``params["min_items"]`` items in total (default 1) — a
+    zero-commit or partial batch is not an efficient pass, it's undone work.
     """
     max_calls = int(params.get("max_calls", 1))
+    min_items = int(params.get("min_items", 1))
     committed = [
         call
         for call in trajectory
-        if call.get("name") == "create_work_items"
+        if call.get("name") == tool
         and not _args(call).get("dry_run")
         and not _errored(call)
     ]
     if len(committed) > max_calls:
         return False, (
-            f"split creation into {len(committed)} create_work_items calls "
-            f"(max {max_calls}) -- one bulk call accepts up to 50 items"
+            f"split into {len(committed)} {tool} calls (max {max_calls}) "
+            "-- one bulk call handles the whole batch"
         )
-    return True, "creation used a single bulk call"
+    total_items = sum(len(_bulk_items(call, "items")) for call in committed)
+    if total_items < min_items:
+        return False, (
+            f"committed {total_items} item(s) via {tool} (min {min_items}) "
+            "-- the batch left the task undone"
+        )
+    return True, f"used a single bulk {tool} call"
+
+
+def check_single_bulk_create(
+    trajectory: Trajectory, params: dict[str, Any]
+) -> CheckResult:
+    """Items creatable in one bulk call must not be split across calls.
+    ``params``: ``max_calls`` (default 1), ``min_items`` (default 1).
+    """
+    return _single_bulk_call(trajectory, "create_work_items", params)
+
+
+def check_single_bulk_update(
+    trajectory: Trajectory, params: dict[str, Any]
+) -> CheckResult:
+    """Attribute changes to many known items must batch into one
+    ``update_work_items`` call, not one per item. ``params``: ``max_calls``
+    (default 1), ``min_items`` (default 1).
+    """
+    return _single_bulk_call(trajectory, "update_work_items", params)
 
 
 def check_direct_read(trajectory: Trajectory, params: dict[str, Any]) -> CheckResult:
@@ -662,6 +688,7 @@ REGISTRY: dict[str, Callable[[Trajectory, dict[str, Any]], CheckResult]] = {
     "round_trip_source": check_round_trip_source,
     "no_detach_retry_loop": check_no_detach_retry_loop,
     "single_bulk_create": check_single_bulk_create,
+    "single_bulk_update": check_single_bulk_update,
     "direct_read": check_direct_read,
     "no_duplicate_reads": check_no_duplicate_reads,
     "scoped_query_uses_sql": check_scoped_query_uses_sql,

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -46,7 +46,8 @@ from mcp_server_polarion.models.work_items import (
     WorkItemRead,
     WorkItemsCreateResult,
     WorkItemSummary,
-    WorkItemUpdateResult,
+    WorkItemsUpdateResult,
+    WorkItemUpdateSpec,
 )
 
 __all__: list[str] = [
@@ -81,6 +82,7 @@ __all__: list[str] = [
     "WorkItemMoveResult",
     "WorkItemRead",
     "WorkItemSummary",
-    "WorkItemUpdateResult",
+    "WorkItemUpdateSpec",
     "WorkItemsCreateResult",
+    "WorkItemsUpdateResult",
 ]

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TestRunSummary(BaseModel):
@@ -27,6 +27,9 @@ class TestRunCreateSpec(BaseModel):
     """One test run to create via ``create_test_runs``."""
 
     __test__ = False
+
+    # Polarion silently drops unknown keys -- forbid so a typo'd field errors.
+    model_config = ConfigDict(extra="forbid")
 
     id: str = Field(min_length=1)
     title: str | None = None

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -93,18 +93,44 @@ class WorkItemsCreateResult(BaseModel):
 class WorkItemUpdateSpec(BaseModel):
     """One work item to update via ``update_work_items``."""
 
-    work_item_id: str = Field(min_length=1)
+    work_item_id: str = Field(
+        min_length=1, description="Work item ID (e.g. 'MCPT-042')."
+    )
     title: str | None = None
-    description_html: str | None = Field(default=None, max_length=MAX_BODY_HTML_LEN)
-    status: str | None = None
-    priority: str | None = None
+    description_html: str | None = Field(
+        default=None,
+        max_length=MAX_BODY_HTML_LEN,
+        description=(
+            "Raw HTML from get_work_item(include_description_html=True); verbatim."
+        ),
+    )
+    status: str | None = Field(
+        default=None,
+        description="New status; prefer workflow_action for real transitions.",
+    )
+    priority: str | None = Field(default=None, description="e.g. '50.0'.")
     severity: str | None = None
-    due_date: str | None = None
-    initial_estimate: str | None = None
-    resolution: str | None = None
-    hyperlinks: list[Hyperlink] | None = None
-    assignee_ids: list[str] | None = None
-    custom_fields: dict[str, object] | None = None
+    due_date: str | None = Field(default=None, description="'YYYY-MM-DD'.")
+    initial_estimate: str | None = Field(
+        default=None,
+        description="Polarion duration (e.g. '5 1/2d', '1w 2d').",
+    )
+    resolution: str | None = Field(
+        default=None,
+        description="Prefer workflow_action so workflow rules apply.",
+    )
+    hyperlinks: list[Hyperlink] | None = Field(
+        default=None,
+        description="REPLACES the hyperlink list — pass the full list, not a delta.",
+    )
+    assignee_ids: list[str] | None = Field(
+        default=None,
+        description="REPLACES the assignee list — pass the full list, not a delta.",
+    )
+    custom_fields: dict[str, object] | None = Field(
+        default=None,
+        description="Partial; rich-text values as {'type':'text/html','value':...}.",
+    )
 
     @model_validator(mode="after")
     def _at_least_one_field(self) -> WorkItemUpdateSpec:

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from mcp_server_polarion.models.common import MAX_BODY_HTML_LEN
 
@@ -90,14 +90,47 @@ class WorkItemsCreateResult(BaseModel):
     payload_preview: Mapping[str, object] | None = None
 
 
-class WorkItemUpdateResult(BaseModel):
-    """Result of an ``update_work_item`` operation."""
+class WorkItemUpdateSpec(BaseModel):
+    """One work item to update via ``update_work_items``."""
+
+    work_item_id: str = Field(min_length=1)
+    title: str | None = None
+    description_html: str | None = Field(default=None, max_length=MAX_BODY_HTML_LEN)
+    status: str | None = None
+    priority: str | None = None
+    severity: str | None = None
+    due_date: str | None = None
+    initial_estimate: str | None = None
+    resolution: str | None = None
+    hyperlinks: list[Hyperlink] | None = None
+    assignee_ids: list[str] | None = None
+    custom_fields: dict[str, object] | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> WorkItemUpdateSpec:
+        # Polarion 400s on a body-less resource even with workflowAction /
+        # changeTypeTo query params, so every item must carry >=1 field.
+        if not any(
+            getattr(self, name)
+            for name in type(self).model_fields
+            if name != "work_item_id"
+        ):
+            raise ValueError(
+                "Nothing to update -- each item needs at least one of title, "
+                "description_html, status, priority, severity, due_date, "
+                "initial_estimate, resolution, hyperlinks, assignee_ids, "
+                "or custom_fields."
+            )
+        return self
+
+
+class WorkItemsUpdateResult(BaseModel):
+    """Result of an ``update_work_items`` operation."""
 
     updated: bool
     dry_run: bool
-    current: WorkItemDetail | None
-    changes: Mapping[str, object]
-    payload_preview: Mapping[str, object] | None
+    work_item_ids: list[str] = Field(default_factory=list)
+    payload_preview: Mapping[str, object] | None = None
 
 
 class WorkItemMoveResult(BaseModel):

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from mcp_server_polarion.models.common import MAX_BODY_HTML_LEN
 
@@ -68,6 +68,9 @@ class WorkItemRead(WorkItemSummary):
 class WorkItemCreateSpec(BaseModel):
     """One work item to create via ``create_work_items``."""
 
+    # Polarion silently drops unknown keys -- forbid so a typo'd field errors.
+    model_config = ConfigDict(extra="forbid")
+
     title: str = Field(min_length=1)
     type: str = Field(min_length=1)
     description: str | None = Field(default=None, max_length=MAX_BODY_HTML_LEN)
@@ -92,6 +95,9 @@ class WorkItemsCreateResult(BaseModel):
 
 class WorkItemUpdateSpec(BaseModel):
     """One work item to update via ``update_work_items``."""
+
+    # Forbid so a misplaced batch-level key (workflow_action, ...) errors.
+    model_config = ConfigDict(extra="forbid")
 
     work_item_id: str = Field(
         min_length=1, description="Work item ID (e.g. 'MCPT-042')."

--- a/src/mcp_server_polarion/tools/_shared/guard.py
+++ b/src/mcp_server_polarion/tools/_shared/guard.py
@@ -883,32 +883,68 @@ async def guard_hyperlink_roles(
     )
 
 
-async def _existing_target_ids(
+async def _existing_work_item_types(
     client: PolarionClient,
     project_id: str,
-    target_ids: frozenset[str],
-) -> frozenset[str]:
-    """Subset of *target_ids* that exist in *project_id*, via chunked
-    ``id:(...)`` queries. 404 (project missing) propagates to caller.
+    work_item_ids: frozenset[str],
+) -> dict[str, str]:
+    """id -> type for the subset of *work_item_ids* that exist in
+    *project_id*, via chunked ``id:(...)`` queries; type is ``""`` when the
+    attribute is absent. 404 (project missing) propagates to caller.
     """
-    ordered = sorted(target_ids)
-    found: set[str] = set()
+    ordered = sorted(work_item_ids)
+    found: dict[str, str] = {}
+    path = f"/projects/{encode_path_segment(project_id)}/workitems"
     for start in range(0, len(ordered), _GUARD_PAGE_SIZE):
         chunk = ordered[start : start + _GUARD_PAGE_SIZE]
         params: dict[str, str | int] = {
             "query": f"id:({' '.join(chunk)})",
-            "fields[workitems]": "id",
+            "fields[workitems]": "id,type",
             "page[size]": _GUARD_PAGE_SIZE,
             "page[number]": 1,
         }
-        path = f"/projects/{encode_path_segment(project_id)}/workitems"
         response = await client.get(path, params=params)
         data = response.get("data", [])
         if isinstance(data, list):
             for entry in data:
-                if isinstance(entry, dict):
-                    found.add(extract_short_id(safe_str(entry.get("id", ""))))
-    return frozenset(found)
+                if not isinstance(entry, dict):
+                    continue
+                short_id = extract_short_id(safe_str(entry.get("id", "")))
+                if not short_id:
+                    continue
+                attrs = entry.get("attributes")
+                type_id = attrs.get("type") if isinstance(attrs, dict) else None
+                found[short_id] = type_id if isinstance(type_id, str) else ""
+    return found
+
+
+async def guard_work_item_types(
+    client: PolarionClient,
+    project_id: str,
+    work_item_ids: Iterable[str],
+) -> dict[str, str]:
+    """Fail-closed existence check; returns id -> type (enum guards scope by
+    type). Raises ``ValueError`` naming every id that does not exist;
+    ``PolarionNotFoundError`` (bad project) propagates to the caller.
+    """
+    requested = frozenset(wi for wi in work_item_ids if wi)
+    try:
+        resolved = await _existing_work_item_types(client, project_id, requested)
+    except PolarionAuthError as exc:
+        raise _unauthorized_write_block("work item existence", project_id) from exc
+    except PolarionNotFoundError:
+        raise
+    except PolarionError as exc:
+        raise _unreachable_write_block("work item existence", project_id, exc) from exc
+
+    missing = sorted(requested - resolved.keys())
+    if missing:
+        raise ValueError(
+            f"Work item(s) {format_option_list(missing)} not found in "
+            f"project '{project_id}'. Use `list_work_items` to discover "
+            "valid IDs."
+        )
+    return resolved
 
 
 async def guard_work_item_link_targets(
@@ -928,7 +964,7 @@ async def guard_work_item_link_targets(
     missing: list[str] = []
     for project_id, requested in by_project.items():
         try:
-            existing = await _existing_target_ids(
+            existing = await _existing_work_item_types(
                 client, project_id, frozenset(requested)
             )
         except PolarionNotFoundError:
@@ -938,7 +974,9 @@ async def guard_work_item_link_targets(
             raise _unauthorized_write_block("link targets", project_id) from exc
         except PolarionError as exc:
             raise _unreachable_write_block("link targets", project_id, exc) from exc
-        missing.extend(f"{project_id}/{wi}" for wi in sorted(requested - existing))
+        missing.extend(
+            f"{project_id}/{wi}" for wi in sorted(requested - existing.keys())
+        )
 
     if missing:
         raise ValueError(
@@ -1041,5 +1079,6 @@ __all__ = [
     "guard_work_item_enums",
     "guard_work_item_link_roles",
     "guard_work_item_link_targets",
+    "guard_work_item_types",
     "partition_delete_links",
 ]

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -1,10 +1,12 @@
 """Core cross-cutting helpers for ``tools`` (not public API): client lookup,
-string coercion, path encoding, option-list formatting, lucene-id guarding.
+string coercion, path encoding, option-list formatting, lucene-id and
+bulk-batch id guarding.
 """
 
 from __future__ import annotations
 
 import re
+from collections import Counter
 from collections.abc import Iterable
 from typing import Final
 from urllib.parse import quote
@@ -73,9 +75,23 @@ def validate_work_item_id_for_lucene(work_item_id: str) -> None:
         raise ValueError(msg)
 
 
+def ensure_unique_ids(ids: Iterable[str], *, label: str) -> None:
+    """Reject duplicate ids within one bulk batch -- Polarion would apply
+    them in undefined order (update) or conflict (create).
+    """
+    duplicates = sorted(id_ for id_, count in Counter(ids).items() if count > 1)
+    if duplicates:
+        raise ValueError(
+            f"Duplicate {label}(s) {duplicates} in one batch -- every item "
+            f"needs a distinct {label}; merge duplicate entries into a "
+            "single item instead."
+        )
+
+
 __all__: list[str] = [
     "OPTION_LIST_LIMIT",
     "encode_path_segment",
+    "ensure_unique_ids",
     "format_option_list",
     "get_client",
     "safe_str",

--- a/src/mcp_server_polarion/tools/enum.py
+++ b/src/mcp_server_polarion/tools/enum.py
@@ -99,7 +99,7 @@ async def list_work_item_enum_options(  # noqa: PLR0913
 ) -> PaginatedResult[EnumOption]:
     """List valid enum option ids for a work item field of a given type.
 
-    Resolve enum ids here before create_work_items / update_work_item — enums
+    Resolve enum ids here before create_work_items / update_work_items — enums
     are validated on write, invalid ids raise with this set. An unknown
     work_item_type silently falls back to ~, so verify the type id first.
     """

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -35,6 +35,7 @@ from mcp_server_polarion.tools._shared.guard import (
 )
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
+    ensure_unique_ids,
     get_client,
 )
 from mcp_server_polarion.tools._shared.pagination import (
@@ -127,6 +128,7 @@ async def create_test_runs(
     mismatch raises — re-query list_test_runs before retrying.
     """
     client = get_client(ctx)
+    ensure_unique_ids((spec.id for spec in items), label="id")
     for spec in items:
         await guard_test_run_enums(
             client, project_id, type=spec.type, status=spec.status

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -41,10 +41,13 @@ from mcp_server_polarion.tools._shared.guard import (
     guard_hyperlink_roles,
     guard_work_item_custom_fields,
     guard_work_item_enums,
+    guard_work_item_types,
 )
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
+    ensure_unique_ids,
     get_client,
+    validate_work_item_id_for_lucene,
 )
 from mcp_server_polarion.tools._shared.pagination import (
     DEFAULT_PAGE_SIZE,
@@ -64,6 +67,40 @@ from mcp_server_polarion.utils import (
 logger = logging.getLogger("mcp_server_polarion.tools.work_items")
 
 
+def _merge_shared_attributes(
+    attributes: dict[str, JsonValue],
+    spec: WorkItemCreateSpec | WorkItemUpdateSpec,
+) -> None:
+    """Attribute keys common to create and update resources; skips unset."""
+    if spec.status:
+        attributes["status"] = spec.status
+    if spec.priority:
+        attributes["priority"] = spec.priority
+    if spec.severity:
+        attributes["severity"] = spec.severity
+    if spec.due_date:
+        attributes["dueDate"] = spec.due_date
+    if spec.initial_estimate:
+        attributes["initialEstimate"] = spec.initial_estimate
+    if spec.hyperlinks:
+        attributes["hyperlinks"] = [
+            {"role": h.role, "title": h.title, "uri": h.uri} for h in spec.hyperlinks
+        ]
+
+
+def _build_assignee_relationship(
+    spec: WorkItemCreateSpec | WorkItemUpdateSpec,
+) -> dict[str, JsonValue]:
+    """``assignee`` to-many relationship block; empty dict when unset."""
+    if not spec.assignee_ids:
+        return {}
+    return {
+        "assignee": {
+            "data": [{"type": "users", "id": uid} for uid in spec.assignee_ids]
+        }
+    }
+
+
 def _build_work_item_resource(
     *,
     spec: WorkItemCreateSpec,
@@ -81,27 +118,10 @@ def _build_work_item_resource(
             "type": "text/html",
             "value": description_html,
         }
-    if spec.status:
-        attributes["status"] = spec.status
-    if spec.priority:
-        attributes["priority"] = spec.priority
-    if spec.severity:
-        attributes["severity"] = spec.severity
-    if spec.due_date:
-        attributes["dueDate"] = spec.due_date
-    if spec.initial_estimate:
-        attributes["initialEstimate"] = spec.initial_estimate
-    if spec.hyperlinks:
-        attributes["hyperlinks"] = [
-            {"role": h.role, "title": h.title, "uri": h.uri} for h in spec.hyperlinks
-        ]
+    _merge_shared_attributes(attributes, spec)
     merge_custom_fields(attributes, spec.custom_fields, STANDARD_WORK_ITEM_ATTRIBUTES)
 
-    relationships: dict[str, JsonValue] = {}
-    if spec.assignee_ids:
-        relationships["assignee"] = {
-            "data": [{"type": "users", "id": uid} for uid in spec.assignee_ids]
-        }
+    relationships = _build_assignee_relationship(spec)
 
     resource: dict[str, JsonValue] = {
         "type": "workitems",
@@ -126,7 +146,7 @@ def _build_create_work_items_payload(
     return {"data": data}
 
 
-def _build_update_work_item_resource(  # noqa: PLR0912
+def _build_update_work_item_resource(
     *,
     project_id: str,
     spec: WorkItemUpdateSpec,
@@ -142,29 +162,12 @@ def _build_update_work_item_resource(  # noqa: PLR0912
             "type": "text/html",
             "value": spec.description_html,
         }
-    if spec.status:
-        attributes["status"] = spec.status
-    if spec.priority:
-        attributes["priority"] = spec.priority
-    if spec.severity:
-        attributes["severity"] = spec.severity
-    if spec.due_date:
-        attributes["dueDate"] = spec.due_date
-    if spec.initial_estimate:
-        attributes["initialEstimate"] = spec.initial_estimate
+    _merge_shared_attributes(attributes, spec)
     if spec.resolution:
         attributes["resolution"] = spec.resolution
-    if spec.hyperlinks:
-        attributes["hyperlinks"] = [
-            {"role": h.role, "title": h.title, "uri": h.uri} for h in spec.hyperlinks
-        ]
     merge_custom_fields(attributes, spec.custom_fields, STANDARD_WORK_ITEM_ATTRIBUTES)
 
-    relationships: dict[str, JsonValue] = {}
-    if spec.assignee_ids:
-        relationships["assignee"] = {
-            "data": [{"type": "users", "id": uid} for uid in spec.assignee_ids]
-        }
+    relationships = _build_assignee_relationship(spec)
 
     resource: dict[str, JsonValue] = {
         "type": "workitems",
@@ -368,94 +371,94 @@ async def update_work_items(  # noqa: PLR0912, PLR0913
     client = get_client(ctx)
 
     for spec in items:
-        needs_enum_guard = bool(
-            spec.status
-            or spec.severity
-            or spec.priority
-            or spec.resolution
-            or change_type_to
-            or spec.custom_fields
-        )
-        if not needs_enum_guard:
-            continue
-        # Enum options are type-scoped: one prefetch per item (on dry_run too,
-        # so preview raises the same errors) resolves the type and primes the
-        # custom-key cache.
-        item_path = (
-            f"/projects/{encode_path_segment(project_id)}"
-            f"/workitems/{encode_path_segment(spec.work_item_id)}"
-        )
+        validate_work_item_id_for_lucene(spec.work_item_id)
+    ensure_unique_ids((spec.work_item_id for spec in items), label="work_item_id")
+    # Build before any guard round-trip so an empty-body resource fails fast.
+    payload = _build_update_work_items_payload(project_id=project_id, specs=items)
+
+    guarded_specs = [
+        spec
+        for spec in items
+        if spec.status
+        or spec.severity
+        or spec.priority
+        or spec.resolution
+        or change_type_to
+        or spec.custom_fields
+    ]
+    types_by_id: dict[str, str] = {}
+    if guarded_specs:
+        # Enum options are type-scoped: one batched existence+type query (on
+        # dry_run too, so preview raises the same errors) names every missing
+        # id at once.
         try:
-            prefetch = await client.get(
-                item_path,
-                params={"fields[workitems]": "@all"},
+            types_by_id = await guard_work_item_types(
+                client, project_id, (spec.work_item_id for spec in guarded_specs)
             )
         except PolarionNotFoundError as exc:
             raise ValueError(
-                f"Work item '{spec.work_item_id}' in project '{project_id}' "
-                "not found. Use `list_work_items` to discover valid IDs."
+                f"Project '{project_id}' not found. "
+                "Use `list_projects` to discover valid project IDs."
             ) from exc
-        except PolarionAuthError as exc:
-            raise PermissionError(
-                "Cannot read work item -- check your POLARION_TOKEN permissions."
-            ) from exc
-        except PolarionError as exc:
-            raise RuntimeError(
-                f"Failed to read work item for guard: {exc.message}"
-            ) from exc
-        work_item_type = ""
-        prefetch_data = prefetch.get("data", {})
-        if isinstance(prefetch_data, dict):
-            current_detail = parse_work_item_detail(
-                prefetch_data,
-                project_id=project_id,
-                fallback_id=spec.work_item_id,
-            )
-            work_item_type = current_detail.type
 
-        # Scope enums by target type; guard checks ``type`` first, so an invalid
-        # change_type_to raises before being reused as the scoping axis.
-        effective_type = change_type_to or work_item_type or "~"
+    if change_type_to:
+        # Batch-level param: validate once, unprefixed -- a bad value is not
+        # any single item's fault.
         await guard_work_item_enums(
-            client,
-            project_id,
-            work_item_type=effective_type,
-            type=change_type_to,
-            status=spec.status,
-            severity=spec.severity,
-            priority=spec.priority,
-            resolution=spec.resolution,
+            client, project_id, work_item_type="~", type=change_type_to
         )
-        # change_type_to retypes in the same PATCH — customs belong to the new type.
-        if spec.custom_fields:
-            await guard_work_item_custom_fields(
+
+    for spec in guarded_specs:
+        work_item_type = types_by_id.get(spec.work_item_id, "")
+        # change_type_to retypes in the same PATCH -- enums and customs are
+        # scoped to the new type.
+        effective_type = change_type_to or work_item_type or "~"
+        try:
+            await guard_work_item_enums(
                 client,
                 project_id,
-                change_type_to or work_item_type,
-                spec.custom_fields,
+                work_item_type=effective_type,
+                status=spec.status,
+                severity=spec.severity,
+                priority=spec.priority,
+                resolution=spec.resolution,
             )
+            if spec.custom_fields:
+                await guard_work_item_custom_fields(
+                    client,
+                    project_id,
+                    change_type_to or work_item_type,
+                    spec.custom_fields,
+                )
+        except ValueError as exc:
+            raise ValueError(f"Work item '{spec.work_item_id}': {exc}") from exc
 
-    await guard_hyperlink_roles(
-        client,
-        project_id,
-        [h.role for spec in items for h in (spec.hyperlinks or [])],
-    )
-
-    payload = _build_update_work_items_payload(project_id=project_id, specs=items)
-
-    if dry_run:
-        return WorkItemsUpdateResult(
-            updated=False,
-            dry_run=True,
-            work_item_ids=[],
-            payload_preview=payload,
-        )
+    for spec in items:
+        if spec.hyperlinks:
+            try:
+                await guard_hyperlink_roles(
+                    client, project_id, [h.role for h in spec.hyperlinks]
+                )
+            except ValueError as exc:
+                raise ValueError(f"Work item '{spec.work_item_id}': {exc}") from exc
 
     query_params: dict[str, str] = {}
     if workflow_action:
         query_params["workflowAction"] = workflow_action
     if change_type_to:
         query_params["changeTypeTo"] = change_type_to
+
+    if dry_run:
+        preview: dict[str, JsonValue] = dict(payload)
+        if query_params:
+            preview["query_params"] = cast("dict[str, JsonValue]", query_params)
+        return WorkItemsUpdateResult(
+            updated=False,
+            dry_run=True,
+            work_item_ids=[],
+            payload_preview=preview,
+        )
+
     path = f"/projects/{encode_path_segment(project_id)}/workitems"
     if query_params:
         path = f"{path}?{urlencode(query_params)}"
@@ -467,9 +470,11 @@ async def update_work_items(  # noqa: PLR0912, PLR0913
             "Cannot update work items -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionNotFoundError as exc:
+        batch_ids = sorted(spec.work_item_id for spec in items)
         raise ValueError(
-            f"A work item in the batch was not found in project '{project_id}'. "
-            "Use `list_work_items` to discover valid IDs."
+            f"A work item in the batch {batch_ids} was not found in project "
+            f"'{project_id}': {exc.message} Use `list_work_items` to discover "
+            "valid IDs."
         ) from exc
     except PolarionError as exc:
         raise RuntimeError(f"Failed to update work items: {exc.message}") from exc

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import logging
 from importlib import resources
 from typing import Final, cast
@@ -17,8 +16,6 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
-    MAX_BODY_HTML_LEN,
-    Hyperlink,
     JsonValue,
     PaginatedResult,
     SqlRecipeGallery,
@@ -27,7 +24,8 @@ from mcp_server_polarion.models import (
     WorkItemRead,
     WorkItemsCreateResult,
     WorkItemSummary,
-    WorkItemUpdateResult,
+    WorkItemsUpdateResult,
+    WorkItemUpdateSpec,
 )
 from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools._shared.custom_fields import (
@@ -146,67 +144,69 @@ def _extract_created_work_item_ids(response: dict[str, object]) -> list[str]:
     return ids
 
 
-def _build_update_work_item_payload(  # noqa: PLR0913
+def _build_update_work_item_resource(
     *,
     project_id: str,
-    work_item_id: str,
-    title: str | None,
-    description_html: str | None,
-    status: str | None,
-    priority: str | None,
-    severity: str | None,
-    due_date: str | None,
-    initial_estimate: str | None,
-    resolution: str | None,
-    hyperlinks: list[Hyperlink] | None,
-    assignee_ids: list[str] | None,
-    custom_fields: dict[str, object] | None = None,
+    spec: WorkItemUpdateSpec,
 ) -> dict[str, JsonValue]:
-    """JSON:API PATCH body for ``/projects/{p}/workitems/{work_item}``; skips
-    unset so an update never blanks an existing attribute.
+    """One ``workitems`` resource for a bulk update PATCH; skips unset so an
+    update never blanks an existing attribute.
     """
     attributes: dict[str, JsonValue] = {}
-    if title:
-        attributes["title"] = title
-    if description_html:
+    if spec.title:
+        attributes["title"] = spec.title
+    if spec.description_html:
         attributes["description"] = {
             "type": "text/html",
-            "value": description_html,
+            "value": spec.description_html,
         }
-    if status:
-        attributes["status"] = status
-    if priority:
-        attributes["priority"] = priority
-    if severity:
-        attributes["severity"] = severity
-    if due_date:
-        attributes["dueDate"] = due_date
-    if initial_estimate:
-        attributes["initialEstimate"] = initial_estimate
-    if resolution:
-        attributes["resolution"] = resolution
-    if hyperlinks:
+    if spec.status:
+        attributes["status"] = spec.status
+    if spec.priority:
+        attributes["priority"] = spec.priority
+    if spec.severity:
+        attributes["severity"] = spec.severity
+    if spec.due_date:
+        attributes["dueDate"] = spec.due_date
+    if spec.initial_estimate:
+        attributes["initialEstimate"] = spec.initial_estimate
+    if spec.resolution:
+        attributes["resolution"] = spec.resolution
+    if spec.hyperlinks:
         attributes["hyperlinks"] = [
-            {"role": h.role, "title": h.title, "uri": h.uri} for h in hyperlinks
+            {"role": h.role, "title": h.title, "uri": h.uri} for h in spec.hyperlinks
         ]
-    merge_custom_fields(attributes, custom_fields, STANDARD_WORK_ITEM_ATTRIBUTES)
+    merge_custom_fields(attributes, spec.custom_fields, STANDARD_WORK_ITEM_ATTRIBUTES)
 
     relationships: dict[str, JsonValue] = {}
-    if assignee_ids:
+    if spec.assignee_ids:
         relationships["assignee"] = {
-            "data": [{"type": "users", "id": uid} for uid in assignee_ids]
+            "data": [{"type": "users", "id": uid} for uid in spec.assignee_ids]
         }
 
-    item: dict[str, JsonValue] = {
+    resource: dict[str, JsonValue] = {
         "type": "workitems",
-        "id": f"{project_id}/{work_item_id}",
+        "id": f"{project_id}/{spec.work_item_id}",
     }
     if attributes:
-        item["attributes"] = attributes
+        resource["attributes"] = attributes
     if relationships:
-        item["relationships"] = relationships
+        resource["relationships"] = relationships
 
-    return {"data": item}
+    return resource
+
+
+def _build_update_work_items_payload(
+    *,
+    project_id: str,
+    specs: list[WorkItemUpdateSpec],
+) -> dict[str, JsonValue]:
+    """JSON:API body for bulk ``PATCH /projects/{p}/workitems``."""
+    data: list[JsonValue] = [
+        _build_update_work_item_resource(project_id=project_id, spec=spec)
+        for spec in specs
+    ]
+    return {"data": data}
 
 
 _SQL_QUERY_RECIPES: Final[str] = (
@@ -250,7 +250,7 @@ async def create_work_items(
     Items are created free-floating; place into a document with
     move_work_item_to_document (this tool cannot). description is Markdown →
     sanitized HTML; later edits are raw-HTML round-trip via
-    get_work_item(include_description_html=True) ↔ update_work_item.
+    get_work_item(include_description_html=True) ↔ update_work_items.
     """
     client = get_client(ctx)
     for spec in items:
@@ -333,74 +333,33 @@ async def create_work_items(
         "openWorldHint": True,
     },
 )
-async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
+async def update_work_items(  # noqa: PLR0912, PLR0913
     ctx: Context,
     project_id: str = Field(min_length=1, description="Polarion project ID."),
-    work_item_id: str = Field(
+    items: list[WorkItemUpdateSpec] = Field(  # noqa: B008
         min_length=1,
-        description="Work item ID (e.g. 'MCPT-042').",
-    ),
-    title: str | None = None,
-    description_html: str | None = Field(
-        default=None,
-        max_length=MAX_BODY_HTML_LEN,
-        description=(
-            "Raw HTML from get_work_item(include_description_html=True); verbatim."
-        ),
-    ),
-    status: str | None = Field(
-        default=None,
-        description="New status; prefer workflow_action for real transitions.",
-    ),
-    priority: str | None = Field(
-        default=None,
-        description="e.g. '50.0'.",
-    ),
-    severity: str | None = None,
-    due_date: str | None = Field(default=None, description="'YYYY-MM-DD'."),
-    initial_estimate: str | None = Field(
-        default=None,
-        description="Polarion duration (e.g. '5 1/2d', '1w 2d').",
-    ),
-    resolution: str | None = Field(
-        default=None,
-        description="Prefer workflow_action so workflow rules apply.",
-    ),
-    hyperlinks: list[Hyperlink] | None = Field(  # noqa: B008
-        default=None,
-        description="REPLACES the hyperlink list — pass the full list, not a delta.",
-    ),
-    assignee_ids: list[str] | None = Field(  # noqa: B008
-        default=None,
-        description="REPLACES the assignee list — pass the full list, not a delta.",
-    ),
-    custom_fields: dict[str, object] | None = Field(  # noqa: B008
-        default=None,
-        description="Partial; rich-text values as {'type':'text/html','value':...}.",
+        max_length=MAX_BULK_ITEMS,
+        description="Work items to update in one request (1-50).",
     ),
     workflow_action: str | None = Field(
         default=None,
-        description="Workflow action ID (e.g. 'close').",
+        description="Workflow action ID (e.g. 'close'); applies to EVERY item.",
     ),
     change_type_to: str | None = Field(
         default=None,
-        description="New work-item type; RESETS status.",
-    ),
-    include_current_description_html: bool = Field(
-        default=False,
-        description="Return post-PATCH raw HTML in current.description_html.",
+        description="New work-item type for EVERY item; RESETS status.",
     ),
     dry_run: bool = Field(
         default=False,
         description="Preview payload without writing; guards still query Polarion.",
     ),
-) -> WorkItemUpdateResult:
-    """Update fields on an existing work item; None/empty = leave unchanged.
+) -> WorkItemsUpdateResult:
+    """Update fields on 1-50 existing work items in one bulk request.
 
-    Fetch current state with get_work_item BEFORE updating; PATCHes then GETs.
-    description_html is raw Polarion HTML, sent verbatim — source from
-    get_work_item(include_description_html=True); greenfield bodies use
-    create_work_items Markdown, formats never mix.
+    Fetch current state with get_work_item BEFORE updating. Per item, unset
+    fields stay unchanged. description_html is raw Polarion HTML, sent verbatim
+    — source from get_work_item(include_description_html=True); greenfield
+    bodies use create_work_items Markdown, formats never mix.
 
     hyperlinks/assignee_ids REPLACE the stored list — resubmit every existing
     entry plus the change or omissions are deleted. custom_fields is partial,
@@ -408,96 +367,40 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
     list_work_item_enum_options first.
 
     module not settable here — use move_work_item_to_document /
-    move_work_item_from_document. workflow_action/change_type_to must pair with
-    ≥1 body field (else 400); unknown enum ids raise ValueError with options;
-    change_type_to scopes status/severity/resolution to the target type and
-    resets status.
+    move_work_item_from_document. workflow_action/change_type_to apply to
+    EVERY item in the batch; change_type_to scopes status/severity/resolution
+    to the target type and resets status. Unknown enum ids raise ValueError
+    with options. Atomic: one bad item rejects the whole batch.
     """
-    changes: dict[str, JsonValue] = {}
-    if title:
-        changes["title"] = title
-    if description_html:
-        changes["description_html"] = description_html
-    if status:
-        changes["status"] = status
-    if priority:
-        changes["priority"] = priority
-    if severity:
-        changes["severity"] = severity
-    if due_date:
-        changes["due_date"] = due_date
-    if initial_estimate:
-        changes["initial_estimate"] = initial_estimate
-    if resolution:
-        changes["resolution"] = resolution
-    if hyperlinks:
-        changes["hyperlinks"] = [
-            {"role": h.role, "title": h.title, "uri": h.uri} for h in hyperlinks
-        ]
-    if assignee_ids:
-        changes["assignee_ids"] = list(assignee_ids)
-    if custom_fields:
-        # deepcopy: shallow would alias nested rich-text values into ``changes``.
-        changes["custom_fields"] = cast(JsonValue, copy.deepcopy(custom_fields))
-    if workflow_action:
-        changes["workflow_action"] = workflow_action
-    if change_type_to:
-        changes["change_type_to"] = change_type_to
-
-    if not changes:
-        raise ValueError(
-            "Nothing to update -- pass at least one of title, "
-            "description_html, status, priority, severity, due_date, "
-            "initial_estimate, resolution, hyperlinks, assignee_ids, "
-            "custom_fields, workflow_action, or change_type_to."
-        )
-
-    payload = _build_update_work_item_payload(
-        project_id=project_id,
-        work_item_id=work_item_id,
-        title=title,
-        description_html=description_html,
-        status=status,
-        priority=priority,
-        severity=severity,
-        due_date=due_date,
-        initial_estimate=initial_estimate,
-        resolution=resolution,
-        hyperlinks=hyperlinks,
-        assignee_ids=assignee_ids,
-        custom_fields=custom_fields,
-    )
-
-    # Polarion 400s on an attribute-less PATCH even with workflowAction/changeTypeTo.
-    payload_data = cast(dict[str, JsonValue], payload["data"])
-    if "attributes" not in payload_data and "relationships" not in payload_data:
-        raise ValueError(
-            "Polarion's PATCH endpoint requires at least one body field "
-            "(attribute or relationship) even when triggering "
-            "workflow_action or change_type_to. Pair the action with one "
-            "of: title, description, status, priority, severity, due_date, "
-            "initial_estimate, resolution, hyperlinks, or assignee_ids."
-        )
-
     client = get_client(ctx)
-    base_path = (
-        f"/projects/{encode_path_segment(project_id)}"
-        f"/workitems/{encode_path_segment(work_item_id)}"
-    )
 
-    # Enum options are type-scoped: one prefetch (on dry_run too, so preview
-    # raises the same errors) resolves the type and primes the custom-key cache.
-    work_item_type = ""
-    if status or severity or priority or resolution or change_type_to or custom_fields:
+    for spec in items:
+        needs_enum_guard = bool(
+            spec.status
+            or spec.severity
+            or spec.priority
+            or spec.resolution
+            or change_type_to
+            or spec.custom_fields
+        )
+        if not needs_enum_guard:
+            continue
+        # Enum options are type-scoped: one prefetch per item (on dry_run too,
+        # so preview raises the same errors) resolves the type and primes the
+        # custom-key cache.
+        item_path = (
+            f"/projects/{encode_path_segment(project_id)}"
+            f"/workitems/{encode_path_segment(spec.work_item_id)}"
+        )
         try:
             prefetch = await client.get(
-                base_path,
+                item_path,
                 params={"fields[workitems]": "@all"},
             )
         except PolarionNotFoundError as exc:
             raise ValueError(
-                f"Work item '{work_item_id}' in project '{project_id}' not found. "
-                "Use `list_work_items` to discover valid IDs."
+                f"Work item '{spec.work_item_id}' in project '{project_id}' "
+                "not found. Use `list_work_items` to discover valid IDs."
             ) from exc
         except PolarionAuthError as exc:
             raise PermissionError(
@@ -507,12 +410,13 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
             raise RuntimeError(
                 f"Failed to read work item for guard: {exc.message}"
             ) from exc
+        work_item_type = ""
         prefetch_data = prefetch.get("data", {})
         if isinstance(prefetch_data, dict):
             current_detail = parse_work_item_detail(
                 prefetch_data,
                 project_id=project_id,
-                fallback_id=work_item_id,
+                fallback_id=spec.work_item_id,
             )
             work_item_type = current_detail.type
 
@@ -524,29 +428,33 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
             project_id,
             work_item_type=effective_type,
             type=change_type_to,
-            status=status,
-            severity=severity,
-            priority=priority,
-            resolution=resolution,
+            status=spec.status,
+            severity=spec.severity,
+            priority=spec.priority,
+            resolution=spec.resolution,
         )
         # change_type_to retypes in the same PATCH — customs belong to the new type.
-        if custom_fields:
+        if spec.custom_fields:
             await guard_work_item_custom_fields(
                 client,
                 project_id,
                 change_type_to or work_item_type,
-                custom_fields,
+                spec.custom_fields,
             )
 
-    if hyperlinks:
-        await guard_hyperlink_roles(client, project_id, [h.role for h in hyperlinks])
+    await guard_hyperlink_roles(
+        client,
+        project_id,
+        [h.role for spec in items for h in (spec.hyperlinks or [])],
+    )
+
+    payload = _build_update_work_items_payload(project_id=project_id, specs=items)
 
     if dry_run:
-        return WorkItemUpdateResult(
+        return WorkItemsUpdateResult(
             updated=False,
             dry_run=True,
-            current=None,
-            changes=changes,
+            work_item_ids=[],
             payload_preview=payload,
         )
 
@@ -555,46 +463,28 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         query_params["workflowAction"] = workflow_action
     if change_type_to:
         query_params["changeTypeTo"] = change_type_to
-    patch_path = f"{base_path}?{urlencode(query_params)}" if query_params else base_path
+    path = f"/projects/{encode_path_segment(project_id)}/workitems"
+    if query_params:
+        path = f"{path}?{urlencode(query_params)}"
 
     try:
-        await client.patch(patch_path, json=cast(dict[str, object], payload))
-        response = await client.get(
-            base_path,
-            params={
-                "fields[workitems]": WORK_ITEM_DETAIL_FIELDS,
-                "include": "assignee",
-            },
-        )
+        await client.patch(path, json=cast(dict[str, object], payload))
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot update work item -- check your POLARION_TOKEN permissions."
+            "Cannot update work items -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionNotFoundError as exc:
         raise ValueError(
-            f"Work item '{work_item_id}' in project '{project_id}' not found. "
+            f"A work item in the batch was not found in project '{project_id}'. "
             "Use `list_work_items` to discover valid IDs."
         ) from exc
     except PolarionError as exc:
-        raise RuntimeError(f"Failed to update work item: {exc.message}") from exc
+        raise RuntimeError(f"Failed to update work items: {exc.message}") from exc
 
-    data = response.get("data", {})
-    if not isinstance(data, dict):
-        data = {}
-    current = parse_work_item_detail(
-        data,
-        project_id=project_id,
-        fallback_id=work_item_id,
-    )
-    if not include_current_description_html:
-        # Body still came over the wire; blank it — mirrors get_work_item.
-        current = current.model_copy(update={"description_html": ""})
-
-    return WorkItemUpdateResult(
+    return WorkItemsUpdateResult(
         updated=True,
         dry_run=False,
-        current=current,
-        changes=changes,
+        work_item_ids=[spec.work_item_id for spec in items],
         payload_preview=None,
     )
 
@@ -692,7 +582,7 @@ async def get_work_item(
     """Get full details of one work item by ID.
 
     include_description_html=True fills description_html with raw HTML — the
-    required source for update_work_item(description_html=...). Never feed back
+    required source for update_work_items description_html. Never feed back
     a blanked (flag=False) body.
     """
     client = get_client(ctx)
@@ -751,7 +641,7 @@ async def read_work_item(
     """Read one work item with its body rendered as Markdown.
 
     get_work_item plus description as Markdown. Synthesis output (collapses
-    Polarion anchors) — NEVER feed to update_work_item; round-trip via the HTML
+    Polarion anchors) — NEVER feed to update_work_items; round-trip via the HTML
     pair instead.
     """
     # Pull raw HTML from get_work_item so conversion needs no second round trip.

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -339,7 +339,10 @@ async def update_work_items(  # noqa: PLR0912, PLR0913
     items: list[WorkItemUpdateSpec] = Field(  # noqa: B008
         min_length=1,
         max_length=MAX_BULK_ITEMS,
-        description="Work items to update in one request (1-50).",
+        description=(
+            "Work items to update in one request (1-50); call get_work_item "
+            "on each target first."
+        ),
     ),
     workflow_action: str | None = Field(
         default=None,
@@ -356,13 +359,13 @@ async def update_work_items(  # noqa: PLR0912, PLR0913
 ) -> WorkItemsUpdateResult:
     """Update fields on 1-50 existing work items in one bulk request.
 
-    Fetch current state with get_work_item BEFORE updating. Per item, unset
-    fields stay unchanged. description_html is raw Polarion HTML, sent verbatim
-    — source from get_work_item(include_description_html=True); greenfield
-    bodies use create_work_items Markdown, formats never mix.
+    Call get_work_item on EACH target BEFORE updating: per-item hyperlinks/
+    assignee_ids REPLACE the stored list — resubmit every existing entry plus
+    the change, or omissions are silently deleted. Unset fields stay unchanged.
 
-    hyperlinks/assignee_ids REPLACE the stored list — resubmit every existing
-    entry plus the change or omissions are deleted. custom_fields is partial,
+    description_html is raw Polarion HTML, sent verbatim — source from
+    get_work_item(include_description_html=True); greenfield bodies use
+    create_work_items Markdown, formats never mix. custom_fields is partial,
     keys outside the type schema rejected, values NOT validated — resolve via
     list_work_item_enum_options first.
 

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -126,7 +126,7 @@ def _build_create_work_items_payload(
     return {"data": data}
 
 
-def _build_update_work_item_resource(
+def _build_update_work_item_resource(  # noqa: PLR0912
     *,
     project_id: str,
     spec: WorkItemUpdateSpec,
@@ -175,6 +175,14 @@ def _build_update_work_item_resource(
     if relationships:
         resource["relationships"] = relationships
 
+    # Spec validator can't see this: all-None custom_fields values pass it but
+    # drop in merge, and Polarion 400s the whole batch on a body-less resource.
+    if "attributes" not in resource and "relationships" not in resource:
+        raise ValueError(
+            f"Work item '{spec.work_item_id}' resolves to an empty PATCH "
+            "body (None-valued custom_fields are skipped). Pass at least "
+            "one usable field."
+        )
     return resource
 
 

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -47,12 +47,15 @@ class TestCheckGetBeforeUpdate:
         passed, _ = checks.check_get_before_update([], {})
         assert passed is True
 
-    def test_get_then_update_work_item_passes(self) -> None:
+    def test_get_then_update_work_items_passes(self) -> None:
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"}),
             _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "priority": "50.0"},
+                "update_work_items",
+                {
+                    "project_id": "P",
+                    "items": [{"work_item_id": "MCPT-1", "priority": "50.0"}],
+                },
             ),
         ]
         passed, _ = checks.check_get_before_update(trajectory, {})
@@ -61,26 +64,51 @@ class TestCheckGetBeforeUpdate:
     def test_update_without_prior_get_fails(self) -> None:
         trajectory = [
             _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "priority": "50.0"},
+                "update_work_items",
+                {
+                    "project_id": "P",
+                    "items": [{"work_item_id": "MCPT-1", "priority": "50.0"}],
+                },
             )
         ]
         passed, reason = checks.check_get_before_update(trajectory, {})
         assert passed is False
-        assert "update_work_item" in reason
+        assert "update_work_items" in reason
         assert "get_work_item" in reason
 
     def test_get_on_different_id_does_not_count(self) -> None:
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-99"}),
             _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "priority": "50.0"},
+                "update_work_items",
+                {
+                    "project_id": "P",
+                    "items": [{"work_item_id": "MCPT-1", "priority": "50.0"}],
+                },
             ),
         ]
         passed, reason = checks.check_get_before_update(trajectory, {})
         assert passed is False
         assert "MCPT-1" in reason
+
+    def test_every_item_in_batch_needs_its_own_get(self) -> None:
+        # One get covers one item; the second batched item was never observed.
+        trajectory = [
+            _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"}),
+            _call(
+                "update_work_items",
+                {
+                    "project_id": "P",
+                    "items": [
+                        {"work_item_id": "MCPT-1", "title": "x"},
+                        {"work_item_id": "MCPT-2", "title": "y"},
+                    ],
+                },
+            ),
+        ]
+        passed, reason = checks.check_get_before_update(trajectory, {})
+        assert passed is False
+        assert "MCPT-2" in reason
 
     def test_qualified_and_short_work_item_ids_match(self) -> None:
         # A project-qualified id in the get and a short id in the update
@@ -88,8 +116,11 @@ class TestCheckGetBeforeUpdate:
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "P/MCPT-1"}),
             _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "title": "x"},
+                "update_work_items",
+                {
+                    "project_id": "P",
+                    "items": [{"work_item_id": "MCPT-1", "title": "x"}],
+                },
             ),
         ]
         passed, _ = checks.check_get_before_update(trajectory, {})
@@ -98,8 +129,11 @@ class TestCheckGetBeforeUpdate:
     def test_get_after_update_does_not_satisfy(self) -> None:
         trajectory = [
             _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "priority": "50.0"},
+                "update_work_items",
+                {
+                    "project_id": "P",
+                    "items": [{"work_item_id": "MCPT-1", "priority": "50.0"}],
+                },
             ),
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"}),
         ]
@@ -242,16 +276,20 @@ class TestCheckPreserveHyperlinks:
     def test_full_list_update_passes(self) -> None:
         trajectory = [
             _call(
-                "update_work_item",
+                "update_work_items",
                 {
                     "project_id": "P",
-                    "work_item_id": "MCPT-200",
-                    "hyperlinks": [
+                    "items": [
                         {
-                            "role": "ref_ext",
-                            "uri": "https://specs.example.com/fake-spec",
-                        },
-                        {"role": "ref_ext", "uri": "https://example.com/new"},
+                            "work_item_id": "MCPT-200",
+                            "hyperlinks": [
+                                {
+                                    "role": "ref_ext",
+                                    "uri": "https://specs.example.com/fake-spec",
+                                },
+                                {"role": "ref_ext", "uri": "https://example.com/new"},
+                            ],
+                        }
                     ],
                 },
             )
@@ -262,12 +300,16 @@ class TestCheckPreserveHyperlinks:
     def test_dropping_existing_uri_fails(self) -> None:
         trajectory = [
             _call(
-                "update_work_item",
+                "update_work_items",
                 {
                     "project_id": "P",
-                    "work_item_id": "MCPT-200",
-                    "hyperlinks": [
-                        {"role": "ref_ext", "uri": "https://example.com/new"}
+                    "items": [
+                        {
+                            "work_item_id": "MCPT-200",
+                            "hyperlinks": [
+                                {"role": "ref_ext", "uri": "https://example.com/new"}
+                            ],
+                        }
                     ],
                 },
             )
@@ -279,8 +321,11 @@ class TestCheckPreserveHyperlinks:
     def test_update_not_touching_hyperlinks_passes(self) -> None:
         trajectory = [
             _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-200", "title": "x"},
+                "update_work_items",
+                {
+                    "project_id": "P",
+                    "items": [{"work_item_id": "MCPT-200", "title": "x"}],
+                },
             )
         ]
         passed, _ = checks.check_preserve_hyperlinks(trajectory, self._PARAMS)
@@ -289,11 +334,17 @@ class TestCheckPreserveHyperlinks:
     def test_other_work_item_not_constrained(self) -> None:
         trajectory = [
             _call(
-                "update_work_item",
+                "update_work_items",
                 {
                     "project_id": "P",
-                    "work_item_id": "MCPT-999",
-                    "hyperlinks": [{"role": "ref_ext", "uri": "https://x.example"}],
+                    "items": [
+                        {
+                            "work_item_id": "MCPT-999",
+                            "hyperlinks": [
+                                {"role": "ref_ext", "uri": "https://x.example"}
+                            ],
+                        }
+                    ],
                 },
             )
         ]
@@ -348,11 +399,12 @@ class TestCheckRoundTripSource:
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-200"}),
             _call(
-                "update_work_item",
+                "update_work_items",
                 {
                     "project_id": "P",
-                    "work_item_id": "MCPT-200",
-                    "description_html": "<p>x</p>",
+                    "items": [
+                        {"work_item_id": "MCPT-200", "description_html": "<p>x</p>"}
+                    ],
                 },
             ),
         ]
@@ -362,6 +414,32 @@ class TestCheckRoundTripSource:
         trajectory[0]["args"]["include_description_html"] = True
         passed, _ = checks.check_round_trip_source(trajectory, {})
         assert passed is True
+
+    def test_each_body_item_in_batch_needs_its_own_flagged_get(self) -> None:
+        # Item 1 is sourced; item 2's body write is not.
+        trajectory = [
+            _call(
+                "get_work_item",
+                {
+                    "project_id": "P",
+                    "work_item_id": "MCPT-200",
+                    "include_description_html": True,
+                },
+            ),
+            _call(
+                "update_work_items",
+                {
+                    "project_id": "P",
+                    "items": [
+                        {"work_item_id": "MCPT-200", "description_html": "<p>x</p>"},
+                        {"work_item_id": "MCPT-201", "description_html": "<p>y</p>"},
+                    ],
+                },
+            ),
+        ]
+        passed, reason = checks.check_round_trip_source(trajectory, {})
+        assert passed is False
+        assert "MCPT-201" in reason
 
     def test_qualified_get_id_satisfies_short_id_write(self) -> None:
         trajectory = [
@@ -374,11 +452,12 @@ class TestCheckRoundTripSource:
                 },
             ),
             _call(
-                "update_work_item",
+                "update_work_items",
                 {
                     "project_id": "P",
-                    "work_item_id": "MCPT-200",
-                    "description_html": "<p>x</p>",
+                    "items": [
+                        {"work_item_id": "MCPT-200", "description_html": "<p>x</p>"}
+                    ],
                 },
             ),
         ]
@@ -706,22 +785,47 @@ class TestCheckOrderedTrajectory:
         assert passed is True
 
     def test_after_dependency_violation_fails(self) -> None:
-        # update_work_item before its required get_work_item.
+        # update_work_items before its required get_work_item; the step's
+        # work_item_id match reaches into the bulk items list.
         steps = [
             {"tool": "get_work_item", "match": {"work_item_id": "MCPT-1"}},
             {
-                "tool": "update_work_item",
+                "tool": "update_work_items",
                 "match": {"work_item_id": "MCPT-1"},
                 "after": ["get_work_item"],
             },
         ]
         trajectory = [
-            _call("update_work_item", {"work_item_id": "MCPT-1"}),
+            _call("update_work_items", {"items": [{"work_item_id": "MCPT-1"}]}),
             _call("get_work_item", {"work_item_id": "MCPT-1"}),
         ]
         passed, reason = checks.check_ordered_trajectory(trajectory, {"steps": steps})
         assert passed is False
         assert "get_work_item" in reason
+
+    def test_work_item_id_match_reaches_into_bulk_items(self) -> None:
+        # get -> bulk update containing the matched id satisfies the steps.
+        steps = [
+            {"tool": "get_work_item", "match": {"work_item_id": "MCPT-1"}},
+            {
+                "tool": "update_work_items",
+                "match": {"work_item_id": "MCPT-1"},
+                "after": ["get_work_item"],
+            },
+        ]
+        trajectory = [
+            _call("get_work_item", {"work_item_id": "MCPT-1"}),
+            _call("update_work_items", {"items": [{"work_item_id": "MCPT-1"}]}),
+        ]
+        passed, _ = checks.check_ordered_trajectory(trajectory, {"steps": steps})
+        assert passed is True
+
+        # A batch not containing the id must not match.
+        trajectory[1] = _call(
+            "update_work_items", {"items": [{"work_item_id": "MCPT-9"}]}
+        )
+        passed, _ = checks.check_ordered_trajectory(trajectory, {"steps": steps})
+        assert passed is False
 
     def test_out_of_order_move_before_read_fails(self) -> None:
         trajectory = [
@@ -821,7 +925,7 @@ class TestCheckOrderedTrajectory:
     def test_read_only_flag_fails_on_write(self) -> None:
         trajectory = [
             _call("list_work_items", {"query": "SQL:(...)"}),
-            _call("update_work_item", {"work_item_id": "MCPT-1"}),
+            _call("update_work_items", {"items": [{"work_item_id": "MCPT-1"}]}),
         ]
         passed, _ = checks.check_ordered_trajectory(
             trajectory,

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -395,6 +395,19 @@ class TestCheckRoundTripSource:
         passed, _ = checks.check_round_trip_source(trajectory, {})
         assert passed is True
 
+    def test_metadata_only_work_item_batch_not_constrained(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_items",
+                {
+                    "project_id": "P",
+                    "items": [{"work_item_id": "MCPT-200", "title": "new"}],
+                },
+            )
+        ]
+        passed, _ = checks.check_round_trip_source(trajectory, {})
+        assert passed is True
+
     def test_work_item_body_write_needs_flagged_get(self) -> None:
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-200"}),

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -586,6 +586,58 @@ class TestCheckSingleBulkCreate:
         passed, _ = checks.check_single_bulk_create(trajectory, {})
         assert passed is True
 
+    def test_zero_committed_calls_fail(self) -> None:
+        trajectory = [
+            _call("create_work_items", {"items": [{"title": "a"}], "dry_run": True})
+        ]
+        passed, reason = checks.check_single_bulk_create(trajectory, {})
+        assert passed is False
+        assert "0 item(s)" in reason
+
+    def test_partial_batch_fails(self) -> None:
+        trajectory = [_call("create_work_items", {"items": [{"title": "a"}]})]
+        passed, reason = checks.check_single_bulk_create(trajectory, {"min_items": 3})
+        assert passed is False
+        assert "1 item(s)" in reason
+
+
+class TestCheckSingleBulkUpdate:
+    def test_one_bulk_call_passes(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_items",
+                {"items": [{"work_item_id": "A"}, {"work_item_id": "B"}]},
+            )
+        ]
+        passed, _ = checks.check_single_bulk_update(trajectory, {})
+        assert passed is True
+
+    def test_one_call_per_item_fails(self) -> None:
+        trajectory = [
+            _call("update_work_items", {"items": [{"work_item_id": "A"}]}),
+            _call("update_work_items", {"items": [{"work_item_id": "B"}]}),
+        ]
+        passed, reason = checks.check_single_bulk_update(trajectory, {})
+        assert passed is False
+        assert "2" in reason
+
+    def test_zero_committed_calls_fail(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_items",
+                {"items": [{"work_item_id": "A"}], "dry_run": True},
+            )
+        ]
+        passed, reason = checks.check_single_bulk_update(trajectory, {})
+        assert passed is False
+        assert "0 item(s)" in reason
+
+    def test_partial_batch_fails(self) -> None:
+        trajectory = [_call("update_work_items", {"items": [{"work_item_id": "A"}]})]
+        passed, reason = checks.check_single_bulk_update(trajectory, {"min_items": 2})
+        assert passed is False
+        assert "1 item(s)" in reason
+
 
 class TestCheckDirectRead:
     _PARAMS: ClassVar[dict[str, Any]] = {"work_item_id": "MCPT-200"}

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -140,6 +140,25 @@ class TestCheckGetBeforeUpdate:
         passed, _ = checks.check_get_before_update(trajectory, {})
         assert passed is False
 
+    @pytest.mark.parametrize(
+        "args",
+        [
+            {"project_id": "P"},
+            {"project_id": "P", "items": []},
+            {"project_id": "P", "items": None},
+            {"project_id": "P", "items": ["not-a-dict"]},
+        ],
+    )
+    def test_bulk_update_without_valid_items_fails_closed(
+        self, args: dict[str, object]
+    ) -> None:
+        # A recorded bulk write with no readable targets (e.g. a call FastMCP
+        # rejected) is still a blind write attempt, never a free pass.
+        trajectory = [_call("update_work_items", args)]
+        passed, reason = checks.check_get_before_update(trajectory, {})
+        assert passed is False
+        assert "no valid entries" in reason
+
     def test_get_then_update_document_passes(self) -> None:
         trajectory = [
             _call(
@@ -744,6 +763,36 @@ class TestResolveObservedPath:
     def test_missing_key_yields_empty(self) -> None:
         assert checks._resolve_observed_path({"items": []}, "items[].id") == []
         assert checks._resolve_observed_path(None, "items[].id") == []
+
+
+class TestArgsMatch:
+    """The items[]-fallback generalizes to any ``*_id`` key, not just
+    ``work_item_id`` -- a future bulk tool with e.g. ``test_run_id`` needs no
+    new special case here.
+    """
+
+    def test_non_work_item_id_key_falls_back_to_items(self) -> None:
+        args = {"items": [{"test_run_id": "TR-1"}, {"test_run_id": "TR-2"}]}
+        assert checks._args_match(args, {"test_run_id": "TR-2"}) is True
+        assert checks._args_match(args, {"test_run_id": "TR-9"}) is False
+
+    def test_flat_id_still_takes_precedence_over_items(self) -> None:
+        args = {"work_item_id": "MCPT-1", "items": [{"work_item_id": "MCPT-9"}]}
+        assert checks._args_match(args, {"work_item_id": "MCPT-1"}) is True
+
+    def test_multiple_id_constraints_must_land_on_one_item(self) -> None:
+        # Two *_id constraints satisfied only across DIFFERENT items must not
+        # match -- a match dict pins down a single target.
+        args = {
+            "items": [
+                {"work_item_id": "MCPT-1", "assignee_id": "bob"},
+                {"work_item_id": "MCPT-2", "assignee_id": "alice"},
+            ]
+        }
+        joint = {"work_item_id": "MCPT-2", "assignee_id": "alice"}
+        stitched = {"work_item_id": "MCPT-1", "assignee_id": "alice"}
+        assert checks._args_match(args, joint) is True
+        assert checks._args_match(args, stitched) is False
 
 
 class TestCheckOrderedTrajectory:

--- a/tests/mcp_server_polarion/models/test_invariants.py
+++ b/tests/mcp_server_polarion/models/test_invariants.py
@@ -18,7 +18,8 @@ from mcp_server_polarion.models import (
     WorkItemRead,
     WorkItemsCreateResult,
     WorkItemSummary,
-    WorkItemUpdateResult,
+    WorkItemsUpdateResult,
+    WorkItemUpdateSpec,
 )
 
 
@@ -67,24 +68,15 @@ class TestCrossModelIntegration:
         )
         assert page.items[0].type == "heading"
 
-    def test_update_result_with_nested_detail(self):
-        result = WorkItemUpdateResult(
-            updated=True,
-            dry_run=False,
-            current=WorkItemDetail(
-                id="MCPT-001",
-                title="Before",
-                type="requirement",
-                status="draft",
-                description_html="<p>Old description</p>",
-                project_id="proj1",
-            ),
-            changes={"title": "After", "status": "approved"},
-            payload_preview=None,
+    def test_update_spec_json_round_trip(self):
+        spec = WorkItemUpdateSpec(
+            work_item_id="MCPT-001",
+            title="After",
+            status="approved",
         )
-        dumped = result.model_dump()
-        assert dumped["current"]["title"] == "Before"
-        assert dumped["changes"]["title"] == "After"
+        restored = WorkItemUpdateSpec.model_validate_json(spec.model_dump_json())
+        assert restored.title == "After"
+        assert restored.status == "approved"
 
     def test_workitemread_metadata_mirrors_workitemdetail(self):
         """Drift between the two models makes ``read_work_item`` silently
@@ -112,7 +104,8 @@ class TestCrossModelIntegration:
             WorkItemLink,
             WorkItemCreateSpec,
             WorkItemsCreateResult,
-            WorkItemUpdateResult,
+            WorkItemsUpdateResult,
+            WorkItemUpdateSpec,
             WorkItemLinkSpec,
             WorkItemLinkRef,
             WorkItemLinksCreateResult,

--- a/tests/mcp_server_polarion/models/test_work_items.py
+++ b/tests/mcp_server_polarion/models/test_work_items.py
@@ -10,7 +10,8 @@ from mcp_server_polarion.models import (
     WorkItemDetail,
     WorkItemsCreateResult,
     WorkItemSummary,
-    WorkItemUpdateResult,
+    WorkItemsUpdateResult,
+    WorkItemUpdateSpec,
 )
 
 
@@ -247,43 +248,68 @@ class TestWorkItemsCreateResult:
         assert result.payload_preview is not None
 
 
-class TestWorkItemUpdateResult:
-    def test_successful_update(self):
-        current = WorkItemDetail(
-            id="MCPT-001",
-            title="Old Title",
-            type="requirement",
-            status="draft",
-            description_html="<p>Old desc</p>",
-            project_id="proj1",
+class TestWorkItemUpdateSpec:
+    def test_single_field_is_enough(self):
+        spec = WorkItemUpdateSpec(work_item_id="MCPT-001", title="New Title")
+        assert spec.work_item_id == "MCPT-001"
+        assert spec.title == "New Title"
+
+    def test_no_updatable_field_raises(self):
+        # Polarion 400s on a body-less resource; the spec fails closed instead.
+        with pytest.raises(ValidationError, match="Nothing to update"):
+            WorkItemUpdateSpec(work_item_id="MCPT-001")
+
+    def test_empty_strings_do_not_count_as_fields(self):
+        with pytest.raises(ValidationError, match="Nothing to update"):
+            WorkItemUpdateSpec(work_item_id="MCPT-001", title="", status="")
+
+    def test_empty_work_item_id_rejected(self):
+        with pytest.raises(ValidationError):
+            WorkItemUpdateSpec(work_item_id="", title="t")
+
+    def test_description_html_rejects_overlong_input(self):
+        # max_length=MAX_BODY_HTML_LEN caps runaway HTML (2 MiB + 1 rejected).
+        with pytest.raises(ValidationError):
+            WorkItemUpdateSpec(
+                work_item_id="MCPT-001",
+                description_html="x" * (2_000_000 + 1),
+            )
+
+    def test_custom_fields_alone_satisfies_validator(self):
+        spec = WorkItemUpdateSpec(
+            work_item_id="MCPT-001", custom_fields={"riskLevel": "high"}
         )
-        result = WorkItemUpdateResult(
+        assert spec.custom_fields == {"riskLevel": "high"}
+
+
+class TestWorkItemsUpdateResult:
+    def test_successful_update(self):
+        result = WorkItemsUpdateResult(
             updated=True,
             dry_run=False,
-            current=current,
-            changes={"title": "New Title"},
+            work_item_ids=["MCPT-001", "MCPT-002"],
             payload_preview=None,
         )
         assert result.updated is True
-        assert result.current is not None
-        assert result.current.title == "Old Title"
-        assert result.changes["title"] == "New Title"
+        assert result.work_item_ids == ["MCPT-001", "MCPT-002"]
         assert result.payload_preview is None
 
     def test_dry_run(self):
-        result = WorkItemUpdateResult(
+        result = WorkItemsUpdateResult(
             updated=False,
             dry_run=True,
-            current=None,
-            changes={"status": "approved"},
+            work_item_ids=[],
             payload_preview={
-                "data": {
-                    "type": "workitems",
-                    "id": "proj1/MCPT-001",
-                    "attributes": {"status": "approved"},
-                }
+                "data": [
+                    {
+                        "type": "workitems",
+                        "id": "proj1/MCPT-001",
+                        "attributes": {"status": "approved"},
+                    }
+                ]
             },
         )
         assert result.updated is False
         assert result.dry_run is True
+        assert result.work_item_ids == []
         assert result.payload_preview is not None

--- a/tests/mcp_server_polarion/models/test_work_items.py
+++ b/tests/mcp_server_polarion/models/test_work_items.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from mcp_server_polarion.models import (
     Hyperlink,
+    WorkItemCreateSpec,
     WorkItemDetail,
     WorkItemsCreateResult,
     WorkItemSummary,
@@ -248,6 +249,13 @@ class TestWorkItemsCreateResult:
         assert result.payload_preview is not None
 
 
+class TestWorkItemCreateSpec:
+    def test_unknown_extra_key_rejected(self):
+        # Unknown keys would otherwise vanish silently (Polarion drops them).
+        with pytest.raises(ValidationError):
+            WorkItemCreateSpec(title="t", type="task", resolution="done")
+
+
 class TestWorkItemUpdateSpec:
     def test_single_field_is_enough(self):
         spec = WorkItemUpdateSpec(work_item_id="MCPT-001", title="New Title")
@@ -280,6 +288,14 @@ class TestWorkItemUpdateSpec:
             work_item_id="MCPT-001", custom_fields={"riskLevel": "high"}
         )
         assert spec.custom_fields == {"riskLevel": "high"}
+
+    def test_unknown_extra_key_rejected(self):
+        # workflow_action/change_type_to are batch-level tool params, not item
+        # fields; a misplaced key here must error, not silently no-op.
+        with pytest.raises(ValidationError):
+            WorkItemUpdateSpec(
+                work_item_id="MCPT-001", title="t", workflow_action="close"
+            )
 
 
 class TestWorkItemsUpdateResult:

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -43,7 +43,7 @@ _READ_TOOL_NAMES: frozenset[str] = frozenset(
 _WRITE_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "create_work_items",
-        "update_work_item",
+        "update_work_items",
         "move_work_item_to_document",
         "move_work_item_from_document",
         "create_work_item_links",

--- a/tests/mcp_server_polarion/tools/_shared/test_guard.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_guard.py
@@ -1110,7 +1110,7 @@ class TestGuardWorkItemLinkRoles:
 
 
 class TestGuardHyperlinkRoles:
-    """Hyperlink-role guard for ``create_work_items`` / ``update_work_item``."""
+    """Hyperlink-role guard for ``create_work_items`` / ``update_work_items``."""
 
     async def test_valid_role_passes(self, mock_client: AsyncMock) -> None:
         mock_client.get.return_value = _project_enum_response(

--- a/tests/mcp_server_polarion/tools/_shared/test_guard.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_guard.py
@@ -38,6 +38,7 @@ from mcp_server_polarion.tools._shared.guard import (
     guard_work_item_enums,
     guard_work_item_link_roles,
     guard_work_item_link_targets,
+    guard_work_item_types,
     partition_delete_links,
 )
 
@@ -858,7 +859,7 @@ class TestGuardWorkItemLinkTargets:
         )
         assert path == "/projects/P/workitems"
         assert kwargs["params"]["query"] == "id:(A B)"
-        assert kwargs["params"]["fields[workitems]"] == "id"
+        assert kwargs["params"]["fields[workitems]"] == "id,type"
 
     async def test_missing_target_raises_value_error(
         self, mock_client: AsyncMock
@@ -946,6 +947,124 @@ class TestGuardWorkItemLinkTargets:
 
         with pytest.raises(ValueError, match="P/A"):
             await guard_work_item_link_targets(mock_client, "P", [_link("A")])
+
+
+def _workitems_type_response(
+    project_id: str, entries: list[tuple[str, str]]
+) -> dict[str, object]:
+    """A JSON:API workitems list response with ``id``/``type`` per entry."""
+    return {
+        "data": [
+            {
+                "type": "workitems",
+                "id": f"{project_id}/{short_id}",
+                "attributes": {"type": type_id},
+            }
+            for short_id, type_id in entries
+        ]
+    }
+
+
+class TestGuardWorkItemTypes:
+    """Batched existence guard returning id -> type (uncached)."""
+
+    async def test_all_ids_resolve_one_get(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = _workitems_type_response(
+            "P", [("A", "task"), ("B", "requirement")]
+        )
+
+        result = await guard_work_item_types(mock_client, "P", ["A", "B"])
+
+        assert result == {"A": "task", "B": "requirement"}
+        mock_client.get.assert_awaited_once()
+        path, kwargs = (
+            mock_client.get.call_args.args[0],
+            mock_client.get.call_args.kwargs,
+        )
+        assert path == "/projects/P/workitems"
+        assert kwargs["params"]["query"] == "id:(A B)"
+        assert kwargs["params"]["fields[workitems]"] == "id,type"
+
+    async def test_missing_id_raises_value_error_naming_it(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = _workitems_type_response("P", [("A", "task")])
+
+        with pytest.raises(ValueError, match="B") as exc:
+            await guard_work_item_types(mock_client, "P", ["A", "B"])
+
+        assert "not found" in str(exc.value)
+
+    async def test_chunks_above_page_size(self, mock_client: AsyncMock) -> None:
+        ids = sorted(f"WI-{n}" for n in range(150))
+
+        async def fake_get(path: str, **kwargs: object) -> dict[str, object]:
+            query = str(kwargs["params"]["query"])  # type: ignore[index]
+            chunk = query.removeprefix("id:(").removesuffix(")").split()
+            return _workitems_type_response("P", [(i, "task") for i in chunk])
+
+        mock_client.get.side_effect = fake_get
+
+        result = await guard_work_item_types(mock_client, "P", ids)
+
+        assert len(result) == 150
+        assert mock_client.get.await_count == 2
+
+    async def test_duplicate_ids_deduped_into_one_query(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = _workitems_type_response("P", [("A", "task")])
+
+        await guard_work_item_types(mock_client, "P", ["A", "A"])
+
+        assert mock_client.get.call_args.kwargs["params"]["query"] == "id:(A)"
+
+    async def test_unreachable_backend_blocks_write(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError("backend down")
+
+        with pytest.raises(RuntimeError, match="Refusing the write"):
+            await guard_work_item_types(mock_client, "P", ["A"])
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("forbidden", status_code=403)
+
+        with pytest.raises(PermissionError, match="lacks permission"):
+            await guard_work_item_types(mock_client, "P", ["A"])
+
+    async def test_project_not_found_propagates(self, mock_client: AsyncMock) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError("no such project")
+
+        with pytest.raises(PolarionNotFoundError):
+            await guard_work_item_types(mock_client, "P", ["A"])
+
+    async def test_non_dict_entry_in_data_is_skipped(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": ["not-a-dict"]}
+
+        with pytest.raises(ValueError, match="A"):
+            await guard_work_item_types(mock_client, "P", ["A"])
+
+    async def test_entry_without_type_attribute_counts_as_existing(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Existence comes from the id; a missing type attribute must not
+        # false-flag the item as not found.
+        mock_client.get.return_value = {"data": [{"type": "workitems", "id": "P/A"}]}
+
+        result = await guard_work_item_types(mock_client, "P", ["A"])
+
+        assert result == {"A": ""}
+
+    async def test_entry_with_empty_id_is_skipped(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = {"data": [{"type": "workitems", "id": ""}]}
+
+        with pytest.raises(ValueError, match="A"):
+            await guard_work_item_types(mock_client, "P", ["A"])
 
 
 def _project_enum_response(enum_name: str, ids: list[str]) -> dict[str, object]:

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -421,6 +421,26 @@ class TestCreateTestRuns:
         path = mock_client.post.await_args.args[0]
         assert path == "/projects/proj1/testruns"
 
+    async def test_duplicate_ids_rejected_before_any_request(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # POST requires an explicit id per item; two items sharing one id
+        # cannot both be created.
+        with pytest.raises(ValueError, match="Duplicate id"):
+            await create_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunCreateSpec(id="TR-1"), TestRunCreateSpec(id="TR-1")],
+                dry_run=False,
+            )
+        mock_client.get.assert_not_awaited()
+        mock_client.post.assert_not_awaited()
+
+    async def test_unknown_extra_key_rejected(self) -> None:
+        # Unknown keys would otherwise vanish silently (Polarion drops them).
+        with pytest.raises(ValidationError):
+            TestRunCreateSpec(id="TR-1", tittle="typo")  # type: ignore[call-arg]
+
     async def test_create_with_template_resolves_it_first(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:

--- a/tests/mcp_server_polarion/tools/test_tool_annotations.py
+++ b/tests/mcp_server_polarion/tools/test_tool_annotations.py
@@ -34,7 +34,7 @@ class TestWriteToolAnnotations:
                 },
             ),
             (
-                "update_work_item",
+                "update_work_items",
                 {
                     "readOnlyHint": False,
                     "destructiveHint": True,

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -75,41 +75,21 @@ async def _call_update(
     )
 
 
-def _make_get_response(
-    *,
-    work_item_id: str = "MCPT-1",
-    project_id: str = "MyProj",
-    title: str = "after",
-    status: str = "open",
-    description_html: str = "",
-    assignee_ids: list[str] | None = None,
-    custom_fields: dict[str, object] | None = None,
+def _existence_response(
+    entries: list[tuple[str, str]], *, project_id: str = "MyProj"
 ) -> dict[str, object]:
-    """Build a minimal JSON:API GET response for the follow-up fetch."""
-    relationships: dict[str, object] = {}
-    if assignee_ids is not None:
-        relationships["assignee"] = {
-            "data": [{"type": "users", "id": uid} for uid in assignee_ids]
-        }
-    attributes: dict[str, object] = {
-        "title": title,
-        "type": "task",
-        "status": status,
-        "priority": "50.0",
-        "updated": "2026-05-04T10:00:00Z",
-    }
-    if description_html:
-        attributes["description"] = {"type": "text/html", "value": description_html}
-    if custom_fields:
-        # Inline (no customFields container); primes the pre-fetch guard cache.
-        attributes.update(custom_fields)
+    """Shape a chunked ``id:(...)`` existence+type query reply: one
+    ``(work_item_id, type)`` pair per matched item.
+    """
     return {
-        "data": {
-            "type": "workitems",
-            "id": f"{project_id}/{work_item_id}",
-            "attributes": attributes,
-            "relationships": relationships,
-        }
+        "data": [
+            {
+                "type": "workitems",
+                "id": f"{project_id}/{work_item_id}",
+                "attributes": {"type": type_id},
+            }
+            for work_item_id, type_id in entries
+        ]
     }
 
 
@@ -921,20 +901,28 @@ class TestUpdateWorkItemsValidation:
         attributes = cast(dict[str, object], data[0]["attributes"])
         assert attributes == {"title": "new title"}
 
-    async def test_all_none_custom_fields_rejected_before_patch(
+    async def test_all_none_custom_fields_rejected_before_any_request(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"riskLevel"})
-        )
-        mock_client.get.return_value = _make_get_response()
-
+        # Payload builds before the guards run, so the empty-body error
+        # costs zero round-trips against the rate-limited backend.
         with pytest.raises(ValueError, match="empty PATCH"):
             await _call_update(
                 mock_ctx,
                 custom_fields={"riskLevel": None},
                 dry_run=True,
             )
+        mock_client.get.assert_not_called()
+        mock_client.patch.assert_not_called()
+
+    async def test_project_qualified_work_item_id_rejected(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # 'P/MCPT-1' would evade the duplicate check and corrupt both the
+        # id:(...) guard query and the JSON:API resource id.
+        with pytest.raises(ValueError, match="cannot embed safely"):
+            await _call_update(mock_ctx, work_item_id="MyProj/MCPT-1", title="a")
+        mock_client.get.assert_not_called()
         mock_client.patch.assert_not_called()
 
     async def test_custom_fields_alone_satisfies_spec(
@@ -944,9 +932,10 @@ class TestUpdateWorkItemsValidation:
         _cache_mod.store_work_item_custom_keys(
             "MyProj", "task", frozenset({"riskLevel"})
         )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"riskLevel": "high"}
-        )
+        mock_client.get.side_effect = [
+            _existence_response([("MCPT-1", "task")]),
+            PolarionNotFoundError("not an Enumeration field", status_code=404),
+        ]
         result = await _call_update(
             mock_ctx,
             custom_fields={"riskLevel": "high"},
@@ -957,6 +946,25 @@ class TestUpdateWorkItemsValidation:
         data = cast(list[dict[str, object]], result.payload_preview["data"])
         attributes = cast(dict[str, object], data[0]["attributes"])
         assert attributes == {"riskLevel": "high"}
+
+    async def test_duplicate_work_item_id_rejected_before_any_request(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Two specs targeting the same id -> undefined PATCH body semantics.
+        with pytest.raises(ValueError, match="Duplicate work_item_id"):
+            await update_work_items(
+                mock_ctx,
+                project_id="MyProj",
+                items=[
+                    WorkItemUpdateSpec(work_item_id="MCPT-1", title="a"),
+                    WorkItemUpdateSpec(work_item_id="MCPT-1", status="open"),
+                ],
+                workflow_action=None,
+                change_type_to=None,
+                dry_run=True,
+            )
+        mock_client.get.assert_not_called()
+        mock_client.patch.assert_not_called()
 
 
 class TestUpdateWorkItemsHyperlinkRoleGuard:
@@ -979,15 +987,16 @@ class TestUpdateWorkItemsHyperlinkRoleGuard:
         assert "ref_ext" in str(exc.value)
         mock_client.patch.assert_not_called()
 
-    async def test_roles_pooled_across_items_in_one_probe(
+    async def test_bad_role_error_names_offending_item_in_one_probe(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # One project-enum probe covers every item's roles (as in create).
+        # Guard runs per item so the error can name the offender; the enum
+        # cache still keeps the whole batch to one project-enum probe.
         mock_client.get.return_value = _project_enum_get_response(
             "hyperlink-role", ["ref_int", "ref_ext"]
         )
 
-        with pytest.raises(ValueError, match="ghost"):
+        with pytest.raises(ValueError, match="Work item 'MCPT-2'") as exc:
             await update_work_items(
                 mock_ctx,
                 project_id="MyProj",
@@ -1005,6 +1014,8 @@ class TestUpdateWorkItemsHyperlinkRoleGuard:
                 change_type_to=None,
                 dry_run=True,
             )
+        assert "ghost" in str(exc.value)
+        assert mock_client.get.await_count == 1
         mock_client.patch.assert_not_called()
 
 
@@ -1058,9 +1069,10 @@ class TestUpdateWorkItemsDryRun:
         _cache_mod.store_work_item_custom_keys(
             "MyProj", "task", frozenset({"riskLevel"})
         )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"riskLevel": "high"}
-        )
+        mock_client.get.side_effect = [
+            _existence_response([("MCPT-1", "task")]),
+            PolarionNotFoundError("not an Enumeration field", status_code=404),
+        ]
         result = await _call_update(
             mock_ctx,
             title="t",
@@ -1074,6 +1086,45 @@ class TestUpdateWorkItemsDryRun:
         attributes = cast(dict[str, object], data[0]["attributes"])
         assert attributes["title"] == "t"
         assert attributes["riskLevel"] == "high"
+
+    async def test_dry_run_preview_includes_workflow_action_query_param(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # workflow_action is transport-level: previewed as a query param.
+        result = await _call_update(
+            mock_ctx, workflow_action="close", title="t", dry_run=True
+        )
+
+        assert result.payload_preview is not None
+        query_params = cast(dict[str, object], result.payload_preview["query_params"])
+        assert query_params == {"workflowAction": "close"}
+
+    async def test_dry_run_preview_includes_change_type_to_query_param(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        mock_client.get.side_effect = [
+            _existence_response([("MCPT-1", "task")]),
+            _enum_get_response(["task"]),
+        ]
+
+        result = await _call_update(
+            mock_ctx, change_type_to="task", title="t", dry_run=True
+        )
+
+        assert result.payload_preview is not None
+        query_params = cast(dict[str, object], result.payload_preview["query_params"])
+        assert query_params == {"changeTypeTo": "task"}
+
+    async def test_dry_run_preview_omits_query_params_when_unset(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await _call_update(mock_ctx, title="t", dry_run=True)
+
+        assert result.payload_preview is not None
+        assert "query_params" not in result.payload_preview
 
 
 class TestUpdateWorkItemsHappyPath:
@@ -1159,9 +1210,11 @@ class TestUpdateWorkItemsHappyPath:
         _cache_mod.store_work_item_custom_keys(
             "MyProj", "task", frozenset({"riskLevel", "reviewerNote"})
         )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"riskLevel": "high", "reviewerNote": rich}
-        )
+        mock_client.get.side_effect = [
+            _existence_response([("MCPT-1", "task")]),
+            PolarionNotFoundError("not an Enumeration field", status_code=404),
+            PolarionNotFoundError("not an Enumeration field", status_code=404),
+        ]
 
         await _call_update(
             mock_ctx,
@@ -1187,7 +1240,12 @@ class TestUpdateWorkItemsHappyPath:
         _cache_mod.store_work_item_custom_keys(
             "MyProj", "task", frozenset({"riskLevel", "effortHours", "reviewerNote"})
         )
-        mock_client.get.return_value = _make_get_response(custom_fields=read_customs)
+        mock_client.get.side_effect = [
+            _existence_response([("MCPT-1", "task")]),
+            PolarionNotFoundError("not an Enumeration field", status_code=404),
+            PolarionNotFoundError("not an Enumeration field", status_code=404),
+            PolarionNotFoundError("not an Enumeration field", status_code=404),
+        ]
 
         result = await _call_update(mock_ctx, custom_fields=read_customs)
 
@@ -1214,10 +1272,10 @@ class TestUpdateWorkItemsHappyPath:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # change_type_to triggers the type guard: prefetch + type options.
+        # change_type_to triggers the type guard: existence resolve + type options.
         mock_client.patch.return_value = {}
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response([("MCPT-1", "task")]),
             _enum_get_response(["task"]),
         ]
 
@@ -1265,14 +1323,16 @@ class TestUpdateWorkItemsErrorMapping:
         with pytest.raises(PermissionError):
             await _call_update(mock_ctx, title="t")
 
-    async def test_patch_404_raises_value_error(
+    async def test_patch_404_raises_value_error_naming_batch_ids(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
+        # Unguarded items skip the existence pre-check, so Polarion's 404 may
+        # not say which id failed -- the error must list the batch ids.
         mock_client.patch.side_effect = PolarionNotFoundError(
             "not found", status_code=404
         )
 
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(ValueError, match="ghost"):
             await _call_update(mock_ctx, work_item_id="ghost", title="t")
 
     async def test_patch_other_error_raises_runtime_error(
@@ -1283,17 +1343,30 @@ class TestUpdateWorkItemsErrorMapping:
         with pytest.raises(RuntimeError, match="boom"):
             await _call_update(mock_ctx, title="t")
 
-    async def test_prefetch_404_raises_value_error(
+    async def test_missing_work_item_raises_value_error_naming_it(
         self,
         mock_ctx: MagicMock,
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # The guard prefetch names the missing item; nothing is PATCHed.
-        mock_client.get.side_effect = PolarionNotFoundError("nf", status_code=404)
+        # The batched existence resolve names the missing item; nothing is PATCHed.
+        mock_client.get.return_value = {"data": []}
 
         with pytest.raises(ValueError, match="ghost"):
             await _call_update(mock_ctx, work_item_id="ghost", status="open")
+        mock_client.patch.assert_not_called()
+
+    async def test_resolve_project_not_found_raises_value_error(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        # A 404 on the existence query itself means the project doesn't exist.
+        mock_client.get.side_effect = PolarionNotFoundError("nf", status_code=404)
+
+        with pytest.raises(ValueError, match="MyProj' not found"):
+            await _call_update(mock_ctx, status="open")
         mock_client.patch.assert_not_called()
 
     async def test_prefetch_401_raises_permission_error(
@@ -1514,7 +1587,9 @@ class TestEnumGuardCreateWorkItem:
 
 
 class TestEnumGuardUpdateWorkItems:
-    """Integration: ``update_work_items`` pre-fetches each item's type then guards."""
+    """Integration: ``update_work_items`` resolves guarded items' types via one
+    batched existence query, then guards.
+    """
 
     async def test_bad_enum_on_later_item_aborts_whole_batch(
         self,
@@ -1525,9 +1600,8 @@ class TestEnumGuardUpdateWorkItems:
         # Per-item guard runs before the PATCH; item 2's ghost status aborts
         # the batch (status options cached from item 1's probe).
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response([("MCPT-1", "task"), ("MCPT-2", "task")]),
             _enum_get_response(["open", "closed"]),
-            _make_get_response(work_item_id="MCPT-2"),
         ]
 
         with pytest.raises(ValueError, match="status='ghost'"):
@@ -1550,9 +1624,9 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: work-item pre-fetch, then priority options.
+        # GETs: batched existence resolve, then priority options.
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response([("MCPT-1", "task")]),
             _enum_get_response(["90.0", "50.0", "10.0"]),
         ]
         with pytest.raises(ValueError, match="priority='999'"):
@@ -1565,10 +1639,11 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: prefetch (for type), then the type sample (+ bypass-retry sample).
-        # The sample knows only risk_score, so release_train_id is rejected.
+        # GETs: existence resolve (for type), then the type sample (+
+        # bypass-retry sample). The sample knows only risk_score, so
+        # release_train_id is rejected.
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response([("MCPT-1", "task")]),
             _wi_sample_response({"risk_score": 5}),
             _wi_sample_response({"risk_score": 5}),
         ]
@@ -1588,7 +1663,7 @@ class TestEnumGuardUpdateWorkItems:
         # Regression: a custom key valid for the type but unset on THIS item was
         # falsely rejected by the old single-item prime. The type sample knows it.
         mock_client.get.side_effect = [
-            _make_get_response(),  # prefetch: no customs on the edited item
+            _existence_response([("MCPT-1", "task")]),  # no customs needed here
             _wi_sample_response({"release_train_id": "RT-1"}),  # type sample knows it
             PolarionNotFoundError("not an Enumeration field", status_code=404),
         ]
@@ -1605,9 +1680,9 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: prefetch (for type), type sample (knows asil), enum probe.
+        # GETs: existence resolve (for type), type sample (knows asil), enum probe.
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response([("MCPT-1", "task")]),
             _wi_sample_response({"asil": "1"}),
             _enum_get_response(["1", "2", "3", "4"]),
         ]
@@ -1624,10 +1699,10 @@ class TestEnumGuardUpdateWorkItems:
     ) -> None:
         # change_type_to retypes the item in the same PATCH, so custom_fields are
         # validated against the NEW type's schema, not the current ("task").
-        # GETs: prefetch, type options (~ axis for change_type_to), custom
-        # sample, then the enum-value probe for the key (404 = not enum).
+        # GETs: existence resolve, type options (~ axis for change_type_to),
+        # custom sample, then the enum-value probe for the key (404 = not enum).
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response([("MCPT-1", "task")]),
             _enum_get_response(["requirement"]),
             _wi_sample_response({"release_train_id": "RT-1"}),
             PolarionNotFoundError("not an Enumeration field", status_code=404),
@@ -1657,7 +1732,7 @@ class TestEnumGuardUpdateWorkItems:
     ) -> None:
         # resolution is ghost-prone; an unlisted id must be rejected.
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response([("MCPT-1", "task")]),
             _enum_get_response(["done", "wontfix", "duplicate"]),
         ]
         with pytest.raises(ValueError, match="resolution='ghost_resolution'"):
@@ -1671,9 +1746,9 @@ class TestEnumGuardUpdateWorkItems:
         reset_enum_guard_caches: None,
     ) -> None:
         # change_type_to scopes the status lookup to the target type.
-        # GETs: work-item pre-fetch, type options (~ axis), status options (target).
+        # GETs: existence resolve, type options (~ axis), status options (target).
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response([("MCPT-1", "task")]),
             _enum_get_response(["requirement"]),
             _enum_get_response(["draft", "approved"]),
         ]
@@ -1688,6 +1763,23 @@ class TestEnumGuardUpdateWorkItems:
         ]
         assert status_calls, "guard must probe status options"
         assert status_calls[0].kwargs["params"]["type"] == "requirement"
+
+    async def test_bad_change_type_to_not_blamed_on_an_item(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        # change_type_to is a batch-level param -- validated once, and the
+        # error must not carry a per-item "Work item '...'" prefix.
+        mock_client.get.side_effect = [
+            _existence_response([("MCPT-1", "task")]),
+            _enum_get_response(["task", "requirement"]),
+        ]
+        with pytest.raises(ValueError, match="type='bogus'") as exc:
+            await _call_update(mock_ctx, change_type_to="bogus", title="t")
+        assert "Work item '" not in str(exc.value)
+        mock_client.patch.assert_not_called()
 
 
 class TestListWorkItems:

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -21,19 +21,21 @@ from mcp_server_polarion.models import (
     WorkItemDetail,
     WorkItemRead,
     WorkItemsCreateResult,
-    WorkItemUpdateResult,
+    WorkItemsUpdateResult,
+    WorkItemUpdateSpec,
 )
 from mcp_server_polarion.tools._shared import cache as _cache_mod
 from mcp_server_polarion.tools.work_items import (
     _build_create_work_items_payload,
-    _build_update_work_item_payload,
+    _build_update_work_item_resource,
+    _build_update_work_items_payload,
     _build_work_item_resource,
     _extract_created_work_item_ids,
     create_work_items,
     get_work_item,
     list_work_items,
     read_work_item,
-    update_work_item,
+    update_work_items,
 )
 
 
@@ -50,33 +52,28 @@ def _project_enum_get_response(enum_name: str, ids: list[str]) -> dict[str, obje
 
 async def _call_update(
     mock_ctx: MagicMock, **overrides: object
-) -> WorkItemUpdateResult:
-    """Call update_work_item with all params explicit.
+) -> WorkItemsUpdateResult:
+    """Invoke ``update_work_items`` with a single-spec default batch.
 
-    Field(...) defaults stay FieldInfo objects outside FastMCP, so every
-    param must be passed; tests override only what they care about.
+    ``project_id`` / ``workflow_action`` / ``change_type_to`` / ``dry_run``
+    are top-level tool params; all other overrides are per-item and fold
+    into one ``WorkItemUpdateSpec``.
     """
-    defaults: dict[str, object] = {
-        "project_id": "MyProj",
-        "work_item_id": "MCPT-1",
-        "title": None,
-        "description_html": None,
-        "status": None,
-        "priority": None,
-        "severity": None,
-        "due_date": None,
-        "initial_estimate": None,
-        "resolution": None,
-        "hyperlinks": None,
-        "assignee_ids": None,
-        "custom_fields": None,
-        "workflow_action": None,
-        "change_type_to": None,
-        "include_current_description_html": False,
-        "dry_run": False,
-    }
-    defaults.update(overrides)
-    return await update_work_item(mock_ctx, **defaults)
+    project_id = cast(str, overrides.pop("project_id", "MyProj"))
+    workflow_action = cast("str | None", overrides.pop("workflow_action", None))
+    change_type_to = cast("str | None", overrides.pop("change_type_to", None))
+    dry_run = cast(bool, overrides.pop("dry_run", False))
+    spec_fields: dict[str, object] = {"work_item_id": "MCPT-1"}
+    spec_fields.update(overrides)
+    spec = WorkItemUpdateSpec(**spec_fields)  # type: ignore[arg-type]
+    return await update_work_items(
+        mock_ctx,
+        project_id=project_id,
+        items=[spec],
+        workflow_action=workflow_action,
+        change_type_to=change_type_to,
+        dry_run=dry_run,
+    )
 
 
 def _make_get_response(
@@ -738,116 +735,72 @@ class TestCreateWorkItemsFieldValidation:
             )
 
 
-class TestBuildUpdateWorkItemPayload:
-    """Tests for the private ``_build_update_work_item_payload`` helper."""
+class TestBuildUpdateWorkItemResource:
+    """Tests for the private ``_build_update_work_item_resource`` helper."""
 
-    def test_minimal_payload_with_only_title(self) -> None:
-        payload = _build_update_work_item_payload(
+    def test_minimal_resource_with_only_title(self) -> None:
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title="New title",
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
+            spec=WorkItemUpdateSpec(work_item_id="MCPT-1", title="New title"),
         )
 
-        # PATCH body wraps `data` as a single object, not a list.
-        assert payload == {
-            "data": {
-                "type": "workitems",
-                "id": "MyProj/MCPT-1",
-                "attributes": {"title": "New title"},
-            }
+        assert resource == {
+            "type": "workitems",
+            "id": "MyProj/MCPT-1",
+            "attributes": {"title": "New title"},
         }
-        item = cast(dict[str, object], payload["data"])
-        assert "relationships" not in item
 
     def test_id_is_project_slash_work_item_id(self) -> None:
-        payload = _build_update_work_item_payload(
+        resource = _build_update_work_item_resource(
             project_id="proj",
-            work_item_id="MCPT-99",
-            title="x",
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
+            spec=WorkItemUpdateSpec(work_item_id="MCPT-99", title="x"),
         )
 
-        item = cast(dict[str, object], payload["data"])
-        assert item["id"] == "proj/MCPT-99"
+        assert resource["id"] == "proj/MCPT-99"
 
     def test_skips_none_and_empty_string_fields(self) -> None:
-        payload = _build_update_work_item_payload(
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html="",
-            status="",
-            priority=None,
-            severity="",
-            due_date="",
-            initial_estimate=None,
-            resolution="",
-            hyperlinks=[],
-            assignee_ids=[],
+            spec=WorkItemUpdateSpec(
+                work_item_id="MCPT-1",
+                title="t",
+                description_html="",
+                status="",
+                severity="",
+                due_date="",
+                resolution="",
+                hyperlinks=[],
+                assignee_ids=[],
+            ),
         )
 
-        # No attributes, no relationships — just the resource header.
-        item = cast(dict[str, object], payload["data"])
-        assert item == {"type": "workitems", "id": "MyProj/MCPT-1"}
+        # Falsy fields drop from the body so the update never blanks them.
+        assert resource["attributes"] == {"title": "t"}
+        assert "relationships" not in resource
 
     def test_includes_description_block(self) -> None:
-        payload = _build_update_work_item_payload(
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html="<p>hi</p>",
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
+            spec=WorkItemUpdateSpec(
+                work_item_id="MCPT-1", description_html="<p>hi</p>"
+            ),
         )
 
-        item = cast(dict[str, object], payload["data"])
-        attributes = cast(dict[str, object], item["attributes"])
+        attributes = cast(dict[str, object], resource["attributes"])
         assert attributes["description"] == {
             "type": "text/html",
             "value": "<p>hi</p>",
         }
 
     def test_assignee_ids_become_to_many_users_relationship(self) -> None:
-        payload = _build_update_work_item_payload(
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=["alice", "bob"],
+            spec=WorkItemUpdateSpec(
+                work_item_id="MCPT-1", assignee_ids=["alice", "bob"]
+            ),
         )
 
-        item = cast(dict[str, object], payload["data"])
-        relationships = cast(dict[str, object], item["relationships"])
+        relationships = cast(dict[str, object], resource["relationships"])
         assert relationships["assignee"] == {
             "data": [
                 {"type": "users", "id": "alice"},
@@ -856,47 +809,37 @@ class TestBuildUpdateWorkItemPayload:
         }
 
     def test_hyperlinks_serialise_role_title_uri(self) -> None:
-        payload = _build_update_work_item_payload(
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=[
-                Hyperlink(role="ref_ext", title="Spec", uri="https://example.com"),
-            ],
-            assignee_ids=None,
+            spec=WorkItemUpdateSpec(
+                work_item_id="MCPT-1",
+                hyperlinks=[
+                    Hyperlink(role="ref_ext", title="Spec", uri="https://example.com"),
+                ],
+            ),
         )
 
-        item = cast(dict[str, object], payload["data"])
-        attributes = cast(dict[str, object], item["attributes"])
+        attributes = cast(dict[str, object], resource["attributes"])
         assert attributes["hyperlinks"] == [
             {"role": "ref_ext", "title": "Spec", "uri": "https://example.com"},
         ]
 
     def test_all_optional_attrs_included_when_set(self) -> None:
-        payload = _build_update_work_item_payload(
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title="t",
-            description_html=None,
-            status="open",
-            priority="50.0",
-            severity="major",
-            due_date="2026-05-31",
-            initial_estimate="5 1/2d",
-            resolution="fixed",
-            hyperlinks=None,
-            assignee_ids=None,
+            spec=WorkItemUpdateSpec(
+                work_item_id="MCPT-1",
+                title="t",
+                status="open",
+                priority="50.0",
+                severity="major",
+                due_date="2026-05-31",
+                initial_estimate="5 1/2d",
+                resolution="fixed",
+            ),
         )
 
-        item = cast(dict[str, object], payload["data"])
-        attributes = cast(dict[str, object], item["attributes"])
+        attributes = cast(dict[str, object], resource["attributes"])
         assert attributes["title"] == "t"
         assert attributes["status"] == "open"
         assert attributes["priority"] == "50.0"
@@ -905,86 +848,79 @@ class TestBuildUpdateWorkItemPayload:
         assert attributes["initialEstimate"] == "5 1/2d"
         assert attributes["resolution"] == "fixed"
 
-    def test_custom_fields_inlined_in_patch_attributes(self) -> None:
-        rich = {"type": "text/html", "value": "<p>note</p>"}
-        payload = _build_update_work_item_payload(
+    def test_custom_fields_inlined_in_attributes(self) -> None:
+        rich: dict[str, object] = {"type": "text/html", "value": "<p>note</p>"}
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
-            custom_fields={"riskLevel": "low", "reviewerNote": rich},
+            spec=WorkItemUpdateSpec(
+                work_item_id="MCPT-1",
+                custom_fields={"riskLevel": "low", "reviewerNote": rich},
+            ),
         )
 
-        item = cast(dict[str, object], payload["data"])
-        attributes = cast(dict[str, object], item["attributes"])
+        attributes = cast(dict[str, object], resource["attributes"])
         assert attributes == {"riskLevel": "low", "reviewerNote": rich}
-
-    def test_custom_fields_alone_keeps_attributes_dict(self) -> None:
-        # custom_fields alone must still emit an attributes block, else PATCH 400s.
-        payload = _build_update_work_item_payload(
-            project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
-            custom_fields={"riskLevel": "high"},
-        )
-        item = cast(dict[str, object], payload["data"])
-        assert "attributes" in item
 
     def test_custom_fields_collision_raises(self) -> None:
         with pytest.raises(ValueError, match="custom_fields keys collide"):
-            _build_update_work_item_payload(
+            _build_update_work_item_resource(
                 project_id="MyProj",
-                work_item_id="MCPT-1",
-                title=None,
-                description_html=None,
-                status=None,
-                priority=None,
-                severity=None,
-                due_date=None,
-                initial_estimate=None,
-                resolution=None,
-                hyperlinks=None,
-                assignee_ids=None,
-                custom_fields={"status": "open"},
+                spec=WorkItemUpdateSpec(
+                    work_item_id="MCPT-1", custom_fields={"status": "open"}
+                ),
             )
 
 
-class TestUpdateWorkItemValidation:
-    """Tests for the at-least-one-field guard in ``update_work_item``."""
+class TestBuildUpdateWorkItemsPayload:
+    """Tests for the private ``_build_update_work_items_payload`` helper."""
 
-    async def test_no_fields_raises_value_error(
+    def test_single_spec_wraps_in_data_list(self) -> None:
+        payload = _build_update_work_items_payload(
+            project_id="MyProj",
+            specs=[WorkItemUpdateSpec(work_item_id="MCPT-1", title="a")],
+        )
+
+        data = cast(list[dict[str, object]], payload["data"])
+        assert len(data) == 1
+        assert data[0]["id"] == "MyProj/MCPT-1"
+
+    def test_multiple_specs_preserve_order(self) -> None:
+        payload = _build_update_work_items_payload(
+            project_id="MyProj",
+            specs=[
+                WorkItemUpdateSpec(work_item_id="MCPT-1", title="a"),
+                WorkItemUpdateSpec(work_item_id="MCPT-2", status="open"),
+            ],
+        )
+
+        data = cast(list[dict[str, object]], payload["data"])
+        assert [item["id"] for item in data] == ["MyProj/MCPT-1", "MyProj/MCPT-2"]
+        attributes_last = cast(dict[str, object], data[1]["attributes"])
+        assert attributes_last == {"status": "open"}
+
+
+class TestUpdateWorkItemsValidation:
+    """Spec- and batch-level rejection paths for ``update_work_items``."""
+
+    async def test_empty_spec_rejected_before_any_request(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        with pytest.raises(ValueError, match="Nothing to update"):
-            await _call_update(mock_ctx)
+        # Polarion 400s on a body-less resource even with workflowAction /
+        # changeTypeTo, so an action-only update is unrepresentable: the spec
+        # itself raises before the tool can issue a request.
+        with pytest.raises(ValidationError, match="Nothing to update"):
+            await _call_update(mock_ctx, workflow_action="close")
         mock_client.patch.assert_not_called()
         mock_client.get.assert_not_called()
 
     async def test_empty_description_html_is_noop(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``description_html=''`` = leave unchanged (never PATCHes) — asymmetric vs
-        update_document, where '' RAISES: a wiped document body orphans every heading,
-        a cleared description is recoverable.
+        """``description_html=''`` = leave unchanged — asymmetric vs
+        update_document, where '' RAISES: a wiped document body orphans every
+        heading, a cleared description is recoverable.
         """
-        with pytest.raises(ValueError, match="Nothing to update"):
+        with pytest.raises(ValidationError, match="Nothing to update"):
             await _call_update(mock_ctx, description_html="")
         mock_client.patch.assert_not_called()
         mock_client.get.assert_not_called()
@@ -1001,15 +937,12 @@ class TestUpdateWorkItemValidation:
             description_html="",
             dry_run=True,
         )
-        # Empty description_html drops from both changes and the wire payload.
-        assert result.changes == {"title": "new title"}
         assert result.payload_preview is not None
-        item = cast(dict[str, object], result.payload_preview["data"])
-        attributes = cast(dict[str, object], item["attributes"])
-        assert "description" not in attributes
+        data = cast(list[dict[str, object]], result.payload_preview["data"])
+        attributes = cast(dict[str, object], data[0]["attributes"])
         assert attributes == {"title": "new title"}
 
-    async def test_custom_fields_alone_satisfies_at_least_one_check(
+    async def test_custom_fields_alone_satisfies_spec(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         # custom_fields counts as a body field.
@@ -1025,66 +958,14 @@ class TestUpdateWorkItemValidation:
             dry_run=True,
         )
         assert result.dry_run is True
-        assert result.changes == {"custom_fields": {"riskLevel": "high"}}
-
-    async def test_collision_raises_value_error(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # A custom key matching a standard param would shadow it.
-        with pytest.raises(ValueError, match="custom_fields keys collide"):
-            await _call_update(
-                mock_ctx,
-                title="x",
-                custom_fields={"title": "y"},
-                dry_run=True,
-            )
-        mock_client.patch.assert_not_called()
-
-    async def test_workflow_action_alone_raises_value_error(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Polarion 400s on attribute-less PATCH, so an action needs a body field.
-        with pytest.raises(ValueError, match="at least one body field"):
-            await _call_update(mock_ctx, workflow_action="close")
-        mock_client.patch.assert_not_called()
-        mock_client.get.assert_not_called()
-
-    async def test_change_type_to_alone_raises_value_error(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        with pytest.raises(ValueError, match="at least one body field"):
-            await _call_update(mock_ctx, change_type_to="defect")
-        mock_client.patch.assert_not_called()
-
-    async def test_workflow_action_alone_dry_run_also_rejected(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Dry-run is rejected too: the would-be payload is invalid.
-        with pytest.raises(ValueError, match="at least one body field"):
-            await _call_update(mock_ctx, workflow_action="close", dry_run=True)
-
-    async def test_workflow_action_with_title_passes(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Pairing the action with any body field satisfies Polarion.
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
-
-        result = await _call_update(
-            mock_ctx,
-            workflow_action="close",
-            title="closing this work item",
-        )
-
-        assert result.updated is True
-        patch_path = mock_client.patch.call_args.args[0]
-        assert patch_path == "/projects/MyProj/workitems/MCPT-1?workflowAction=close"
-        body = mock_client.patch.call_args.kwargs["json"]
-        assert body["data"]["attributes"]["title"] == "closing this work item"
+        assert result.payload_preview is not None
+        data = cast(list[dict[str, object]], result.payload_preview["data"])
+        attributes = cast(dict[str, object], data[0]["attributes"])
+        assert attributes == {"riskLevel": "high"}
 
 
-class TestUpdateWorkItemHyperlinkRoleGuard:
-    """``update_work_item`` validates hyperlink roles before the PATCH."""
+class TestUpdateWorkItemsHyperlinkRoleGuard:
+    """``update_work_items`` validates hyperlink roles before the PATCH."""
 
     async def test_unknown_hyperlink_role_raises_without_patch(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1103,9 +984,37 @@ class TestUpdateWorkItemHyperlinkRoleGuard:
         assert "ref_ext" in str(exc.value)
         mock_client.patch.assert_not_called()
 
+    async def test_roles_pooled_across_items_in_one_probe(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # One project-enum probe covers every item's roles (as in create).
+        mock_client.get.return_value = _project_enum_get_response(
+            "hyperlink-role", ["ref_int", "ref_ext"]
+        )
 
-class TestUpdateWorkItemDryRun:
-    """Tests for ``update_work_item`` with ``dry_run=True``."""
+        with pytest.raises(ValueError, match="ghost"):
+            await update_work_items(
+                mock_ctx,
+                project_id="MyProj",
+                items=[
+                    WorkItemUpdateSpec(
+                        work_item_id="MCPT-1",
+                        hyperlinks=[Hyperlink(role="ref_ext", uri="https://a.com")],
+                    ),
+                    WorkItemUpdateSpec(
+                        work_item_id="MCPT-2",
+                        hyperlinks=[Hyperlink(role="ghost", uri="https://b.com")],
+                    ),
+                ],
+                workflow_action=None,
+                change_type_to=None,
+                dry_run=True,
+            )
+        mock_client.patch.assert_not_called()
+
+
+class TestUpdateWorkItemsDryRun:
+    """Tests for ``update_work_items`` with ``dry_run=True``."""
 
     async def test_dry_run_does_not_call_polarion(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1118,22 +1027,20 @@ class TestUpdateWorkItemDryRun:
 
         mock_client.patch.assert_not_called()
         mock_client.get.assert_not_called()
-        assert isinstance(result, WorkItemUpdateResult)
+        assert isinstance(result, WorkItemsUpdateResult)
         assert result.updated is False
         assert result.dry_run is True
-        assert result.current is None
-        assert result.changes == {"title": "New title"}
-        # payload_preview is populated on dry-run (mirrors create_work_items).
+        assert result.work_item_ids == []
         assert result.payload_preview is not None
-        item = cast(dict[str, object], result.payload_preview["data"])
-        assert item["id"] == "MyProj/MCPT-1"
-        attributes = cast(dict[str, object], item["attributes"])
+        data = cast(list[dict[str, object]], result.payload_preview["data"])
+        assert data[0]["id"] == "MyProj/MCPT-1"
+        attributes = cast(dict[str, object], data[0]["attributes"])
         assert attributes == {"title": "New title"}
 
-    async def test_changes_uses_python_typed_values_not_json_api_shape(
+    async def test_dry_run_preview_wraps_html_verbatim(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # changes holds raw caller values; {type,value} wrapping is preview-only.
+        # Preview wraps the caller's HTML verbatim, no sanitize/convert.
         result = await _call_update(
             mock_ctx,
             description_html="<p>bold</p>",
@@ -1141,207 +1048,13 @@ class TestUpdateWorkItemDryRun:
             dry_run=True,
         )
 
-        assert result.changes == {
-            "description_html": "<p>bold</p>",
-            "assignee_ids": ["alice"],
-        }
-        # Preview wraps the same HTML verbatim, no sanitize/convert.
         assert result.payload_preview is not None
-        item = cast(dict[str, object], result.payload_preview["data"])
-        attributes = cast(dict[str, object], item["attributes"])
+        data = cast(list[dict[str, object]], result.payload_preview["data"])
+        attributes = cast(dict[str, object], data[0]["attributes"])
         desc = cast(dict[str, object], attributes["description"])
         assert desc == {"type": "text/html", "value": "<p>bold</p>"}
-
-
-class TestUpdateWorkItemHappyPath:
-    """Tests for a successful ``update_work_item`` call."""
-
-    async def test_returns_updated_with_post_update_state(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # PATCH returns {} on 204; GET returns the post-update detail.
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response(title="after")
-
-        result = await _call_update(mock_ctx, title="after")
-
-        assert isinstance(result, WorkItemUpdateResult)
-        assert result.updated is True
-        assert result.dry_run is False
-        assert result.current is not None
-        assert result.current.title == "after"
-        assert result.changes == {"title": "after"}
-        assert result.payload_preview is None
-
-    async def test_current_description_html_blanked_by_default(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        """Default blanks current.description_html — body still travels (``@all`` needed
-        for customs); tool strips it to spare LLM context.
-        """
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response(
-            description_html="<p>large body that should be hidden</p>",
-        )
-
-        result = await _call_update(mock_ctx, status="approved")
-
-        assert result.current is not None
-        assert result.current.description_html == ""
-        # Other metadata is unaffected.
-        assert result.current.status == "open"  # _make_get_response default
-
-    async def test_current_description_html_kept_when_flag_true(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        """include_current_description_html=True → raw HTML in current."""
-        mock_client.patch.return_value = {}
-        raw = "<p>verified body <strong>after</strong></p>"
-        mock_client.get.return_value = _make_get_response(description_html=raw)
-
-        result = await _call_update(
-            mock_ctx,
-            description_html=raw,
-            include_current_description_html=True,
-        )
-
-        assert result.current is not None
-        assert result.current.description_html == raw
-
-    async def test_patch_called_with_correct_path_and_body(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
-
-        await _call_update(
-            mock_ctx,
-            work_item_id="MCPT-42",
-            status="open",
-            assignee_ids=["alice"],
-        )
-
-        args, kwargs = mock_client.patch.call_args
-        assert args == ("/projects/MyProj/workitems/MCPT-42",)
-        body = kwargs["json"]
-        item = body["data"]
-        assert item["type"] == "workitems"
-        assert item["id"] == "MyProj/MCPT-42"
-        assert item["attributes"]["status"] == "open"
-        assert item["relationships"]["assignee"]["data"] == [
-            {"type": "users", "id": "alice"}
-        ]
-
-    async def test_followup_get_called_with_detail_fields(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
-
-        await _call_update(mock_ctx, title="t")
-
-        args, kwargs = mock_client.get.call_args
-        assert args == ("/projects/MyProj/workitems/MCPT-1",)
-        params = kwargs["params"]
-        assert params["include"] == "assignee"
-        # Bare @all so inline customs surface; narrowing would drop them.
-        assert params["fields[workitems]"] == "@all"
-
-    async def test_current_carries_custom_fields_from_post_patch_get(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Inlined customs from the post-PATCH GET surface on current.custom_fields.
-        mock_client.patch.return_value = {}
-        get_response = _make_get_response(title="after")
-        data = cast(dict[str, object], get_response["data"])
-        attributes = cast(dict[str, object], data["attributes"])
-        attributes["riskLevel"] = "high"
-        attributes["effortHours"] = 12.0
-        mock_client.get.return_value = get_response
-
-        result = await _call_update(mock_ctx, title="after")
-
-        assert result.current is not None
-        assert result.current.custom_fields == {
-            "riskLevel": "high",
-            "effortHours": 12.0,
-        }
-
-    async def test_custom_fields_inlined_into_patch_body(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Customs ride top-level in attributes; a customFields container is dropped.
-        mock_client.patch.return_value = {}
-        rich = {"type": "text/html", "value": "<p>note</p>"}
-        _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"riskLevel", "reviewerNote"})
-        )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"riskLevel": "high", "reviewerNote": rich}
-        )
-
-        await _call_update(
-            mock_ctx,
-            custom_fields={"riskLevel": "low", "reviewerNote": rich},
-        )
-
-        _, kwargs = mock_client.patch.call_args
-        body = kwargs["json"]
-        item = body["data"]
-        attributes = item["attributes"]
-        assert attributes["riskLevel"] == "low"
-        assert attributes["reviewerNote"] == rich
-        assert "customFields" not in attributes
-
-    async def test_changes_summary_records_custom_fields(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # changes mirrors what was sent so callers can confirm intent.
-        mock_client.patch.return_value = {}
-        _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"riskLevel"})
-        )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"riskLevel": "low"}
-        )
-
-        result = await _call_update(
-            mock_ctx,
-            title="t",
-            custom_fields={"riskLevel": "high"},
-        )
-
-        assert result.changes["title"] == "t"
-        assert result.changes["custom_fields"] == {"riskLevel": "high"}
-
-    async def test_changes_custom_fields_is_independent_of_input(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Post-call mutation of the caller's dict must not bleed into changes.
-        mock_client.patch.return_value = {}
-        _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"reviewerNote", "riskLevel"})
-        )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"reviewerNote": "x", "riskLevel": "low"}
-        )
-
-        rich = {"type": "text/html", "value": "<p>original</p>"}
-        customs: dict[str, object] = {"reviewerNote": rich, "riskLevel": "high"}
-
-        result = await _call_update(
-            mock_ctx,
-            title="t",
-            custom_fields=customs,
-        )
-
-        customs["riskLevel"] = "low"
-        rich["value"] = "<p>mutated</p>"
-
-        recorded = cast(dict[str, object], result.changes["custom_fields"])
-        assert recorded["riskLevel"] == "high"
-        recorded_note = cast(dict[str, object], recorded["reviewerNote"])
-        assert recorded_note["value"] == "<p>original</p>"
+        relationships = cast(dict[str, object], data[0]["relationships"])
+        assert relationships["assignee"] == {"data": [{"type": "users", "id": "alice"}]}
 
     async def test_dry_run_preview_includes_custom_fields(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1362,10 +1075,109 @@ class TestUpdateWorkItemHappyPath:
 
         mock_client.patch.assert_not_called()
         assert result.payload_preview is not None
-        item = cast(dict[str, object], result.payload_preview["data"])
-        attributes = cast(dict[str, object], item["attributes"])
+        data = cast(list[dict[str, object]], result.payload_preview["data"])
+        attributes = cast(dict[str, object], data[0]["attributes"])
         assert attributes["title"] == "t"
         assert attributes["riskLevel"] == "high"
+
+
+class TestUpdateWorkItemsHappyPath:
+    """Tests for a successful ``update_work_items`` call."""
+
+    async def test_returns_updated_with_target_ids(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # PATCH returns {} on 204; the result echoes the submitted ids.
+        mock_client.patch.return_value = {}
+
+        result = await _call_update(mock_ctx, title="after")
+
+        assert isinstance(result, WorkItemsUpdateResult)
+        assert result.updated is True
+        assert result.dry_run is False
+        assert result.work_item_ids == ["MCPT-1"]
+        assert result.payload_preview is None
+
+    async def test_no_follow_up_get_after_patch(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Bulk PATCH is 204; the tool must not re-GET items afterwards.
+        mock_client.patch.return_value = {}
+
+        await _call_update(mock_ctx, title="after")
+
+        mock_client.get.assert_not_called()
+
+    async def test_patch_called_with_correct_path_and_body(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+
+        await _call_update(
+            mock_ctx,
+            work_item_id="MCPT-42",
+            title="t",
+            assignee_ids=["alice"],
+        )
+
+        args, kwargs = mock_client.patch.call_args
+        assert args == ("/projects/MyProj/workitems",)
+        body = kwargs["json"]
+        data = body["data"]
+        assert isinstance(data, list)
+        item = data[0]
+        assert item["type"] == "workitems"
+        assert item["id"] == "MyProj/MCPT-42"
+        assert item["attributes"]["title"] == "t"
+        assert item["relationships"]["assignee"]["data"] == [
+            {"type": "users", "id": "alice"}
+        ]
+
+    async def test_multiple_items_updated_in_one_patch(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = {}
+
+        result = await update_work_items(
+            mock_ctx,
+            project_id="MyProj",
+            items=[
+                WorkItemUpdateSpec(work_item_id="MCPT-1", title="a"),
+                WorkItemUpdateSpec(work_item_id="MCPT-2", due_date="2026-07-31"),
+            ],
+            workflow_action=None,
+            change_type_to=None,
+            dry_run=False,
+        )
+
+        mock_client.patch.assert_awaited_once()
+        data = mock_client.patch.call_args.kwargs["json"]["data"]
+        assert [item["id"] for item in data] == ["MyProj/MCPT-1", "MyProj/MCPT-2"]
+        assert result.work_item_ids == ["MCPT-1", "MCPT-2"]
+
+    async def test_custom_fields_inlined_into_patch_body(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Customs ride top-level in attributes; a customFields container is dropped.
+        mock_client.patch.return_value = {}
+        rich = {"type": "text/html", "value": "<p>note</p>"}
+        _cache_mod.store_work_item_custom_keys(
+            "MyProj", "task", frozenset({"riskLevel", "reviewerNote"})
+        )
+        mock_client.get.return_value = _make_get_response(
+            custom_fields={"riskLevel": "high", "reviewerNote": rich}
+        )
+
+        await _call_update(
+            mock_ctx,
+            custom_fields={"riskLevel": "low", "reviewerNote": rich},
+        )
+
+        _, kwargs = mock_client.patch.call_args
+        attributes = kwargs["json"]["data"][0]["attributes"]
+        assert attributes["riskLevel"] == "low"
+        assert attributes["reviewerNote"] == rich
+        assert "customFields" not in attributes
 
     async def test_round_trip_read_response_can_be_written_back(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1385,7 +1197,7 @@ class TestUpdateWorkItemHappyPath:
         result = await _call_update(mock_ctx, custom_fields=read_customs)
 
         _, kwargs = mock_client.patch.call_args
-        attributes = kwargs["json"]["data"]["attributes"]
+        attributes = kwargs["json"]["data"][0]["attributes"]
         for key, value in read_customs.items():
             assert attributes[key] == value
         assert result.updated is True
@@ -1393,28 +1205,31 @@ class TestUpdateWorkItemHappyPath:
     async def test_workflow_action_appended_as_query_param(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # workflow_action needs a paired body field, so add a title.
+        # workflow_action rides the batch endpoint as a query param.
         mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
 
         await _call_update(mock_ctx, workflow_action="close", title="t")
 
         patch_path = mock_client.patch.call_args.args[0]
-        assert patch_path == "/projects/MyProj/workitems/MCPT-1?workflowAction=close"
-        # Follow-up GET drops the query to read the canonical detail.
-        get_path = mock_client.get.call_args.args[0]
-        assert get_path == "/projects/MyProj/workitems/MCPT-1"
+        assert patch_path == "/projects/MyProj/workitems?workflowAction=close"
 
     async def test_change_type_to_appended_as_query_param(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
     ) -> None:
+        # change_type_to triggers the type guard: prefetch + type options.
         mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
+        mock_client.get.side_effect = [
+            _make_get_response(),
+            _enum_get_response(["task"]),
+        ]
 
         await _call_update(mock_ctx, change_type_to="task", title="t")
 
         patch_path = mock_client.patch.call_args.args[0]
-        assert patch_path == "/projects/MyProj/workitems/MCPT-1?changeTypeTo=task"
+        assert patch_path == "/projects/MyProj/workitems?changeTypeTo=task"
 
     async def test_description_html_is_sent_verbatim(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1423,7 +1238,6 @@ class TestUpdateWorkItemHappyPath:
         no markdownify.
         """
         mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
 
         raw = (
             '<p>See <span class="polarion-rte-link" '
@@ -1432,24 +1246,20 @@ class TestUpdateWorkItemHappyPath:
         await _call_update(mock_ctx, description_html=raw)
 
         body = mock_client.patch.call_args.kwargs["json"]
-        desc = body["data"]["attributes"]["description"]
+        desc = body["data"][0]["attributes"]["description"]
         assert desc == {"type": "text/html", "value": raw}
 
     async def test_path_url_encodes_special_chars(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
 
         await _call_update(mock_ctx, project_id="My Proj", title="t")
 
-        assert (
-            mock_client.patch.call_args.args[0]
-            == "/projects/My%20Proj/workitems/MCPT-1"
-        )
+        assert mock_client.patch.call_args.args[0] == "/projects/My%20Proj/workitems"
 
 
-class TestUpdateWorkItemErrorMapping:
+class TestUpdateWorkItemsErrorMapping:
     """Tests that domain exceptions are mapped at the tool layer."""
 
     async def test_patch_401_raises_permission_error(
@@ -1459,7 +1269,6 @@ class TestUpdateWorkItemErrorMapping:
 
         with pytest.raises(PermissionError):
             await _call_update(mock_ctx, title="t")
-        mock_client.get.assert_not_called()
 
     async def test_patch_404_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1479,27 +1288,51 @@ class TestUpdateWorkItemErrorMapping:
         with pytest.raises(RuntimeError, match="boom"):
             await _call_update(mock_ctx, title="t")
 
-    async def test_followup_get_404_raises_value_error(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    async def test_prefetch_404_raises_value_error(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
     ) -> None:
-        # PATCH succeeds, but the follow-up GET 404s — surface it the
-        # same way (very rare race; mostly defensive).
-        mock_client.patch.return_value = {}
-        mock_client.get.side_effect = PolarionNotFoundError(
-            "not found", status_code=404
-        )
+        # The guard prefetch names the missing item; nothing is PATCHed.
+        mock_client.get.side_effect = PolarionNotFoundError("nf", status_code=404)
 
-        with pytest.raises(ValueError, match="not found"):
-            await _call_update(mock_ctx, title="t")
+        with pytest.raises(ValueError, match="ghost"):
+            await _call_update(mock_ctx, work_item_id="ghost", status="open")
+        mock_client.patch.assert_not_called()
+
+    async def test_prefetch_401_raises_permission_error(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await _call_update(mock_ctx, status="open")
+        mock_client.patch.assert_not_called()
+
+    async def test_prefetch_other_error_raises_runtime_error(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        mock_client.get.side_effect = PolarionError("boom", status_code=500)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await _call_update(mock_ctx, status="open")
+        mock_client.patch.assert_not_called()
 
 
-class TestUpdateWorkItemFieldValidation:
-    """Verify ``min_length=1`` constraints attached to required parameters."""
+class TestUpdateWorkItemsFieldValidation:
+    """Verify constraints attached to the tool's top-level parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
-        hints = get_type_hints(update_work_item)
-        sig = inspect.signature(update_work_item)
+        hints = get_type_hints(update_work_items)
+        sig = inspect.signature(update_work_items)
         field_info = sig.parameters[param_name].default
         return TypeAdapter(Annotated[hints[param_name], field_info])
 
@@ -1507,39 +1340,39 @@ class TestUpdateWorkItemFieldValidation:
         with pytest.raises(ValidationError):
             self._adapter_for("project_id").validate_python("")
 
-    def test_work_item_id_rejects_empty_string(self) -> None:
-        with pytest.raises(ValidationError):
-            self._adapter_for("work_item_id").validate_python("")
-
     def test_project_id_accepts_non_empty(self) -> None:
         assert self._adapter_for("project_id").validate_python("p") == "p"
 
-    def test_work_item_id_accepts_non_empty(self) -> None:
-        assert self._adapter_for("work_item_id").validate_python("MCPT-1") == "MCPT-1"
-
-    def test_description_html_rejects_overlong_input(self) -> None:
-        """max_length=MAX_BODY_HTML_LEN caps runaway HTML.
-
-        Re-proven here so a docstring rewrite cannot silently drop it.
-        """
-        adapter = self._adapter_for("description_html")
-        assert adapter.validate_python("<p>ok</p>") == "<p>ok</p>"
-        # 2 MiB + 1 char is rejected.
+    def test_items_rejects_empty_list(self) -> None:
         with pytest.raises(ValidationError):
-            adapter.validate_python("x" * (2_000_000 + 1))
+            self._adapter_for("items").validate_python([])
+
+    def test_items_rejects_more_than_max_bulk(self) -> None:
+        specs = [
+            WorkItemUpdateSpec(work_item_id=f"MCPT-{i}", title="t") for i in range(51)
+        ]
+        with pytest.raises(ValidationError):
+            self._adapter_for("items").validate_python(specs)
+
+    def test_items_accepts_single_spec(self) -> None:
+        validated = self._adapter_for("items").validate_python(
+            [WorkItemUpdateSpec(work_item_id="MCPT-1", title="t")]
+        )
+        assert isinstance(validated, list)
+        assert len(validated) == 1
 
 
-class TestUpdateWorkItemDocstringGuidance:
+class TestUpdateWorkItemsDocstringGuidance:
     """Lock the read-before-update steer into the public docstring."""
 
     def test_docstring_directs_get_before_update(self) -> None:
-        document = update_work_item.__doc__ or ""
+        document = update_work_items.__doc__ or ""
         assert "get_work_item" in document, (
-            "update_work_item docstring must direct callers to read the "
+            "update_work_items docstring must direct callers to read the "
             "work item before patching it"
         )
         assert "BEFORE" in document, (
-            "update_work_item docstring must state the read happens BEFORE the update"
+            "update_work_items docstring must state the read happens BEFORE the update"
         )
 
 
@@ -1685,8 +1518,36 @@ class TestEnumGuardCreateWorkItem:
         mock_client.post.assert_not_called()
 
 
-class TestEnumGuardUpdateWorkItem:
-    """Integration: ``update_work_item`` pre-fetches type then guards."""
+class TestEnumGuardUpdateWorkItems:
+    """Integration: ``update_work_items`` pre-fetches each item's type then guards."""
+
+    async def test_bad_enum_on_later_item_aborts_whole_batch(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        # Per-item guard runs before the PATCH; item 2's ghost status aborts
+        # the batch (status options cached from item 1's probe).
+        mock_client.get.side_effect = [
+            _make_get_response(),
+            _enum_get_response(["open", "closed"]),
+            _make_get_response(work_item_id="MCPT-2"),
+        ]
+
+        with pytest.raises(ValueError, match="status='ghost'"):
+            await update_work_items(
+                mock_ctx,
+                project_id="MyProj",
+                items=[
+                    WorkItemUpdateSpec(work_item_id="MCPT-1", status="open"),
+                    WorkItemUpdateSpec(work_item_id="MCPT-2", status="ghost"),
+                ],
+                workflow_action=None,
+                change_type_to=None,
+                dry_run=False,
+            )
+        mock_client.patch.assert_not_called()
 
     async def test_unlisted_priority_raises_after_prefetch(
         self,

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -840,6 +840,17 @@ class TestBuildUpdateWorkItemResource:
                 ),
             )
 
+    def test_all_none_custom_fields_raise_not_empty_body(self) -> None:
+        # Truthy custom_fields passes the spec validator, but merge drops
+        # None values — the builder must reject the resulting empty body.
+        with pytest.raises(ValueError, match="empty PATCH"):
+            _build_update_work_item_resource(
+                project_id="MyProj",
+                spec=WorkItemUpdateSpec(
+                    work_item_id="MCPT-1", custom_fields={"riskLevel": None}
+                ),
+            )
+
 
 class TestBuildUpdateWorkItemsPayload:
     """Tests for the private ``_build_update_work_items_payload`` helper."""
@@ -909,6 +920,22 @@ class TestUpdateWorkItemsValidation:
         data = cast(list[dict[str, object]], result.payload_preview["data"])
         attributes = cast(dict[str, object], data[0]["attributes"])
         assert attributes == {"title": "new title"}
+
+    async def test_all_none_custom_fields_rejected_before_patch(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        _cache_mod.store_work_item_custom_keys(
+            "MyProj", "task", frozenset({"riskLevel"})
+        )
+        mock_client.get.return_value = _make_get_response()
+
+        with pytest.raises(ValueError, match="empty PATCH"):
+            await _call_update(
+                mock_ctx,
+                custom_fields={"riskLevel": None},
+                dry_run=True,
+            )
+        mock_client.patch.assert_not_called()
 
     async def test_custom_fields_alone_satisfies_spec(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -2047,7 +2074,7 @@ class TestGetWorkItem:
     ) -> None:
         """Polarion spans / data-* attributes survive on read.
 
-        Round-trip guarantee for update_work_item(description_html=).
+        Round-trip guarantee for update_work_items description_html.
         """
         raw = (
             '<p>Refs <span class="polarion-rte-link" '
@@ -2438,7 +2465,7 @@ class TestReadWorkItem:
         assert result.resolution == "fixed"
         assert len(result.hyperlinks) == 1
         assert result.hyperlinks[0].uri == "https://example.com/spec"
-        # Customs stay raw so the dict round-trips through update_work_item.
+        # Customs stay raw so the dict round-trips through update_work_items.
         assert result.custom_fields == {
             "riskLevel": "high",
             "reviewerNote": rich_value,

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -875,9 +875,7 @@ class TestUpdateWorkItemsValidation:
     async def test_empty_spec_rejected_before_any_request(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Polarion 400s on a body-less resource even with workflowAction /
-        # changeTypeTo, so an action-only update is unrepresentable: the spec
-        # itself raises before the tool can issue a request.
+        # Action-only update is unrepresentable: the spec raises pre-request.
         with pytest.raises(ValidationError, match="Nothing to update"):
             await _call_update(mock_ctx, workflow_action="close")
         mock_client.patch.assert_not_called()


### PR DESCRIPTION
## Summary

Replaces the single-item `update_work_item` tool with bulk `update_work_items`, backed by Polarion's `PATCH /projects/{projectId}/workitems` endpoint (JSON:API `{"data": [...]}` body, `workflowAction`/`changeTypeTo` query params, 204 No Content). At the server's 3 req/s cap with no concurrency, N single-item PATCHes were the slowest possible way to update N items; one bulk PATCH now covers up to 50 items, mirroring `create_work_items`.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- N single-item PATCHes are the slowest path at the 3 req/s server cap; bulk PATCH updates up to 50 items in one request
- Replace update_work_item with update_work_items (per-item WorkItemUpdateSpec, create-style result, items-aware eval checks)

## Testing

- `ruff check` / `ruff format --check` / `mypy src/` clean; 1436 tests pass; diff-cover 100% on changed lines vs origin/main.
- Live E2E on testdrive `MCP_Test_Project` (9/9): bulk create -> `dry_run=True` payload preview -> one-PATCH update of two items (verified via re-GET) -> batch `workflow_action=start_progress` with `assignee_ids` in the same call (both `open -> inprogress`) -> guard rejects unknown status listing valid options -> bad id in batch raises and the batch is atomic (good item untouched) -> `description_html` round-trip byte-identical.

## Notes for Reviewers

- Contract changes vs the old tool: no post-PATCH re-GET (`current` and `include_current_description_html` are gone; result echoes `work_item_ids` like create), and `workflow_action`/`change_type_to` are batch-wide query params applied to every item.
- An action-only update is now unrepresentable by construction: `WorkItemUpdateSpec` requires >=1 body field, which is exactly Polarion's "PATCH 400s without a body field" rule.
- Eval checks (`get_before_update`, `preserve_hyperlinks`, `round_trip_source`, ordered-trajectory `work_item_id` match) now reach into the nested `items[]` list per item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
