### PR TITLE
feat(test-runs): bulk create_test_runs tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
 - `/backlinkedworkitems` unsupported — back direction via `query=linkedWorkItems:{wi}`, so back results have `role=None`.
 - Polarion validate neither custom-field ids (unknown keys persist; wrong-type 400), nor enum values, nor link targets/roles — `guard.py` validate pre-write. `getAvailableOptions` = only key→enum-options API (non-enum/unknown → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (`data` = dict, not list).
 - Custom fields inline under `attributes` (no `customFields` container; `@all` tokens dropped). `GET /projects/{p}/documents` absent on some builds.
+- Testruns: POST require explicit `id` (400 without; UI-only autofill); enums resolve only under `testing` context (`~` 404); no `getAvailableOptions` → custom-field enum values unguardable (keys only); `isTemplate` served only on templates.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **P
 
 ## Features
 
-- **28 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
+- **29 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
 - **Read** — render documents as Markdown, search with Lucene or SQL, walk incoming/outgoing links, resolve enum options.
-- **Write** — create and update work items and documents, manage links, reorganize document structure, post comments.
+- **Write** — create and update work items and documents, create test runs, manage links, reorganize document structure, post comments.
 - **Safe writes** — every write tool supports `dry_run`, and pre-write guards validate fields, enum values, and link targets before hitting Polarion.
 - **Built for LLMs** — strict async, fully typed, pagination on every list tool, docstrings written as the assistant's manual.
 
@@ -181,6 +181,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | `update_work_item` | Update an existing work item |
 | `create_document` | Create a new document |
 | `update_document` | Update document metadata, body, or workflow status |
+| `create_test_runs` | Create one or more test runs, optionally from a template |
 | `create_work_item_links` | Create one or more outgoing links from a source work item |
 | `update_work_item_link` | Update `suspect` / `revision` on one outgoing link |
 | `delete_work_item_links` | Delete one or more outgoing links from a source work item |
@@ -237,6 +238,8 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 > "Update the description of MCPT-042 with the revised text I'll paste, keeping the existing formatting."
 
 > "Add a comment on the SRS document asking the owner to clarify section 4, then reply to thread T-12 marking it resolved."
+
+> "Create a test run REG-SPRINT-7 in project MCPT from the 'Regression' template with status 'open'."
 
 </details>
 

--- a/evals/cases/triggers.py
+++ b/evals/cases/triggers.py
@@ -184,4 +184,15 @@ CASES: list[Case] = [
         expect="list_test_runs",
         reject=["list_work_items"],
     ),
+    _case(
+        "TRIG-CREATE-TEST-RUN",
+        f"Create a new manual test run with id 'Fake-TR-Sprint9' in project "
+        f"'{PROJECT}'.",
+        "triggers_tool",
+        intent="Creating a test run must call create_test_runs, not "
+        "create_work_items (a run is not a work item).",
+        covers=["create_test_runs"],
+        expect="create_test_runs",
+        reject=["create_work_items"],
+    ),
 ]

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -294,10 +294,13 @@ class FakePolarion:
                 200, json=self._enum_response(enum.group(1), enum.group(2))
             )
 
-        project_enum = re.search(r"/enumerations/~/([^/]+)/~$", path)
+        # Context-qualified names ("testing/testrun-type") are separate seed
+        # keys, so wildcard-context probes for them 404 like live Polarion.
+        project_enum = re.search(r"/enumerations/([^/]+)/([^/]+)/~$", path)
         if project_enum:
-            name = project_enum.group(1)
-            options = self.seeds.project_enums.get(name)
+            context, name = project_enum.groups()
+            key = name if context == "~" else f"{context}/{name}"
+            options = self.seeds.project_enums.get(key)
             if options is None:
                 return httpx.Response(404, json={"errors": [{"status": "404"}]})
             return httpx.Response(
@@ -305,7 +308,7 @@ class FakePolarion:
                 json={
                     "data": {
                         "type": "enumerations",
-                        "id": f"~/{name}/~",
+                        "id": f"{context}/{name}/~",
                         "attributes": {"options": [{"id": o} for o in options]},
                     }
                 },
@@ -363,6 +366,27 @@ class FakePolarion:
             data = [self._work_item_resource(w) for w in items]
             return httpx.Response(
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
+            )
+
+        # Single test run (template-guard pre-read); isTemplate is served only
+        # on templates, mirroring live Polarion omitting it on instances.
+        single_tr = re.search(r"/testruns/([^/]+)$", path)
+        if single_tr:
+            tr = self.seeds.test_runs.get(single_tr.group(1))
+            if tr is None:
+                return httpx.Response(404, json={"errors": [{"status": "404"}]})
+            attributes: dict[str, Any] = {"id": tr.short_id}
+            if tr.is_template:
+                attributes["isTemplate"] = True
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "type": "testruns",
+                        "id": f"{PROJECT}/{tr.short_id}",
+                        "attributes": attributes,
+                    }
+                },
             )
 
         # Test runs: templates=true returns blueprints, else actual instances.
@@ -468,6 +492,27 @@ class FakePolarion:
                         "data": [
                             {"type": "workitems", "id": f"{PROJECT}/MCPT-{9001 + i}"}
                             for i in range(submitted)
+                        ]
+                    },
+                )
+            if path.endswith("/testruns"):
+                # Polarion honors the client-supplied id verbatim; echo it back.
+                ids: list[str] = []
+                if isinstance(body, dict) and isinstance(body.get("data"), list):
+                    for i, entry in enumerate(body["data"]):
+                        attrs = (
+                            entry.get("attributes") if isinstance(entry, dict) else None
+                        )
+                        rid = attrs.get("id") if isinstance(attrs, dict) else None
+                        ids.append(str(rid) if rid else f"TR-{9001 + i}")
+                else:
+                    ids = ["TR-9001"]
+                return httpx.Response(
+                    201,
+                    json={
+                        "data": [
+                            {"type": "testruns", "id": f"{PROJECT}/{rid}"}
+                            for rid in ids
                         ]
                     },
                 )

--- a/evals/harness/fixtures.py
+++ b/evals/harness/fixtures.py
@@ -274,10 +274,8 @@ SEEDS = Seeds(
             ("approved", False),
         ],
     },
-    # Project-level enums (``/enumerations/{context}/{name}/~``) -- dict-shaped
-    # ``data`` with ``attributes.options[].id``, unlike getAvailableOptions'
-    # list. Bare keys live in the ``~`` context; testrun enums only resolve
-    # under ``testing`` (mirrors live 404 on the wildcard context).
+    # Project-level enums served dict-shaped (attributes.options[].id), unlike
+    # getAvailableOptions' list. Key context: bare = "~", testrun = "testing".
     project_enums={
         "hyperlink-role": ["ref_int", "ref_ext"],
         "workitem-link-role": ["relates_to", "parent", "satisfies", "verifies"],

--- a/evals/harness/fixtures.py
+++ b/evals/harness/fixtures.py
@@ -53,6 +53,9 @@ SECTION_A_PART_ID = f"heading_{DOC_HEADING_ID}"
 # Test run instance served by list_test_runs (TRIG-LIST-TEST-RUNS).
 TEST_RUN_ID = "Fake-TR-001"
 
+# Template blueprint; create_test_runs resolves it via the template guard.
+TEST_RUN_TEMPLATE_ID = "Fake-TR-Template"
+
 TS = "2026-01-01T00:00:00.000Z"
 
 
@@ -215,6 +218,13 @@ SEEDS = Seeds(
             status="open",
             finished_on=TS,
         ),
+        TEST_RUN_TEMPLATE_ID: TestRun(
+            TEST_RUN_TEMPLATE_ID,
+            "Fake Run Template",
+            type="manual",
+            status="open",
+            is_template=True,
+        ),
     },
     # Forward (outgoing) work-item links: source short id -> [(role, target short
     # id)]. CHILD_REQ has a parent + a test case; UNCOVERED_REQ deliberately none.
@@ -264,10 +274,14 @@ SEEDS = Seeds(
             ("approved", False),
         ],
     },
-    # Project-level enums (``/enumerations/~/{name}/~``) -- dict-shaped ``data``
-    # with ``attributes.options[].id``, unlike getAvailableOptions' list.
+    # Project-level enums (``/enumerations/{context}/{name}/~``) -- dict-shaped
+    # ``data`` with ``attributes.options[].id``, unlike getAvailableOptions'
+    # list. Bare keys live in the ``~`` context; testrun enums only resolve
+    # under ``testing`` (mirrors live 404 on the wildcard context).
     project_enums={
         "hyperlink-role": ["ref_int", "ref_ext"],
         "workitem-link-role": ["relates_to", "parent", "satisfies", "verifies"],
+        "testing/testrun-type": ["manual", "automated"],
+        "testing/testrun-status": ["open", "inProgress", "finished"],
     },
 )

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -36,7 +36,11 @@ from mcp_server_polarion.models.links import (
     WorkItemLinkUpdateSpec,
 )
 from mcp_server_polarion.models.projects import ProjectSummary
