### PR TITLE
refactor(evals): unify case factory in _shared

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -98,10 +98,12 @@ fails and the release is blocked (fail-closed).
 
 1. Add a pure check to [`evaluators/checks.py`](evaluators/checks.py) and register
    it in `REGISTRY` (or reuse one). Keep it a function of the trajectory only.
-2. Add a `Case` to the behaviour file — triggers/safety (`1.0`),
-   efficiency/orchestration (`0.8`). Give it an `intent` and a `covers` list. An
-   orchestration case derives `covers` from its steps and usually reuses the
-   `ordered_trajectory` check, declaring its step sequence in `params`.
+2. Add a `Case` to the behaviour file via its `_case` helper — a thin wrapper
+   binding the category threshold (triggers/safety `1.0`,
+   efficiency/orchestration `0.8`) over the shared factory in
+   [`cases/_shared.py`](cases/_shared.py). Give it an `intent` and a `covers`
+   list. An orchestration case instead takes typed `steps` (the `Step` dict),
+   derives `covers` from them, and is fixed to the `ordered_trajectory` check.
 3. Phrase the task neutrally — never state the rule, or you test the prompt
    instead of the tool docstrings (the only guard).
 4. If the case covers a previously-uncovered tool, drop it from the `DEFERRED`

--- a/evals/cases/_shared.py
+++ b/evals/cases/_shared.py
@@ -1,0 +1,48 @@
+"""Shared Case factory: every behaviour category builds the one metadata shape
+(``check``/``params``/``min_pass_rate``/``intent``/``covers``) that ``run.py``
+and ``CheckDispatchEvaluator`` consume. Category files bind their threshold via
+a thin ``_case`` wrapper around :func:`make_case`.
+"""
+
+from __future__ import annotations
+
+from typing import Required, TypedDict
+
+from strands_evals import Case
+
+
+class Step(TypedDict, total=False):
+    """One ``ordered_trajectory`` step: the accepted tool(s), arg constraints,
+    and ordering/id-threading deps. Mirrors the DSL read back out of untyped
+    ``Case.metadata`` by ``evaluators.checks.check_ordered_trajectory``.
+    """
+
+    tool: Required[str | list[str]]
+    match: dict[str, str]
+    after: list[str]
+    observed_arg: str | list[str]
+    observed_in: str
+    observed_path: str
+
+
+def make_case(
+    name: str,
+    prompt: str,
+    check: str,
+    *,
+    intent: str,
+    covers: list[str],
+    min_pass_rate: float,
+    **params: object,
+) -> Case:
+    return Case(
+        name=name,
+        input=prompt,
+        metadata={
+            "check": check,
+            "params": params,
+            "min_pass_rate": min_pass_rate,
+            "intent": intent,
+            "covers": covers,
+        },
+    )

--- a/evals/cases/efficiency.py
+++ b/evals/cases/efficiency.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from strands_evals import Case
 
+from evals.cases._shared import make_case
 from evals.harness.fixtures import DOC, FLOATING_TASK_ID, SPACE
 
 MIN_PASS_RATE = 0.8
@@ -23,16 +24,14 @@ def _case(
     covers: list[str],
     **params: object,
 ) -> Case:
-    return Case(
-        name=name,
-        input=prompt,
-        metadata={
-            "check": check,
-            "params": params,
-            "min_pass_rate": MIN_PASS_RATE,
-            "intent": intent,
-            "covers": covers,
-        },
+    return make_case(
+        name,
+        prompt,
+        check,
+        intent=intent,
+        covers=covers,
+        min_pass_rate=MIN_PASS_RATE,
+        **params,
     )
 
 

--- a/evals/cases/orchestration.py
+++ b/evals/cases/orchestration.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from strands_evals import Case
 
+from evals.cases._shared import Step, make_case
 from evals.harness.fixtures import (
     CHILD_REQ_ID,
     DOC,
@@ -25,8 +26,8 @@ MIN_PASS_RATE = 0.8
 
 # Reused step fragments. Move runs after create (new id, via ``after``) and
 # after read_document_parts (anchor, via observed-id source).
-_READ_PARTS = {"tool": "read_document_parts", "match": {"document_name": DOC}}
-_MOVE_ANCHORED = {
+_READ_PARTS: Step = {"tool": "read_document_parts", "match": {"document_name": DOC}}
+_MOVE_ANCHORED: Step = {
     "tool": "move_work_item_to_document",
     "match": {"target_document_name": DOC},
     "after": ["create_work_items"],
@@ -36,29 +37,28 @@ _MOVE_ANCHORED = {
 }
 
 
-def _step_tools(step: dict[str, object]) -> list[str]:
+def _step_tools(step: Step) -> list[str]:
     tool = step["tool"]
-    return [tool] if isinstance(tool, str) else list(tool)  # type: ignore[arg-type]
+    return [tool] if isinstance(tool, str) else list(tool)
 
 
-def _covers(steps: list[dict[str, object]]) -> list[str]:
+def _covers(steps: list[Step]) -> list[str]:
     """Tools a case exercises = every tool named across its steps."""
     return sorted({t for step in steps for t in _step_tools(step)})
 
 
-def _case(name: str, prompt: str, *, intent: str, **params: object) -> Case:
-    steps = params.get("steps", [])
-    assert isinstance(steps, list)
-    return Case(
-        name=name,
-        input=prompt,
-        metadata={
-            "check": "ordered_trajectory",
-            "params": params,
-            "min_pass_rate": MIN_PASS_RATE,
-            "intent": intent,
-            "covers": _covers(steps),
-        },
+def _case(
+    name: str, prompt: str, *, intent: str, steps: list[Step], **params: object
+) -> Case:
+    return make_case(
+        name,
+        prompt,
+        "ordered_trajectory",
+        intent=intent,
+        covers=_covers(steps),
+        min_pass_rate=MIN_PASS_RATE,
+        steps=steps,
+        **params,
     )
 
 

--- a/evals/cases/safety.py
+++ b/evals/cases/safety.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from strands_evals import Case
 
+from evals.cases._shared import make_case
 from evals.harness.fixtures import (
     DOC,
     FLOATING_TASK_HYPERLINK_URI,
@@ -31,16 +32,14 @@ def _case(
     covers: list[str],
     **params: object,
 ) -> Case:
-    return Case(
-        name=name,
-        input=prompt,
-        metadata={
-            "check": check,
-            "params": params,
-            "min_pass_rate": MIN_PASS_RATE,
-            "intent": intent,
-            "covers": covers,
-        },
+    return make_case(
+        name,
+        prompt,
+        check,
+        intent=intent,
+        covers=covers,
+        min_pass_rate=MIN_PASS_RATE,
+        **params,
     )
 
 

--- a/evals/cases/triggers.py
+++ b/evals/cases/triggers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from strands_evals import Case
 
+from evals.cases._shared import make_case
 from evals.harness.fixtures import (
     CHILD_REQ_ID,
     DOC,
@@ -30,16 +31,14 @@ def _case(
     covers: list[str],
     **params: object,
 ) -> Case:
-    return Case(
-        name=name,
-        input=prompt,
-        metadata={
-            "check": check,
-            "params": params,
-            "min_pass_rate": MIN_PASS_RATE,
-            "intent": intent,
-            "covers": covers,
-        },
+    return make_case(
+        name,
+        prompt,
+        check,
+        intent=intent,
+        covers=covers,
+        min_pass_rate=MIN_PASS_RATE,
+        **params,
     )
 
 

--- a/tests/evals/cases/test_shared.py
+++ b/tests/evals/cases/test_shared.py
@@ -1,0 +1,56 @@
+"""Shared-factory invariants: ``make_case`` assembles the one metadata shape
+every category consumes, threading ``min_pass_rate`` and extra params through
+verbatim.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("strands_evals")
+
+from evals.cases._shared import make_case
+
+
+class TestMakeCase:
+    def test_builds_expected_metadata_shape(self) -> None:
+        case = make_case(
+            "X-1",
+            "do a thing",
+            "readonly",
+            intent="stay read-only",
+            covers=["get_document"],
+            min_pass_rate=1.0,
+            foo="bar",
+        )
+        assert case.name == "X-1"
+        assert case.input == "do a thing"
+        assert case.metadata == {
+            "check": "readonly",
+            "params": {"foo": "bar"},
+            "min_pass_rate": 1.0,
+            "intent": "stay read-only",
+            "covers": ["get_document"],
+        }
+
+    def test_min_pass_rate_passes_through(self) -> None:
+        case = make_case(
+            "X-2",
+            "p",
+            "direct_read",
+            intent="i",
+            covers=["get_work_item"],
+            min_pass_rate=0.8,
+        )
+        assert (case.metadata or {})["min_pass_rate"] == 0.8
+
+    def test_no_extra_params_yields_empty_params(self) -> None:
+        case = make_case(
+            "X-3",
+            "p",
+            "readonly",
+            intent="i",
+            covers=["get_document"],
+            min_pass_rate=1.0,
+        )
+        assert (case.metadata or {})["params"] == {}


### PR DESCRIPTION
## Summary

The four eval case files (`triggers.py`, `safety.py`, `efficiency.py`, `orchestration.py`) built the exact same `Case.metadata` shape through divergent local helpers: three copy-pasted identical `_case` bodies (differing only in the `MIN_PASS_RATE` they close over), and a fourth orchestration-specific variant with a different signature and an untyped step DSL. This PR converges them on one shared factory (`evals/cases/_shared.py:make_case`) plus a typed `Step` DSL, while keeping orchestration's justified covers-from-steps derivation.

Pure structural refactor - the built `Case` objects are provably unchanged (see Testing), so the eval gate's behaviour cannot differ and no LLM re-run is needed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Four case files built identical metadata via divergent copy-pasted helpers
- Extract shared make_case + typed Step; category files keep thin _case wrappers

## Testing

- Metadata equivalence proof: JSON dump of all 37 cases' `(name, input, metadata)` before/after the refactor is byte-identical; `evals.run --list` catalog output also identical.
- The four existing case test files pass **unchanged**; full suite `1485 passed`.
- `ruff check` / `ruff format --check` / `mypy src/` green; `mypy evals/cases/` clean except the pre-existing `strands_evals` missing-stubs warning (outside CI scope).
- `diff-cover` vs `origin/main`: 26 changed lines, 100% covered.

## Notes for Reviewers

- Orchestration keeps its category-specific `_case` shape (explicit `steps`, fixed `ordered_trajectory` check, derived `covers`) by design - a manual `covers` list could drift from `steps`.
- `_step_tools` intentionally stays duplicated between `cases/orchestration.py` (typed `Step`) and `evaluators/checks.py` (untyped trajectory metadata); sharing would force casts on one side or `Any` on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)