### PR TITLE
docs(test-runs): drop false SQL claim in query

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Other clients (VS Code, Claude Desktop, Cursor) — see [Client Configuration](#
 | `list_projects` | List accessible projects |
 | `list_documents` | List documents in a project |
 | `list_work_items` | List work items in a project (Lucene/SQL query) |
-| `list_test_runs` | List test runs in a project (Lucene/SQL query, templates filter) |
+| `list_test_runs` | List test runs in a project (Lucene query, templates filter) |
 | `get_sql_query_recipes` | Fetch copy-paste SQL recipes for advanced queries |
 | `get_document` | Get document metadata, optionally with the raw body HTML |
 | `read_document` | Render a document end-to-end as Markdown |

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -190,8 +190,8 @@ async def list_test_runs(  # noqa: PLR0913
     query: str | None = Field(
         default=None,
         description=(
-            "Optional Lucene filter (e.g. 'status:open', 'author.id:devemberx') "
-            "OR a 'SQL:(...)' prefix for native SQL."
+            "Optional Lucene filter (e.g. 'status:open', 'author.id:devemberx', "
+            "'HAS_VALUE:<field>' to match runs with that field populated)."
         ),
     ),
     templates: bool = Field(
@@ -205,7 +205,7 @@ async def list_test_runs(  # noqa: PLR0913
 
     Returns actual run instances by default; set templates=True for the reusable
     template blueprints instead. Filter with a Lucene query (status:open,
-    type:manual, author.id:<userid>) or omit for all.
+    type:manual, author.id:<userid>, HAS_VALUE:<field>) or omit for all.
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -223,25 +223,23 @@ class TestListTestRuns:
         _, kwargs = mock_client.get.call_args
         assert "query" not in kwargs["params"]
 
-    async def test_sql_prefix_query_passed_verbatim(
+    async def test_has_value_query_passed_verbatim(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        sql_query = (
-            "SQL:(SELECT tr.* FROM POLARION.TESTRUN tr WHERE tr.C_STATUS = 'open')"
-        )
+        has_value_query = "HAS_VALUE:goal"
         mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
 
         await list_test_runs(
             mock_ctx,
             project_id="proj1",
-            query=sql_query,
+            query=has_value_query,
             templates=False,
             page_size=100,
             page_number=1,
         )
 
         _, kwargs = mock_client.get.call_args
-        assert kwargs["params"]["query"] == sql_query
+        assert kwargs["params"]["query"] == has_value_query
 
     async def test_templates_true_adds_param(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -323,6 +321,26 @@ class TestListTestRuns:
                 page_size=100,
                 page_number=1,
             )
+
+
+class TestListTestRunsQueryDocumentation:
+    """Lock the query docs to Lucene-only — ``SQL:(...)`` on ``/testruns`` 400s
+    on the live server (the endpoint wraps the query verbatim into Lucene), so
+    even a "no SQL" disclaimer must not reintroduce the token an LLM could copy.
+    """
+
+    def test_query_docs_promise_lucene_only(self) -> None:
+        field_info = inspect.signature(list_test_runs).parameters["query"].default
+        assert "SQL" not in field_info.description, (
+            "list_test_runs query description must not mention SQL -- "
+            "/testruns has no SQL support (400 verified live)"
+        )
+        assert "HAS_VALUE" in field_info.description, (
+            "list_test_runs query description must document the HAS_VALUE filter"
+        )
+        assert "SQL" not in (list_test_runs.__doc__ or ""), (
+            "list_test_runs docstring must not mention SQL"
+        )
 
 
 class TestBuildCreateTestRunsPayload:


### PR DESCRIPTION
## Summary

`list_test_runs`' `query` parameter docs promised a `SQL:(...)` prefix that can never work. Verified live on the testdrive server: `/testruns` embeds the query verbatim into a Lucene expression, so any SQL prefix 400s (`Unparseable query: ...(SQL:(...))...`); the global `/testruns` endpoint is 404 (does not exist). An LLM following the old description was guaranteed a 400.

This PR is docs-only: the `query` description now promises Lucene only, including the live-verified `HAS_VALUE:<field>` filter (matches runs where a field is populated -- the endpoint itself uses `HAS_VALUE:isTemplate` internally). README table row corrected, a doc-lock test added so the SQL token cannot creep back, and the old SQL-passthrough test repurposed to the HAS_VALUE filter.

No production code path changes -- the custom-field-key guard is untouched (an earlier draft that swapped it to a per-key HAS_VALUE oracle was dropped: same correctness/blind-spot as today's full-scan, and its cost win only shows on run-heavy projects, not worth the added structure).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- SQL:(...) on /testruns 400s live (query wrapped verbatim into Lucene); the docs promised a prefix that can never work
- Reword query docs to Lucene-only incl. HAS_VALUE:<field>, fix README row, add a doc-lock test, drop the SQL test

## Testing

- ruff / ruff format / mypy / pytest all green (1483 passed); diff has no executable lines to cover
- Endpoint behavior verified live on testdrive: `SQL:(SELECT ... FROM POLARION.TEST_RUN)` -> 400 Unparseable, global `/testruns` -> 404, Lucene `status:open` and `HAS_VALUE:goal` both work

## Notes for Reviewers

- README line 28 ("search with Lucene or SQL") kept deliberately -- truthful in aggregate since `list_work_items` genuinely supports `SQL:(...)`; the per-tool table now carries the accurate scoping.
- Branch is still named `refactor/test-run-has-value-guard` from the dropped guard draft; the change is now docs-only. Rename on request.