-from mcp_server_polarion.models.test_runs import TestRunSummary
+from mcp_server_polarion.models.test_runs import (
+    TestRunCreateSpec,
+    TestRunsCreateResult,
+    TestRunSummary,
+)
 from mcp_server_polarion.models.work_items import (
     Hyperlink,
     SqlRecipeGallery,
@@ -67,7 +71,9 @@ __all__: list[str] = [
     "PaginatedResult",
     "ProjectSummary",
     "SqlRecipeGallery",
+    "TestRunCreateSpec",
     "TestRunSummary",
+    "TestRunsCreateResult",
     "WorkItemCommentSpec",
     "WorkItemCreateSpec",
     "WorkItemDetail",

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -10,8 +10,7 @@ from pydantic import BaseModel, Field
 class TestRunSummary(BaseModel):
     """Compact test-run representation for list results."""
 
-    # Test*-named models look like test classes to pytest when imported into
-    # a test module; __test__ = False opts every importer out at the source.
+    # pytest collects Test*-named classes as tests on import; opt out here.
     __test__ = False
 
     id: str

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -1,8 +1,10 @@
-"""Test run models — compact summaries for list results."""
+"""Test run models — summaries, create specs, and write results."""
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from collections.abc import Mapping
+
+from pydantic import BaseModel, Field
 
 
 class TestRunSummary(BaseModel):
@@ -16,3 +18,26 @@ class TestRunSummary(BaseModel):
     updated: str = ""
     author_name: str = ""
     is_template: bool = False
+
+
+class TestRunCreateSpec(BaseModel):
+    """One test run to create via ``create_test_runs``."""
+
+    id: str = Field(min_length=1)
+    title: str | None = None
+    type: str | None = None
+    status: str | None = None
+    template_id: str | None = Field(
+        default=None,
+        description="Same-project template run id; the run inherits its config.",
+    )
+    custom_fields: dict[str, object] | None = None
+
+
+class TestRunsCreateResult(BaseModel):
+    """Result of a ``create_test_runs`` operation."""
+
+    created: bool
+    dry_run: bool
+    test_run_ids: list[str] = Field(default_factory=list)
+    payload_preview: Mapping[str, object] | None = None

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -10,6 +10,10 @@ from pydantic import BaseModel, Field
 class TestRunSummary(BaseModel):
     """Compact test-run representation for list results."""
 
+    # Test*-named models look like test classes to pytest when imported into
+    # a test module; __test__ = False opts every importer out at the source.
+    __test__ = False
+
     id: str
     title: str
     type: str
@@ -22,6 +26,8 @@ class TestRunSummary(BaseModel):
 
 class TestRunCreateSpec(BaseModel):
     """One test run to create via ``create_test_runs``."""
+
+    __test__ = False
 
     id: str = Field(min_length=1)
     title: str | None = None
@@ -36,6 +42,8 @@ class TestRunCreateSpec(BaseModel):
 
 class TestRunsCreateResult(BaseModel):
     """Result of a ``create_test_runs`` operation."""
+
+    __test__ = False
 
     created: bool
     dry_run: bool

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -1,6 +1,9 @@
 """In-process TTL caches for near-static project facts, sparing the server's
 tight budget (<=3 req/s, no concurrency). Owns ALL cache state; tool logic
 reaches it only through the typed get / store wrappers.
+
+Layout: the ``TTLCache`` primitive and shared types first, then one block per
+cache — its module-level instance immediately followed by its wrappers.
 """
 
 from __future__ import annotations
@@ -76,28 +79,11 @@ _ENUM_NOT_FOUND_TTL_SECONDS: Final[float] = 600.0
 # New documents must surface within ~1 min (create also invalidates on write).
 _DOCUMENT_LIST_TTL_SECONDS: Final[float] = 60.0
 
+
 # project_id -> discovered documents in display order.
 _document_list_cache: TTLCache[str, tuple[DiscoveredDocument, ...]] = TTLCache(
     _DOCUMENT_LIST_TTL_SECONDS
 )
-# (project, resource, field, type) -> valid option ids.
-_enum_option_cache: TTLCache[tuple[str, Resource, str, str], frozenset[str]] = TTLCache(
-    _GUARD_TTL_SECONDS
-)
-# (project, enum_name) -> project-level enum option ids (no type axis).
-_project_enum_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
-    _GUARD_TTL_SECONDS
-)
-# (project, work_item_type) -> full custom-field key schema (MIN-per-key sample).
-_work_item_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
-    _GUARD_TTL_SECONDS
-)
-# (project, document_type) -> custom-field key schema; document-side mirror.
-_document_type_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
-    _GUARD_TTL_SECONDS
-)
-# project -> testrun custom-field key schema (project config, no type axis).
-_test_run_custom_key_cache: TTLCache[str, frozenset[str]] = TTLCache(_GUARD_TTL_SECONDS)
 
 
 def get_cached_documents(project_id: str) -> list[DiscoveredDocument] | None:
