### PR TITLE
feat(tools)!: bulk update_work_items replaces flat

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | Tool | Description |
 |---|---|
 | `create_work_items` | Create one or more work items in a single request |
-| `update_work_item` | Update a work item's fields, body, or workflow status |
+| `update_work_items` | Update fields, body, or workflow status on one or more work items |
 | `create_document` | Create a new document |
 | `update_document` | Update document metadata, body, or workflow status |
 | `create_test_runs` | Create one or more test runs, optionally from a template |

--- a/evals/cases/efficiency.py
+++ b/evals/cases/efficiency.py
@@ -9,7 +9,13 @@ from __future__ import annotations
 
 from strands_evals import Case
 
-from evals.harness.fixtures import DOC, FLOATING_TASK_ID, SPACE
+from evals.harness.fixtures import (
+    CHILD_REQ_ID,
+    DOC,
+    FLOATING_TASK_ID,
+    SPACE,
+    UNCOVERED_REQ_ID,
+)
 
 MIN_PASS_RATE = 0.8
 
@@ -44,6 +50,19 @@ CASES: list[Case] = [
         intent="Bulk-creatable items use one create call; splitting across calls "
         "fails.",
         covers=["create_work_items"],
+    ),
+    _case(
+        "EFF-BULK-UPDATE",
+        f"Rename these work items: {CHILD_REQ_ID} to 'Fake child requirement v2', "
+        f"{UNCOVERED_REQ_ID} to 'Fake uncovered requirement v2', and "
+        f"{FLOATING_TASK_ID} to 'Fake floating task v2'.",
+        "single_bulk_write",
+        intent="Metadata changes to several known items use ONE committed "
+        "update_work_items call covering all of them; a per-item split or "
+        "zero commits fails.",
+        covers=["update_work_items"],
+        tool="update_work_items",
+        min_total_items=3,
     ),
     _case(
         "EFF-DIRECT-GET",

--- a/evals/cases/efficiency.py
+++ b/evals/cases/efficiency.py
@@ -40,7 +40,7 @@ CASES: list[Case] = [
     _case(
         "EFF-BULK-CREATE",
         "Create three new tasks titled 'Fake alpha', 'Fake beta', and 'Fake gamma'.",
-        "single_bulk_create",
+        "single_bulk_write",
         intent="Bulk-creatable items use one create call; splitting across calls "
         "fails.",
         covers=["create_work_items"],

--- a/evals/cases/orchestration.py
+++ b/evals/cases/orchestration.py
@@ -214,7 +214,7 @@ CASES: list[Case] = [
         steps=[
             {"tool": "get_work_item", "match": {"work_item_id": FLOATING_TASK_ID}},
             {
-                "tool": "update_work_item",
+                "tool": "update_work_items",
                 "match": {"work_item_id": FLOATING_TASK_ID},
                 "after": ["get_work_item"],
             },

--- a/evals/cases/safety.py
+++ b/evals/cases/safety.py
@@ -59,7 +59,7 @@ CASES: list[Case] = [
         "get_before_update",
         intent="An update must be preceded by a get on the same item; a blind "
         "update fails.",
-        covers=["get_work_item", "update_work_item"],
+        covers=["get_work_item", "update_work_items"],
     ),
     _case(
         "SAFE-REPLY-RESOLVE",
@@ -78,7 +78,7 @@ CASES: list[Case] = [
         "preserve_hyperlinks",
         intent="A REPLACE-list update must carry every pre-existing URI; "
         "dropping one fails.",
-        covers=["get_work_item", "update_work_item"],
+        covers=["get_work_item", "update_work_items"],
         work_item_id=FLOATING_TASK_ID,
         required_uris=[FLOATING_TASK_HYPERLINK_URI],
     ),

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -15,7 +15,7 @@ CheckResult = tuple[bool, str]
 WRITE_TOOLS: frozenset[str] = frozenset(
     {
         "create_work_items",
-        "update_work_item",
+        "update_work_items",
         "move_work_item_to_document",
         "move_work_item_from_document",
         "create_work_item_links",
@@ -74,6 +74,20 @@ def _errored(call: dict[str, Any]) -> bool:
     return isinstance(result, dict) and "error" in result
 
 
+def _expand_item_calls(call: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten a bulk call into per-item pseudo-calls: each dict entry of
+    ``args["items"]`` merged over the top-level args (batch-level keys like
+    ``project_id`` stay visible); identity for flat calls.
+    """
+    args = _args(call)
+    items = args.get("items")
+    if not isinstance(items, list):
+        return [call]
+    return [
+        {**call, "args": {**args, **item}} for item in items if isinstance(item, dict)
+    ]
+
+
 def check_readonly(trajectory: Trajectory, _params: dict[str, Any]) -> CheckResult:
     """No write tool may be called on a read-only task."""
     used = [n for n in _names(trajectory) if n in WRITE_TOOLS]
@@ -82,11 +96,14 @@ def check_readonly(trajectory: Trajectory, _params: dict[str, Any]) -> CheckResu
     return True, "no write tools called"
 
 
-_UPDATE_TO_GET: dict[str, tuple[str, tuple[str, ...]]] = {
-    "update_work_item": ("get_work_item", ("project_id", "work_item_id")),
+# Last element: True when the tool is a bulk call whose per-item ids live in
+# ``args["items"]`` (checked via ``_expand_item_calls``); False = flat call.
+_UPDATE_TO_GET: dict[str, tuple[str, tuple[str, ...], bool]] = {
+    "update_work_items": ("get_work_item", ("project_id", "work_item_id"), True),
     "update_document": (
         "get_document",
         ("project_id", "space_id", "document_name"),
+        False,
     ),
 }
 
@@ -115,20 +132,24 @@ def check_get_before_update(
         spec = _UPDATE_TO_GET.get(name)
         if spec is None:
             continue
-        get_name, id_keys = spec
-        target = _target_key(call, id_keys)
-        seen = False
-        for earlier in trajectory[:i]:
-            if earlier.get("name") != get_name:
-                continue
-            if _target_key(earlier, id_keys) == target:
-                seen = True
-                break
-        if not seen:
-            return False, (
-                f"called {name}({target}) without a prior {get_name}({target}) "
-                f"-- update must observe current state first"
+        get_name, id_keys, bulk = spec
+        subcalls = _expand_item_calls(call) if bulk else [call]
+        if not subcalls:
+            # Fail closed: a bulk write carrying no per-item dicts is still a
+            # blind write attempt, not a free pass.
+            return False, f"called {name} with no readable items"
+        for sub in subcalls:
+            target = _target_key(sub, id_keys)
+            seen = any(
+                earlier.get("name") == get_name
+                and _target_key(earlier, id_keys) == target
+                for earlier in trajectory[:i]
             )
+            if not seen:
+                return False, (
+                    f"called {name}({target}) without a prior {get_name}({target}) "
+                    f"-- update must observe current state first"
+                )
     return True, "every update_* was preceded by a matching get_*"
 
 
@@ -182,36 +203,40 @@ def check_preserve_hyperlinks(
     target = _short_id(params.get("work_item_id", ""))
     required = [str(u) for u in params.get("required_uris", [])]
     for call in trajectory:
-        if call.get("name") != "update_work_item":
+        if call.get("name") != "update_work_items":
             continue
-        args = _args(call)
-        if _short_id(args.get("work_item_id", "")) != target:
-            continue
-        hyperlinks = args.get("hyperlinks")
-        if not hyperlinks:
-            continue
-        uris = {str(h.get("uri", "")) for h in hyperlinks if isinstance(h, dict)}
-        missing = [u for u in required if u not in uris]
-        if missing:
-            return False, (
-                f"update_work_item replaced hyperlinks on {target} without "
-                f"pre-existing URI(s) {missing} -- the full list must be passed"
-            )
+        for sub in _expand_item_calls(call):
+            args = _args(sub)
+            if _short_id(args.get("work_item_id", "")) != target:
+                continue
+            hyperlinks = args.get("hyperlinks")
+            if not hyperlinks:
+                continue
+            uris = {str(h.get("uri", "")) for h in hyperlinks if isinstance(h, dict)}
+            missing = [u for u in required if u not in uris]
+            if missing:
+                return False, (
+                    f"update_work_items replaced hyperlinks on {target} without "
+                    f"pre-existing URI(s) {missing} -- the full list must be passed"
+                )
     return True, "no hyperlink update dropped a pre-existing URI"
 
 
-_BODY_WRITE_TO_SOURCE: dict[str, tuple[str, str, str, tuple[str, ...]]] = {
+# Last element mirrors _UPDATE_TO_GET: True = bulk items in ``args["items"]``.
+_BODY_WRITE_TO_SOURCE: dict[str, tuple[str, str, str, tuple[str, ...], bool]] = {
     "update_document": (
         "home_page_content_html",
         "get_document",
         "include_homepage_content_html",
         ("project_id", "space_id", "document_name"),
+        False,
     ),
-    "update_work_item": (
+    "update_work_items": (
         "description_html",
         "get_work_item",
         "include_description_html",
         ("project_id", "work_item_id"),
+        True,
     ),
 }
 
@@ -226,21 +251,23 @@ def check_round_trip_source(
         spec = _BODY_WRITE_TO_SOURCE.get(call.get("name", ""))
         if spec is None:
             continue
-        body_arg, get_name, flag_arg, id_keys = spec
-        if not _args(call).get(body_arg):
-            continue
-        target = _target_key(call, id_keys)
-        sourced = any(
-            earlier.get("name") == get_name
-            and _target_key(earlier, id_keys) == target
-            and bool(_args(earlier).get(flag_arg))
-            for earlier in trajectory[:i]
-        )
-        if not sourced:
-            return False, (
-                f"{call.get('name')}({target}) wrote {body_arg} without a prior "
-                f"{get_name}({flag_arg}=True) -- body was not round-trip sourced"
+        body_arg, get_name, flag_arg, id_keys, bulk = spec
+        for sub in _expand_item_calls(call) if bulk else [call]:
+            if not _args(sub).get(body_arg):
+                continue
+            target = _target_key(sub, id_keys)
+            sourced = any(
+                earlier.get("name") == get_name
+                and _target_key(earlier, id_keys) == target
+                and bool(_args(earlier).get(flag_arg))
+                for earlier in trajectory[:i]
             )
+            if not sourced:
+                return False, (
+                    f"{call.get('name')}({target}) wrote {body_arg} without a "
+                    f"prior {get_name}({flag_arg}=True) -- body was not "
+                    "round-trip sourced"
+                )
     return True, "every body write was round-trip sourced"
 
 
@@ -268,28 +295,38 @@ def check_no_detach_retry_loop(
     return True, "no retry loop against a free-floating item"
 
 
-def check_single_bulk_create(
+def check_single_bulk_write(
     trajectory: Trajectory, params: dict[str, Any]
 ) -> CheckResult:
-    """Items creatable in one bulk call must not be split across calls.
-
-    Counts committed ``create_work_items`` calls (``dry_run`` previews and
-    guard-rejected calls excluded). ``params["max_calls"]`` defaults to 1.
+    """Items writable in one bulk call must not be split across calls or left
+    partial. ``params``: ``tool`` (default ``create_work_items``), ``max_calls``
+    (default 1), ``min_total_items`` (optional) — committed (non-``dry_run``,
+    non-errored) batches must carry at least that many items in total; a
+    zero-commit or partial batch is undone work, not an efficient pass.
     """
+    tool = str(params.get("tool", "create_work_items"))
     max_calls = int(params.get("max_calls", 1))
     committed = [
         call
         for call in trajectory
-        if call.get("name") == "create_work_items"
+        if call.get("name") == tool
         and not _args(call).get("dry_run")
         and not _errored(call)
     ]
     if len(committed) > max_calls:
         return False, (
-            f"split creation into {len(committed)} create_work_items calls "
+            f"split the batch into {len(committed)} {tool} calls "
             f"(max {max_calls}) -- one bulk call accepts up to 50 items"
         )
-    return True, "creation used a single bulk call"
+    min_total = params.get("min_total_items")
+    if min_total is not None:
+        total = sum(len(_expand_item_calls(call)) for call in committed)
+        if total < int(min_total):
+            return False, (
+                f"committed {total} item(s) via {tool} (min {min_total}) "
+                "-- the batch left the task undone"
+            )
+    return True, f"used a single bulk {tool} call"
 
 
 def check_direct_read(trajectory: Trajectory, params: dict[str, Any]) -> CheckResult:
@@ -398,13 +435,21 @@ def _resolve_observed_path(result: object, path: str) -> list[str]:
 
 
 def _args_match(args: dict[str, Any], match: dict[str, Any]) -> bool:
-    """All ``match`` entries equal the call's args (``*_id`` via ``_short_id``)."""
+    """All ``match`` entries equal the call's args (``*_id`` via ``_short_id``).
+    A key absent at the top level may be satisfied by any per-item dict in a
+    bulk call's ``args["items"]``.
+    """
+    items = [i for i in args.get("items") or [] if isinstance(i, dict)]
     for key, expected in match.items():
-        actual = args.get(key)
+        candidates = (
+            [args.get(key)]
+            if key in args
+            else [item.get(key) for item in items if key in item]
+        )
         if key.endswith("_id"):
-            if _short_id(actual) != _short_id(expected):
+            if not any(_short_id(c) == _short_id(expected) for c in candidates):
                 return False
-        elif actual != expected:
+        elif expected not in candidates:
             return False
     return True
 
@@ -447,7 +492,7 @@ def check_ordered_trajectory(
     if (
         params.get("max_create_calls") is not None
         and not (
-            r := check_single_bulk_create(
+            r := check_single_bulk_write(
                 trajectory, {"max_calls": params["max_create_calls"]}
             )
         )[0]
@@ -568,7 +613,7 @@ REGISTRY: dict[str, Callable[[Trajectory, dict[str, Any]], CheckResult]] = {
     "preserve_hyperlinks": check_preserve_hyperlinks,
     "round_trip_source": check_round_trip_source,
     "no_detach_retry_loop": check_no_detach_retry_loop,
-    "single_bulk_create": check_single_bulk_create,
+    "single_bulk_write": check_single_bulk_write,
     "direct_read": check_direct_read,
     "no_duplicate_reads": check_no_duplicate_reads,
     "scoped_query_uses_sql": check_scoped_query_uses_sql,

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -51,7 +51,6 @@ from mcp_server_polarion.models.work_items import (
     WorkItemsCreateResult,
     WorkItemSummary,
     WorkItemsUpdateResult,
-    WorkItemUpdateResult,
     WorkItemUpdateSpec,
 )
 
@@ -89,7 +88,6 @@ __all__: list[str] = [
     "WorkItemMoveResult",
     "WorkItemRead",
     "WorkItemSummary",
-    "WorkItemUpdateResult",
     "WorkItemUpdateSpec",
     "WorkItemsCreateResult",
     "WorkItemsUpdateResult",

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -50,7 +50,9 @@ from mcp_server_polarion.models.work_items import (
     WorkItemRead,
     WorkItemsCreateResult,
     WorkItemSummary,
+    WorkItemsUpdateResult,
     WorkItemUpdateResult,
+    WorkItemUpdateSpec,
 )
 
 __all__: list[str] = [
@@ -88,5 +90,7 @@ __all__: list[str] = [
     "WorkItemRead",
     "WorkItemSummary",
     "WorkItemUpdateResult",
+    "WorkItemUpdateSpec",
     "WorkItemsCreateResult",
+    "WorkItemsUpdateResult",
 ]

--- a/src/mcp_server_polarion/models/links.py
+++ b/src/mcp_server_polarion/models/links.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class WorkItemLink(BaseModel):
@@ -25,6 +25,9 @@ class WorkItemLink(BaseModel):
 class WorkItemLinkSpec(BaseModel):
     """One link to create under a source work item."""
 
+    # LLM input model: reject typo keys instead of silently dropping them.
+    model_config = ConfigDict(extra="forbid")
+
     role: str = Field(min_length=1)
     target_work_item_id: str = Field(min_length=1)
     target_project_id: str | None = None
@@ -34,6 +37,8 @@ class WorkItemLinkSpec(BaseModel):
 
 class WorkItemLinkRef(BaseModel):
     """One existing link identified for deletion."""
+
+    model_config = ConfigDict(extra="forbid")
 
     role: str = Field(min_length=1)
     target_work_item_id: str = Field(min_length=1)
@@ -62,6 +67,8 @@ class WorkItemLinksDeleteResult(BaseModel):
 
 class WorkItemLinkUpdateSpec(BaseModel):
     """One existing link to update; ``suspect``/``revision`` tri-state, ≥1 set."""
+
+    model_config = ConfigDict(extra="forbid")
 
     role: str = Field(min_length=1)
     target_work_item_id: str = Field(min_length=1)

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TestRunSummary(BaseModel):
@@ -27,6 +27,9 @@ class TestRunCreateSpec(BaseModel):
     """One test run to create via ``create_test_runs``."""
 
     __test__ = False
+
+    # LLM input model: reject typo keys instead of silently dropping them.
+    model_config = ConfigDict(extra="forbid")
 
     id: str = Field(min_length=1)
     title: str | None = None

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -180,16 +180,6 @@ class WorkItemsUpdateResult(BaseModel):
     payload_preview: Mapping[str, object] | None = None
 
 
-class WorkItemUpdateResult(BaseModel):
-    """Result of an ``update_work_item`` operation."""
-
-    updated: bool
-    dry_run: bool
-    current: WorkItemDetail | None
-    changes: Mapping[str, object]
-    payload_preview: Mapping[str, object] | None
-
-
 class WorkItemMoveResult(BaseModel):
     """Result of a ``move_work_item_to_document`` or sibling move-document call."""
 

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from mcp_server_polarion.models.common import MAX_BODY_HTML_LEN
 
@@ -90,6 +90,91 @@ class WorkItemsCreateResult(BaseModel):
     """Result of a ``create_work_items`` operation."""
 
     created: bool
+    dry_run: bool
+    work_item_ids: list[str] = Field(default_factory=list)
+    payload_preview: Mapping[str, object] | None = None
+
+
+class WorkItemUpdateSpec(BaseModel):
+    """One work item's changes in an ``update_work_items`` batch; unset
+    fields stay unchanged."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    work_item_id: str = Field(
+        min_length=1, description="Work item ID (e.g. 'MCPT-042')."
+    )
+    title: str | None = None
+    description_html: str | None = Field(
+        default=None,
+        max_length=MAX_BODY_HTML_LEN,
+        description=(
+            "Raw HTML from get_work_item(include_description_html=True); verbatim."
+        ),
+    )
+    status: str | None = Field(
+        default=None,
+        description="New status; prefer workflow_action for real transitions.",
+    )
+    priority: str | None = Field(default=None, description="e.g. '50.0'.")
+    severity: str | None = None
+    due_date: str | None = Field(default=None, description="'YYYY-MM-DD'.")
+    initial_estimate: str | None = Field(
+        default=None,
+        description="Polarion duration (e.g. '5 1/2d', '1w 2d').",
+    )
+    resolution: str | None = Field(
+        default=None,
+        description="Prefer workflow_action so workflow rules apply.",
+    )
+    hyperlinks: list[Hyperlink] | None = Field(
+        default=None,
+        description="REPLACES the hyperlink list — pass the full list, not a delta.",
+    )
+    assignee_ids: list[str] | None = Field(
+        default=None,
+        description="REPLACES the assignee list — pass the full list, not a delta.",
+    )
+    custom_fields: dict[str, object] | None = Field(
+        default=None,
+        description="Partial; rich-text values as {'type':'text/html','value':...}.",
+    )
+
+    @model_validator(mode="after")
+    def _require_effective_change(self) -> WorkItemUpdateSpec:
+        # None-valued custom entries are dropped at payload build; an item
+        # reduced to an attribute-less resource would 400 the whole batch.
+        effective = (
+            self.title
+            or self.description_html
+            or self.status
+            or self.priority
+            or self.severity
+            or self.due_date
+            or self.initial_estimate
+            or self.resolution
+            or self.hyperlinks
+            or self.assignee_ids
+            or (
+                self.custom_fields
+                and any(value is not None for value in self.custom_fields.values())
+            )
+        )
+        if not effective:
+            msg = (
+                f"work item '{self.work_item_id}': no effective change -- set "
+                "at least one field (custom_fields values of None are "
+                "dropped); workflow_action/change_type_to also need >=1 body "
+                "field per item."
+            )
+            raise ValueError(msg)
+        return self
+
+
+class WorkItemsUpdateResult(BaseModel):
+    """Result of an ``update_work_items`` operation."""
+
+    updated: bool
     dry_run: bool
     work_item_ids: list[str] = Field(default_factory=list)
     payload_preview: Mapping[str, object] | None = None

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -129,7 +129,10 @@ class WorkItemUpdateSpec(BaseModel):
     )
     hyperlinks: list[Hyperlink] | None = Field(
         default=None,
-        description="REPLACES the hyperlink list — pass the full list, not a delta.",
+        description=(
+            "REPLACES the stored hyperlink list — to add one, resubmit every "
+            "existing hyperlink plus the new entry."
+        ),
     )
     assignee_ids: list[str] | None = Field(
         default=None,

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from mcp_server_polarion.models.common import MAX_BODY_HTML_LEN
 
@@ -31,6 +31,9 @@ class WorkItemSummary(BaseModel):
 
 class Hyperlink(BaseModel):
     """A single external hyperlink attached to a work item."""
+
+    # LLM input model: reject typo keys instead of silently dropping them.
+    model_config = ConfigDict(extra="forbid")
 
     role: str
     title: str = ""
@@ -67,6 +70,8 @@ class WorkItemRead(WorkItemSummary):
 
 class WorkItemCreateSpec(BaseModel):
     """One work item to create via ``create_work_items``."""
+
+    model_config = ConfigDict(extra="forbid")
 
     title: str = Field(min_length=1)
     type: str = Field(min_length=1)

--- a/src/mcp_server_polarion/tools/_shared/guard.py
+++ b/src/mcp_server_polarion/tools/_shared/guard.py
@@ -911,6 +911,64 @@ async def _existing_target_ids(
     return frozenset(found)
 
 
+async def resolve_work_item_types(
+    client: PolarionClient,
+    project_id: str,
+    work_item_ids: Iterable[str],
+) -> dict[str, str]:
+    """Existence check plus short id -> type map for a bulk batch, via chunked
+    ``id:(...)`` queries (enum guards scope options by type). Fail-closed:
+    raises ``ValueError`` naming every missing id before any write.
+    """
+    requested = sorted({wi for wi in work_item_ids if wi})
+    if not requested:
+        return {}
+
+    resolved: dict[str, str] = {}
+    path = f"/projects/{encode_path_segment(project_id)}/workitems"
+    for start in range(0, len(requested), _GUARD_PAGE_SIZE):
+        chunk = requested[start : start + _GUARD_PAGE_SIZE]
+        params: dict[str, str | int] = {
+            "query": f"id:({' '.join(chunk)})",
+            "fields[workitems]": "id,type",
+            "page[size]": _GUARD_PAGE_SIZE,
+            "page[number]": 1,
+        }
+        try:
+            response = await client.get(path, params=params)
+        except PolarionNotFoundError as exc:
+            raise ValueError(
+                f"Project '{project_id}' not found. Use `list_projects` to "
+                "discover valid project IDs."
+            ) from exc
+        except PolarionAuthError as exc:
+            raise _unauthorized_write_block("work item existence", project_id) from exc
+        except PolarionError as exc:
+            raise _unreachable_write_block(
+                "work item existence", project_id, exc
+            ) from exc
+        data = response.get("data", [])
+        if not isinstance(data, list):
+            continue
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            attributes = entry.get("attributes")
+            resolved[extract_short_id(safe_str(entry.get("id", "")))] = (
+                safe_str(attributes.get("type", ""))
+                if isinstance(attributes, dict)
+                else ""
+            )
+
+    missing = sorted(set(requested) - resolved.keys())
+    if missing:
+        raise ValueError(
+            f"Work item(s) {format_option_list(missing)} not found in project "
+            f"'{project_id}'. Use `list_work_items` to discover valid IDs."
+        )
+    return resolved
+
+
 async def guard_work_item_link_targets(
     client: PolarionClient,
     source_project_id: str,
@@ -1042,4 +1100,5 @@ __all__ = [
     "guard_work_item_link_roles",
     "guard_work_item_link_targets",
     "partition_delete_links",
+    "resolve_work_item_types",
 ]

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -5,7 +5,9 @@ string coercion, path encoding, option-list formatting, lucene-id guarding.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
+from collections import Counter
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from typing import Final
 from urllib.parse import quote
 
@@ -73,11 +75,39 @@ def validate_work_item_id_for_lucene(work_item_id: str) -> None:
         raise ValueError(msg)
 
 
+def ensure_unique_ids(ids: Iterable[str], *, label: str) -> None:
+    """Reject duplicate ids within one bulk batch — the server's apply order
+    for duplicate resources in a single request is undefined.
+    """
+    duplicates = sorted(id_ for id_, count in Counter(ids).items() if count > 1)
+    if duplicates:
+        msg = (
+            f"Duplicate {label}(s) {duplicates} in one batch; merge the "
+            f"changes for each id into a single item."
+        )
+        raise ValueError(msg)
+
+
+@contextmanager
+def reraise_with_item_context(index: int, item_id: str) -> Iterator[None]:
+    """Prefix a per-item guard ``ValueError`` with the batch position and id so
+    bulk-tool errors name the offending item; other exceptions (project-level
+    auth/backend failures) pass through unwrapped.
+    """
+    try:
+        yield
+    except ValueError as exc:
+        msg = f"items[{index}] ('{item_id}'): {exc}"
+        raise ValueError(msg) from exc
+
+
 __all__: list[str] = [
     "OPTION_LIST_LIMIT",
     "encode_path_segment",
+    "ensure_unique_ids",
     "format_option_list",
     "get_client",
+    "reraise_with_item_context",
     "safe_str",
     "validate_work_item_id_for_lucene",
 ]

--- a/src/mcp_server_polarion/tools/enum.py
+++ b/src/mcp_server_polarion/tools/enum.py
@@ -99,7 +99,7 @@ async def list_work_item_enum_options(  # noqa: PLR0913
 ) -> PaginatedResult[EnumOption]:
     """List valid enum option ids for a work item field of a given type.
 
-    Resolve enum ids here before create_work_items / update_work_item — enums
+    Resolve enum ids here before create_work_items / update_work_items — enums
     are validated on write, invalid ids raise with this set. An unknown
     work_item_type silently falls back to ~, so verify the type id first.
     """

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -35,6 +35,7 @@ from mcp_server_polarion.tools._shared.guard import (
 )
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
+    ensure_unique_ids,
     get_client,
 )
 from mcp_server_polarion.tools._shared.pagination import (
@@ -127,6 +128,7 @@ async def create_test_runs(
     mismatch raises — re-query list_test_runs before retrying.
     """
     client = get_client(ctx)
+    ensure_unique_ids((spec.id for spec in items), label="id")
     for spec in items:
         await guard_test_run_enums(
             client, project_id, type=spec.type, status=spec.status

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import logging
 from importlib import resources
 from typing import Final, cast
@@ -17,8 +16,6 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
-    MAX_BODY_HTML_LEN,
-    Hyperlink,
     JsonValue,
     PaginatedResult,
     SqlRecipeGallery,
@@ -27,7 +24,8 @@ from mcp_server_polarion.models import (
     WorkItemRead,
     WorkItemsCreateResult,
     WorkItemSummary,
-    WorkItemUpdateResult,
+    WorkItemsUpdateResult,
+    WorkItemUpdateSpec,
 )
 from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools._shared.custom_fields import (
@@ -43,10 +41,14 @@ from mcp_server_polarion.tools._shared.guard import (
     guard_hyperlink_roles,
     guard_work_item_custom_fields,
     guard_work_item_enums,
+    resolve_work_item_types,
 )
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
+    ensure_unique_ids,
     get_client,
+    reraise_with_item_context,
+    validate_work_item_id_for_lucene,
 )
 from mcp_server_polarion.tools._shared.pagination import (
     DEFAULT_PAGE_SIZE,
@@ -128,67 +130,82 @@ def _build_create_work_items_payload(
     return {"data": data}
 
 
-def _build_update_work_item_payload(  # noqa: PLR0913
+def _build_update_work_item_resource(
     *,
     project_id: str,
-    work_item_id: str,
-    title: str | None,
-    description_html: str | None,
-    status: str | None,
-    priority: str | None,
-    severity: str | None,
-    due_date: str | None,
-    initial_estimate: str | None,
-    resolution: str | None,
-    hyperlinks: list[Hyperlink] | None,
-    assignee_ids: list[str] | None,
-    custom_fields: dict[str, object] | None = None,
+    spec: WorkItemUpdateSpec,
 ) -> dict[str, JsonValue]:
-    """JSON:API PATCH body for ``/projects/{p}/workitems/{work_item}``; skips
-    unset so an update never blanks an existing attribute.
+    """One ``workitems`` resource for the bulk PATCH; skips unset so an
+    update never blanks an existing attribute. The spec validator guarantees
+    at least one attribute or relationship survives.
     """
     attributes: dict[str, JsonValue] = {}
-    if title:
-        attributes["title"] = title
-    if description_html:
+    if spec.title:
+        attributes["title"] = spec.title
+    if spec.description_html:
         attributes["description"] = {
             "type": "text/html",
-            "value": description_html,
+            "value": spec.description_html,
         }
-    if status:
-        attributes["status"] = status
-    if priority:
-        attributes["priority"] = priority
-    if severity:
-        attributes["severity"] = severity
-    if due_date:
-        attributes["dueDate"] = due_date
-    if initial_estimate:
-        attributes["initialEstimate"] = initial_estimate
-    if resolution:
-        attributes["resolution"] = resolution
-    if hyperlinks:
+    if spec.status:
+        attributes["status"] = spec.status
+    if spec.priority:
+        attributes["priority"] = spec.priority
+    if spec.severity:
+        attributes["severity"] = spec.severity
+    if spec.due_date:
+        attributes["dueDate"] = spec.due_date
+    if spec.initial_estimate:
+        attributes["initialEstimate"] = spec.initial_estimate
+    if spec.resolution:
+        attributes["resolution"] = spec.resolution
+    if spec.hyperlinks:
         attributes["hyperlinks"] = [
-            {"role": h.role, "title": h.title, "uri": h.uri} for h in hyperlinks
+            {"role": h.role, "title": h.title, "uri": h.uri} for h in spec.hyperlinks
         ]
-    merge_custom_fields(attributes, custom_fields, STANDARD_WORK_ITEM_ATTRIBUTES)
+    merge_custom_fields(attributes, spec.custom_fields, STANDARD_WORK_ITEM_ATTRIBUTES)
 
     relationships: dict[str, JsonValue] = {}
-    if assignee_ids:
+    if spec.assignee_ids:
         relationships["assignee"] = {
-            "data": [{"type": "users", "id": uid} for uid in assignee_ids]
+            "data": [{"type": "users", "id": uid} for uid in spec.assignee_ids]
         }
 
-    item: dict[str, JsonValue] = {
+    resource: dict[str, JsonValue] = {
         "type": "workitems",
-        "id": f"{project_id}/{work_item_id}",
+        "id": f"{project_id}/{spec.work_item_id}",
     }
     if attributes:
-        item["attributes"] = attributes
+        resource["attributes"] = attributes
     if relationships:
-        item["relationships"] = relationships
+        resource["relationships"] = relationships
 
-    return {"data": item}
+    return resource
+
+
+def _build_update_work_items_payload(
+    *,
+    project_id: str,
+    specs: list[WorkItemUpdateSpec],
+) -> dict[str, JsonValue]:
+    """JSON:API body for bulk ``PATCH /projects/{p}/workitems``."""
+    data: list[JsonValue] = [
+        _build_update_work_item_resource(project_id=project_id, spec=spec)
+        for spec in specs
+    ]
+    return {"data": data}
+
+
+def _update_query_params(
+    workflow_action: str | None, change_type_to: str | None
+) -> dict[str, str]:
+    """Request-wide PATCH query params; both apply to every item in the batch."""
+    params: dict[str, str] = {}
+    if workflow_action:
+        params["workflowAction"] = workflow_action
+    if change_type_to:
+        params["changeTypeTo"] = change_type_to
+    return params
 
 
 _SQL_QUERY_RECIPES: Final[str] = (
@@ -232,7 +249,7 @@ async def create_work_items(
     Items are created free-floating; place into a document with
     move_work_item_to_document (this tool cannot). description is Markdown →
     sanitized HTML; later edits are raw-HTML round-trip via
-    get_work_item(include_description_html=True) ↔ update_work_item.
+    get_work_item(include_description_html=True) ↔ update_work_items.
     """
     client = get_client(ctx)
     for spec in items:
@@ -315,268 +332,135 @@ async def create_work_items(
         "openWorldHint": True,
     },
 )
-async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
+async def update_work_items(  # noqa: PLR0913
     ctx: Context,
     project_id: str = Field(min_length=1, description="Polarion project ID."),
-    work_item_id: str = Field(
+    items: list[WorkItemUpdateSpec] = Field(  # noqa: B008
         min_length=1,
-        description="Work item ID (e.g. 'MCPT-042').",
-    ),
-    title: str | None = None,
-    description_html: str | None = Field(
-        default=None,
-        max_length=MAX_BODY_HTML_LEN,
+        max_length=MAX_BULK_ITEMS,
         description=(
-            "Raw HTML from get_work_item(include_description_html=True); verbatim."
+            "Per-item changes (1-50). hyperlinks/assignee_ids REPLACE the "
+            "stored lists — read each item first and pass full lists, not "
+            "deltas."
         ),
-    ),
-    status: str | None = Field(
-        default=None,
-        description="New status; prefer workflow_action for real transitions.",
-    ),
-    priority: str | None = Field(
-        default=None,
-        description="e.g. '50.0'.",
-    ),
-    severity: str | None = None,
-    due_date: str | None = Field(default=None, description="'YYYY-MM-DD'."),
-    initial_estimate: str | None = Field(
-        default=None,
-        description="Polarion duration (e.g. '5 1/2d', '1w 2d').",
-    ),
-    resolution: str | None = Field(
-        default=None,
-        description="Prefer workflow_action so workflow rules apply.",
-    ),
-    hyperlinks: list[Hyperlink] | None = Field(  # noqa: B008
-        default=None,
-        description="REPLACES the hyperlink list — pass the full list, not a delta.",
-    ),
-    assignee_ids: list[str] | None = Field(  # noqa: B008
-        default=None,
-        description="REPLACES the assignee list — pass the full list, not a delta.",
-    ),
-    custom_fields: dict[str, object] | None = Field(  # noqa: B008
-        default=None,
-        description="Partial; rich-text values as {'type':'text/html','value':...}.",
     ),
     workflow_action: str | None = Field(
         default=None,
-        description="Workflow action ID (e.g. 'close').",
+        description="Workflow action ID (e.g. 'close'); applies to EVERY item.",
     ),
     change_type_to: str | None = Field(
         default=None,
-        description="New work-item type; RESETS status.",
-    ),
-    include_current_description_html: bool = Field(
-        default=False,
-        description="Return post-PATCH raw HTML in current.description_html.",
+        description="New work-item type for EVERY item; RESETS status.",
     ),
     dry_run: bool = Field(
         default=False,
         description="Preview payload without writing; guards still query Polarion.",
     ),
-) -> WorkItemUpdateResult:
-    """Update fields on an existing work item; None/empty = leave unchanged.
+) -> WorkItemsUpdateResult:
+    """Update fields on 1-50 existing work items in one bulk PATCH; unset
+    fields stay unchanged. Per-item hyperlinks/assignee_ids REPLACE the
+    stored lists — fetch current state with get_work_item BEFORE updating
+    and resubmit every existing entry plus the change, or omissions are
+    silently deleted.
 
-    Fetch current state with get_work_item BEFORE updating; PATCHes then GETs.
     description_html is raw Polarion HTML, sent verbatim — source from
     get_work_item(include_description_html=True); greenfield bodies use
-    create_work_items Markdown, formats never mix.
-
-    hyperlinks/assignee_ids REPLACE the stored list — resubmit every existing
-    entry plus the change or omissions are deleted. custom_fields is partial,
+    create_work_items Markdown, formats never mix. custom_fields is partial,
     keys outside the type schema rejected, values NOT validated — resolve via
     list_work_item_enum_options first.
 
     module not settable here — use move_work_item_to_document /
-    move_work_item_from_document. workflow_action/change_type_to must pair with
-    ≥1 body field (else 400); unknown enum ids raise ValueError with options;
-    change_type_to scopes status/severity/resolution to the target type and
-    resets status.
+    move_work_item_from_document. workflow_action/change_type_to apply to
+    EVERY item; each item needs ≥1 body field (else 400); change_type_to
+    scopes status/severity/resolution to the target type and resets status.
+    Unknown enum ids and missing/duplicate work_item_ids raise ValueError.
+    Atomic: one bad item rejects the whole batch. Returns ids only — re-read
+    via get_work_item if needed.
     """
-    changes: dict[str, JsonValue] = {}
-    if title:
-        changes["title"] = title
-    if description_html:
-        changes["description_html"] = description_html
-    if status:
-        changes["status"] = status
-    if priority:
-        changes["priority"] = priority
-    if severity:
-        changes["severity"] = severity
-    if due_date:
-        changes["due_date"] = due_date
-    if initial_estimate:
-        changes["initial_estimate"] = initial_estimate
-    if resolution:
-        changes["resolution"] = resolution
-    if hyperlinks:
-        changes["hyperlinks"] = [
-            {"role": h.role, "title": h.title, "uri": h.uri} for h in hyperlinks
-        ]
-    if assignee_ids:
-        changes["assignee_ids"] = list(assignee_ids)
-    if custom_fields:
-        # deepcopy: shallow would alias nested rich-text values into ``changes``.
-        changes["custom_fields"] = cast(JsonValue, copy.deepcopy(custom_fields))
-    if workflow_action:
-        changes["workflow_action"] = workflow_action
-    if change_type_to:
-        changes["change_type_to"] = change_type_to
-
-    if not changes:
-        raise ValueError(
-            "Nothing to update -- pass at least one of title, "
-            "description_html, status, priority, severity, due_date, "
-            "initial_estimate, resolution, hyperlinks, assignee_ids, "
-            "custom_fields, workflow_action, or change_type_to."
-        )
-
-    payload = _build_update_work_item_payload(
-        project_id=project_id,
-        work_item_id=work_item_id,
-        title=title,
-        description_html=description_html,
-        status=status,
-        priority=priority,
-        severity=severity,
-        due_date=due_date,
-        initial_estimate=initial_estimate,
-        resolution=resolution,
-        hyperlinks=hyperlinks,
-        assignee_ids=assignee_ids,
-        custom_fields=custom_fields,
-    )
-
-    # Polarion 400s on an attribute-less PATCH even with workflowAction/changeTypeTo.
-    payload_data = cast(dict[str, JsonValue], payload["data"])
-    if "attributes" not in payload_data and "relationships" not in payload_data:
-        raise ValueError(
-            "Polarion's PATCH endpoint requires at least one body field "
-            "(attribute or relationship) even when triggering "
-            "workflow_action or change_type_to. Pair the action with one "
-            "of: title, description, status, priority, severity, due_date, "
-            "initial_estimate, resolution, hyperlinks, or assignee_ids."
-        )
-
     client = get_client(ctx)
-    base_path = (
-        f"/projects/{encode_path_segment(project_id)}"
-        f"/workitems/{encode_path_segment(work_item_id)}"
+
+    # Ids are embedded into the id:(...) existence query below.
+    for spec in items:
+        validate_work_item_id_for_lucene(spec.work_item_id)
+    ensure_unique_ids((spec.work_item_id for spec in items), label="work_item_id")
+    payload = _build_update_work_items_payload(project_id=project_id, specs=items)
+
+    # One batched query resolves existence + type for every item (on dry_run
+    # too, so preview raises the same errors); enum options are type-scoped.
+    types_by_id = await resolve_work_item_types(
+        client, project_id, (spec.work_item_id for spec in items)
     )
 
-    # Enum options are type-scoped: one prefetch (on dry_run too, so preview
-    # raises the same errors) resolves the type and primes the custom-key cache.
-    work_item_type = ""
-    if status or severity or priority or resolution or change_type_to or custom_fields:
-        try:
-            prefetch = await client.get(
-                base_path,
-                params={"fields[workitems]": "@all"},
-            )
-        except PolarionNotFoundError as exc:
-            raise ValueError(
-                f"Work item '{work_item_id}' in project '{project_id}' not found. "
-                "Use `list_work_items` to discover valid IDs."
-            ) from exc
-        except PolarionAuthError as exc:
-            raise PermissionError(
-                "Cannot read work item -- check your POLARION_TOKEN permissions."
-            ) from exc
-        except PolarionError as exc:
-            raise RuntimeError(
-                f"Failed to read work item for guard: {exc.message}"
-            ) from exc
-        prefetch_data = prefetch.get("data", {})
-        if isinstance(prefetch_data, dict):
-            current_detail = parse_work_item_detail(
-                prefetch_data,
-                project_id=project_id,
-                fallback_id=work_item_id,
-            )
-            work_item_type = current_detail.type
-
-        # Scope enums by target type; guard checks ``type`` first, so an invalid
-        # change_type_to raises before being reused as the scoping axis.
-        effective_type = change_type_to or work_item_type or "~"
+    if change_type_to:
+        # Request-wide param: validate once on its own axis, unprefixed — a
+        # bad value is not any single item's fault.
         await guard_work_item_enums(
-            client,
-            project_id,
-            work_item_type=effective_type,
-            type=change_type_to,
-            status=status,
-            severity=severity,
-            priority=priority,
-            resolution=resolution,
+            client, project_id, work_item_type=change_type_to, type=change_type_to
         )
-        # change_type_to retypes in the same PATCH — customs belong to the new type.
-        if custom_fields:
-            await guard_work_item_custom_fields(
-                client,
-                project_id,
-                change_type_to or work_item_type,
-                custom_fields,
-            )
 
-    if hyperlinks:
-        await guard_hyperlink_roles(client, project_id, [h.role for h in hyperlinks])
+    for index, spec in enumerate(items):
+        # change_type_to retypes in the same PATCH — enums and customs are
+        # scoped to the new type.
+        effective_type = change_type_to or types_by_id.get(spec.work_item_id, "")
+        with reraise_with_item_context(index, spec.work_item_id):
+            if spec.status or spec.severity or spec.priority or spec.resolution:
+                await guard_work_item_enums(
+                    client,
+                    project_id,
+                    work_item_type=effective_type or "~",
+                    status=spec.status,
+                    severity=spec.severity,
+                    priority=spec.priority,
+                    resolution=spec.resolution,
+                )
+            if spec.custom_fields:
+                await guard_work_item_custom_fields(
+                    client, project_id, effective_type, spec.custom_fields
+                )
+
+    await guard_hyperlink_roles(
+        client,
+        project_id,
+        [h.role for spec in items for h in (spec.hyperlinks or [])],
+    )
+
+    query_params = _update_query_params(workflow_action, change_type_to)
 
     if dry_run:
-        return WorkItemUpdateResult(
+        preview: dict[str, JsonValue] = dict(payload)
+        if query_params:
+            preview["query_params"] = cast("dict[str, JsonValue]", dict(query_params))
+        return WorkItemsUpdateResult(
             updated=False,
             dry_run=True,
-            current=None,
-            changes=changes,
-            payload_preview=payload,
+            work_item_ids=[],
+            payload_preview=preview,
         )
 
-    query_params: dict[str, str] = {}
-    if workflow_action:
-        query_params["workflowAction"] = workflow_action
-    if change_type_to:
-        query_params["changeTypeTo"] = change_type_to
-    patch_path = f"{base_path}?{urlencode(query_params)}" if query_params else base_path
+    path = f"/projects/{encode_path_segment(project_id)}/workitems"
+    if query_params:
+        path = f"{path}?{urlencode(query_params)}"
 
     try:
-        await client.patch(patch_path, json=cast(dict[str, object], payload))
-        response = await client.get(
-            base_path,
-            params={
-                "fields[workitems]": WORK_ITEM_DETAIL_FIELDS,
-                "include": "assignee",
-            },
-        )
+        await client.patch(path, json=cast(dict[str, object], payload))
     except PolarionAuthError as exc:
         raise PermissionError(
-            "Cannot update work item -- check your POLARION_TOKEN permissions."
+            "Cannot update work items -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionNotFoundError as exc:
+        # Race fallback: existence was verified above, so a PATCH 404 means
+        # the batch changed under us.
         raise ValueError(
-            f"Work item '{work_item_id}' in project '{project_id}' not found. "
-            "Use `list_work_items` to discover valid IDs."
+            f"A work item in the batch was not found in project '{project_id}': "
+            f"{exc.message} Use `list_work_items` to discover valid IDs."
         ) from exc
     except PolarionError as exc:
-        raise RuntimeError(f"Failed to update work item: {exc.message}") from exc
+        raise RuntimeError(f"Failed to update work items: {exc.message}") from exc
 
-    data = response.get("data", {})
-    if not isinstance(data, dict):
-        data = {}
-    current = parse_work_item_detail(
-        data,
-        project_id=project_id,
-        fallback_id=work_item_id,
-    )
-    if not include_current_description_html:
-        # Body still came over the wire; blank it — mirrors get_work_item.
-        current = current.model_copy(update={"description_html": ""})
-
-    return WorkItemUpdateResult(
+    return WorkItemsUpdateResult(
         updated=True,
         dry_run=False,
-        current=current,
-        changes=changes,
+        work_item_ids=[spec.work_item_id for spec in items],
         payload_preview=None,
     )
 
@@ -674,7 +558,7 @@ async def get_work_item(
     """Get full details of one work item by ID.
 
     include_description_html=True fills description_html with raw HTML — the
-    required source for update_work_item(description_html=...). Never feed back
+    required source for update_work_items description_html. Never feed back
     a blanked (flag=False) body.
     """
     client = get_client(ctx)
@@ -733,7 +617,7 @@ async def read_work_item(
     """Read one work item with its body rendered as Markdown.
 
     get_work_item plus description as Markdown. Synthesis output (collapses
-    Polarion anchors) — NEVER feed to update_work_item; round-trip via the HTML
+    Polarion anchors) — NEVER feed to update_work_items; round-trip via the HTML
     pair instead.
     """
     # Pull raw HTML from get_work_item so conversion needs no second round trip.

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -359,9 +359,9 @@ async def update_work_items(  # noqa: PLR0913
 ) -> WorkItemsUpdateResult:
     """Update fields on 1-50 existing work items in one bulk PATCH; unset
     fields stay unchanged. Per-item hyperlinks/assignee_ids REPLACE the
-    stored lists — fetch current state with get_work_item BEFORE updating
-    and resubmit every existing entry plus the change, or omissions are
-    silently deleted.
+    stored lists: even to add ONE entry, call get_work_item on the target
+    BEFORE updating and resubmit every existing entry plus the new one —
+    anything omitted is silently deleted.
 
     description_html is raw Polarion HTML, sent verbatim — source from
     get_work_item(include_description_html=True); greenfield bodies use

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -417,12 +417,12 @@ async def update_work_items(  # noqa: PLR0913
                 await guard_work_item_custom_fields(
                     client, project_id, effective_type, spec.custom_fields
                 )
-
-    await guard_hyperlink_roles(
-        client,
-        project_id,
-        [h.role for spec in items for h in (spec.hyperlinks or [])],
-    )
+            if spec.hyperlinks:
+                # Per item (option cache makes repeats free) so a bad role is
+                # attributed to its batch position like the other guards.
+                await guard_hyperlink_roles(
+                    client, project_id, [h.role for h in spec.hyperlinks]
+                )
 
     query_params = _update_query_params(workflow_action, change_type_to)
 

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -19,6 +19,30 @@ def _call(
     return {"name": name, "args": args or {}, "result": result}
 
 
+def _update_call(*items: dict[str, Any], project: str = "P") -> dict[str, Any]:
+    """A bulk ``update_work_items`` call with per-item dicts."""
+    return _call("update_work_items", {"project_id": project, "items": list(items)})
+
+
+class TestExpandItemCalls:
+    """``_expand_item_calls`` flattens bulk calls into per-item pseudo-calls."""
+
+    def test_flat_call_is_identity(self) -> None:
+        call = _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"})
+        assert checks._expand_item_calls(call) == [call]
+
+    def test_items_merge_over_batch_args(self) -> None:
+        call = _update_call({"work_item_id": "MCPT-1", "title": "a"})
+        (sub,) = checks._expand_item_calls(call)
+        assert sub["args"]["project_id"] == "P"
+        assert sub["args"]["work_item_id"] == "MCPT-1"
+        assert sub["args"]["title"] == "a"
+
+    def test_non_dict_items_are_dropped(self) -> None:
+        call = _call("update_work_items", {"items": ["garbage", 42]})
+        assert checks._expand_item_calls(call) == []
+
+
 class TestCheckReadonly:
     def test_pure_read_passes(self) -> None:
         trajectory = [_call("get_document"), _call("read_document_parts")]
@@ -47,36 +71,58 @@ class TestCheckGetBeforeUpdate:
         passed, _ = checks.check_get_before_update([], {})
         assert passed is True
 
-    def test_get_then_update_work_item_passes(self) -> None:
+    def test_get_then_update_work_items_passes(self) -> None:
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"}),
-            _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "priority": "50.0"},
-            ),
+            _update_call({"work_item_id": "MCPT-1", "priority": "50.0"}),
         ]
         passed, _ = checks.check_get_before_update(trajectory, {})
         assert passed is True
 
     def test_update_without_prior_get_fails(self) -> None:
+        trajectory = [_update_call({"work_item_id": "MCPT-1", "priority": "50.0"})]
+        passed, reason = checks.check_get_before_update(trajectory, {})
+        assert passed is False
+        assert "update_work_items" in reason
+        assert "get_work_item" in reason
+
+    def test_every_item_needs_its_own_prior_get(self) -> None:
+        # Item A was read, item B was not: the bulk write is still blind on B.
         trajectory = [
-            _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "priority": "50.0"},
-            )
+            _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"}),
+            _update_call(
+                {"work_item_id": "MCPT-1", "title": "a"},
+                {"work_item_id": "MCPT-2", "title": "b"},
+            ),
         ]
         passed, reason = checks.check_get_before_update(trajectory, {})
         assert passed is False
-        assert "update_work_item" in reason
-        assert "get_work_item" in reason
+        assert "MCPT-2" in reason
+
+    def test_all_items_covered_by_gets_passes(self) -> None:
+        trajectory = [
+            _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"}),
+            _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-2"}),
+            _update_call(
+                {"work_item_id": "MCPT-1", "title": "a"},
+                {"work_item_id": "MCPT-2", "title": "b"},
+            ),
+        ]
+        passed, _ = checks.check_get_before_update(trajectory, {})
+        assert passed is True
+
+    def test_bulk_update_without_readable_items_fails(self) -> None:
+        # A bulk write carrying no per-item dicts is still a blind write
+        # attempt, not a free pass.
+        trajectory = [_call("update_work_items", {"project_id": "P", "items": []})]
+        passed, reason = checks.check_get_before_update(trajectory, {})
+        assert passed is False
+        assert "no readable items" in reason
 
     def test_get_on_different_id_does_not_count(self) -> None:
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-99"}),
-            _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "priority": "50.0"},
-            ),
+            _update_call({"work_item_id": "MCPT-1", "priority": "50.0"}),
         ]
         passed, reason = checks.check_get_before_update(trajectory, {})
         assert passed is False
@@ -87,20 +133,14 @@ class TestCheckGetBeforeUpdate:
         # target the same item; the check must not false-fail.
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "P/MCPT-1"}),
-            _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "title": "x"},
-            ),
+            _update_call({"work_item_id": "MCPT-1", "title": "x"}),
         ]
         passed, _ = checks.check_get_before_update(trajectory, {})
         assert passed is True
 
     def test_get_after_update_does_not_satisfy(self) -> None:
         trajectory = [
-            _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-1", "priority": "50.0"},
-            ),
+            _update_call({"work_item_id": "MCPT-1", "priority": "50.0"}),
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"}),
         ]
         passed, _ = checks.check_get_before_update(trajectory, {})
@@ -241,10 +281,8 @@ class TestCheckPreserveHyperlinks:
 
     def test_full_list_update_passes(self) -> None:
         trajectory = [
-            _call(
-                "update_work_item",
+            _update_call(
                 {
-                    "project_id": "P",
                     "work_item_id": "MCPT-200",
                     "hyperlinks": [
                         {
@@ -253,7 +291,7 @@ class TestCheckPreserveHyperlinks:
                         },
                         {"role": "ref_ext", "uri": "https://example.com/new"},
                     ],
-                },
+                }
             )
         ]
         passed, _ = checks.check_preserve_hyperlinks(trajectory, self._PARAMS)
@@ -261,10 +299,25 @@ class TestCheckPreserveHyperlinks:
 
     def test_dropping_existing_uri_fails(self) -> None:
         trajectory = [
-            _call(
-                "update_work_item",
+            _update_call(
                 {
-                    "project_id": "P",
+                    "work_item_id": "MCPT-200",
+                    "hyperlinks": [
+                        {"role": "ref_ext", "uri": "https://example.com/new"}
+                    ],
+                }
+            )
+        ]
+        passed, reason = checks.check_preserve_hyperlinks(trajectory, self._PARAMS)
+        assert passed is False
+        assert "fake-spec" in reason
+
+    def test_dropping_uri_on_later_item_fails(self) -> None:
+        # The offending item hides behind a benign one in the same batch.
+        trajectory = [
+            _update_call(
+                {"work_item_id": "MCPT-1", "title": "x"},
+                {
                     "work_item_id": "MCPT-200",
                     "hyperlinks": [
                         {"role": "ref_ext", "uri": "https://example.com/new"}
@@ -277,24 +330,17 @@ class TestCheckPreserveHyperlinks:
         assert "fake-spec" in reason
 
     def test_update_not_touching_hyperlinks_passes(self) -> None:
-        trajectory = [
-            _call(
-                "update_work_item",
-                {"project_id": "P", "work_item_id": "MCPT-200", "title": "x"},
-            )
-        ]
+        trajectory = [_update_call({"work_item_id": "MCPT-200", "title": "x"})]
         passed, _ = checks.check_preserve_hyperlinks(trajectory, self._PARAMS)
         assert passed is True
 
     def test_other_work_item_not_constrained(self) -> None:
         trajectory = [
-            _call(
-                "update_work_item",
+            _update_call(
                 {
-                    "project_id": "P",
                     "work_item_id": "MCPT-999",
                     "hyperlinks": [{"role": "ref_ext", "uri": "https://x.example"}],
-                },
+                }
             )
         ]
         passed, _ = checks.check_preserve_hyperlinks(trajectory, self._PARAMS)
@@ -347,14 +393,7 @@ class TestCheckRoundTripSource:
     def test_work_item_body_write_needs_flagged_get(self) -> None:
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-200"}),
-            _call(
-                "update_work_item",
-                {
-                    "project_id": "P",
-                    "work_item_id": "MCPT-200",
-                    "description_html": "<p>x</p>",
-                },
-            ),
+            _update_call({"work_item_id": "MCPT-200", "description_html": "<p>x</p>"}),
         ]
         passed, _ = checks.check_round_trip_source(trajectory, {})
         assert passed is False
@@ -362,6 +401,26 @@ class TestCheckRoundTripSource:
         trajectory[0]["args"]["include_description_html"] = True
         passed, _ = checks.check_round_trip_source(trajectory, {})
         assert passed is True
+
+    def test_body_write_on_later_item_needs_its_own_flagged_get(self) -> None:
+        # Only item 1 was round-trip sourced; item 2's body write is not.
+        trajectory = [
+            _call(
+                "get_work_item",
+                {
+                    "project_id": "P",
+                    "work_item_id": "MCPT-200",
+                    "include_description_html": True,
+                },
+            ),
+            _update_call(
+                {"work_item_id": "MCPT-200", "description_html": "<p>x</p>"},
+                {"work_item_id": "MCPT-300", "description_html": "<p>y</p>"},
+            ),
+        ]
+        passed, reason = checks.check_round_trip_source(trajectory, {})
+        assert passed is False
+        assert "MCPT-300" in reason
 
     def test_qualified_get_id_satisfies_short_id_write(self) -> None:
         trajectory = [
@@ -373,14 +432,7 @@ class TestCheckRoundTripSource:
                     "include_description_html": True,
                 },
             ),
-            _call(
-                "update_work_item",
-                {
-                    "project_id": "P",
-                    "work_item_id": "MCPT-200",
-                    "description_html": "<p>x</p>",
-                },
-            ),
+            _update_call({"work_item_id": "MCPT-200", "description_html": "<p>x</p>"}),
         ]
         passed, _ = checks.check_round_trip_source(trajectory, {})
         assert passed is True
@@ -438,12 +490,12 @@ class TestCheckNoDetachRetryLoop:
         assert passed is True
 
 
-class TestCheckSingleBulkCreate:
+class TestCheckSingleBulkWrite:
     def test_one_bulk_call_passes(self) -> None:
         trajectory = [
             _call("create_work_items", {"items": [{"title": "a"}, {"title": "b"}]})
         ]
-        passed, _ = checks.check_single_bulk_create(trajectory, {})
+        passed, _ = checks.check_single_bulk_write(trajectory, {})
         assert passed is True
 
     def test_split_calls_fail(self) -> None:
@@ -451,7 +503,7 @@ class TestCheckSingleBulkCreate:
             _call("create_work_items", {"items": [{"title": "a"}]}),
             _call("create_work_items", {"items": [{"title": "b"}]}),
         ]
-        passed, reason = checks.check_single_bulk_create(trajectory, {})
+        passed, reason = checks.check_single_bulk_write(trajectory, {})
         assert passed is False
         assert "2" in reason
 
@@ -460,7 +512,7 @@ class TestCheckSingleBulkCreate:
             _call("create_work_items", {"items": [{"title": "a"}], "dry_run": True}),
             _call("create_work_items", {"items": [{"title": "a"}]}),
         ]
-        passed, _ = checks.check_single_bulk_create(trajectory, {})
+        passed, _ = checks.check_single_bulk_write(trajectory, {})
         assert passed is True
 
     def test_errored_call_not_counted(self) -> None:
@@ -472,7 +524,53 @@ class TestCheckSingleBulkCreate:
             ),
             _call("create_work_items", {"items": [{"title": "a"}]}),
         ]
-        passed, _ = checks.check_single_bulk_create(trajectory, {})
+        passed, _ = checks.check_single_bulk_write(trajectory, {})
+        assert passed is True
+
+    def test_tool_param_targets_bulk_update(self) -> None:
+        trajectory = [
+            _update_call({"work_item_id": "MCPT-1", "title": "a"}),
+            _update_call({"work_item_id": "MCPT-2", "title": "b"}),
+        ]
+        passed, reason = checks.check_single_bulk_write(
+            trajectory, {"tool": "update_work_items"}
+        )
+        assert passed is False
+        assert "update_work_items" in reason
+
+    def test_min_total_items_fails_on_partial_batch(self) -> None:
+        # One committed call but only one of the three required items: the
+        # batch left the task undone, not an efficient pass.
+        trajectory = [_update_call({"work_item_id": "MCPT-1", "title": "a"})]
+        passed, reason = checks.check_single_bulk_write(
+            trajectory, {"tool": "update_work_items", "min_total_items": 3}
+        )
+        assert passed is False
+        assert "3" in reason
+
+    def test_min_total_items_fails_on_zero_commits(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_items",
+                {"items": [{"work_item_id": "MCPT-1", "title": "a"}]},
+                result={"error": "ToolError: not found"},
+            )
+        ]
+        passed, _ = checks.check_single_bulk_write(
+            trajectory, {"tool": "update_work_items", "min_total_items": 1}
+        )
+        assert passed is False
+
+    def test_min_total_items_met_passes(self) -> None:
+        trajectory = [
+            _update_call(
+                {"work_item_id": "MCPT-1", "title": "a"},
+                {"work_item_id": "MCPT-2", "title": "b"},
+            )
+        ]
+        passed, _ = checks.check_single_bulk_write(
+            trajectory, {"tool": "update_work_items", "min_total_items": 2}
+        )
         assert passed is True
 
 
@@ -706,22 +804,40 @@ class TestCheckOrderedTrajectory:
         assert passed is True
 
     def test_after_dependency_violation_fails(self) -> None:
-        # update_work_item before its required get_work_item.
+        # update_work_items before its required get_work_item.
         steps = [
             {"tool": "get_work_item", "match": {"work_item_id": "MCPT-1"}},
             {
-                "tool": "update_work_item",
+                "tool": "update_work_items",
                 "match": {"work_item_id": "MCPT-1"},
                 "after": ["get_work_item"],
             },
         ]
         trajectory = [
-            _call("update_work_item", {"work_item_id": "MCPT-1"}),
+            _update_call({"work_item_id": "MCPT-1", "title": "x"}),
             _call("get_work_item", {"work_item_id": "MCPT-1"}),
         ]
         passed, reason = checks.check_ordered_trajectory(trajectory, {"steps": steps})
         assert passed is False
         assert "get_work_item" in reason
+
+    def test_match_key_satisfied_by_bulk_item(self) -> None:
+        # A step's work_item_id constraint matches a per-item id nested in a
+        # bulk call's args["items"].
+        steps = [
+            {"tool": "get_work_item", "match": {"work_item_id": "MCPT-1"}},
+            {
+                "tool": "update_work_items",
+                "match": {"work_item_id": "MCPT-1"},
+                "after": ["get_work_item"],
+            },
+        ]
+        trajectory = [
+            _call("get_work_item", {"work_item_id": "MCPT-1"}),
+            _update_call({"work_item_id": "MCPT-1", "title": "x"}),
+        ]
+        passed, _ = checks.check_ordered_trajectory(trajectory, {"steps": steps})
+        assert passed is True
 
     def test_out_of_order_move_before_read_fails(self) -> None:
         trajectory = [
@@ -821,7 +937,7 @@ class TestCheckOrderedTrajectory:
     def test_read_only_flag_fails_on_write(self) -> None:
         trajectory = [
             _call("list_work_items", {"query": "SQL:(...)"}),
-            _call("update_work_item", {"work_item_id": "MCPT-1"}),
+            _update_call({"work_item_id": "MCPT-1", "title": "x"}),
         ]
         passed, _ = checks.check_ordered_trajectory(
             trajectory,

--- a/tests/mcp_server_polarion/models/test_invariants.py
+++ b/tests/mcp_server_polarion/models/test_invariants.py
@@ -19,7 +19,6 @@ from mcp_server_polarion.models import (
     WorkItemsCreateResult,
     WorkItemSummary,
     WorkItemsUpdateResult,
-    WorkItemUpdateResult,
     WorkItemUpdateSpec,
 )
 
@@ -69,24 +68,15 @@ class TestCrossModelIntegration:
         )
         assert page.items[0].type == "heading"
 
-    def test_update_result_with_nested_detail(self):
-        result = WorkItemUpdateResult(
+    def test_update_result_json_round_trip(self):
+        result = WorkItemsUpdateResult(
             updated=True,
             dry_run=False,
-            current=WorkItemDetail(
-                id="MCPT-001",
-                title="Before",
-                type="requirement",
-                status="draft",
-                description_html="<p>Old description</p>",
-                project_id="proj1",
-            ),
-            changes={"title": "After", "status": "approved"},
+            work_item_ids=["MCPT-001", "MCPT-002"],
             payload_preview=None,
         )
-        dumped = result.model_dump()
-        assert dumped["current"]["title"] == "Before"
-        assert dumped["changes"]["title"] == "After"
+        restored = WorkItemsUpdateResult.model_validate_json(result.model_dump_json())
+        assert restored.work_item_ids == ["MCPT-001", "MCPT-002"]
 
     def test_workitemread_metadata_mirrors_workitemdetail(self):
         """Drift between the two models makes ``read_work_item`` silently
@@ -114,7 +104,6 @@ class TestCrossModelIntegration:
             WorkItemLink,
             WorkItemCreateSpec,
             WorkItemsCreateResult,
-            WorkItemUpdateResult,
             WorkItemUpdateSpec,
             WorkItemsUpdateResult,
             WorkItemLinkSpec,

--- a/tests/mcp_server_polarion/models/test_invariants.py
+++ b/tests/mcp_server_polarion/models/test_invariants.py
@@ -18,7 +18,9 @@ from mcp_server_polarion.models import (
     WorkItemRead,
     WorkItemsCreateResult,
     WorkItemSummary,
+    WorkItemsUpdateResult,
     WorkItemUpdateResult,
+    WorkItemUpdateSpec,
 )
 
 
@@ -113,6 +115,8 @@ class TestCrossModelIntegration:
             WorkItemCreateSpec,
             WorkItemsCreateResult,
             WorkItemUpdateResult,
+            WorkItemUpdateSpec,
+            WorkItemsUpdateResult,
             WorkItemLinkSpec,
             WorkItemLinkRef,
             WorkItemLinksCreateResult,

--- a/tests/mcp_server_polarion/models/test_links.py
+++ b/tests/mcp_server_polarion/models/test_links.py
@@ -11,6 +11,7 @@ from mcp_server_polarion.models import (
     WorkItemLinksCreateResult,
     WorkItemLinksDeleteResult,
     WorkItemLinkSpec,
+    WorkItemLinkUpdateSpec,
 )
 
 
@@ -106,6 +107,34 @@ class TestWorkItemLinkSpec:
     def test_target_work_item_id_min_length(self):
         with pytest.raises(ValidationError):
             WorkItemLinkSpec(role="parent", target_work_item_id="")
+
+    def test_typo_key_rejected(self):
+        # extra='forbid': a typo key must error, not silently drop the field.
+        with pytest.raises(ValidationError, match="suspct"):
+            WorkItemLinkSpec.model_validate(
+                {"role": "parent", "target_work_item_id": "MCPT-2", "suspct": True}
+            )
+
+    def test_ref_typo_key_rejected(self):
+        with pytest.raises(ValidationError, match="target_projct_id"):
+            WorkItemLinkRef.model_validate(
+                {
+                    "role": "parent",
+                    "target_work_item_id": "MCPT-2",
+                    "target_projct_id": "P",
+                }
+            )
+
+    def test_update_spec_typo_key_rejected(self):
+        with pytest.raises(ValidationError, match="revison"):
+            WorkItemLinkUpdateSpec.model_validate(
+                {
+                    "role": "parent",
+                    "target_work_item_id": "MCPT-2",
+                    "suspect": True,
+                    "revison": "1234",
+                }
+            )
 
 
 class TestWorkItemLinkRef:

--- a/tests/mcp_server_polarion/models/test_test_runs.py
+++ b/tests/mcp_server_polarion/models/test_test_runs.py
@@ -1,0 +1,21 @@
+"""Tests for test run models in ``mcp_server_polarion.models.test_runs``."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from mcp_server_polarion.models import TestRunCreateSpec
+
+
+class TestTestRunCreateSpec:
+    def test_minimal_spec(self):
+        spec = TestRunCreateSpec(id="RUN-1")
+        assert spec.id == "RUN-1"
+        assert spec.title is None
+        assert spec.custom_fields is None
+
+    def test_typo_key_rejected(self):
+        # extra='forbid': a typo key must error, not silently drop the field.
+        with pytest.raises(ValidationError, match="titel"):
+            TestRunCreateSpec.model_validate({"id": "RUN-1", "titel": "oops"})

--- a/tests/mcp_server_polarion/models/test_work_items.py
+++ b/tests/mcp_server_polarion/models/test_work_items.py
@@ -13,7 +13,6 @@ from mcp_server_polarion.models import (
     WorkItemsCreateResult,
     WorkItemSummary,
     WorkItemsUpdateResult,
-    WorkItemUpdateResult,
     WorkItemUpdateSpec,
 )
 
@@ -332,41 +331,20 @@ class TestWorkItemsCreateResult:
         assert result.payload_preview is not None
 
 
-class TestWorkItemUpdateResult:
-    def test_successful_update(self):
-        current = WorkItemDetail(
-            id="MCPT-001",
-            title="Old Title",
-            type="requirement",
-            status="draft",
-            description_html="<p>Old desc</p>",
-            project_id="proj1",
-        )
-        result = WorkItemUpdateResult(
-            updated=True,
-            dry_run=False,
-            current=current,
-            changes={"title": "New Title"},
-            payload_preview=None,
-        )
-        assert result.updated is True
-        assert result.current is not None
-        assert result.current.title == "Old Title"
-        assert result.changes["title"] == "New Title"
-        assert result.payload_preview is None
-
-    def test_dry_run(self):
-        result = WorkItemUpdateResult(
+class TestWorkItemsUpdateResultDryRun:
+    def test_dry_run_preview(self):
+        result = WorkItemsUpdateResult(
             updated=False,
             dry_run=True,
-            current=None,
-            changes={"status": "approved"},
+            work_item_ids=[],
             payload_preview={
-                "data": {
-                    "type": "workitems",
-                    "id": "proj1/MCPT-001",
-                    "attributes": {"status": "approved"},
-                }
+                "data": [
+                    {
+                        "type": "workitems",
+                        "id": "proj1/MCPT-001",
+                        "attributes": {"status": "approved"},
+                    }
+                ]
             },
         )
         assert result.updated is False

--- a/tests/mcp_server_polarion/models/test_work_items.py
+++ b/tests/mcp_server_polarion/models/test_work_items.py
@@ -6,13 +6,80 @@ import pytest
 from pydantic import ValidationError
 
 from mcp_server_polarion.models import (
+    MAX_BODY_HTML_LEN,
     Hyperlink,
     WorkItemCreateSpec,
     WorkItemDetail,
     WorkItemsCreateResult,
     WorkItemSummary,
+    WorkItemsUpdateResult,
     WorkItemUpdateResult,
+    WorkItemUpdateSpec,
 )
+
+
+class TestWorkItemUpdateSpec:
+    def test_minimal_title_change(self):
+        spec = WorkItemUpdateSpec(work_item_id="MCPT-1", title="t")
+        assert spec.work_item_id == "MCPT-1"
+        assert spec.title == "t"
+        assert spec.custom_fields is None
+
+    def test_work_item_id_min_length(self):
+        with pytest.raises(ValidationError):
+            WorkItemUpdateSpec(work_item_id="", title="t")
+
+    def test_all_unset_rejected_naming_id(self):
+        with pytest.raises(ValidationError, match="MCPT-7") as exc:
+            WorkItemUpdateSpec(work_item_id="MCPT-7")
+        assert "no effective change" in str(exc.value)
+
+    def test_none_only_custom_fields_rejected(self):
+        # {"k": None} is truthy but merge_custom_fields drops None values,
+        # which would yield an attribute-less resource that 400s the batch.
+        with pytest.raises(ValidationError, match="no effective change"):
+            WorkItemUpdateSpec(work_item_id="MCPT-1", custom_fields={"risk": None})
+
+    def test_custom_fields_with_one_real_value_pass(self):
+        spec = WorkItemUpdateSpec(
+            work_item_id="MCPT-1", custom_fields={"a": None, "b": "v"}
+        )
+        assert spec.custom_fields == {"a": None, "b": "v"}
+
+    def test_empty_hyperlinks_alone_rejected(self):
+        with pytest.raises(ValidationError, match="no effective change"):
+            WorkItemUpdateSpec(work_item_id="MCPT-1", hyperlinks=[])
+
+    def test_empty_assignee_ids_alone_rejected(self):
+        with pytest.raises(ValidationError, match="no effective change"):
+            WorkItemUpdateSpec(work_item_id="MCPT-1", assignee_ids=[])
+
+    def test_hyperlinks_alone_pass(self):
+        spec = WorkItemUpdateSpec(
+            work_item_id="MCPT-1",
+            hyperlinks=[Hyperlink(role="ref_ext", uri="https://x")],
+        )
+        assert spec.hyperlinks is not None
+
+    def test_typo_key_rejected(self):
+        with pytest.raises(ValidationError, match="titel"):
+            WorkItemUpdateSpec.model_validate(
+                {"work_item_id": "MCPT-1", "titel": "oops"}
+            )
+
+    def test_description_html_max_length(self):
+        with pytest.raises(ValidationError):
+            WorkItemUpdateSpec(
+                work_item_id="MCPT-1",
+                description_html="x" * (MAX_BODY_HTML_LEN + 1),
+            )
+
+
+class TestWorkItemsUpdateResult:
+    def test_defaults(self):
+        result = WorkItemsUpdateResult(updated=True, dry_run=False)
+        assert result.work_item_ids == []
+        assert result.payload_preview is None
 
 
 class TestInputSpecsForbidUnknownKeys:

--- a/tests/mcp_server_polarion/models/test_work_items.py
+++ b/tests/mcp_server_polarion/models/test_work_items.py
@@ -7,11 +7,29 @@ from pydantic import ValidationError
 
 from mcp_server_polarion.models import (
     Hyperlink,
+    WorkItemCreateSpec,
     WorkItemDetail,
     WorkItemsCreateResult,
     WorkItemSummary,
     WorkItemUpdateResult,
 )
+
+
+class TestInputSpecsForbidUnknownKeys:
+    """LLM-input models must reject typo keys instead of silently dropping
+    the intended field (extra='forbid')."""
+
+    def test_create_spec_typo_key_rejected(self):
+        with pytest.raises(ValidationError, match="descripion"):
+            WorkItemCreateSpec.model_validate(
+                {"title": "t", "type": "task", "descripion": "oops"}
+            )
+
+    def test_hyperlink_typo_key_rejected(self):
+        with pytest.raises(ValidationError, match="titel"):
+            Hyperlink.model_validate(
+                {"role": "ref_ext", "uri": "https://x", "titel": "oops"}
+            )
 
 
 class TestWorkItemSummary:

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -44,7 +44,7 @@ _WRITE_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "create_work_items",
         "create_test_runs",
-        "update_work_item",
+        "update_work_items",
         "move_work_item_to_document",
         "move_work_item_from_document",
         "create_work_item_links",

--- a/tests/mcp_server_polarion/tools/_shared/test_guard.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_guard.py
@@ -914,6 +914,15 @@ class TestResolveWorkItemTypes:
 
         assert await resolve_work_item_types(mock_client, "P", ["A"]) == {"A": ""}
 
+    async def test_non_list_data_treated_as_missing(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Defensive: a malformed reply must not pass the existence check.
+        mock_client.get.return_value = {"data": {"type": "workitems"}}
+
+        with pytest.raises(ValueError, match="not found"):
+            await resolve_work_item_types(mock_client, "P", ["A"])
+
     async def test_project_not_found_raises_value_error(
         self, mock_client: AsyncMock
     ) -> None:

--- a/tests/mcp_server_polarion/tools/_shared/test_guard.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_guard.py
@@ -1215,7 +1215,7 @@ class TestGuardWorkItemLinkRoles:
 
 
 class TestGuardHyperlinkRoles:
-    """Hyperlink-role guard for ``create_work_items`` / ``update_work_item``."""
+    """Hyperlink-role guard for ``create_work_items`` / ``update_work_items``."""
 
     async def test_valid_role_passes(self, mock_client: AsyncMock) -> None:
         mock_client.get.return_value = _project_enum_response(

--- a/tests/mcp_server_polarion/tools/_shared/test_guard.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_guard.py
@@ -39,6 +39,7 @@ from mcp_server_polarion.tools._shared.guard import (
     guard_work_item_link_roles,
     guard_work_item_link_targets,
     partition_delete_links,
+    resolve_work_item_types,
 )
 
 
@@ -839,6 +840,105 @@ def _link(target: str, *, project: str | None = None) -> WorkItemLinkSpec:
     return WorkItemLinkSpec(
         role="relates_to", target_work_item_id=target, target_project_id=project
     )
+
+
+def _typed_workitems_response(
+    project_id: str, pairs: list[tuple[str, str]]
+) -> dict[str, object]:
+    """A JSON:API workitems list response carrying each item's ``type``."""
+    return {
+        "data": [
+            {
+                "type": "workitems",
+                "id": f"{project_id}/{short_id}",
+                "attributes": {"type": type_id},
+            }
+            for short_id, type_id in pairs
+        ],
+        "meta": {"totalCount": len(pairs)},
+    }
+
+
+class TestResolveWorkItemTypes:
+    """Batched existence + type lookup backing bulk update guards."""
+
+    async def test_all_found_maps_id_to_type(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = _typed_workitems_response(
+            "P", [("A", "task"), ("B", "requirement")]
+        )
+
+        types = await resolve_work_item_types(mock_client, "P", ["B", "A"])
+
+        assert types == {"A": "task", "B": "requirement"}
+        mock_client.get.assert_awaited_once()
+        path = mock_client.get.call_args.args[0]
+        params = mock_client.get.call_args.kwargs["params"]
+        assert path == "/projects/P/workitems"
+        assert params["query"] == "id:(A B)"
+        assert params["fields[workitems]"] == "id,type"
+
+    async def test_missing_ids_all_named(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = _typed_workitems_response("P", [("A", "task")])
+
+        with pytest.raises(ValueError, match=r"\['B', 'C'\]") as exc:
+            await resolve_work_item_types(mock_client, "P", ["A", "B", "C"])
+
+        assert "list_work_items" in str(exc.value)
+
+    async def test_empty_ids_no_request(self, mock_client: AsyncMock) -> None:
+        assert await resolve_work_item_types(mock_client, "P", []) == {}
+        mock_client.get.assert_not_awaited()
+
+    async def test_chunks_above_page_size(self, mock_client: AsyncMock) -> None:
+        ids = sorted(f"WI-{n}" for n in range(150))
+
+        async def fake_get(path: str, **kwargs: object) -> dict[str, object]:
+            query = str(kwargs["params"]["query"])  # type: ignore[index]
+            chunk = query.removeprefix("id:(").removesuffix(")").split()
+            return _typed_workitems_response("P", [(i, "task") for i in chunk])
+
+        mock_client.get.side_effect = fake_get
+
+        types = await resolve_work_item_types(mock_client, "P", ids)
+
+        assert mock_client.get.await_count == 2
+        assert len(types) == 150
+
+    async def test_missing_type_attribute_maps_to_empty(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Defensive: entry without attributes still counts as existing.
+        mock_client.get.return_value = {
+            "data": [{"type": "workitems", "id": "P/A"}, "not-a-dict"]
+        }
+
+        assert await resolve_work_item_types(mock_client, "P", ["A"]) == {"A": ""}
+
+    async def test_project_not_found_raises_value_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "no such project", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="Project 'P' not found"):
+            await resolve_work_item_types(mock_client, "P", ["A"])
+
+    async def test_unreachable_backend_blocks_write(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError("backend down")
+
+        with pytest.raises(RuntimeError, match="Refusing the write"):
+            await resolve_work_item_types(mock_client, "P", ["A"])
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("forbidden", status_code=403)
+
+        with pytest.raises(PermissionError, match="lacks permission"):
+            await resolve_work_item_types(mock_client, "P", ["A"])
 
 
 class TestGuardWorkItemLinkTargets:

--- a/tests/mcp_server_polarion/tools/_shared/test_helpers.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_helpers.py
@@ -12,8 +12,10 @@ import pytest
 from mcp_server_polarion.tools._shared.helpers import (
     OPTION_LIST_LIMIT,
     encode_path_segment,
+    ensure_unique_ids,
     format_option_list,
     get_client,
+    reraise_with_item_context,
     safe_str,
     validate_work_item_id_for_lucene,
 )
@@ -125,3 +127,61 @@ class TestGetClient:
     def test_returns_injected_client(self, mock_ctx: MagicMock) -> None:
         client = mock_ctx.lifespan_context["polarion_client"]
         assert get_client(mock_ctx) is client
+
+
+class TestEnsureUniqueIds:
+    """Tests for `ensure_unique_ids`."""
+
+    def test_unique_ids_pass(self) -> None:
+        assert ensure_unique_ids(["A-1", "A-2"], label="work_item_id") is None
+
+    def test_empty_passes(self) -> None:
+        assert ensure_unique_ids([], label="work_item_id") is None
+
+    def test_duplicates_rejected_naming_each_once_sorted(self) -> None:
+        with pytest.raises(ValueError, match=r"\['A-1', 'B-2'\]") as exc_info:
+            ensure_unique_ids(["B-2", "A-1", "B-2", "A-1", "A-1"], label="work_item_id")
+        message = str(exc_info.value)
+        assert "work_item_id" in message
+        assert "single item" in message
+
+    def test_label_interpolated(self) -> None:
+        with pytest.raises(ValueError, match="test run id"):
+            ensure_unique_ids(["X", "X"], label="test run id")
+
+    def test_accepts_generator(self) -> None:
+        with pytest.raises(ValueError, match=r"\['X'\]"):
+            ensure_unique_ids((i for i in ["X", "X"]), label="id")
+
+
+class TestReraiseWithItemContext:
+    """Tests for `reraise_with_item_context`."""
+
+    def test_value_error_prefixed_with_position_and_id(self) -> None:
+        original = ValueError("unknown status 'ghost'")
+        with (
+            pytest.raises(
+                ValueError, match=r"items\[2\] \('MCPT-9'\): unknown status 'ghost'"
+            ) as exc_info,
+            reraise_with_item_context(2, "MCPT-9"),
+        ):
+            raise original
+        assert exc_info.value.__cause__ is original
+
+    def test_permission_error_passes_through(self) -> None:
+        with (
+            pytest.raises(PermissionError, match=r"^denied$"),
+            reraise_with_item_context(0, "MCPT-1"),
+        ):
+            raise PermissionError("denied")
+
+    def test_runtime_error_passes_through(self) -> None:
+        with (
+            pytest.raises(RuntimeError, match=r"^backend down$"),
+            reraise_with_item_context(0, "MCPT-1"),
+        ):
+            raise RuntimeError("backend down")
+
+    def test_no_exception_is_noop(self) -> None:
+        with reraise_with_item_context(0, "MCPT-1"):
+            pass

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -398,6 +398,24 @@ class TestBuildCreateTestRunsPayload:
 class TestCreateTestRuns:
     """Tests for the ``create_test_runs`` tool."""
 
+    async def test_duplicate_ids_rejected_before_any_request(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Client-supplied ids can collide; the server would 409 after
+        # partially creating the batch.
+        with pytest.raises(ValueError, match=r"Duplicate id\(s\) \['TR-1'\]"):
+            await create_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[
+                    TestRunCreateSpec(id="TR-1", title="a"),
+                    TestRunCreateSpec(id="TR-1", title="b"),
+                ],
+                dry_run=False,
+            )
+        mock_client.get.assert_not_awaited()
+        mock_client.post.assert_not_awaited()
+
     async def test_minimal_create_posts_and_returns_ids(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:

--- a/tests/mcp_server_polarion/tools/test_tool_annotations.py
+++ b/tests/mcp_server_polarion/tools/test_tool_annotations.py
@@ -43,7 +43,7 @@ class TestWriteToolAnnotations:
                 },
             ),
             (
-                "update_work_item",
+                "update_work_items",
                 {
                     "readOnlyHint": False,
                     "destructiveHint": True,

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -888,6 +888,32 @@ class TestUpdateWorkItemsHyperlinkRoleGuard:
         assert "ref_ext" in str(exc.value)
         mock_client.patch.assert_not_called()
 
+    async def test_bad_role_names_offending_item_via_cache(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Item 0's role passes; item 1 reuses the cached options (no second
+        # enum GET) and is rejected with its batch position and id.
+        mock_client.get.side_effect = [
+            _existence_response(("MCPT-1", "task"), ("MCPT-2", "task")),
+            _project_enum_get_response("hyperlink-role", ["ref_int", "ref_ext"]),
+        ]
+
+        with pytest.raises(ValueError, match=r"items\[1\] \('MCPT-2'\)"):
+            await _call_update(
+                mock_ctx,
+                items=[
+                    _spec(hyperlinks=[Hyperlink(role="ref_ext", uri="https://a.com")]),
+                    _spec(
+                        work_item_id="MCPT-2",
+                        hyperlinks=[Hyperlink(role="ghost", uri="https://b.com")],
+                    ),
+                ],
+                dry_run=True,
+            )
+
+        assert mock_client.get.await_count == 2
+        mock_client.patch.assert_not_called()
+
 
 class TestUpdateWorkItemsDryRun:
     """Tests for ``update_work_items`` with ``dry_run=True``."""

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -21,18 +21,21 @@ from mcp_server_polarion.models import (
     WorkItemDetail,
     WorkItemRead,
     WorkItemsCreateResult,
-    WorkItemUpdateResult,
+    WorkItemsUpdateResult,
+    WorkItemUpdateSpec,
 )
 from mcp_server_polarion.tools._shared import cache as _cache_mod
+from mcp_server_polarion.tools._shared.fields import MAX_BULK_ITEMS
 from mcp_server_polarion.tools.work_items import (
     _build_create_work_items_payload,
-    _build_update_work_item_payload,
+    _build_update_work_item_resource,
+    _build_update_work_items_payload,
     _build_work_item_resource,
     create_work_items,
     get_work_item,
     list_work_items,
     read_work_item,
-    update_work_item,
+    update_work_items,
 )
 
 
@@ -47,72 +50,43 @@ def _project_enum_get_response(enum_name: str, ids: list[str]) -> dict[str, obje
     }
 
 
+def _spec(**overrides: object) -> WorkItemUpdateSpec:
+    """One update spec with a default id; tests override what they need."""
+    fields: dict[str, object] = {"work_item_id": "MCPT-1"}
+    fields.update(overrides)
+    return WorkItemUpdateSpec(**fields)  # type: ignore[arg-type]
+
+
 async def _call_update(
     mock_ctx: MagicMock, **overrides: object
-) -> WorkItemUpdateResult:
-    """Call update_work_item with all params explicit.
+) -> WorkItemsUpdateResult:
+    """Call update_work_items with all params explicit.
 
     Field(...) defaults stay FieldInfo objects outside FastMCP, so every
     param must be passed; tests override only what they care about.
     """
     defaults: dict[str, object] = {
         "project_id": "MyProj",
-        "work_item_id": "MCPT-1",
-        "title": None,
-        "description_html": None,
-        "status": None,
-        "priority": None,
-        "severity": None,
-        "due_date": None,
-        "initial_estimate": None,
-        "resolution": None,
-        "hyperlinks": None,
-        "assignee_ids": None,
-        "custom_fields": None,
+        "items": [_spec(title="t")],
         "workflow_action": None,
         "change_type_to": None,
-        "include_current_description_html": False,
         "dry_run": False,
     }
     defaults.update(overrides)
-    return await update_work_item(mock_ctx, **defaults)
+    return await update_work_items(mock_ctx, **defaults)
 
 
-def _make_get_response(
-    *,
-    work_item_id: str = "MCPT-1",
-    project_id: str = "MyProj",
-    title: str = "after",
-    status: str = "open",
-    description_html: str = "",
-    assignee_ids: list[str] | None = None,
-    custom_fields: dict[str, object] | None = None,
-) -> dict[str, object]:
-    """Build a minimal JSON:API GET response for the follow-up fetch."""
-    relationships: dict[str, object] = {}
-    if assignee_ids is not None:
-        relationships["assignee"] = {
-            "data": [{"type": "users", "id": uid} for uid in assignee_ids]
-        }
-    attributes: dict[str, object] = {
-        "title": title,
-        "type": "task",
-        "status": status,
-        "priority": "50.0",
-        "updated": "2026-05-04T10:00:00Z",
-    }
-    if description_html:
-        attributes["description"] = {"type": "text/html", "value": description_html}
-    if custom_fields:
-        # Inline (no customFields container); primes the pre-fetch guard cache.
-        attributes.update(custom_fields)
+def _existence_response(*pairs: tuple[str, str]) -> dict[str, object]:
+    """Reply to the batched ``id:(...)`` existence/type query."""
     return {
-        "data": {
-            "type": "workitems",
-            "id": f"{project_id}/{work_item_id}",
-            "attributes": attributes,
-            "relationships": relationships,
-        }
+        "data": [
+            {
+                "type": "workitems",
+                "id": f"MyProj/{short_id}",
+                "attributes": {"type": type_id},
+            }
+            for short_id, type_id in pairs
+        ]
     }
 
 
@@ -708,116 +682,48 @@ class TestCreateWorkItemsFieldValidation:
             )
 
 
-class TestBuildUpdateWorkItemPayload:
-    """Tests for the private ``_build_update_work_item_payload`` helper."""
+class TestBuildUpdateWorkItemsPayload:
+    """Tests for the private bulk-update payload builders."""
 
-    def test_minimal_payload_with_only_title(self) -> None:
-        payload = _build_update_work_item_payload(
-            project_id="MyProj",
-            work_item_id="MCPT-1",
-            title="New title",
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
+    def test_minimal_resource_with_only_title(self) -> None:
+        resource = _build_update_work_item_resource(
+            project_id="MyProj", spec=_spec(title="New title")
         )
 
-        # PATCH body wraps `data` as a single object, not a list.
-        assert payload == {
-            "data": {
-                "type": "workitems",
-                "id": "MyProj/MCPT-1",
-                "attributes": {"title": "New title"},
-            }
+        assert resource == {
+            "type": "workitems",
+            "id": "MyProj/MCPT-1",
+            "attributes": {"title": "New title"},
         }
-        item = cast(dict[str, object], payload["data"])
-        assert "relationships" not in item
 
-    def test_id_is_project_slash_work_item_id(self) -> None:
-        payload = _build_update_work_item_payload(
-            project_id="proj",
-            work_item_id="MCPT-99",
-            title="x",
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
-        )
-
-        item = cast(dict[str, object], payload["data"])
-        assert item["id"] == "proj/MCPT-99"
-
-    def test_skips_none_and_empty_string_fields(self) -> None:
-        payload = _build_update_work_item_payload(
+    def test_payload_wraps_data_as_list_in_input_order(self) -> None:
+        payload = _build_update_work_items_payload(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html="",
-            status="",
-            priority=None,
-            severity="",
-            due_date="",
-            initial_estimate=None,
-            resolution="",
-            hyperlinks=[],
-            assignee_ids=[],
+            specs=[_spec(title="a"), _spec(work_item_id="MCPT-2", title="b")],
         )
 
-        # No attributes, no relationships — just the resource header.
-        item = cast(dict[str, object], payload["data"])
-        assert item == {"type": "workitems", "id": "MyProj/MCPT-1"}
+        data = cast(list[dict[str, object]], payload["data"])
+        assert [item["id"] for item in data] == ["MyProj/MCPT-1", "MyProj/MCPT-2"]
 
     def test_includes_description_block(self) -> None:
-        payload = _build_update_work_item_payload(
-            project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html="<p>hi</p>",
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
+        resource = _build_update_work_item_resource(
+            project_id="MyProj", spec=_spec(description_html="<p>hi</p>")
         )
 
-        item = cast(dict[str, object], payload["data"])
-        attributes = cast(dict[str, object], item["attributes"])
+        attributes = cast(dict[str, object], resource["attributes"])
         assert attributes["description"] == {
             "type": "text/html",
             "value": "<p>hi</p>",
         }
 
     def test_assignee_ids_become_to_many_users_relationship(self) -> None:
-        payload = _build_update_work_item_payload(
-            project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=["alice", "bob"],
+        resource = _build_update_work_item_resource(
+            project_id="MyProj", spec=_spec(assignee_ids=["alice", "bob"])
         )
 
-        item = cast(dict[str, object], payload["data"])
-        relationships = cast(dict[str, object], item["relationships"])
+        # Relationship-only change: no attributes block at all.
+        assert "attributes" not in resource
+        relationships = cast(dict[str, object], resource["relationships"])
         assert relationships["assignee"] == {
             "data": [
                 {"type": "users", "id": "alice"},
@@ -826,247 +732,156 @@ class TestBuildUpdateWorkItemPayload:
         }
 
     def test_hyperlinks_serialise_role_title_uri(self) -> None:
-        payload = _build_update_work_item_payload(
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=[
-                Hyperlink(role="ref_ext", title="Spec", uri="https://example.com"),
-            ],
-            assignee_ids=None,
+            spec=_spec(
+                hyperlinks=[
+                    Hyperlink(role="ref_ext", title="Spec", uri="https://example.com")
+                ]
+            ),
         )
 
-        item = cast(dict[str, object], payload["data"])
-        attributes = cast(dict[str, object], item["attributes"])
+        attributes = cast(dict[str, object], resource["attributes"])
         assert attributes["hyperlinks"] == [
             {"role": "ref_ext", "title": "Spec", "uri": "https://example.com"},
         ]
 
     def test_all_optional_attrs_included_when_set(self) -> None:
-        payload = _build_update_work_item_payload(
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title="t",
-            description_html=None,
-            status="open",
-            priority="50.0",
-            severity="major",
-            due_date="2026-05-31",
-            initial_estimate="5 1/2d",
-            resolution="fixed",
-            hyperlinks=None,
-            assignee_ids=None,
+            spec=_spec(
+                title="t",
+                status="open",
+                priority="50.0",
+                severity="major",
+                due_date="2026-05-31",
+                initial_estimate="5 1/2d",
+                resolution="fixed",
+            ),
         )
 
-        item = cast(dict[str, object], payload["data"])
-        attributes = cast(dict[str, object], item["attributes"])
-        assert attributes["title"] == "t"
-        assert attributes["status"] == "open"
-        assert attributes["priority"] == "50.0"
-        assert attributes["severity"] == "major"
-        assert attributes["dueDate"] == "2026-05-31"
-        assert attributes["initialEstimate"] == "5 1/2d"
-        assert attributes["resolution"] == "fixed"
+        attributes = cast(dict[str, object], resource["attributes"])
+        assert attributes == {
+            "title": "t",
+            "status": "open",
+            "priority": "50.0",
+            "severity": "major",
+            "dueDate": "2026-05-31",
+            "initialEstimate": "5 1/2d",
+            "resolution": "fixed",
+        }
 
-    def test_custom_fields_inlined_in_patch_attributes(self) -> None:
+    def test_custom_fields_inlined_in_attributes(self) -> None:
         rich = {"type": "text/html", "value": "<p>note</p>"}
-        payload = _build_update_work_item_payload(
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
-            custom_fields={"riskLevel": "low", "reviewerNote": rich},
+            spec=_spec(custom_fields={"riskLevel": "low", "reviewerNote": rich}),
         )
 
-        item = cast(dict[str, object], payload["data"])
-        attributes = cast(dict[str, object], item["attributes"])
+        attributes = cast(dict[str, object], resource["attributes"])
         assert attributes == {"riskLevel": "low", "reviewerNote": rich}
 
-    def test_custom_fields_alone_keeps_attributes_dict(self) -> None:
-        # custom_fields alone must still emit an attributes block, else PATCH 400s.
-        payload = _build_update_work_item_payload(
+    def test_none_valued_custom_entries_dropped(self) -> None:
+        # Polarion reads explicit None as "clear default"; the write contract
+        # skips them, and the spec validator has already ensured >=1 survives.
+        resource = _build_update_work_item_resource(
             project_id="MyProj",
-            work_item_id="MCPT-1",
-            title=None,
-            description_html=None,
-            status=None,
-            priority=None,
-            severity=None,
-            due_date=None,
-            initial_estimate=None,
-            resolution=None,
-            hyperlinks=None,
-            assignee_ids=None,
-            custom_fields={"riskLevel": "high"},
+            spec=_spec(custom_fields={"cleared": None, "kept": "v"}),
         )
-        item = cast(dict[str, object], payload["data"])
-        assert "attributes" in item
+
+        attributes = cast(dict[str, object], resource["attributes"])
+        assert attributes == {"kept": "v"}
 
     def test_custom_fields_collision_raises(self) -> None:
         with pytest.raises(ValueError, match="custom_fields keys collide"):
-            _build_update_work_item_payload(
+            _build_update_work_item_resource(
                 project_id="MyProj",
-                work_item_id="MCPT-1",
-                title=None,
-                description_html=None,
-                status=None,
-                priority=None,
-                severity=None,
-                due_date=None,
-                initial_estimate=None,
-                resolution=None,
-                hyperlinks=None,
-                assignee_ids=None,
-                custom_fields={"status": "open"},
+                spec=_spec(custom_fields={"status": "open"}),
             )
 
 
-class TestUpdateWorkItemValidation:
-    """Tests for the at-least-one-field guard in ``update_work_item``."""
+class TestUpdateWorkItemsValidation:
+    """Batch-level validation before any Polarion round-trip."""
 
-    async def test_no_fields_raises_value_error(
+    async def test_duplicate_ids_rejected_before_any_request(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        with pytest.raises(ValueError, match="Nothing to update"):
-            await _call_update(mock_ctx)
+        with pytest.raises(ValueError, match="Duplicate work_item_id"):
+            await _call_update(
+                mock_ctx,
+                items=[_spec(title="a"), _spec(title="b")],
+            )
+        mock_client.get.assert_not_called()
         mock_client.patch.assert_not_called()
+
+    async def test_lucene_unsafe_id_rejected_before_any_request(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Project-qualified ids ('P/MCPT-1') are rejected too: '/' is outside
+        # the charset embedded into the id:(...) existence query.
+        with pytest.raises(ValueError, match="outside"):
+            await _call_update(
+                mock_ctx, items=[_spec(work_item_id="MyProj/MCPT-1", title="t")]
+            )
         mock_client.get.assert_not_called()
 
-    async def test_empty_description_html_is_noop(
+    async def test_missing_ids_named_before_patch(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``description_html=''`` = leave unchanged (never PATCHes) — asymmetric vs
-        update_document, where '' RAISES: a wiped document body orphans every heading,
-        a cleared description is recoverable.
-        """
-        with pytest.raises(ValueError, match="Nothing to update"):
-            await _call_update(mock_ctx, description_html="")
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
+
+        with pytest.raises(ValueError, match="MCPT-9") as exc:
+            await _call_update(
+                mock_ctx,
+                items=[
+                    _spec(title="a"),
+                    _spec(work_item_id="MCPT-9", title="b"),
+                ],
+            )
+
+        assert "list_work_items" in str(exc.value)
         mock_client.patch.assert_not_called()
-        mock_client.get.assert_not_called()
 
-    async def test_empty_description_html_with_other_field_drops_description(
+    async def test_missing_ids_checked_on_dry_run_too(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``description_html=''`` is skipped from the PATCH body even when
-        paired with other fields — the existing description is preserved.
-        """
-        result = await _call_update(
-            mock_ctx,
-            title="new title",
-            description_html="",
-            dry_run=True,
-        )
-        # Empty description_html drops from both changes and the wire payload.
-        assert result.changes == {"title": "new title"}
-        assert result.payload_preview is not None
-        item = cast(dict[str, object], result.payload_preview["data"])
-        attributes = cast(dict[str, object], item["attributes"])
-        assert "description" not in attributes
-        assert attributes == {"title": "new title"}
+        # Preview must raise the same errors as the real write.
+        mock_client.get.return_value = _existence_response()
 
-    async def test_custom_fields_alone_satisfies_at_least_one_check(
+        with pytest.raises(ValueError, match="MCPT-1"):
+            await _call_update(mock_ctx, items=[_spec(title="t")], dry_run=True)
+
+    async def test_collision_raises_before_any_request(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # custom_fields counts as a body field.
-        _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"riskLevel"})
-        )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"riskLevel": "high"}
-        )
-        result = await _call_update(
-            mock_ctx,
-            custom_fields={"riskLevel": "high"},
-            dry_run=True,
-        )
-        assert result.dry_run is True
-        assert result.changes == {"custom_fields": {"riskLevel": "high"}}
-
-    async def test_collision_raises_value_error(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # A custom key matching a standard param would shadow it.
+        # A custom key matching a standard attribute would shadow it; the
+        # payload is built before any guard round-trip, so this fails fast.
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             await _call_update(
                 mock_ctx,
-                title="x",
-                custom_fields={"title": "y"},
-                dry_run=True,
+                items=[_spec(title="x", custom_fields={"title": "y"})],
             )
-        mock_client.patch.assert_not_called()
-
-    async def test_workflow_action_alone_raises_value_error(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Polarion 400s on attribute-less PATCH, so an action needs a body field.
-        with pytest.raises(ValueError, match="at least one body field"):
-            await _call_update(mock_ctx, workflow_action="close")
-        mock_client.patch.assert_not_called()
         mock_client.get.assert_not_called()
-
-    async def test_change_type_to_alone_raises_value_error(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        with pytest.raises(ValueError, match="at least one body field"):
-            await _call_update(mock_ctx, change_type_to="defect")
         mock_client.patch.assert_not_called()
 
-    async def test_workflow_action_alone_dry_run_also_rejected(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Dry-run is rejected too: the would-be payload is invalid.
-        with pytest.raises(ValueError, match="at least one body field"):
-            await _call_update(mock_ctx, workflow_action="close", dry_run=True)
 
-    async def test_workflow_action_with_title_passes(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Pairing the action with any body field satisfies Polarion.
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
-
-        result = await _call_update(
-            mock_ctx,
-            workflow_action="close",
-            title="closing this work item",
-        )
-
-        assert result.updated is True
-        patch_path = mock_client.patch.call_args.args[0]
-        assert patch_path == "/projects/MyProj/workitems/MCPT-1?workflowAction=close"
-        body = mock_client.patch.call_args.kwargs["json"]
-        assert body["data"]["attributes"]["title"] == "closing this work item"
-
-
-class TestUpdateWorkItemHyperlinkRoleGuard:
-    """``update_work_item`` validates hyperlink roles before the PATCH."""
+class TestUpdateWorkItemsHyperlinkRoleGuard:
+    """``update_work_items`` validates hyperlink roles before the PATCH."""
 
     async def test_unknown_hyperlink_role_raises_without_patch(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        mock_client.get.return_value = _project_enum_get_response(
-            "hyperlink-role", ["ref_int", "ref_ext"]
-        )
+        mock_client.get.side_effect = [
+            _existence_response(("MCPT-1", "task")),
+            _project_enum_get_response("hyperlink-role", ["ref_int", "ref_ext"]),
+        ]
 
         with pytest.raises(ValueError, match="ghost") as exc:
             await _call_update(
                 mock_ctx,
-                hyperlinks=[Hyperlink(role="ghost", uri="https://e.com")],
+                items=[
+                    _spec(hyperlinks=[Hyperlink(role="ghost", uri="https://e.com")])
+                ],
                 dry_run=True,
             )
 
@@ -1074,402 +889,234 @@ class TestUpdateWorkItemHyperlinkRoleGuard:
         mock_client.patch.assert_not_called()
 
 
-class TestUpdateWorkItemDryRun:
-    """Tests for ``update_work_item`` with ``dry_run=True``."""
+class TestUpdateWorkItemsDryRun:
+    """Tests for ``update_work_items`` with ``dry_run=True``."""
 
-    async def test_dry_run_does_not_call_polarion(
+    async def test_dry_run_skips_patch_but_validates_existence(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
+
         result = await _call_update(
-            mock_ctx,
-            title="New title",
-            dry_run=True,
+            mock_ctx, items=[_spec(title="New title")], dry_run=True
         )
 
         mock_client.patch.assert_not_called()
-        mock_client.get.assert_not_called()
-        assert isinstance(result, WorkItemUpdateResult)
+        mock_client.get.assert_awaited_once()
+        assert isinstance(result, WorkItemsUpdateResult)
         assert result.updated is False
         assert result.dry_run is True
-        assert result.current is None
-        assert result.changes == {"title": "New title"}
-        # payload_preview is populated on dry-run (mirrors create_work_items).
+        assert result.work_item_ids == []
         assert result.payload_preview is not None
-        item = cast(dict[str, object], result.payload_preview["data"])
-        assert item["id"] == "MyProj/MCPT-1"
-        attributes = cast(dict[str, object], item["attributes"])
+        data = cast(list[dict[str, object]], result.payload_preview["data"])
+        assert data[0]["id"] == "MyProj/MCPT-1"
+        attributes = cast(dict[str, object], data[0]["attributes"])
         assert attributes == {"title": "New title"}
 
-    async def test_changes_uses_python_typed_values_not_json_api_shape(
+    async def test_dry_run_preview_carries_query_params(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # changes holds raw caller values; {type,value} wrapping is preview-only.
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
+
         result = await _call_update(
             mock_ctx,
-            description_html="<p>bold</p>",
-            assignee_ids=["alice"],
+            items=[_spec(title="t")],
+            workflow_action="close",
             dry_run=True,
         )
 
-        assert result.changes == {
-            "description_html": "<p>bold</p>",
-            "assignee_ids": ["alice"],
-        }
-        # Preview wraps the same HTML verbatim, no sanitize/convert.
         assert result.payload_preview is not None
-        item = cast(dict[str, object], result.payload_preview["data"])
-        attributes = cast(dict[str, object], item["attributes"])
-        desc = cast(dict[str, object], attributes["description"])
-        assert desc == {"type": "text/html", "value": "<p>bold</p>"}
+        assert result.payload_preview["query_params"] == {"workflowAction": "close"}
 
-
-class TestUpdateWorkItemHappyPath:
-    """Tests for a successful ``update_work_item`` call."""
-
-    async def test_returns_updated_with_post_update_state(
+    async def test_dry_run_preview_keeps_raw_html_verbatim(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # PATCH returns {} on 204; GET returns the post-update detail.
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response(title="after")
-
-        result = await _call_update(mock_ctx, title="after")
-
-        assert isinstance(result, WorkItemUpdateResult)
-        assert result.updated is True
-        assert result.dry_run is False
-        assert result.current is not None
-        assert result.current.title == "after"
-        assert result.changes == {"title": "after"}
-        assert result.payload_preview is None
-
-    async def test_current_description_html_blanked_by_default(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        """Default blanks current.description_html — body still travels (``@all`` needed
-        for customs); tool strips it to spare LLM context.
-        """
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response(
-            description_html="<p>large body that should be hidden</p>",
+        # Round-trip guarantee: no sanitize, no markdownify.
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
+        raw = (
+            '<p>See <span class="polarion-rte-link" '
+            'data-item-id="MCPT-7" data-scope="MyProj">MCPT-7</span></p>'
         )
 
-        result = await _call_update(mock_ctx, status="approved")
+        result = await _call_update(
+            mock_ctx, items=[_spec(description_html=raw)], dry_run=True
+        )
 
-        assert result.current is not None
-        assert result.current.description_html == ""
-        # Other metadata is unaffected.
-        assert result.current.status == "open"  # _make_get_response default
+        assert result.payload_preview is not None
+        data = cast(list[dict[str, object]], result.payload_preview["data"])
+        attributes = cast(dict[str, object], data[0]["attributes"])
+        assert attributes["description"] == {"type": "text/html", "value": raw}
 
-    async def test_current_description_html_kept_when_flag_true(
+
+class TestUpdateWorkItemsHappyPath:
+    """Tests for a successful ``update_work_items`` call."""
+
+    async def test_returns_ids_in_input_order(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """include_current_description_html=True → raw HTML in current."""
+        mock_client.get.return_value = _existence_response(
+            ("MCPT-1", "task"), ("MCPT-2", "task")
+        )
         mock_client.patch.return_value = {}
-        raw = "<p>verified body <strong>after</strong></p>"
-        mock_client.get.return_value = _make_get_response(description_html=raw)
 
         result = await _call_update(
             mock_ctx,
-            description_html=raw,
-            include_current_description_html=True,
+            items=[_spec(title="a"), _spec(work_item_id="MCPT-2", title="b")],
         )
 
-        assert result.current is not None
-        assert result.current.description_html == raw
+        assert isinstance(result, WorkItemsUpdateResult)
+        assert result.updated is True
+        assert result.dry_run is False
+        assert result.work_item_ids == ["MCPT-1", "MCPT-2"]
+        assert result.payload_preview is None
 
-    async def test_patch_called_with_correct_path_and_body(
+    async def test_patch_called_with_collection_path_and_list_body(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
+        mock_client.get.return_value = _existence_response(("MCPT-42", "task"))
         mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
 
         await _call_update(
             mock_ctx,
-            work_item_id="MCPT-42",
-            status="open",
-            assignee_ids=["alice"],
+            items=[_spec(work_item_id="MCPT-42", title="t", assignee_ids=["alice"])],
         )
 
         args, kwargs = mock_client.patch.call_args
-        assert args == ("/projects/MyProj/workitems/MCPT-42",)
-        body = kwargs["json"]
-        item = body["data"]
+        assert args == ("/projects/MyProj/workitems",)
+        data = kwargs["json"]["data"]
+        assert isinstance(data, list)
+        item = data[0]
         assert item["type"] == "workitems"
         assert item["id"] == "MyProj/MCPT-42"
-        assert item["attributes"]["status"] == "open"
+        assert item["attributes"]["title"] == "t"
         assert item["relationships"]["assignee"]["data"] == [
             {"type": "users", "id": "alice"}
         ]
 
-    async def test_followup_get_called_with_detail_fields(
+    async def test_no_followup_get_after_patch(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
+        # ids-only result: the old per-item re-GET is gone (50 items would
+        # cost 50 extra requests at the 3 req/s cap).
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
         mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
 
-        await _call_update(mock_ctx, title="t")
+        await _call_update(mock_ctx, items=[_spec(title="t")])
 
-        args, kwargs = mock_client.get.call_args
-        assert args == ("/projects/MyProj/workitems/MCPT-1",)
-        params = kwargs["params"]
-        assert params["include"] == "assignee"
-        # Bare @all so inline customs surface; narrowing would drop them.
-        assert params["fields[workitems]"] == "@all"
+        assert mock_client.get.await_count == 1
 
-    async def test_current_carries_custom_fields_from_post_patch_get(
+    async def test_workflow_action_and_change_type_to_query_params(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Inlined customs from the post-PATCH GET surface on current.custom_fields.
+        mock_client.get.side_effect = [
+            _existence_response(("MCPT-1", "task")),
+            _enum_get_response(["defect"]),
+        ]
         mock_client.patch.return_value = {}
-        get_response = _make_get_response(title="after")
-        data = cast(dict[str, object], get_response["data"])
-        attributes = cast(dict[str, object], data["attributes"])
-        attributes["riskLevel"] = "high"
-        attributes["effortHours"] = 12.0
-        mock_client.get.return_value = get_response
 
-        result = await _call_update(mock_ctx, title="after")
+        await _call_update(
+            mock_ctx,
+            items=[_spec(title="t")],
+            workflow_action="close",
+            change_type_to="defect",
+        )
 
-        assert result.current is not None
-        assert result.current.custom_fields == {
-            "riskLevel": "high",
-            "effortHours": 12.0,
+        patch_path = mock_client.patch.call_args.args[0]
+        assert patch_path == (
+            "/projects/MyProj/workitems?workflowAction=close&changeTypeTo=defect"
+        )
+
+    async def test_description_html_is_sent_verbatim(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
+        mock_client.patch.return_value = {}
+        raw = (
+            '<p>See <span class="polarion-rte-link" '
+            'data-item-id="MCPT-7" data-scope="MyProj">MCPT-7</span></p>'
+        )
+
+        await _call_update(mock_ctx, items=[_spec(description_html=raw)])
+
+        data = mock_client.patch.call_args.kwargs["json"]["data"]
+        assert data[0]["attributes"]["description"] == {
+            "type": "text/html",
+            "value": raw,
         }
 
     async def test_custom_fields_inlined_into_patch_body(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Customs ride top-level in attributes; a customFields container is dropped.
-        mock_client.patch.return_value = {}
-        rich = {"type": "text/html", "value": "<p>note</p>"}
+        # Customs ride top-level in attributes; the key is pre-cached and the
+        # enum-value probe 404s (not an enum field, defers to Polarion).
         _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"riskLevel", "reviewerNote"})
+            "MyProj", "task", frozenset({"riskLevel"})
         )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"riskLevel": "high", "reviewerNote": rich}
-        )
+        mock_client.get.side_effect = [
+            _existence_response(("MCPT-1", "task")),
+            PolarionNotFoundError("not an Enumeration field", status_code=404),
+        ]
+        mock_client.patch.return_value = {}
 
-        await _call_update(
-            mock_ctx,
-            custom_fields={"riskLevel": "low", "reviewerNote": rich},
-        )
+        await _call_update(mock_ctx, items=[_spec(custom_fields={"riskLevel": "low"})])
 
-        _, kwargs = mock_client.patch.call_args
-        body = kwargs["json"]
-        item = body["data"]
-        attributes = item["attributes"]
+        data = mock_client.patch.call_args.kwargs["json"]["data"]
+        attributes = data[0]["attributes"]
         assert attributes["riskLevel"] == "low"
-        assert attributes["reviewerNote"] == rich
         assert "customFields" not in attributes
-
-    async def test_changes_summary_records_custom_fields(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # changes mirrors what was sent so callers can confirm intent.
-        mock_client.patch.return_value = {}
-        _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"riskLevel"})
-        )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"riskLevel": "low"}
-        )
-
-        result = await _call_update(
-            mock_ctx,
-            title="t",
-            custom_fields={"riskLevel": "high"},
-        )
-
-        assert result.changes["title"] == "t"
-        assert result.changes["custom_fields"] == {"riskLevel": "high"}
-
-    async def test_changes_custom_fields_is_independent_of_input(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Post-call mutation of the caller's dict must not bleed into changes.
-        mock_client.patch.return_value = {}
-        _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"reviewerNote", "riskLevel"})
-        )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"reviewerNote": "x", "riskLevel": "low"}
-        )
-
-        rich = {"type": "text/html", "value": "<p>original</p>"}
-        customs: dict[str, object] = {"reviewerNote": rich, "riskLevel": "high"}
-
-        result = await _call_update(
-            mock_ctx,
-            title="t",
-            custom_fields=customs,
-        )
-
-        customs["riskLevel"] = "low"
-        rich["value"] = "<p>mutated</p>"
-
-        recorded = cast(dict[str, object], result.changes["custom_fields"])
-        assert recorded["riskLevel"] == "high"
-        recorded_note = cast(dict[str, object], recorded["reviewerNote"])
-        assert recorded_note["value"] == "<p>original</p>"
-
-    async def test_dry_run_preview_includes_custom_fields(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Dry-run echoes merged standard+custom attrs.
-        _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"riskLevel"})
-        )
-        mock_client.get.return_value = _make_get_response(
-            custom_fields={"riskLevel": "high"}
-        )
-        result = await _call_update(
-            mock_ctx,
-            title="t",
-            custom_fields={"riskLevel": "high"},
-            dry_run=True,
-        )
-
-        mock_client.patch.assert_not_called()
-        assert result.payload_preview is not None
-        item = cast(dict[str, object], result.payload_preview["data"])
-        attributes = cast(dict[str, object], item["attributes"])
-        assert attributes["title"] == "t"
-        assert attributes["riskLevel"] == "high"
-
-    async def test_round_trip_read_response_can_be_written_back(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # Read custom_fields must write back unchanged: symmetric read/write shapes.
-        read_customs: dict[str, object] = {
-            "riskLevel": "high",
-            "effortHours": 8.0,
-            "reviewerNote": {"type": "text/html", "value": "<p>x</p>"},
-        }
-        mock_client.patch.return_value = {}
-        _cache_mod.store_work_item_custom_keys(
-            "MyProj", "task", frozenset({"riskLevel", "effortHours", "reviewerNote"})
-        )
-        mock_client.get.return_value = _make_get_response(custom_fields=read_customs)
-
-        result = await _call_update(mock_ctx, custom_fields=read_customs)
-
-        _, kwargs = mock_client.patch.call_args
-        attributes = kwargs["json"]["data"]["attributes"]
-        for key, value in read_customs.items():
-            assert attributes[key] == value
-        assert result.updated is True
-
-    async def test_workflow_action_appended_as_query_param(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # workflow_action needs a paired body field, so add a title.
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
-
-        await _call_update(mock_ctx, workflow_action="close", title="t")
-
-        patch_path = mock_client.patch.call_args.args[0]
-        assert patch_path == "/projects/MyProj/workitems/MCPT-1?workflowAction=close"
-        # Follow-up GET drops the query to read the canonical detail.
-        get_path = mock_client.get.call_args.args[0]
-        assert get_path == "/projects/MyProj/workitems/MCPT-1"
-
-    async def test_change_type_to_appended_as_query_param(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
-
-        await _call_update(mock_ctx, change_type_to="task", title="t")
-
-        patch_path = mock_client.patch.call_args.args[0]
-        assert patch_path == "/projects/MyProj/workitems/MCPT-1?changeTypeTo=task"
-
-    async def test_description_html_is_sent_verbatim(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        """Core round-trip guarantee: description_html PATCHed verbatim — no sanitize,
-        no markdownify.
-        """
-        mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
-
-        raw = (
-            '<p>See <span class="polarion-rte-link" '
-            'data-item-id="MCPT-7" data-scope="MyProj">MCPT-7</span></p>'
-        )
-        await _call_update(mock_ctx, description_html=raw)
-
-        body = mock_client.patch.call_args.kwargs["json"]
-        desc = body["data"]["attributes"]["description"]
-        assert desc == {"type": "text/html", "value": raw}
 
     async def test_path_url_encodes_special_chars(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
         mock_client.patch.return_value = {}
-        mock_client.get.return_value = _make_get_response()
 
-        await _call_update(mock_ctx, project_id="My Proj", title="t")
+        await _call_update(mock_ctx, project_id="My Proj", items=[_spec(title="t")])
 
-        assert (
-            mock_client.patch.call_args.args[0]
-            == "/projects/My%20Proj/workitems/MCPT-1"
-        )
+        assert mock_client.patch.call_args.args[0] == "/projects/My%20Proj/workitems"
 
 
-class TestUpdateWorkItemErrorMapping:
+class TestUpdateWorkItemsErrorMapping:
     """Tests that domain exceptions are mapped at the tool layer."""
 
     async def test_patch_401_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
         mock_client.patch.side_effect = PolarionAuthError("auth", status_code=401)
 
         with pytest.raises(PermissionError):
-            await _call_update(mock_ctx, title="t")
-        mock_client.get.assert_not_called()
+            await _call_update(mock_ctx, items=[_spec(title="t")])
 
     async def test_patch_404_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
+        # Race fallback: existence passed above, then the batch changed.
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
         mock_client.patch.side_effect = PolarionNotFoundError(
             "not found", status_code=404
         )
 
-        with pytest.raises(ValueError, match="not found"):
-            await _call_update(mock_ctx, work_item_id="ghost", title="t")
+        with pytest.raises(ValueError, match="list_work_items"):
+            await _call_update(mock_ctx, items=[_spec(title="t")])
 
     async def test_patch_other_error_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
+        mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
         mock_client.patch.side_effect = PolarionError("boom", status_code=500)
 
         with pytest.raises(RuntimeError, match="boom"):
-            await _call_update(mock_ctx, title="t")
-
-    async def test_followup_get_404_raises_value_error(
-        self, mock_ctx: MagicMock, mock_client: AsyncMock
-    ) -> None:
-        # PATCH succeeds, but the follow-up GET 404s — surface it the
-        # same way (very rare race; mostly defensive).
-        mock_client.patch.return_value = {}
-        mock_client.get.side_effect = PolarionNotFoundError(
-            "not found", status_code=404
-        )
-
-        with pytest.raises(ValueError, match="not found"):
-            await _call_update(mock_ctx, title="t")
+            await _call_update(mock_ctx, items=[_spec(title="t")])
 
 
-class TestUpdateWorkItemFieldValidation:
-    """Verify ``min_length=1`` constraints attached to required parameters."""
+class TestUpdateWorkItemsFieldValidation:
+    """Verify Field constraints attached to the tool parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
-        hints = get_type_hints(update_work_item)
-        sig = inspect.signature(update_work_item)
+        hints = get_type_hints(update_work_items)
+        sig = inspect.signature(update_work_items)
         field_info = sig.parameters[param_name].default
         return TypeAdapter(Annotated[hints[param_name], field_info])
 
@@ -1477,40 +1124,50 @@ class TestUpdateWorkItemFieldValidation:
         with pytest.raises(ValidationError):
             self._adapter_for("project_id").validate_python("")
 
-    def test_work_item_id_rejects_empty_string(self) -> None:
-        with pytest.raises(ValidationError):
-            self._adapter_for("work_item_id").validate_python("")
-
     def test_project_id_accepts_non_empty(self) -> None:
         assert self._adapter_for("project_id").validate_python("p") == "p"
 
-    def test_work_item_id_accepts_non_empty(self) -> None:
-        assert self._adapter_for("work_item_id").validate_python("MCPT-1") == "MCPT-1"
-
-    def test_description_html_rejects_overlong_input(self) -> None:
-        """max_length=MAX_BODY_HTML_LEN caps runaway HTML.
-
-        Re-proven here so a docstring rewrite cannot silently drop it.
-        """
-        adapter = self._adapter_for("description_html")
-        assert adapter.validate_python("<p>ok</p>") == "<p>ok</p>"
-        # 2 MiB + 1 char is rejected.
+    def test_items_rejects_empty_list(self) -> None:
         with pytest.raises(ValidationError):
-            adapter.validate_python("x" * (2_000_000 + 1))
+            self._adapter_for("items").validate_python([])
+
+    def test_items_rejects_more_than_max_bulk(self) -> None:
+        items = [
+            {"work_item_id": f"MCPT-{i}", "title": "t"}
+            for i in range(MAX_BULK_ITEMS + 1)
+        ]
+        with pytest.raises(ValidationError):
+            self._adapter_for("items").validate_python(items)
+
+    def test_items_accepts_max_bulk(self) -> None:
+        items = [
+            {"work_item_id": f"MCPT-{i}", "title": "t"} for i in range(MAX_BULK_ITEMS)
+        ]
+        validated = self._adapter_for("items").validate_python(items)
+        assert len(cast(list[object], validated)) == MAX_BULK_ITEMS
 
 
-class TestUpdateWorkItemDocstringGuidance:
-    """Lock the read-before-update steer into the public docstring."""
+class TestUpdateWorkItemsDocstringGuidance:
+    """Lock the read-before-update and REPLACE steers into the tool docs."""
 
     def test_docstring_directs_get_before_update(self) -> None:
-        document = update_work_item.__doc__ or ""
+        document = update_work_items.__doc__ or ""
         assert "get_work_item" in document, (
-            "update_work_item docstring must direct callers to read the "
+            "update_work_items docstring must direct callers to read each "
             "work item before patching it"
         )
         assert "BEFORE" in document, (
-            "update_work_item docstring must state the read happens BEFORE the update"
+            "update_work_items docstring must state the read happens BEFORE the update"
         )
+
+    def test_replace_steer_leads_docstring_and_items_field(self) -> None:
+        # Per-item fields nest one level deeper than the old flat tool, so
+        # the REPLACE steer must stay in the highest-salience spots.
+        document = update_work_items.__doc__ or ""
+        first_paragraph = document.split("\n\n")[0]
+        assert "REPLACE" in first_paragraph
+        items_field = inspect.signature(update_work_items).parameters["items"].default
+        assert "REPLACE" in (items_field.description or "")
 
 
 class TestEnumGuardCreateWorkItem:
@@ -1655,42 +1312,76 @@ class TestEnumGuardCreateWorkItem:
         mock_client.post.assert_not_called()
 
 
-class TestEnumGuardUpdateWorkItem:
-    """Integration: ``update_work_item`` pre-fetches type then guards."""
+class TestEnumGuardUpdateWorkItems:
+    """Integration: ``update_work_items`` resolves types then guards per item."""
 
-    async def test_unlisted_priority_raises_after_prefetch(
+    async def test_unlisted_priority_raises_after_type_resolution(
         self,
         mock_ctx: MagicMock,
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: work-item pre-fetch, then priority options.
+        # GETs: batched existence/type query, then priority options.
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response(("MCPT-1", "task")),
             _enum_get_response(["90.0", "50.0", "10.0"]),
         ]
-        with pytest.raises(ValueError, match="priority='999'"):
-            await _call_update(mock_ctx, priority="999")
-        mock_client.patch.assert_not_called()
 
-    async def test_unknown_custom_field_key_raises_after_prefetch(
+        with pytest.raises(ValueError, match="priority='999'"):
+            await _call_update(mock_ctx, items=[_spec(priority="999")])
+
+        mock_client.patch.assert_not_called()
+        probes = [
+            c
+            for c in mock_client.get.call_args_list
+            if "fields/priority/actions/getAvailableOptions" in c.args[0]
+        ]
+        # Enum options are scoped to the type resolved by the batched query.
+        assert probes[0].kwargs["params"]["type"] == "task"
+
+    async def test_guard_error_names_offending_item(
         self,
         mock_ctx: MagicMock,
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: prefetch (for type), then the type sample (+ bypass-retry sample).
-        # The sample knows only risk_score, so release_train_id is rejected.
+        # Item 1 passes; item 2 reuses the cached options and is rejected
+        # with its batch position and id.
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response(("MCPT-1", "task"), ("MCPT-2", "task")),
+            _enum_get_response(["50.0"]),
+        ]
+
+        with pytest.raises(ValueError, match=r"items\[1\] \('MCPT-2'\)"):
+            await _call_update(
+                mock_ctx,
+                items=[
+                    _spec(priority="50.0"),
+                    _spec(work_item_id="MCPT-2", priority="999"),
+                ],
+            )
+
+        mock_client.patch.assert_not_called()
+
+    async def test_unknown_custom_field_key_raises(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        # GETs: existence, then the type sample (+ bypass-retry sample).
+        mock_client.get.side_effect = [
+            _existence_response(("MCPT-1", "task")),
             _wi_sample_response({"risk_score": 5}),
             _wi_sample_response({"risk_score": 5}),
         ]
+
         with pytest.raises(ValueError, match="release_train_id"):
             await _call_update(
                 mock_ctx,
-                custom_fields={"release_train_id": "RT-42"},
+                items=[_spec(custom_fields={"release_train_id": "RT-42"})],
             )
+
         mock_client.patch.assert_not_called()
 
     async def test_type_key_unset_on_item_passes_via_sample(
@@ -1699,35 +1390,40 @@ class TestEnumGuardUpdateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Regression: a custom key valid for the type but unset on THIS item was
-        # falsely rejected by the old single-item prime. The type sample knows it.
+        # Regression: a custom key valid for the type but unset on THIS item
+        # must pass — the type sample knows it even when the item does not.
         mock_client.get.side_effect = [
-            _make_get_response(),  # prefetch: no customs on the edited item
-            _wi_sample_response({"release_train_id": "RT-1"}),  # type sample knows it
+            _existence_response(("MCPT-1", "task")),
+            _wi_sample_response({"release_train_id": "RT-1"}),
             PolarionNotFoundError("not an Enumeration field", status_code=404),
         ]
+
         result = await _call_update(
-            mock_ctx, custom_fields={"release_train_id": "RT-42"}, dry_run=True
+            mock_ctx,
+            items=[_spec(custom_fields={"release_train_id": "RT-42"})],
+            dry_run=True,
         )
 
-        assert result.dry_run is True  # type: ignore[attr-defined]
+        assert result.dry_run is True
         mock_client.patch.assert_not_called()
 
-    async def test_custom_field_enum_value_rejected_on_update(
+    async def test_custom_field_enum_value_rejected(
         self,
         mock_ctx: MagicMock,
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: prefetch (for type), type sample (knows asil), enum probe.
+        # GETs: existence, type sample (knows asil), enum probe — '9' is not
+        # among the field's options.
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response(("MCPT-1", "task")),
             _wi_sample_response({"asil": "1"}),
             _enum_get_response(["1", "2", "3", "4"]),
         ]
 
         with pytest.raises(ValueError, match=r"'asil'.*'9'"):
-            await _call_update(mock_ctx, custom_fields={"asil": "9"})
+            await _call_update(mock_ctx, items=[_spec(custom_fields={"asil": "9"})])
+
         mock_client.patch.assert_not_called()
 
     async def test_custom_fields_scoped_to_change_type_to(
@@ -1736,23 +1432,25 @@ class TestEnumGuardUpdateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # change_type_to retypes the item in the same PATCH, so custom_fields are
-        # validated against the NEW type's schema, not the current ("task").
-        # GETs: prefetch, type options (~ axis for change_type_to), custom
-        # sample, then the enum-value probe for the key (404 = not enum).
+        # change_type_to retypes the items in the same PATCH, so custom_fields
+        # are validated against the NEW type's schema, not the current one.
+        # GETs: existence, type options (change_type_to axis), custom sample,
+        # then the enum-value probe for the key (404 = not enum).
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response(("MCPT-1", "task")),
             _enum_get_response(["requirement"]),
             _wi_sample_response({"release_train_id": "RT-1"}),
             PolarionNotFoundError("not an Enumeration field", status_code=404),
         ]
+
         result = await _call_update(
             mock_ctx,
+            items=[_spec(custom_fields={"release_train_id": "RT-42"})],
             change_type_to="requirement",
-            custom_fields={"release_train_id": "RT-42"},
             dry_run=True,
         )
-        assert result.dry_run is True  # type: ignore[attr-defined]
+
+        assert result.dry_run is True
         sample_calls = [
             c
             for c in mock_client.get.call_args_list
@@ -1763,19 +1461,20 @@ class TestEnumGuardUpdateWorkItem:
         assert "c_type = 'requirement'" in query
         assert "c_type = 'task'" not in query
 
-    async def test_unlisted_resolution_raises_after_prefetch(
+    async def test_unlisted_resolution_raises(
         self,
         mock_ctx: MagicMock,
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # resolution is ghost-prone; an unlisted id must be rejected.
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response(("MCPT-1", "task")),
             _enum_get_response(["done", "wontfix", "duplicate"]),
         ]
+
         with pytest.raises(ValueError, match="resolution='ghost_resolution'"):
-            await _call_update(mock_ctx, resolution="ghost_resolution")
+            await _call_update(mock_ctx, items=[_spec(resolution="ghost_resolution")])
+
         mock_client.patch.assert_not_called()
 
     async def test_status_scoped_by_target_type_on_change_type_to(
@@ -1784,17 +1483,22 @@ class TestEnumGuardUpdateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # change_type_to scopes the status lookup to the target type.
-        # GETs: work-item pre-fetch, type options (~ axis), status options (target).
+        # GETs: existence, type options (change_type_to axis), status options
+        # scoped to the target type.
         mock_client.get.side_effect = [
-            _make_get_response(),
+            _existence_response(("MCPT-1", "task")),
             _enum_get_response(["requirement"]),
             _enum_get_response(["draft", "approved"]),
         ]
+
         result = await _call_update(
-            mock_ctx, change_type_to="requirement", status="draft", dry_run=True
+            mock_ctx,
+            items=[_spec(status="draft")],
+            change_type_to="requirement",
+            dry_run=True,
         )
-        assert result.dry_run is True  # type: ignore[attr-defined]
+
+        assert result.dry_run is True
         status_calls = [
             c
             for c in mock_client.get.call_args_list
@@ -1802,6 +1506,58 @@ class TestEnumGuardUpdateWorkItem:
         ]
         assert status_calls, "guard must probe status options"
         assert status_calls[0].kwargs["params"]["type"] == "requirement"
+
+    async def test_heterogeneous_batch_probes_each_type(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        # Two items of different types: status options are probed once per
+        # resolved type (the option cache is keyed by type).
+        mock_client.get.side_effect = [
+            _existence_response(("MCPT-1", "task"), ("MCPT-2", "requirement")),
+            _enum_get_response(["draft", "open"]),
+            _enum_get_response(["draft", "approved"]),
+        ]
+
+        result = await _call_update(
+            mock_ctx,
+            items=[
+                _spec(status="draft"),
+                _spec(work_item_id="MCPT-2", status="draft"),
+            ],
+            dry_run=True,
+        )
+
+        assert result.dry_run is True
+        status_calls = [
+            c
+            for c in mock_client.get.call_args_list
+            if "fields/status/actions/getAvailableOptions" in c.args[0]
+        ]
+        assert [c.kwargs["params"]["type"] for c in status_calls] == [
+            "task",
+            "requirement",
+        ]
+
+    async def test_guard_runs_on_dry_run_too(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        mock_client.get.side_effect = [
+            _existence_response(("MCPT-1", "task")),
+            _enum_get_response(["done"]),
+        ]
+
+        with pytest.raises(ValueError, match="resolution='ghost'"):
+            await _call_update(
+                mock_ctx, items=[_spec(resolution="ghost")], dry_run=True
+            )
+
+        mock_client.patch.assert_not_called()
 
 
 class TestListWorkItems:
@@ -2188,7 +1944,7 @@ class TestGetWorkItem:
     ) -> None:
         """Polarion spans / data-* attributes survive on read.
 
-        Round-trip guarantee for update_work_item(description_html=).
+        Round-trip guarantee for update_work_items description_html.
         """
         raw = (
             '<p>Refs <span class="polarion-rte-link" '
@@ -2579,7 +2335,7 @@ class TestReadWorkItem:
         assert result.resolution == "fixed"
         assert len(result.hyperlinks) == 1
         assert result.hyperlinks[0].uri == "https://example.com/spec"
-        # Customs stay raw so the dict round-trips through update_work_item.
+        # Customs stay raw so the dict round-trips through update_work_items.
         assert result.custom_fields == {
             "riskLevel": "high",
             "reviewerNote": rich_value,

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -1172,6 +1172,20 @@ class TestUpdateWorkItemsFieldValidation:
         validated = self._adapter_for("items").validate_python(items)
         assert len(cast(list[object], validated)) == MAX_BULK_ITEMS
 
+    def test_typo_key_in_one_item_rejects_batch_naming_index(self) -> None:
+        # extra='forbid' smoke: without it, 'descrition' would sail through
+        # to Polarion and persist verbatim as a ghost custom field. The whole
+        # batch must be rejected at parse time, naming the offending index.
+        items: list[dict[str, object]] = [
+            {"work_item_id": f"MCPT-{i}", "title": "t"} for i in range(1, 6)
+        ]
+        items[3] = {"work_item_id": "MCPT-4", "descrition": "<p>x</p>"}
+
+        with pytest.raises(ValidationError, match=r"3\.descrition") as exc:
+            self._adapter_for("items").validate_python(items)
+
+        assert exc.value.errors()[0]["type"] == "extra_forbidden"
+
 
 class TestUpdateWorkItemsDocstringGuidance:
     """Lock the read-before-update and REPLACE steers into the tool docs."""


### PR DESCRIPTION
## Summary

Replaces the single-item `update_work_item` tool with bulk `update_work_items`, backed by Polarion's collection `PATCH /projects/{projectId}/workitems` endpoint (JSON:API `{"data": [...]}` body, request-wide `workflowAction`/`changeTypeTo` query params, 204 No Content). At the server's 3 req/s cap with no concurrency and a 1.5 s client post-write delay, N single-item PATCHes were the slowest possible way to update N items; one bulk PATCH now covers up to 50, mirroring `create_work_items`/`create_test_runs`.

Guard strategy for a batch: one chunked `id:(...)` query resolves existence **and** per-item type (replacing the old per-item `fields=@all` prefetch), enum/custom-field guards loop per item with the process-global option caches shared across the batch, and per-item guard failures are prefixed `items[{i}] ('{id}')`. Duplicate `work_item_id`s are rejected client-side (server apply-order is undefined); `create_test_runs` gets the same duplicate-id rejection for its client-supplied ids. All LLM-input spec models now carry `extra="forbid"` -- a typo key like `descripion` used to be silently dropped, writing nothing and raising nothing.

The result is ids-only (`WorkItemsUpdateResult`): the old post-PATCH re-GET (and `include_current_description_html`) is gone -- for a full batch it would cost 50 extra requests and x50 LLM context.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- N single PATCHes were the slowest path at the 3 req/s cap; bulk PATCH /workitems covers 1-50 items in one call
- update_work_items: batched existence+type guard, per-item enum/custom guards, dup-id rejection, forbid specs

## Testing

- `ruff check` / `ruff format --check` / `mypy src/` clean; 1522 tests pass; `diff-cover --fail-under=90` at **100%** changed-line coverage.
- Eval smoke (openai/gpt-4o-mini): every touched case re-run locally -- SAFE-UPDATE-NEEDS-GET 3/3, ORCH-CONDITIONAL-UPDATE 3/3, new EFF-BULK-UPDATE (one committed call, 3 items) 8/8, SAFE-HYPERLINK-PRESERVE 10/10 over two 5-run batches. The hyperlink case initially regressed to 0.2 with per-item fields nested one level deeper; recovered by spelling out the add-ONE-entry REPLACE contract in the lead docstring and the spec field. Full gate left to the CI evals job (a local full run is also in flight).
- E2E against testdrive `MCP_Test_Project` (scratch items MCPT-531/533): dry_run writes nothing; committed 2-item retitle in one call verified via `get_work_item`; **atomicity probe confirmed** -- a batch with one unparseable `due_date` 400s and the valid item's title stays unchanged (the "Atomic" docstring claim is now empirically verified); missing-id probe rejected client-side naming `MCPT-999999`; original titles restored.

## Notes for Reviewers

- `workflow_action`/`change_type_to` are request-wide query params in the REST API, so they stay tool-level and apply to every item in the batch.
- Follow-ups (separate PRs): split the 1100-line `_shared/guard.py` into a `_shared/guard/` subpackage, then bulk `update_test_runs` reusing `ensure_unique_ids`/`reraise_with_item_context`/the batched existence-resolver pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