@@ -117,6 +103,12 @@ def store_cached_documents(
 def invalidate_documents_cache(project_id: str) -> None:
     """Drop the cached document list for *project_id*, if any."""
     _document_list_cache.invalidate(project_id)
+
+
+# (project, resource, field, type) -> valid option ids.
+_enum_option_cache: TTLCache[tuple[str, Resource, str, str], frozenset[str]] = TTLCache(
+    _GUARD_TTL_SECONDS
+)
 
 
 def get_cached_enum_options(
@@ -148,6 +140,12 @@ def store_cached_enum_options(  # noqa: PLR0913
     )
 
 
+# (project, enum_name) -> project-level enum option ids (no type axis).
+_project_enum_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
+    _GUARD_TTL_SECONDS
+)
+
+
 def get_cached_project_enum(
     project_id: str,
     enum_name: str,
@@ -163,6 +161,12 @@ def store_cached_project_enum(
 ) -> None:
     """Cache the valid option ids for the project enum for ``_GUARD_TTL_SECONDS``."""
     _project_enum_cache.set((project_id, enum_name), option_ids)
+
+
+# (project, work_item_type) -> full custom-field key schema (MIN-per-key sample).
+_work_item_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
+    _GUARD_TTL_SECONDS
+)
 
 
 def get_work_item_custom_keys(
@@ -189,6 +193,12 @@ def invalidate_work_item_custom_keys(project_id: str, work_item_type: str) -> No
     _work_item_custom_key_cache.invalidate((project_id, work_item_type))
 
 
+# (project, document_type) -> custom-field key schema; document-side mirror.
+_document_type_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
+    _GUARD_TTL_SECONDS
+)
+
+
 def get_document_type_custom_keys(
     project_id: str,
     document_type: str,
@@ -211,6 +221,10 @@ def store_document_type_custom_keys(
 def invalidate_document_type_custom_keys(project_id: str, document_type: str) -> None:
     """Drop the cached schema for ``(project, document_type)`` (bypass-retry)."""
     _document_type_custom_key_cache.invalidate((project_id, document_type))
+
+
+# project -> testrun custom-field key schema (project config, no type axis).
+_test_run_custom_key_cache: TTLCache[str, frozenset[str]] = TTLCache(_GUARD_TTL_SECONDS)
 
 
 def get_test_run_custom_keys(project_id: str) -> frozenset[str] | None:

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -96,6 +96,8 @@ _work_item_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCach
 _document_type_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
     _GUARD_TTL_SECONDS
 )
+# project -> testrun custom-field key schema (project config, no type axis).
+_test_run_custom_key_cache: TTLCache[str, frozenset[str]] = TTLCache(_GUARD_TTL_SECONDS)
 
 
 def get_cached_documents(project_id: str) -> list[DiscoveredDocument] | None:
@@ -211,6 +213,23 @@ def invalidate_document_type_custom_keys(project_id: str, document_type: str) ->
     _document_type_custom_key_cache.invalidate((project_id, document_type))
 
 
+def get_test_run_custom_keys(project_id: str) -> frozenset[str] | None:
+    """Return the cached testrun custom-field key schema, or ``None`` on miss."""
+    return _test_run_custom_key_cache.get(project_id)
+
+
+def store_test_run_custom_keys(project_id: str, keys: frozenset[str]) -> None:
+    """Replace any prior set — each sample is the full key set, so an admin
+    removal shrinks the schema on expiry.
+    """
+    _test_run_custom_key_cache.set(project_id, keys)
+
+
+def invalidate_test_run_custom_keys(project_id: str) -> None:
+    """Drop the cached testrun schema for *project_id* (used by the bypass-retry)."""
+    _test_run_custom_key_cache.invalidate(project_id)
+
+
 __all__ = [
     "DiscoveredDocument",
     "Resource",
@@ -219,13 +238,16 @@ __all__ = [
     "get_cached_enum_options",
     "get_cached_project_enum",
     "get_document_type_custom_keys",
+    "get_test_run_custom_keys",
     "get_work_item_custom_keys",
     "invalidate_document_type_custom_keys",
     "invalidate_documents_cache",
+    "invalidate_test_run_custom_keys",
     "invalidate_work_item_custom_keys",
     "store_cached_documents",
     "store_cached_enum_options",
     "store_cached_project_enum",
     "store_document_type_custom_keys",
+    "store_test_run_custom_keys",
     "store_work_item_custom_keys",
 ]

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -1,9 +1,6 @@
 """In-process TTL caches for near-static project facts, sparing the server's
 tight budget (<=3 req/s, no concurrency). Owns ALL cache state; tool logic
 reaches it only through the typed get / store wrappers.
-
-Layout: the ``TTLCache`` primitive and shared types first, then one block per
-cache — its module-level instance immediately followed by its wrappers.
 """
 
 from __future__ import annotations

--- a/src/mcp_server_polarion/tools/_shared/custom_fields.py
+++ b/src/mcp_server_polarion/tools/_shared/custom_fields.py
@@ -60,8 +60,7 @@ STANDARD_DOCUMENT_ATTRIBUTES: Final[frozenset[str]] = frozenset(
 )
 
 
-# Test-run mirror; testrun custom fields (e.g. rich-text description/goal on
-# default projects) sit inline under attributes just like work items.
+# Testrun custom fields sit inline under attributes, like work items.
 STANDARD_TEST_RUN_ATTRIBUTES: Final[frozenset[str]] = frozenset(
     {
         "id",

--- a/src/mcp_server_polarion/tools/_shared/custom_fields.py
+++ b/src/mcp_server_polarion/tools/_shared/custom_fields.py
@@ -60,6 +60,29 @@ STANDARD_DOCUMENT_ATTRIBUTES: Final[frozenset[str]] = frozenset(
 )
 
 
+# Test-run mirror; testrun custom fields (e.g. rich-text description/goal on
+# default projects) sit inline under attributes just like work items.
+STANDARD_TEST_RUN_ATTRIBUTES: Final[frozenset[str]] = frozenset(
+    {
+        "id",
+        "type",
+        "title",
+        "status",
+        "created",
+        "updated",
+        "finishedOn",
+        "groupId",
+        "homePageContent",
+        "idPrefix",
+        "isTemplate",
+        "keepInHistory",
+        "query",
+        "selectTestCasesBy",
+        "useReportFromTemplate",
+    }
+)
+
+
 def extract_custom_fields(
     attributes: dict[str, object],
     standard: frozenset[str],
@@ -99,6 +122,7 @@ def merge_custom_fields(
 
 __all__: list[str] = [
     "STANDARD_DOCUMENT_ATTRIBUTES",
+    "STANDARD_TEST_RUN_ATTRIBUTES",
     "STANDARD_WORK_ITEM_ATTRIBUTES",
     "extract_custom_fields",
     "merge_custom_fields",

--- a/src/mcp_server_polarion/tools/_shared/guard.py
+++ b/src/mcp_server_polarion/tools/_shared/guard.py
@@ -4,9 +4,6 @@ real options and raises before the write. Fail-closed — validation error block
 the write (auth → ``PermissionError``, else ``RuntimeError``); only a
 *successful* empty option set and a 404 defer to Polarion. Caching in
 :mod:`...tools._shared.cache`.
-
-Layout: shared fail-closed helpers and option fetchers first, then the guards
-grouped by domain — work items, documents, test runs, links.
 """
 
 from __future__ import annotations

--- a/src/mcp_server_polarion/tools/_shared/guard.py
+++ b/src/mcp_server_polarion/tools/_shared/guard.py
@@ -4,6 +4,9 @@ real options and raises before the write. Fail-closed — validation error block
 the write (auth → ``PermissionError``, else ``RuntimeError``); only a
 *successful* empty option set and a 404 defer to Polarion. Caching in
 :mod:`...tools._shared.cache`.
+
+Layout: shared fail-closed helpers and option fetchers first, then the guards
+grouped by domain — work items, documents, test runs, links.
 """
 
 from __future__ import annotations
@@ -182,57 +185,92 @@ async def _check_enum(  # noqa: PLR0913
     )
 
 
-async def guard_work_item_enums(  # noqa: PLR0913
+async def fetch_project_enum_option_ids(
     client: PolarionClient,
     project_id: str,
-    work_item_type: str,
-    *,
-    type: str | None = None,
-    status: str | None = None,
-    severity: str | None = None,
-    priority: str | None = None,
-    resolution: str | None = None,
-) -> None:
-    """Validate supplied work-item enum args against ``getAvailableOptions``.
-
-    ``work_item_type`` scopes status/severity/resolution/priority (``'~'`` =
-    type-agnostic); ``type`` checked first so an invalid type raises before
-    being reused as the scoping axis.
+    enum_name: str,
+    context: str = "~",
+) -> frozenset[str]:
+    """Valid option ids for a project-level enum not in ``getAvailableOptions``
+    (link/hyperlink role, testrun type/status). ``context`` is the enumeration
+    context path segment (``testing`` for testrun enums; ``~`` does NOT
+    resolve them). Response ``data`` is a dict (not list), options at
+    ``data.attributes.options[].id``. Cached; fail-closed like
+    :func:`fetch_enum_option_ids`.
     """
-    if type is not None and type != "":
-        await _check_enum(client, project_id, "workitems", "type", "~", type)
-    if status is not None and status != "":
-        await _check_enum(
-            client, project_id, "workitems", "status", work_item_type, status
+    cache_key = f"{context}/{enum_name}"
+    cached = get_cached_project_enum(project_id, cache_key)
+    if cached is not None:
+        return cached
+
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/enumerations/{encode_path_segment(context)}"
+        f"/{encode_path_segment(enum_name)}/~"
+    )
+    try:
+        response = await client.get(path, params={"fields[enumerations]": "@all"})
+    except PolarionNotFoundError:
+        logger.warning(
+            "enumeration '%s' returned 404 for project=%s; skipping role "
+            "validation -- the enumeration is unsupported here, so there is "
+            "nothing to validate against.",
+            enum_name,
+            project_id,
         )
-    if severity is not None and severity != "":
-        await _check_enum(
-            client, project_id, "workitems", "severity", work_item_type, severity
-        )
-    if priority is not None and priority != "":
-        await _check_enum(
-            client, project_id, "workitems", "priority", work_item_type, priority
-        )
-    if resolution is not None and resolution != "":
-        await _check_enum(
-            client, project_id, "workitems", "resolution", work_item_type, resolution
-        )
+        store_cached_project_enum(project_id, cache_key, frozenset())
+        return frozenset()
+    except PolarionAuthError as exc:
+        raise _unauthorized_write_block(f"{enum_name} options", project_id) from exc
+    except PolarionError as exc:
+        raise _unreachable_write_block(f"{enum_name} options", project_id, exc) from exc
+
+    ids: set[str] = set()
+    data = response.get("data", {})
+    if isinstance(data, dict):
+        attributes = data.get("attributes")
+        options = attributes.get("options") if isinstance(attributes, dict) else None
+        if isinstance(options, list):
+            for entry in options:
+                if not isinstance(entry, dict):
+                    continue
+                opt_id = entry.get("id")
+                if isinstance(opt_id, str) and opt_id:
+                    ids.add(opt_id)
+
+    option_ids = frozenset(ids)
+    store_cached_project_enum(project_id, cache_key, option_ids)
+    return option_ids
 
 
-async def guard_document_enums(
+async def _check_project_enum_roles(  # noqa: PLR0913
     client: PolarionClient,
     project_id: str,
-    document_type: str,
+    enum_name: str,
+    roles: Iterable[str],
     *,
-    type: str | None = None,
-    status: str | None = None,
+    field_label: str,
+    discovery_hint: str,
+    context: str = "~",
 ) -> None:
-    """Validate every supplied document enum arg against ``getAvailableOptions``."""
-    if type is not None and type != "":
-        await _check_enum(client, project_id, "documents", "type", "~", type)
-    if status is not None and status != "":
-        await _check_enum(
-            client, project_id, "documents", "status", document_type, status
+    requested = {role for role in roles if role}
+    if not requested:
+        return
+
+    option_ids = await fetch_project_enum_option_ids(
+        client, project_id, enum_name, context
+    )
+    # Empty set = no options / enum unsupported; defer.
+    if not option_ids:
+        return
+
+    unknown = sorted(requested - option_ids)
+    if unknown:
+        raise ValueError(
+            f"{field_label} id(s) {unknown} are not valid in project "
+            f"'{project_id}'. Valid options: {format_option_list(option_ids)}. "
+            f"An unknown {field_label} ghosts silently (never matches Lucene) "
+            f"-- {discovery_hint}"
         )
 
 
@@ -347,6 +385,43 @@ def _custom_keys_from_data_list(
     return frozenset(keys)
 
 
+async def guard_work_item_enums(  # noqa: PLR0913
+    client: PolarionClient,
+    project_id: str,
+    work_item_type: str,
+    *,
+    type: str | None = None,
+    status: str | None = None,
+    severity: str | None = None,
+    priority: str | None = None,
+    resolution: str | None = None,
+) -> None:
+    """Validate supplied work-item enum args against ``getAvailableOptions``.
+
+    ``work_item_type`` scopes status/severity/resolution/priority (``'~'`` =
+    type-agnostic); ``type`` checked first so an invalid type raises before
+    being reused as the scoping axis.
+    """
+    if type is not None and type != "":
+        await _check_enum(client, project_id, "workitems", "type", "~", type)
+    if status is not None and status != "":
+        await _check_enum(
+            client, project_id, "workitems", "status", work_item_type, status
+        )
+    if severity is not None and severity != "":
+        await _check_enum(
+            client, project_id, "workitems", "severity", work_item_type, severity
+        )
+    if priority is not None and priority != "":
+        await _check_enum(
+            client, project_id, "workitems", "priority", work_item_type, priority
+        )
+    if resolution is not None and resolution != "":
+        await _check_enum(
+            client, project_id, "workitems", "resolution", work_item_type, resolution
+        )
+
+
 async def _fetch_work_item_type_custom_keys(
     client: PolarionClient,
     project_id: str,
@@ -458,6 +533,23 @@ async def guard_work_item_custom_fields(
     await _check_custom_field_enum_values(
         client, project_id, "workitems", work_item_type, custom_fields
     )
+
+
+async def guard_document_enums(
+    client: PolarionClient,
+    project_id: str,
+    document_type: str,
+    *,
+    type: str | None = None,
+    status: str | None = None,
+) -> None:
+    """Validate every supplied document enum arg against ``getAvailableOptions``."""
+    if type is not None and type != "":
+        await _check_enum(client, project_id, "documents", "type", "~", type)
+    if status is not None and status != "":
+        await _check_enum(
+            client, project_id, "documents", "status", document_type, status
+        )
 
 
 async def _fetch_document_type_custom_keys(
@@ -578,201 +670,6 @@ async def guard_document_custom_fields(
     await _check_document_custom_keys(client, project_id, document_type, custom_fields)
     await _check_custom_field_enum_values(
         client, project_id, "documents", document_type, custom_fields
-    )
-
-
-async def _existing_target_ids(
-    client: PolarionClient,
-    project_id: str,
-    target_ids: frozenset[str],
-) -> frozenset[str]:
-    """Subset of *target_ids* that exist in *project_id*, via chunked
-    ``id:(...)`` queries. 404 (project missing) propagates to caller.
-    """
-    ordered = sorted(target_ids)
-    found: set[str] = set()
-    for start in range(0, len(ordered), _GUARD_PAGE_SIZE):
-        chunk = ordered[start : start + _GUARD_PAGE_SIZE]
-        params: dict[str, str | int] = {
-            "query": f"id:({' '.join(chunk)})",
-            "fields[workitems]": "id",
-            "page[size]": _GUARD_PAGE_SIZE,
-            "page[number]": 1,
-        }
-        path = f"/projects/{encode_path_segment(project_id)}/workitems"
-        response = await client.get(path, params=params)
-        data = response.get("data", [])
-        if isinstance(data, list):
-            for entry in data:
-                if isinstance(entry, dict):
-                    found.add(extract_short_id(safe_str(entry.get("id", ""))))
-    return frozenset(found)
-
-
-async def guard_work_item_link_targets(
-    client: PolarionClient,
-    source_project_id: str,
-    links: list[WorkItemLinkSpec],
-) -> None:
-    """Reject links whose target work item does not exist — Polarion stores a
-    nonexistent target as a silent dangling link (HTTP 201, empty
-    title/type/status). One ``id:(...)`` query per target project.
-    """
-    by_project: dict[str, set[str]] = {}
-    for spec in links:
-        target_project = spec.target_project_id or source_project_id
-        by_project.setdefault(target_project, set()).add(spec.target_work_item_id)
-
-    missing: list[str] = []
-    for project_id, requested in by_project.items():
-        try:
-            existing = await _existing_target_ids(
-                client, project_id, frozenset(requested)
-            )
-        except PolarionNotFoundError:
-            missing.extend(f"{project_id}/{wi}" for wi in sorted(requested))
-            continue
-        except PolarionAuthError as exc:
-            raise _unauthorized_write_block("link targets", project_id) from exc
-        except PolarionError as exc:
-            raise _unreachable_write_block("link targets", project_id, exc) from exc
-        missing.extend(f"{project_id}/{wi}" for wi in sorted(requested - existing))
-
-    if missing:
-        raise ValueError(
-            f"Link target work item(s) {format_option_list(missing)} do not exist. "
-            f"A nonexistent target stores as a silent dangling link (HTTP 201, empty "
-            f"title/type/status) -- use list_work_items to find valid target ids first."
-        )
-
-
-async def fetch_project_enum_option_ids(
-    client: PolarionClient,
-    project_id: str,
-    enum_name: str,
-    context: str = "~",
-) -> frozenset[str]:
-    """Valid option ids for a project-level enum not in ``getAvailableOptions``
-    (link/hyperlink role, testrun type/status). ``context`` is the enumeration
-    context path segment (``testing`` for testrun enums; ``~`` does NOT
-    resolve them). Response ``data`` is a dict (not list), options at
-    ``data.attributes.options[].id``. Cached; fail-closed like
-    :func:`fetch_enum_option_ids`.
-    """
-    cache_key = f"{context}/{enum_name}"
-    cached = get_cached_project_enum(project_id, cache_key)
-    if cached is not None:
-        return cached
-
-    path = (
-        f"/projects/{encode_path_segment(project_id)}"
-        f"/enumerations/{encode_path_segment(context)}"
-        f"/{encode_path_segment(enum_name)}/~"
-    )
-    try:
-        response = await client.get(path, params={"fields[enumerations]": "@all"})
-    except PolarionNotFoundError:
-        logger.warning(
-            "enumeration '%s' returned 404 for project=%s; skipping role "
-            "validation -- the enumeration is unsupported here, so there is "
-            "nothing to validate against.",
-            enum_name,
-            project_id,
-        )
-        store_cached_project_enum(project_id, cache_key, frozenset())
-        return frozenset()
-    except PolarionAuthError as exc:
-        raise _unauthorized_write_block(f"{enum_name} options", project_id) from exc
-    except PolarionError as exc:
-        raise _unreachable_write_block(f"{enum_name} options", project_id, exc) from exc
-
-    ids: set[str] = set()
-    data = response.get("data", {})
-    if isinstance(data, dict):
-        attributes = data.get("attributes")
-        options = attributes.get("options") if isinstance(attributes, dict) else None
-        if isinstance(options, list):
-            for entry in options:
-                if not isinstance(entry, dict):
-                    continue
-                opt_id = entry.get("id")
-                if isinstance(opt_id, str) and opt_id:
-                    ids.add(opt_id)
-
-    option_ids = frozenset(ids)
-    store_cached_project_enum(project_id, cache_key, option_ids)
-    return option_ids
-
-
-async def _check_project_enum_roles(  # noqa: PLR0913
-    client: PolarionClient,
-    project_id: str,
-    enum_name: str,
-    roles: Iterable[str],
-    *,
-    field_label: str,
-    discovery_hint: str,
-    context: str = "~",
-) -> None:
-    requested = {role for role in roles if role}
-    if not requested:
-        return
-
-    option_ids = await fetch_project_enum_option_ids(
-        client, project_id, enum_name, context
-    )
-    # Empty set = no options / enum unsupported; defer.
-    if not option_ids:
-        return
-
-    unknown = sorted(requested - option_ids)
-    if unknown:
-        raise ValueError(
-            f"{field_label} id(s) {unknown} are not valid in project "
-            f"'{project_id}'. Valid options: {format_option_list(option_ids)}. "
-            f"An unknown {field_label} ghosts silently (never matches Lucene) "
-            f"-- {discovery_hint}"
-        )
-
-
-async def guard_work_item_link_roles(
-    client: PolarionClient,
-    project_id: str,
-    roles: Iterable[str],
-) -> None:
-    """Reject link roles not in ``workitem-link-role`` — an unknown role stores
-    verbatim (HTTP 201) as a ghost link.
-    """
-    await _check_project_enum_roles(
-        client,
-        project_id,
-        "workitem-link-role",
-        roles,
-        field_label="role",
-        discovery_hint=(
-            "read an existing link with list_work_item_links to see the "
-            "project's configured roles."
-        ),
-    )
-
-
-async def guard_hyperlink_roles(
-    client: PolarionClient,
-    project_id: str,
-    roles: Iterable[str],
-) -> None:
-    """Reject hyperlink roles not in the project's ``hyperlink-role`` enum
-    (typically ``ref_int``/``ref_ext``) — unknown roles ghost silently.
-    """
-    await _check_project_enum_roles(
-        client,
-        project_id,
-        "hyperlink-role",
-        roles,
-        field_label="hyperlink role",
-        discovery_hint=(
-            "use a configured id such as 'ref_int' (internal) or 'ref_ext' (external)."
-        ),
     )
 
 
@@ -946,6 +843,112 @@ async def guard_test_run_custom_fields(
     if not custom_fields:
         return
     await _check_test_run_custom_keys(client, project_id, custom_fields)
+
+
+async def guard_work_item_link_roles(
+    client: PolarionClient,
+    project_id: str,
+    roles: Iterable[str],
+) -> None:
+    """Reject link roles not in ``workitem-link-role`` — an unknown role stores
+    verbatim (HTTP 201) as a ghost link.
+    """
+    await _check_project_enum_roles(
+        client,
+        project_id,
+        "workitem-link-role",
+        roles,
+        field_label="role",
+        discovery_hint=(
+            "read an existing link with list_work_item_links to see the "
+            "project's configured roles."
+        ),
+    )
+
+
+async def guard_hyperlink_roles(
+    client: PolarionClient,
+    project_id: str,
+    roles: Iterable[str],
+) -> None:
+    """Reject hyperlink roles not in the project's ``hyperlink-role`` enum
+    (typically ``ref_int``/``ref_ext``) — unknown roles ghost silently.
+    """
+    await _check_project_enum_roles(
+        client,
+        project_id,
+        "hyperlink-role",
+        roles,
+        field_label="hyperlink role",
+        discovery_hint=(
+            "use a configured id such as 'ref_int' (internal) or 'ref_ext' (external)."
+        ),
+    )
+
+
+async def _existing_target_ids(
+    client: PolarionClient,
+    project_id: str,
+    target_ids: frozenset[str],
+) -> frozenset[str]:
+    """Subset of *target_ids* that exist in *project_id*, via chunked
+    ``id:(...)`` queries. 404 (project missing) propagates to caller.
+    """
+    ordered = sorted(target_ids)
+    found: set[str] = set()
+    for start in range(0, len(ordered), _GUARD_PAGE_SIZE):
+        chunk = ordered[start : start + _GUARD_PAGE_SIZE]
+        params: dict[str, str | int] = {
+            "query": f"id:({' '.join(chunk)})",
+            "fields[workitems]": "id",
+            "page[size]": _GUARD_PAGE_SIZE,
+            "page[number]": 1,
+        }
+        path = f"/projects/{encode_path_segment(project_id)}/workitems"
+        response = await client.get(path, params=params)
+        data = response.get("data", [])
+        if isinstance(data, list):
+            for entry in data:
+                if isinstance(entry, dict):
+                    found.add(extract_short_id(safe_str(entry.get("id", ""))))
+    return frozenset(found)
+
+
+async def guard_work_item_link_targets(
+    client: PolarionClient,
+    source_project_id: str,
+    links: list[WorkItemLinkSpec],
+) -> None:
+    """Reject links whose target work item does not exist — Polarion stores a
+    nonexistent target as a silent dangling link (HTTP 201, empty
+    title/type/status). One ``id:(...)`` query per target project.
+    """
+    by_project: dict[str, set[str]] = {}
+    for spec in links:
+        target_project = spec.target_project_id or source_project_id
+        by_project.setdefault(target_project, set()).add(spec.target_work_item_id)
+
+    missing: list[str] = []
+    for project_id, requested in by_project.items():
+        try:
+            existing = await _existing_target_ids(
+                client, project_id, frozenset(requested)
+            )
+        except PolarionNotFoundError:
+            missing.extend(f"{project_id}/{wi}" for wi in sorted(requested))
+            continue
+        except PolarionAuthError as exc:
+            raise _unauthorized_write_block("link targets", project_id) from exc
+        except PolarionError as exc:
+            raise _unreachable_write_block("link targets", project_id, exc) from exc
+        missing.extend(f"{project_id}/{wi}" for wi in sorted(requested - existing))
+
+    if missing:
+        raise ValueError(
+            f"Link target work item(s) {format_option_list(missing)} do not exist. "
+            f"A nonexistent target stores as a silent dangling link (HTTP 201, empty "
+            f"title/type/status) -- use list_work_items to find valid target ids first."
+        )
 
 
 async def _existing_forward_link_ids(

--- a/src/mcp_server_polarion/tools/_shared/guard.py
+++ b/src/mcp_server_polarion/tools/_shared/guard.py
@@ -23,16 +23,20 @@ from mcp_server_polarion.tools._shared.cache import (
     get_cached_enum_options,
     get_cached_project_enum,
     get_document_type_custom_keys,
+    get_test_run_custom_keys,
     get_work_item_custom_keys,
     invalidate_document_type_custom_keys,
+    invalidate_test_run_custom_keys,
     invalidate_work_item_custom_keys,
     store_cached_enum_options,
     store_cached_project_enum,
     store_document_type_custom_keys,
+    store_test_run_custom_keys,
     store_work_item_custom_keys,
 )
 from mcp_server_polarion.tools._shared.custom_fields import (
     STANDARD_DOCUMENT_ATTRIBUTES,
+    STANDARD_TEST_RUN_ATTRIBUTES,
     STANDARD_WORK_ITEM_ATTRIBUTES,
 )
 from mcp_server_polarion.tools._shared.fields import (
@@ -646,19 +650,24 @@ async def fetch_project_enum_option_ids(
     client: PolarionClient,
     project_id: str,
     enum_name: str,
+    context: str = "~",
 ) -> frozenset[str]:
     """Valid option ids for a project-level enum not in ``getAvailableOptions``
-    (link/hyperlink role). Response ``data`` is a dict (not list), options at
+    (link/hyperlink role, testrun type/status). ``context`` is the enumeration
+    context path segment (``testing`` for testrun enums; ``~`` does NOT
+    resolve them). Response ``data`` is a dict (not list), options at
     ``data.attributes.options[].id``. Cached; fail-closed like
     :func:`fetch_enum_option_ids`.
     """
-    cached = get_cached_project_enum(project_id, enum_name)
+    cache_key = f"{context}/{enum_name}"
+    cached = get_cached_project_enum(project_id, cache_key)
     if cached is not None:
         return cached
 
     path = (
         f"/projects/{encode_path_segment(project_id)}"
-        f"/enumerations/~/{encode_path_segment(enum_name)}/~"
+        f"/enumerations/{encode_path_segment(context)}"
+        f"/{encode_path_segment(enum_name)}/~"
     )
     try:
         response = await client.get(path, params={"fields[enumerations]": "@all"})
@@ -670,7 +679,7 @@ async def fetch_project_enum_option_ids(
             enum_name,
             project_id,
         )
-        store_cached_project_enum(project_id, enum_name, frozenset())
+        store_cached_project_enum(project_id, cache_key, frozenset())
         return frozenset()
     except PolarionAuthError as exc:
         raise _unauthorized_write_block(f"{enum_name} options", project_id) from exc
@@ -691,7 +700,7 @@ async def fetch_project_enum_option_ids(
                     ids.add(opt_id)
 
     option_ids = frozenset(ids)
-    store_cached_project_enum(project_id, enum_name, option_ids)
+    store_cached_project_enum(project_id, cache_key, option_ids)
     return option_ids
 
 
@@ -703,12 +712,15 @@ async def _check_project_enum_roles(  # noqa: PLR0913
     *,
     field_label: str,
     discovery_hint: str,
+    context: str = "~",
 ) -> None:
     requested = {role for role in roles if role}
     if not requested:
         return
 
-    option_ids = await fetch_project_enum_option_ids(client, project_id, enum_name)
+    option_ids = await fetch_project_enum_option_ids(
+        client, project_id, enum_name, context
+    )
     # Empty set = no options / enum unsupported; defer.
     if not option_ids:
         return
@@ -762,6 +774,178 @@ async def guard_hyperlink_roles(
             "use a configured id such as 'ref_int' (internal) or 'ref_ext' (external)."
         ),
     )
+
+
+async def guard_test_run_enums(
+    client: PolarionClient,
+    project_id: str,
+    *,
+    type: str | None = None,
+    status: str | None = None,
+) -> None:
+    """Validate test-run ``type``/``status`` against the ``testing``-context
+    project enumerations — testruns have no ``getAvailableOptions`` endpoint,
+    and the ``~`` wildcard context does not resolve these enums.
+    """
+    await _check_project_enum_roles(
+        client,
+        project_id,
+        "testrun-type",
+        [type] if type else [],
+        field_label="test run type",
+        discovery_hint="use list_test_runs to see values in use.",
+        context="testing",
+    )
+    await _check_project_enum_roles(
+        client,
+        project_id,
+        "testrun-status",
+        [status] if status else [],
+        field_label="test run status",
+        discovery_hint="use list_test_runs to see values in use.",
+        context="testing",
+    )
+
+
+async def guard_test_run_templates(
+    client: PolarionClient,
+    project_id: str,
+    template_ids: Iterable[str],
+) -> None:
+    """Resolve each template id before the write — Polarion doesn't validate
+    relationship targets. Run instances are rejected too: ``isTemplate`` is
+    served only (as ``true``) on templates, absent on instances.
+    """
+    for template_id in sorted({t for t in template_ids if t}):
+        path = (
+            f"/projects/{encode_path_segment(project_id)}"
+            f"/testruns/{encode_path_segment(template_id)}"
+        )
+        try:
+            response = await client.get(
+                path, params={"fields[testruns]": "id,isTemplate"}
+            )
+        except PolarionNotFoundError as exc:
+            raise ValueError(
+                f"Test run template '{template_id}' not found in project "
+                f"'{project_id}'. Use list_test_runs(templates=True) to "
+                f"discover template ids."
+            ) from exc
+        except PolarionAuthError as exc:
+            raise _unauthorized_write_block("test run templates", project_id) from exc
+        except PolarionError as exc:
+            raise _unreachable_write_block(
+                "test run templates", project_id, exc
+            ) from exc
+
+        data = response.get("data", {})
+        attributes = data.get("attributes") if isinstance(data, dict) else None
+        is_template = (
+            attributes.get("isTemplate") if isinstance(attributes, dict) else None
+        )
+        if is_template is not True:
+            raise ValueError(
+                f"Test run '{template_id}' in project '{project_id}' is a run "
+                f"instance, not a template. Use list_test_runs(templates=True) "
+                f"to discover template ids."
+            )
+
+
+async def _fetch_test_run_custom_keys(
+    client: PolarionClient,
+    project_id: str,
+) -> frozenset[str]:
+    """Union of custom-field keys sampled from the project's runs and
+    templates — testrun custom fields are project config (no type axis, no
+    SQL needed). Cached even if empty.
+    """
+    path = f"/projects/{encode_path_segment(project_id)}/testruns"
+    keys: set[str] = set()
+    for templates in (False, True):
+        base_params: dict[str, str | int] = {
+            "fields[testruns]": "@all",
+            "page[size]": _GUARD_PAGE_SIZE,
+        }
+        if templates:
+            base_params["templates"] = "true"
+        page_number = 1
+        while True:
+            try:
+                response = await client.get(
+                    path, params={**base_params, "page[number]": page_number}
+                )
+            except PolarionAuthError as exc:
+                raise _unauthorized_write_block(
+                    "custom_fields keys", project_id
+                ) from exc
+            except PolarionError as exc:
+                raise _unreachable_write_block(
+                    "custom_fields keys", project_id, exc
+                ) from exc
+            data = response.get("data", [])
+            if not isinstance(data, list):
+                break
+            keys.update(
+                _custom_keys_from_data_list(response, STANDARD_TEST_RUN_ATTRIBUTES)
+            )
+            if len(data) < _GUARD_PAGE_SIZE:
+                break
+            page_number += 1
+
+    result = frozenset(keys)
+    store_test_run_custom_keys(project_id, result)
+    return result
+
+
+async def _check_test_run_custom_keys(
+    client: PolarionClient,
+    project_id: str,
+    custom_fields: dict[str, object],
+) -> None:
+    """Test-run mirror of :func:`_check_work_item_custom_keys` (project scope)."""
+    schema = get_test_run_custom_keys(project_id)
+    fetched_fresh = schema is None
+    if schema is None:
+        schema = await _fetch_test_run_custom_keys(client, project_id)
+
+    if all(key in schema for key in custom_fields):
+        return
+
+    # Unknown key may be admin-added since caching; refetch once before rejecting.
+    if not fetched_fresh:
+        invalidate_test_run_custom_keys(project_id)
+        schema = await _fetch_test_run_custom_keys(client, project_id)
+
+    if not schema:
+        raise RuntimeError(
+            f"Cannot verify custom_fields {format_option_list(custom_fields)} for "
+            f"test runs in project '{project_id}': no existing test run has custom "
+            f"fields populated, so the schema can't be sampled. Refusing the write "
+            f"-- an unknown key ghosts silently (invisible to UI/Lucene). Do not "
+            f"create runs to work around this; ask the user to confirm these "
+            f"custom-field ids exist for test runs."
+        )
+
+    _reject_unknown_custom_keys(
+        custom_fields,
+        schema,
+        scope=f"test runs in project '{project_id}'",
+        discovery_tool="sample of existing runs",
+    )
+
+
+async def guard_test_run_custom_fields(
+    client: PolarionClient,
+    project_id: str,
+    custom_fields: dict[str, object],
+) -> None:
+    """Validate ``custom_fields`` keys before a test-run write. Keys only —
+    testruns have no ``getAvailableOptions``, so enum-typed *values* defer to
+    Polarion (wrong option ids there ghost; keys are the guardable axis).
+    """
+    if not custom_fields:
+        return
+    await _check_test_run_custom_keys(client, project_id, custom_fields)
 
 
 async def _existing_forward_link_ids(
@@ -850,6 +1034,9 @@ __all__ = [
     "guard_document_custom_fields",
     "guard_document_enums",
     "guard_hyperlink_roles",
+    "guard_test_run_custom_fields",
+    "guard_test_run_enums",
+    "guard_test_run_templates",
     "guard_work_item_custom_fields",
     "guard_work_item_enums",
     "guard_work_item_link_roles",

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -92,6 +92,23 @@ def extract_short_id(full_id: str) -> str:
     return full_id.rsplit("/", maxsplit=1)[-1]
 
 
+def extract_created_short_ids(response: dict[str, object]) -> list[str]:
+    """Short resource ids from a bulk 201 response, relying on Polarion echoing
+    ``data`` in submission order (call-site count check catches missing ids,
+    not reordered ones).
+    """
+    data = response.get("data")
+    if not isinstance(data, list):
+        return []
+    ids: list[str] = []
+    for item in data:
+        if isinstance(item, dict):
+            full_id = safe_str(item.get("id", ""))
+            if full_id:
+                ids.append(extract_short_id(full_id))
+    return ids
+
+
 def parse_included_work_item_map(
     response: dict[str, object],
 ) -> dict[str, dict[str, object]]:
@@ -377,6 +394,7 @@ def parse_enum_option(entry: dict[str, object]) -> EnumOption:
 
 __all__: list[str] = [
     "WorkItemSummaryKwargs",
+    "extract_created_short_ids",
     "extract_relationship_id",
     "extract_relationship_ids",
     "extract_short_id",

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -1,6 +1,8 @@
-"""Test run tools — list and search test runs in a project."""
+"""Test run tools — list, search, and create test runs in a project."""
 
 from __future__ import annotations
+
+from typing import cast
 
 from fastmcp import Context
 from pydantic import Field
@@ -10,9 +12,27 @@ from mcp_server_polarion.core.exceptions import (
     PolarionError,
     PolarionNotFoundError,
 )
-from mcp_server_polarion.models import PaginatedResult, TestRunSummary
+from mcp_server_polarion.models import (
+    JsonValue,
+    PaginatedResult,
+    TestRunCreateSpec,
+    TestRunsCreateResult,
+    TestRunSummary,
+)
 from mcp_server_polarion.server import mcp
-from mcp_server_polarion.tools._shared.fields import TEST_RUN_LIST_FIELDS
+from mcp_server_polarion.tools._shared.custom_fields import (
+    STANDARD_TEST_RUN_ATTRIBUTES,
+    merge_custom_fields,
+)
+from mcp_server_polarion.tools._shared.fields import (
+    MAX_BULK_ITEMS,
+    TEST_RUN_LIST_FIELDS,
+)
+from mcp_server_polarion.tools._shared.guard import (
+    guard_test_run_custom_fields,
+    guard_test_run_enums,
+    guard_test_run_templates,
+)
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     get_client,
@@ -21,7 +41,142 @@ from mcp_server_polarion.tools._shared.pagination import (
     DEFAULT_PAGE_SIZE,
     make_page,
 )
-from mcp_server_polarion.tools._shared.parse import parse_test_run_summaries
+from mcp_server_polarion.tools._shared.parse import (
+    extract_created_short_ids,
+    parse_test_run_summaries,
+)
+
+
+def _build_test_run_resource(
+    *,
+    project_id: str,
+    spec: TestRunCreateSpec,
+) -> dict[str, JsonValue]:
+    """One ``testruns`` resource for a bulk create POST; skips unset so the
+    template (or Polarion default) fills them.
+    """
+    attributes: dict[str, JsonValue] = {"id": spec.id}
+    if spec.title:
+        attributes["title"] = spec.title
+    if spec.type:
+        attributes["type"] = spec.type
+    if spec.status:
+        attributes["status"] = spec.status
+    merge_custom_fields(attributes, spec.custom_fields, STANDARD_TEST_RUN_ATTRIBUTES)
+
+    resource: dict[str, JsonValue] = {
+        "type": "testruns",
+        "attributes": attributes,
+    }
+    if spec.template_id:
+        resource["relationships"] = {
+            "template": {
+                "data": {
+                    "type": "testruns",
+                    "id": f"{project_id}/{spec.template_id}",
+                }
+            }
+        }
+    return resource
+
+
+def _build_create_test_runs_payload(
+    *,
+    project_id: str,
+    specs: list[TestRunCreateSpec],
+) -> dict[str, JsonValue]:
+    """JSON:API body for bulk ``POST /projects/{p}/testruns``."""
+    data: list[JsonValue] = [
+        _build_test_run_resource(project_id=project_id, spec=spec) for spec in specs
+    ]
+    return {"data": data}
+
+
+@mcp.tool(
+    tags={"write"},
+    timeout=60.0,
+    annotations={
+        # Additive: non-destructive; a retry 409s on the same explicit id.
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+async def create_test_runs(
+    ctx: Context,
+    project_id: str = Field(min_length=1, description="Polarion project ID."),
+    items: list[TestRunCreateSpec] = Field(  # noqa: B008
+        min_length=1,
+        max_length=MAX_BULK_ITEMS,
+        description="Test runs to create in one request (1-50).",
+    ),
+    dry_run: bool = Field(
+        default=False,
+        description="Preview payload without writing; guards still query Polarion.",
+    ),
+) -> TestRunsCreateResult:
+    """Create 1-50 test runs in one project in a single bulk request.
+
+    id is required per item (Polarion REST does not auto-generate one).
+    type/status are validated against the project's testing enumerations and
+    template_id against existing templates (list_test_runs(templates=True)) —
+    unknown ids raise ValueError. custom_fields keys are validated against a
+    sample of existing runs; enum-typed custom values are not (test runs have
+    no options API). Atomic: one bad item rejects the whole batch; an id-count
+    mismatch raises — re-query list_test_runs before retrying.
+    """
+    client = get_client(ctx)
+    for spec in items:
+        await guard_test_run_enums(
+            client, project_id, type=spec.type, status=spec.status
+        )
+    await guard_test_run_templates(
+        client, project_id, [spec.template_id for spec in items if spec.template_id]
+    )
+    for spec in items:
+        if spec.custom_fields:
+            await guard_test_run_custom_fields(client, project_id, spec.custom_fields)
+
+    payload = _build_create_test_runs_payload(project_id=project_id, specs=items)
+
+    if dry_run:
+        return TestRunsCreateResult(
+            created=False,
+            dry_run=True,
+            test_run_ids=[],
+            payload_preview=payload,
+        )
+
+    path = f"/projects/{encode_path_segment(project_id)}/testruns"
+    try:
+        response = await client.post(path, json=cast(dict[str, object], payload))
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot create test runs -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Project '{project_id}' not found. "
+            "Use `list_projects` to discover valid project IDs."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(f"Failed to create test runs: {exc.message}") from exc
+
+    new_ids = extract_created_short_ids(response)
+    if len(new_ids) != len(items):
+        raise RuntimeError(
+            f"Polarion accepted the bulk create but returned {len(new_ids)} "
+            f"ids for {len(items)} requested runs. The batch may be partially "
+            "created; verify with list_test_runs before retrying."
+        )
+
+    return TestRunsCreateResult(
+        created=True,
+        dry_run=False,
+        test_run_ids=new_ids,
+        payload_preview=None,
+    )
 
 
 @mcp.tool(

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -47,14 +47,13 @@ from mcp_server_polarion.tools._shared.guard import (
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     get_client,
-    safe_str,
 )
 from mcp_server_polarion.tools._shared.pagination import (
     DEFAULT_PAGE_SIZE,
     make_page,
 )
 from mcp_server_polarion.tools._shared.parse import (
-    extract_short_id,
+    extract_created_short_ids,
     parse_work_item_detail,
     parse_work_item_summaries,
 )
@@ -127,23 +126,6 @@ def _build_create_work_items_payload(
         for spec, html in zip(specs, descriptions_html, strict=True)
     ]
     return {"data": data}
-
-
-def _extract_created_work_item_ids(response: dict[str, object]) -> list[str]:
-    """Short work-item ids from a bulk 201 response, relying on Polarion echoing
-    ``data`` in submission order (call-site count check catches missing ids,
-    not reordered ones).
-    """
-    data = response.get("data")
-    if not isinstance(data, list):
-        return []
-    ids: list[str] = []
-    for item in data:
-        if isinstance(item, dict):
-            full_id = safe_str(item.get("id", ""))
-            if full_id:
-                ids.append(extract_short_id(full_id))
-    return ids
 
 
 def _build_update_work_item_payload(  # noqa: PLR0913
@@ -307,7 +289,7 @@ async def create_work_items(
     except PolarionError as exc:
         raise RuntimeError(f"Failed to create work items: {exc.message}") from exc
 
-    new_ids = _extract_created_work_item_ids(response)
+    new_ids = extract_created_short_ids(response)
     if len(new_ids) != len(items):
         raise RuntimeError(
             f"Polarion accepted the bulk create but returned {len(new_ids)} "

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -27,6 +27,7 @@ from evals.harness.fixtures import (
     SEEDS,
     SPACE,
     TEST_RUN_ID,
+    TEST_RUN_TEMPLATE_ID,
     TESTCASE_ID,
 )
 
@@ -191,8 +192,46 @@ class TestTestRunRouting:
             FakePolarion(), f"/projects/{PROJECT}/testruns", templates="true"
         )
         payload = _json(response)
-        assert payload["meta"]["totalCount"] == 0
-        assert payload["included"] == []
+        assert payload["meta"]["totalCount"] == 1
+        run = payload["data"][0]
+        assert run["id"].rsplit("/", 1)[-1] == TEST_RUN_TEMPLATE_ID
+        assert run["attributes"]["isTemplate"] is True
+
+    def test_single_template_serves_is_template(self) -> None:
+        response = _get(
+            FakePolarion(), f"/projects/{PROJECT}/testruns/{TEST_RUN_TEMPLATE_ID}"
+        )
+        assert response.status_code == 200
+        attributes = _json(response)["data"]["attributes"]
+        assert attributes["isTemplate"] is True
+
+    def test_single_instance_omits_is_template(self) -> None:
+        # Live Polarion omits isTemplate on run instances; the template guard
+        # relies on the absence to reject instances passed as templates.
+        response = _get(FakePolarion(), f"/projects/{PROJECT}/testruns/{TEST_RUN_ID}")
+        assert response.status_code == 200
+        assert "isTemplate" not in _json(response)["data"]["attributes"]
+
+    def test_single_missing_run_is_404(self) -> None:
+        response = _get(FakePolarion(), f"/projects/{PROJECT}/testruns/Nope")
+        assert response.status_code == 404
+
+    def test_testing_context_enum_resolves(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/enumerations/testing/testrun-type/~",
+        )
+        assert response.status_code == 200
+        ids = [o["id"] for o in _json(response)["data"]["attributes"]["options"]]
+        assert ids == ["manual", "automated"]
+
+    def test_wildcard_context_does_not_resolve_testrun_enum(self) -> None:
+        # Mirrors live Polarion: testrun enums 404 outside the testing context.
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/enumerations/~/testrun-type/~",
+        )
+        assert response.status_code == 404
 
 
 class TestWorkItemResource:
@@ -225,6 +264,38 @@ class TestMutations:
         ids = [entry["id"] for entry in _json(response)["data"]]
         assert len(ids) == 3
         assert len(set(ids)) == 3
+
+    def test_post_testruns_echoes_submitted_ids(self) -> None:
+        fake = FakePolarion()
+        response = _mutate(
+            fake,
+            "POST",
+            f"/projects/{PROJECT}/testruns",
+            {
+                "data": [
+                    {"type": "testruns", "attributes": {"id": "Fake-TR-New"}},
+                    {"type": "testruns", "attributes": {"id": "Fake-TR-New2"}},
+                ]
+            },
+        )
+        assert response.status_code == 201
+        ids = [entry["id"] for entry in _json(response)["data"]]
+        assert ids == [f"{PROJECT}/Fake-TR-New", f"{PROJECT}/Fake-TR-New2"]
+
+    def test_post_testruns_without_ids_still_echoes_entries(self) -> None:
+        fake = FakePolarion()
+        response = _mutate(
+            fake, "POST", f"/projects/{PROJECT}/testruns", {"data": [{}, {}]}
+        )
+        ids = [entry["id"] for entry in _json(response)["data"]]
+        assert len(ids) == 2
+        assert len(set(ids)) == 2
+
+    def test_post_testruns_without_body_falls_back_to_one_id(self) -> None:
+        fake = FakePolarion()
+        response = _mutate(fake, "POST", f"/projects/{PROJECT}/testruns")
+        assert response.status_code == 201
+        assert len(_json(response)["data"]) == 1
 
     def test_post_documents_echoes_module_id(self) -> None:
         fake = FakePolarion()

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -43,6 +43,7 @@ _READ_TOOL_NAMES: frozenset[str] = frozenset(
 _WRITE_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "create_work_items",
+        "create_test_runs",
         "update_work_item",
         "move_work_item_to_document",
         "move_work_item_from_document",

--- a/tests/mcp_server_polarion/tools/_shared/test_guard.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_guard.py
@@ -19,6 +19,7 @@ from mcp_server_polarion.models import WorkItemLinkSpec
 from mcp_server_polarion.tools._shared import cache as cache_mod
 from mcp_server_polarion.tools._shared.cache import (
     store_document_type_custom_keys,
+    store_test_run_custom_keys,
     store_work_item_custom_keys,
 )
 from mcp_server_polarion.tools._shared.guard import (
@@ -30,6 +31,9 @@ from mcp_server_polarion.tools._shared.guard import (
     guard_document_custom_fields,
     guard_document_enums,
     guard_hyperlink_roles,
+    guard_test_run_custom_fields,
+    guard_test_run_enums,
+    guard_test_run_templates,
     guard_work_item_custom_fields,
     guard_work_item_enums,
     guard_work_item_link_roles,
@@ -45,6 +49,7 @@ def _reset_caches() -> None:
     cache_mod._project_enum_cache.clear()
     cache_mod._work_item_custom_key_cache.clear()
     cache_mod._document_type_custom_key_cache.clear()
+    cache_mod._test_run_custom_key_cache.clear()
 
 
 @pytest.fixture
@@ -1245,3 +1250,270 @@ class TestPartitionDeleteLinks:
                 "MCPT-1",
                 ["P/MCPT-1/parent/P/MCPT-2"],
             )
+
+
+def _tr_list(*attrs: dict[str, object]) -> dict[str, object]:
+    """JSON:API list response of test runs with the given ``attributes`` dicts."""
+    return {
+        "data": [
+            {"type": "testruns", "id": f"P/TR-{i}", "attributes": a}
+            for i, a in enumerate(attrs)
+        ]
+    }
+
+
+class TestGuardTestRunEnums:
+    """type/status validated via the ``testing``-context enumerations."""
+
+    async def test_valid_type_and_status_pass(self, mock_client: AsyncMock) -> None:
+        mock_client.get.side_effect = [
+            _project_enum_response("testrun-type", ["manual", "automated"]),
+            _project_enum_response("testrun-status", ["open", "inProgress"]),
+        ]
+
+        await guard_test_run_enums(mock_client, "P", type="manual", status="open")
+
+        assert mock_client.get.await_count == 2
+        paths = [call.args[0] for call in mock_client.get.await_args_list]
+        assert paths == [
+            "/projects/P/enumerations/testing/testrun-type/~",
+            "/projects/P/enumerations/testing/testrun-status/~",
+        ]
+
+    async def test_unknown_type_raises_with_options(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = _project_enum_response(
+            "testrun-type", ["manual", "automated"]
+        )
+
+        with pytest.raises(ValueError, match="test run type") as exc:
+            await guard_test_run_enums(mock_client, "P", type="ghost")
+
+        assert "manual" in str(exc.value)
+
+    async def test_unknown_status_raises(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = _project_enum_response(
+            "testrun-status", ["open"]
+        )
+
+        with pytest.raises(ValueError, match="test run status"):
+            await guard_test_run_enums(mock_client, "P", status="ghost")
+
+    async def test_none_args_skip_all_checks(self, mock_client: AsyncMock) -> None:
+        await guard_test_run_enums(mock_client, "P")
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_testing_context_cached_apart_from_wildcard(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Same enum name under "~" must not satisfy the "testing"-context probe;
+        # the composite cache key keeps the two contexts distinct.
+        mock_client.get.side_effect = [
+            _project_enum_response("testrun-type", ["stale"]),
+            _project_enum_response("testrun-type", ["manual"]),
+        ]
+        await fetch_project_enum_option_ids(mock_client, "P", "testrun-type")
+
+        await guard_test_run_enums(mock_client, "P", type="manual")
+
+        assert mock_client.get.await_count == 2
+
+    async def test_enum_404_defers(self, mock_client: AsyncMock) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
+
+        await guard_test_run_enums(mock_client, "P", type="anything")
+
+
+class TestGuardTestRunTemplates:
+    """Template ids resolved (and ``isTemplate`` proven) before the write."""
+
+    @staticmethod
+    def _template_response(
+        run_id: str, *, is_template: bool | None
+    ) -> dict[str, object]:
+        attributes: dict[str, object] = {"id": run_id}
+        if is_template is not None:
+            attributes["isTemplate"] = is_template
+        return {
+            "data": {
+                "type": "testruns",
+                "id": f"P/{run_id}",
+                "attributes": attributes,
+            }
+        }
+
+    async def test_existing_template_passes(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = self._template_response(
+            "Empty", is_template=True
+        )
+
+        await guard_test_run_templates(mock_client, "P", ["Empty"])
+
+        path = mock_client.get.await_args.args[0]
+        assert path == "/projects/P/testruns/Empty"
+        params = mock_client.get.await_args.kwargs["params"]
+        assert params["fields[testruns]"] == "id,isTemplate"
+
+    async def test_missing_template_raises_value_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
+
+        with pytest.raises(ValueError, match="templates=True"):
+            await guard_test_run_templates(mock_client, "P", ["Ghost"])
+
+    async def test_run_instance_rejected(self, mock_client: AsyncMock) -> None:
+        # Instances omit isTemplate entirely (observed on Polarion 2506).
+        mock_client.get.return_value = self._template_response("test", is_template=None)
+
+        with pytest.raises(ValueError, match="run instance"):
+            await guard_test_run_templates(mock_client, "P", ["test"])
+
+    async def test_duplicate_ids_checked_once(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = self._template_response(
+            "Empty", is_template=True
+        )
+
+        await guard_test_run_templates(mock_client, "P", ["Empty", "Empty"])
+
+        assert mock_client.get.await_count == 1
+
+    async def test_empty_ids_skip_requests(self, mock_client: AsyncMock) -> None:
+        await guard_test_run_templates(mock_client, "P", [])
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("forbidden", status_code=403)
+
+        with pytest.raises(PermissionError, match="lacks permission"):
+            await guard_test_run_templates(mock_client, "P", ["Empty"])
+
+    async def test_polarion_error_blocks_write(self, mock_client: AsyncMock) -> None:
+        mock_client.get.side_effect = PolarionError("backend down")
+
+        with pytest.raises(RuntimeError, match="Refusing the write"):
+            await guard_test_run_templates(mock_client, "P", ["Empty"])
+
+
+class TestGuardTestRunCustomFieldKeys:
+    """Key-only validation via the project-wide run + template sample."""
+
+    async def test_no_custom_fields_short_circuits(
+        self, mock_client: AsyncMock
+    ) -> None:
+        await guard_test_run_custom_fields(mock_client, "P", {})
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_cached_schema_passes_without_sample(
+        self, mock_client: AsyncMock
+    ) -> None:
+        store_test_run_custom_keys("P", frozenset({"goal"}))
+
+        await guard_test_run_custom_fields(mock_client, "P", {"goal": "x"})
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_sample_unions_runs_and_templates(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = [
+            _tr_list({"id": "R1", "title": "r", "goal": "g"}),
+            _tr_list({"id": "T1", "title": "t", "description": "d"}),
+        ]
+
+        await guard_test_run_custom_fields(
+            mock_client, "P", {"goal": "x", "description": "y"}
+        )
+
+        assert mock_client.get.await_count == 2
+        first, second = mock_client.get.await_args_list
+        assert first.args[0] == "/projects/P/testruns"
+        assert first.kwargs["params"]["fields[testruns]"] == "@all"
+        assert "templates" not in first.kwargs["params"]
+        assert second.kwargs["params"]["templates"] == "true"
+        # Standard attributes (id/title) stay out of the schema.
+        assert cache_mod._test_run_custom_key_cache.get("P") == frozenset(
+            {"goal", "description"}
+        )
+
+    async def test_unknown_key_against_fresh_sample_rejects(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = [
+            _tr_list({"id": "R1", "goal": "g"}),
+            {"data": []},
+        ]
+
+        with pytest.raises(ValueError) as exc:
+            await guard_test_run_custom_fields(mock_client, "P", {"nope": 1})
+
+        msg = str(exc.value)
+        assert "nope" in msg
+        assert "goal" in msg
+        assert mock_client.get.await_count == 2
+
+    async def test_empty_sample_fails_closed(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = {"data": []}
+
+        with pytest.raises(RuntimeError, match="Refusing the write") as exc:
+            await guard_test_run_custom_fields(mock_client, "P", {"goal": "x"})
+
+        assert "ask the user" in str(exc.value).lower()
+
+    async def test_malformed_data_stops_sampling_and_fails_closed(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Non-list ``data`` ends each sampling loop; nothing sampled -> refuse.
+        mock_client.get.return_value = {"data": "junk"}
+
+        with pytest.raises(RuntimeError, match="Refusing the write"):
+            await guard_test_run_custom_fields(mock_client, "P", {"goal": "x"})
+
+        assert mock_client.get.await_count == 2
+
+    async def test_cached_unknown_key_refetches_then_passes(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Stale cached schema triggers one fresh re-sample before rejecting.
+        store_test_run_custom_keys("P", frozenset({"goal"}))
+        mock_client.get.side_effect = [
+            _tr_list({"id": "R1", "goal": "g", "description": "d"}),
+            {"data": []},
+        ]
+
+        await guard_test_run_custom_fields(mock_client, "P", {"description": "y"})
+
+        assert mock_client.get.await_count == 2
+
+    async def test_paginates_full_pages(self, mock_client: AsyncMock) -> None:
+        page1 = _tr_list(*({"id": "R", f"k{i}": 1} for i in range(_GUARD_PAGE_SIZE)))
+        page2 = _tr_list({"id": "R", "late_key": 9})
+        mock_client.get.side_effect = [page1, page2, {"data": []}]
+
+        await guard_test_run_custom_fields(mock_client, "P", {"late_key": 9})
+
+        # Full instance page forces page 2; templates add the third GET.
+        assert mock_client.get.await_count == 3
+        schema = cache_mod._test_run_custom_key_cache.get("P")
+        assert schema is not None
+        assert "late_key" in schema
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("forbidden", status_code=403)
+
+        with pytest.raises(PermissionError, match="lacks permission"):
+            await guard_test_run_custom_fields(mock_client, "P", {"goal": "x"})
+
+    async def test_polarion_error_blocks_write(self, mock_client: AsyncMock) -> None:
+        mock_client.get.side_effect = PolarionError("backend down")
+
+        with pytest.raises(RuntimeError, match="Refusing the write"):
+            await guard_test_run_custom_fields(mock_client, "P", {"goal": "x"})

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from mcp_server_polarion.models import Comment, WorkItemSummary
 from mcp_server_polarion.tools._shared.parse import (
     _parse_comment,
+    extract_created_short_ids,
     extract_relationship_id,
     extract_relationship_ids,
     extract_short_id,
@@ -91,6 +92,35 @@ class TestExtractShortId:
 
     def test_no_slash_returns_input(self) -> None:
         assert extract_short_id("MCPT-001") == "MCPT-001"
+
+
+class TestExtractCreatedShortIds:
+    """Tests for `extract_created_short_ids` (bulk-create 201 echo)."""
+
+    def test_extracts_short_ids_in_order(self) -> None:
+        response: dict[str, object] = {
+            "data": [
+                {"type": "workitems", "id": "MyProj/MCPT-042"},
+                {"type": "testruns", "id": "MyProj/TR-043"},
+            ]
+        }
+        assert extract_created_short_ids(response) == ["MCPT-042", "TR-043"]
+
+    def test_returns_empty_when_data_missing(self) -> None:
+        assert extract_created_short_ids({}) == []
+
+    def test_returns_empty_when_data_not_a_list(self) -> None:
+        assert extract_created_short_ids({"data": {"id": "MyProj/MCPT-1"}}) == []
+
+    def test_skips_entries_missing_id_or_not_dict(self) -> None:
+        response: dict[str, object] = {
+            "data": [
+                {"type": "workitems", "id": "MyProj/MCPT-1"},
+                {"type": "workitems"},
+                "not a dict",
+            ]
+        }
+        assert extract_created_short_ids(response) == ["MCPT-1"]
 
 
 class TestParseIncludedWorkItemMap:

--- a/tests/mcp_server_polarion/tools/conftest.py
+++ b/tests/mcp_server_polarion/tools/conftest.py
@@ -18,6 +18,7 @@ def _clear_guard_caches() -> None:
     _cache_mod._project_enum_cache.clear()
     _cache_mod._work_item_custom_key_cache.clear()
     _cache_mod._document_type_custom_key_cache.clear()
+    _cache_mod._test_run_custom_key_cache.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -1,5 +1,5 @@
-"""Tests for the ``list_test_runs`` tool — response parsing, param forwarding,
-error mapping, and page-size field bounds.
+"""Tests for the test run tools — list parsing/param forwarding, bulk create
+payloads and guards, error mapping, and field bounds.
 """
 
 from __future__ import annotations
@@ -16,8 +16,26 @@ from mcp_server_polarion.core.exceptions import (
     PolarionError,
     PolarionNotFoundError,
 )
-from mcp_server_polarion.models import PaginatedResult
-from mcp_server_polarion.tools.test_runs import list_test_runs
+from mcp_server_polarion.models import PaginatedResult, TestRunCreateSpec
+from mcp_server_polarion.tools.test_runs import (
+    _build_create_test_runs_payload,
+    create_test_runs,
+    list_test_runs,
+)
+
+# Pydantic model, not a test case — silence pytest's collection attempt.
+TestRunCreateSpec.__test__ = False  # type: ignore[attr-defined]
+
+
+def _template_response(run_id: str) -> dict[str, object]:
+    """Single-testrun GET body the template guard accepts."""
+    return {
+        "data": {
+            "type": "testruns",
+            "id": f"proj1/{run_id}",
+            "attributes": {"id": run_id, "isTemplate": True},
+        }
+    }
 
 
 class TestListTestRuns:
@@ -308,6 +326,283 @@ class TestListTestRuns:
                 page_size=100,
                 page_number=1,
             )
+
+
+class TestBuildCreateTestRunsPayload:
+    """Direct payload-builder unit tests."""
+
+    def test_full_spec_builds_attributes_and_template(self) -> None:
+        payload = _build_create_test_runs_payload(
+            project_id="proj1",
+            specs=[
+                TestRunCreateSpec(
+                    id="TR-100",
+                    title="Sprint 9 Regression",
+                    type="manual",
+                    status="open",
+                    template_id="Empty",
+                    custom_fields={"goal": "verify release"},
+                )
+            ],
+        )
+
+        assert payload == {
+            "data": [
+                {
+                    "type": "testruns",
+                    "attributes": {
+                        "id": "TR-100",
+                        "title": "Sprint 9 Regression",
+                        "type": "manual",
+                        "status": "open",
+                        "goal": "verify release",
+                    },
+                    "relationships": {
+                        "template": {"data": {"type": "testruns", "id": "proj1/Empty"}}
+                    },
+                }
+            ]
+        }
+
+    def test_minimal_spec_sends_only_id(self) -> None:
+        payload = _build_create_test_runs_payload(
+            project_id="proj1", specs=[TestRunCreateSpec(id="TR-1")]
+        )
+
+        data = payload["data"]
+        assert isinstance(data, list)
+        resource = data[0]
+        assert isinstance(resource, dict)
+        assert resource["attributes"] == {"id": "TR-1"}
+        assert "relationships" not in resource
+
+    def test_multiple_specs_keep_order(self) -> None:
+        payload = _build_create_test_runs_payload(
+            project_id="proj1",
+            specs=[TestRunCreateSpec(id="TR-1"), TestRunCreateSpec(id="TR-2")],
+        )
+
+        data = payload["data"]
+        assert isinstance(data, list)
+        ids = [
+            r["attributes"]["id"]  # type: ignore[call-overload, index]
+            for r in data
+        ]
+        assert ids == ["TR-1", "TR-2"]
+
+    def test_custom_field_shadowing_standard_attribute_raises(self) -> None:
+        with pytest.raises(ValueError, match="standard Polarion attributes"):
+            _build_create_test_runs_payload(
+                project_id="proj1",
+                specs=[TestRunCreateSpec(id="TR-1", custom_fields={"title": "x"})],
+            )
+
+
+class TestCreateTestRuns:
+    """Tests for the ``create_test_runs`` tool."""
+
+    async def test_minimal_create_posts_and_returns_ids(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "testruns", "id": "proj1/TR-1"}]
+        }
+
+        result = await create_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            items=[TestRunCreateSpec(id="TR-1")],
+            dry_run=False,
+        )
+
+        assert result.created is True
+        assert result.dry_run is False
+        assert result.test_run_ids == ["TR-1"]
+        assert result.payload_preview is None
+        # No enums / template / custom fields supplied -> no guard traffic.
+        mock_client.get.assert_not_awaited()
+        path = mock_client.post.await_args.args[0]
+        assert path == "/projects/proj1/testruns"
+
+    async def test_create_with_template_resolves_it_first(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = _template_response("Empty")
+        mock_client.post.return_value = {
+            "data": [{"type": "testruns", "id": "proj1/TR-2"}]
+        }
+
+        result = await create_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            items=[TestRunCreateSpec(id="TR-2", template_id="Empty")],
+            dry_run=False,
+        )
+
+        assert result.test_run_ids == ["TR-2"]
+        assert mock_client.get.await_args.args[0] == "/projects/proj1/testruns/Empty"
+        payload = mock_client.post.await_args.kwargs["json"]
+        assert payload["data"][0]["relationships"]["template"]["data"] == {
+            "type": "testruns",
+            "id": "proj1/Empty",
+        }
+
+    async def test_dry_run_returns_payload_without_posting(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await create_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            items=[TestRunCreateSpec(id="TR-3", title="Preview")],
+            dry_run=True,
+        )
+
+        assert result.created is False
+        assert result.dry_run is True
+        assert result.test_run_ids == []
+        assert result.payload_preview is not None
+        data = result.payload_preview["data"]
+        assert isinstance(data, list)
+        mock_client.post.assert_not_awaited()
+
+    async def test_unknown_type_blocks_before_post(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "type": "enumerations",
+                "id": "testrun-type",
+                "attributes": {"options": [{"id": "manual"}, {"id": "automated"}]},
+            }
+        }
+
+        with pytest.raises(ValueError, match="test run type"):
+            await create_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunCreateSpec(id="TR-4", type="ghost")],
+                dry_run=False,
+            )
+
+        mock_client.post.assert_not_awaited()
+
+    async def test_custom_fields_guarded_against_sample(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = [
+            {
+                "data": [
+                    {
+                        "type": "testruns",
+                        "id": "proj1/R1",
+                        "attributes": {"id": "R1", "goal": "g"},
+                    }
+                ]
+            },
+            {"data": []},
+        ]
+        mock_client.post.return_value = {
+            "data": [{"type": "testruns", "id": "proj1/TR-5"}]
+        }
+
+        result = await create_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            items=[TestRunCreateSpec(id="TR-5", custom_fields={"goal": "x"})],
+            dry_run=False,
+        )
+
+        assert result.test_run_ids == ["TR-5"]
+        # Sampled instances then templates before the POST.
+        assert mock_client.get.await_count == 2
+
+    async def test_project_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await create_test_runs(
+                mock_ctx,
+                project_id="missing",
+                items=[TestRunCreateSpec(id="TR-6")],
+                dry_run=False,
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await create_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunCreateSpec(id="TR-7")],
+                dry_run=False,
+            )
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionError("boom", status_code=500)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await create_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunCreateSpec(id="TR-8")],
+                dry_run=False,
+            )
+
+    async def test_id_count_mismatch_raises(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {"data": []}
+
+        with pytest.raises(RuntimeError, match="list_test_runs"):
+            await create_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunCreateSpec(id="TR-9")],
+                dry_run=False,
+            )
+
+
+class TestCreateTestRunsFieldValidation:
+    """Bulk bounds + spec constraints via ``TypeAdapter`` rebuild."""
+
+    @staticmethod
+    def _adapter(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(create_test_runs)
+        sig = inspect.signature(create_test_runs)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_empty_items_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("items").validate_python([])
+
+    def test_items_above_max_rejected(self) -> None:
+        specs = [{"id": f"TR-{i}"} for i in range(51)]
+        with pytest.raises(ValidationError):
+            self._adapter("items").validate_python(specs)
+
+    def test_items_at_max_accepted(self) -> None:
+        specs = [{"id": f"TR-{i}"} for i in range(50)]
+        validated = self._adapter("items").validate_python(specs)
+        assert isinstance(validated, list)
+        assert len(validated) == 50
+
+    def test_empty_project_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("project_id").validate_python("")
+
+    def test_spec_requires_non_empty_id(self) -> None:
+        with pytest.raises(ValidationError):
+            TestRunCreateSpec(id="")
 
 
 class TestListTestRunsFieldValidation:

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -23,9 +23,6 @@ from mcp_server_polarion.tools.test_runs import (
     list_test_runs,
 )
 
-# Pydantic model, not a test case — silence pytest's collection attempt.
-TestRunCreateSpec.__test__ = False  # type: ignore[attr-defined]
-
 
 def _template_response(run_id: str) -> dict[str, object]:
     """Single-testrun GET body the template guard accepts."""

--- a/tests/mcp_server_polarion/tools/test_tool_annotations.py
+++ b/tests/mcp_server_polarion/tools/test_tool_annotations.py
@@ -34,6 +34,15 @@ class TestWriteToolAnnotations:
                 },
             ),
             (
+                "create_test_runs",
+                {
+                    "readOnlyHint": False,
+                    "destructiveHint": False,
+                    "idempotentHint": False,
+                    "openWorldHint": True,
+                },
+            ),
+            (
                 "update_work_item",
                 {
                     "readOnlyHint": False,

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -28,7 +28,6 @@ from mcp_server_polarion.tools.work_items import (
     _build_create_work_items_payload,
     _build_update_work_item_payload,
     _build_work_item_resource,
-    _extract_created_work_item_ids,
     create_work_items,
     get_work_item,
     list_work_items,
@@ -354,35 +353,6 @@ class TestBuildCreateWorkItemsPayload:
                 specs=[WorkItemCreateSpec(title="a", type="task")],
                 descriptions_html=[],
             )
-
-
-class TestExtractCreatedWorkItemIds:
-    """Tests for the private ``_extract_created_work_item_ids`` helper."""
-
-    def test_extracts_short_ids_in_order(self) -> None:
-        response: dict[str, object] = {
-            "data": [
-                {"type": "workitems", "id": "MyProj/MCPT-042"},
-                {"type": "workitems", "id": "MyProj/MCPT-043"},
-            ]
-        }
-        assert _extract_created_work_item_ids(response) == ["MCPT-042", "MCPT-043"]
-
-    def test_returns_empty_when_data_missing(self) -> None:
-        assert _extract_created_work_item_ids({}) == []
-
-    def test_returns_empty_when_data_not_a_list(self) -> None:
-        assert _extract_created_work_item_ids({"data": {"id": "MyProj/MCPT-1"}}) == []
-
-    def test_skips_entries_missing_id_or_not_dict(self) -> None:
-        response: dict[str, object] = {
-            "data": [
-                {"type": "workitems", "id": "MyProj/MCPT-1"},
-                {"type": "workitems"},
-                "not a dict",
-            ]
-        }
-        assert _extract_created_work_item_ids(response) == ["MCPT-1"]
 
 
 class TestCreateWorkItemsDryRun:


### PR DESCRIPTION
## Summary

Adds a `create_test_runs` write tool: bulk `POST /projects/{p}/testruns` following the `create_work_items` pattern, with a deliberately minimal parameter surface (`id`, `title`, `type`, `status`, `template_id`, `custom_fields`). All guard routes and payload shapes were verified live against testdrive `MCP_Test_Project` (smoke create/delete included; REST 400s without an explicit `id`).

- **Enum guards**: test runs have no `getAvailableOptions` endpoint, so `type`/`status` validate against the `testing`-context project enumerations (`fetch_project_enum_option_ids` gained a `context` param; the `~` wildcard context 404s for these enums).
- **Template guard**: resolves each `template_id` pre-write and rejects run instances (`isTemplate` is only served on templates).
- **Custom-field guard**: key-only validation against a project-scoped sample of existing runs + templates; enum-typed *values* cannot be pre-validated (no options API) and defer to Polarion, noted in the tool docstring.
- `_extract_created_work_item_ids` moved to `parse.extract_created_short_ids` and shared by both bulk create tools.

Review follow-ups:
- `guard.py` / `cache.py` regrouped by domain (pure reorder, AST-identical definitions; each cache instance now sits beside its wrappers).
- `Test*`-named Pydantic models set `__test__ = False` at the source, replacing the per-test-file monkeypatch.
- README (tool table, count, example prompt) and CLAUDE.md (testrun REST gotchas) document the new tool.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Test runs could only be listed; creating them required the Polarion UI.
- Add bulk create_test_runs with testing-context enum, template, and custom-field key guards (all fail closed).

## Testing

- `ruff check` / `ruff format` / `mypy src/` clean; 1482 tests pass.
- `diff-cover` vs origin/main: 100% on all 208 changed lines.
- Live smoke test on testdrive MCP_Test_Project: POST with explicit id (201, id honored), POST with template relationship (201, config inherited), no-id variants all 400, created runs deleted afterwards.
- New eval trigger case TRIG-CREATE-TEST-RUN (covers gate); fake Polarion serves testruns POST/single-GET and context-qualified enumerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
