### PR TITLE
feat(html): polarion table style + caption widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Other clients (VS Code, Claude Desktop, Cursor) — see [Client Configuration](#
 | `list_work_items` | List work items in a project (Lucene/SQL query) |
 | `list_test_runs` | List test runs in a project (Lucene query, templates filter) |
 | `get_sql_query_recipes` | Fetch copy-paste SQL recipes for advanced queries |
+| `get_html_recipes` | Fetch copy-paste Polarion HTML templates for raw-HTML body edits |
 | `get_document` | Get document metadata, optionally with the raw body HTML |
 | `read_document` | Render a document end-to-end as Markdown |
 | `read_document_parts` | List a document's structural parts with embedded work item metadata |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **P
 
 ## Features
 
-- **29 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
+- **30 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
 - **Read** — render documents as Markdown, search with Lucene or SQL, walk incoming/outgoing links, resolve enum options.
 - **Write** — create and update work items and documents, create test runs, manage links, reorganize document structure, post comments.
 - **Safe writes** — every write tool supports `dry_run`, and pre-write guards validate fields, enum values, and link targets before hitting Polarion.

--- a/evals/cases/efficiency.py
+++ b/evals/cases/efficiency.py
@@ -89,4 +89,14 @@ CASES: list[Case] = [
         covers=["move_work_item_from_document"],
         floating_ids=[FLOATING_TASK_ID],
     ),
+    _case(
+        "EFF-TABLE-RECIPE-SOURCED",
+        f"Append a two-column table listing the milestones 'M1: design' and "
+        f"'M2: review' to the description of work item {FLOATING_TASK_ID}, "
+        f"with a numbered caption 'Milestones' below it.",
+        "table_html_recipe_sourced",
+        intent="Raw-HTML table edits are template-sourced (get_html_recipes "
+        "before the update); hand-written table markup fails.",
+        covers=["update_work_item", "get_html_recipes"],
+    ),
 ]

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -372,6 +372,39 @@ def check_scoped_query_uses_sql(
     return True, "no Lucene module query issued; any SQL was recipe-sourced"
 
 
+def check_table_html_recipe_sourced(
+    trajectory: Trajectory, _params: dict[str, Any]
+) -> CheckResult:
+    """Table HTML written through an update tool must be recipe-sourced —
+    ``get_html_recipes`` first. The task demands a table, so a trajectory that
+    never writes one fails too (a refusal must not pass vacuously).
+    """
+    recipes_seen = False
+    wrote_table = False
+    for call in trajectory:
+        name = call.get("name")
+        if name == "get_html_recipes":
+            recipes_seen = True
+            continue
+        if name not in {"update_work_item", "update_document"}:
+            continue
+        args = _args(call)
+        body = str(
+            args.get("description_html") or args.get("home_page_content_html") or ""
+        )
+        if "<table" not in body.lower():
+            continue
+        wrote_table = True
+        if not recipes_seen:
+            return False, (
+                f"{name} wrote table HTML without a prior get_html_recipes -- "
+                "adapt a template, do not hand-write table markup"
+            )
+    if not wrote_table:
+        return False, "no update call wrote a <table> -- the task requires one"
+    return True, "table HTML update was recipe-sourced"
+
+
 def _resolve_observed_path(result: object, path: str) -> list[str]:
     """Collect string leaf values at ``path`` from a recorded tool result.
 
@@ -572,5 +605,6 @@ REGISTRY: dict[str, Callable[[Trajectory, dict[str, Any]], CheckResult]] = {
     "direct_read": check_direct_read,
     "no_duplicate_reads": check_no_duplicate_reads,
     "scoped_query_uses_sql": check_scoped_query_uses_sql,
+    "table_html_recipe_sourced": check_table_html_recipe_sourced,
     "ordered_trajectory": check_ordered_trajectory,
 }

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -42,6 +42,7 @@ from mcp_server_polarion.models.test_runs import (
     TestRunSummary,
 )
 from mcp_server_polarion.models.work_items import (
+    HtmlRecipeGallery,
     Hyperlink,
     SqlRecipeGallery,
     WorkItemCreateSpec,
@@ -66,6 +67,7 @@ __all__: list[str] = [
     "DocumentSummary",
     "DocumentUpdateResult",
     "EnumOption",
+    "HtmlRecipeGallery",
     "Hyperlink",
     "JsonValue",
     "PaginatedResult",

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -15,6 +15,12 @@ class SqlRecipeGallery(BaseModel):
     recipes: str
 
 
+class HtmlRecipeGallery(BaseModel):
+    """Copy-paste Polarion HTML templates returned by ``get_html_recipes``."""
+
+    recipes: str
+
+
 class WorkItemSummary(BaseModel):
     """Compact work-item representation for list and search results."""
 

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -70,6 +70,7 @@ from mcp_server_polarion.utils import (
     first_anchorless_block,
     html_to_markdown,
     markdown_to_html,
+    polarionify_html,
     sanitize_html,
     stamp_block_ids,
 )
@@ -846,7 +847,8 @@ async def update_document(  # noqa: PLR0913
         description=(
             "New body as raw HTML from "
             "get_document(include_homepage_content_html=True); '' rejected; "
-            "anchorless blocks get id= auto-stamped."
+            "anchorless blocks get id= auto-stamped. New tables/captions/"
+            "widgets: call get_html_recipes first and adapt a template."
         ),
     ),
     auto_suspect: bool | None = Field(
@@ -886,6 +888,8 @@ async def update_document(  # noqa: PLR0913
       move_work_item_to_document, NOT this tool.
     - A polarion_wiki macro name=module-workitem <div> leaves the work item's
       module unset — attach via move_work_item_to_document.
+    - New table/caption/widget HTML must be adapted from get_html_recipes
+      templates, never hand-written.
 
     workflow_action must pair with ≥1 attribute (else 400). Unknown status/type
     raise ValueError; custom_fields keys outside the document type's schema are
@@ -1070,7 +1074,9 @@ async def create_document(  # noqa: PLR0913
     with options; custom_fields keys validated against the document type schema.
 
     home_page_content is Markdown → sanitized HTML, blocks auto-stamped with
-    unique ids. Post-create edits round-trip raw HTML via
+    unique ids. Markdown tables get native Polarion styling; a paragraph
+    starting 'Table:' directly after a table becomes a numbered caption
+    widget. Post-create edits round-trip raw HTML via
     get_document(include_homepage_content_html=True) ↔ update_document; add work
     items via move_work_item_to_document.
     """
@@ -1086,7 +1092,9 @@ async def create_document(  # noqa: PLR0913
         await guard_document_custom_fields(client, project_id, type, custom_fields)
 
     home_page_content_html = (
-        stamp_block_ids(sanitize_html(markdown_to_html(home_page_content)))
+        stamp_block_ids(
+            polarionify_html(sanitize_html(markdown_to_html(home_page_content)))
+        )
         if home_page_content
         else ""
     )

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -847,8 +847,9 @@ async def update_document(  # noqa: PLR0913
         description=(
             "New body as raw HTML from "
             "get_document(include_homepage_content_html=True); '' rejected; "
-            "anchorless blocks get id= auto-stamped. New tables/captions/"
-            "widgets: call get_html_recipes first and adapt a template."
+            "anchorless blocks get id= auto-stamped. New tables, captions, or "
+            "other Polarion constructs: call get_html_recipes first and adapt "
+            "a template."
         ),
     ),
     auto_suspect: bool | None = Field(
@@ -888,8 +889,9 @@ async def update_document(  # noqa: PLR0913
       move_work_item_to_document, NOT this tool.
     - A polarion_wiki macro name=module-workitem <div> leaves the work item's
       module unset — attach via move_work_item_to_document.
-    - New table/caption/widget HTML must be adapted from get_html_recipes
-      templates, never hand-written.
+    - Polarion-specific constructs (tables, captions, links, TOC/TOF widgets,
+      page breaks) must be adapted from get_html_recipes templates, never
+      hand-written.
 
     workflow_action must pair with ≥1 attribute (else 400). Unknown status/type
     raise ValueError; custom_fields keys outside the document type's schema are

--- a/src/mcp_server_polarion/tools/guides/html_recipes.md
+++ b/src/mcp_server_polarion/tools/guides/html_recipes.md
@@ -1,0 +1,100 @@
+# Polarion HTML recipes — raw-HTML edits via update_work_item / update_document
+
+Templates for hand-writing Polarion-native HTML when editing a body fetched
+with `get_work_item(include_description_html=True)` /
+`get_document(include_homepage_content_html=True)`. Splice new blocks in;
+never rewrite existing markup (round-trip bodies are sent verbatim).
+
+Markdown given to `create_work_items` / `create_document` gets tables and
+`Table:` captions converted automatically — these recipes are for the
+raw-HTML update path only.
+
+## Styled table
+
+A bare `<table>` renders without borders or header shading in the Polarion UI.
+Use the house style:
+
+```html
+<table class="polarion-Document-table" style="width: 100%;max-width: 1280px;margin-left: 0px;margin-right: auto;border: 1px solid #CCCCCC;empty-cells: show;border-collapse: collapse;">
+  <tbody>
+    <tr>
+      <th style="font-weight: bold;background-color: #F0F0F0;text-align: left;vertical-align: top;border: 1px solid #CCCCCC;padding: 5px;">Header</th>
+    </tr>
+    <tr>
+      <td style="text-align: left;vertical-align: top;border: 1px solid #CCCCCC;padding: 5px;">Cell</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+Every `<th>` / `<td>` needs its inline style — Polarion has no stylesheet for
+plain cells.
+
+## Numbered caption (Table / Figure)
+
+Place directly after the table (or image). The `#` span is replaced by an
+auto-number and feeds the Table of Tables / Table of Figures widgets:
+
+```html
+<p class="polarion-rte-caption-paragraph" style="text-align: left;">Table <span data-sequence="Table" class="polarion-rte-caption">#</span> Caption text</p>
+```
+
+For figures use `Figure` in both the leading text and `data-sequence`:
+
+```html
+<p class="polarion-rte-caption-paragraph" style="text-align: left;">Figure <span data-sequence="Figure" class="polarion-rte-caption">#</span> Caption text</p>
+```
+
+## Links to work items, cross references, wiki pages
+
+Rendered links are empty `polarion-rte-link` spans — the target lives in
+`data-*` attributes, the text is generated at render time (`data-option-id`:
+`short` = id only, `long` = id + title, `default`):
+
+```html
+<span class="polarion-rte-link" data-type="workItem" id="fake" data-item-id="MCPT-555" data-option-id="long"></span>
+<span class="polarion-rte-link" data-type="crossReference" id="fake" data-item-id="MCPT-555" data-option-id="long"></span>
+<span class="polarion-rte-link" data-type="richPage" id="fake" data-item-name="Page Name" data-space-name="Space Name" data-option-id="default"></span>
+```
+
+`id="fake"` is the literal stored value — keep it. `crossReference` renders as
+a section/outline reference to the target; `workItem` renders as an item link;
+`richPage` links a wiki page by space + name. External URLs stay ordinary
+`<a href="https://...">` anchors.
+
+## Document-body widgets (update_document only)
+
+Table of Contents, and Table of Tables / Figures (`tof` macro, one per
+`data-sequence`):
+
+```html
+<div id="polarion_wiki macro name=toc"></div>
+<div data-sequence="Table" id="polarion_wiki macro name=tof;params=uid=16"></div>
+<div data-sequence="Figure" id="polarion_wiki macro name=tof;params=uid=17"></div>
+```
+
+Page break:
+
+```html
+<div id="polarion_wiki macro name=page_break;params=uid=23" contentEditable="false" data-is-landscape="false"></div>
+```
+
+`uid` must be unique within the document (duplicated ids are rejected with
+HTTP 400) — pick values not present in the body. These widgets are
+homePageContent-only; they do nothing inside a work item description.
+
+## Macro ids on tables — do NOT add
+
+UI-created tables carry `id="polarion_wiki macro name=table;params=..."`.
+Never fabricate one: REST-rendered tables work without it, and a duplicated id
+is rejected (HTTP 400). When editing an existing table, keep whatever `id` it
+already has.
+
+## Scope — bodies only, never metadata
+
+These templates are for work item `description` and document
+`homePageContent`. Rich-text custom fields (`{"type": "text/html", "value":
+...}`) are metadata: their values pass to Polarion verbatim, and caption
+widgets / rte-links / macro ids must NOT be used there — they only resolve in
+a body render context. A plain unstyled table is fine inside a custom field
+value.

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -18,6 +18,7 @@ from mcp_server_polarion.core.exceptions import (
 )
 from mcp_server_polarion.models import (
     MAX_BODY_HTML_LEN,
+    HtmlRecipeGallery,
     Hyperlink,
     JsonValue,
     PaginatedResult,
@@ -60,6 +61,7 @@ from mcp_server_polarion.tools._shared.parse import (
 from mcp_server_polarion.utils import (
     html_to_markdown,
     markdown_to_html,
+    polarionify_html,
     sanitize_html,
 )
 
@@ -197,6 +199,12 @@ _SQL_QUERY_RECIPES: Final[str] = (
     .read_text(encoding="utf-8")
 )
 
+_HTML_RECIPES: Final[str] = (
+    resources.files("mcp_server_polarion.tools")
+    .joinpath("guides", "html_recipes.md")
+    .read_text(encoding="utf-8")
+)
+
 
 @mcp.tool(
     tags={"write"},
@@ -233,6 +241,8 @@ async def create_work_items(
     move_work_item_to_document (this tool cannot). description is Markdown →
     sanitized HTML; later edits are raw-HTML round-trip via
     get_work_item(include_description_html=True) ↔ update_work_item.
+    Markdown tables get native Polarion styling; a paragraph starting
+    'Table:' directly after a table becomes a numbered caption widget.
     """
     client = get_client(ctx)
     for spec in items:
@@ -257,7 +267,9 @@ async def create_work_items(
             )
 
     descriptions_html = [
-        sanitize_html(markdown_to_html(spec.description)) if spec.description else ""
+        polarionify_html(sanitize_html(markdown_to_html(spec.description)))
+        if spec.description
+        else ""
         for spec in items
     ]
 
@@ -327,7 +339,9 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
         default=None,
         max_length=MAX_BODY_HTML_LEN,
         description=(
-            "Raw HTML from get_work_item(include_description_html=True); verbatim."
+            "Any table or caption in it must come from a get_html_recipes "
+            "template. Raw HTML from get_work_item("
+            "include_description_html=True); verbatim."
         ),
     ),
     status: str | None = Field(
@@ -382,7 +396,8 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
     Fetch current state with get_work_item BEFORE updating; PATCHes then GETs.
     description_html is raw Polarion HTML, sent verbatim — source from
     get_work_item(include_description_html=True); greenfield bodies use
-    create_work_items Markdown, formats never mix.
+    create_work_items Markdown, formats never mix. New table/caption HTML must
+    be adapted from get_html_recipes templates, never hand-written.
 
     hyperlinks/assignee_ids REPLACE the stored list — resubmit every existing
     entry plus the change or omissions are deleted. custom_fields is partial,
@@ -593,6 +608,22 @@ async def get_sql_query_recipes() -> SqlRecipeGallery:
     table schema.
     """
     return SqlRecipeGallery(recipes=_SQL_QUERY_RECIPES)
+
+
+@mcp.tool(
+    tags={"read"},
+    annotations={"readOnlyHint": True},
+)
+async def get_html_recipes() -> HtmlRecipeGallery:
+    """Fetch the required HTML templates for tables, captions, links, and
+    widgets written via update_work_item / update_document.
+
+    Any new <table>, numbered caption, work-item / cross-reference / wiki-page
+    link, or TOC / Table-of-Figures widget must be adapted from these
+    templates — plain hand-written markup renders unstyled and breaks
+    numbering. Also covers macro-id and metadata-scope caveats.
+    """
+    return HtmlRecipeGallery(recipes=_HTML_RECIPES)
 
 
 @mcp.tool(

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -396,8 +396,9 @@ async def update_work_item(  # noqa: PLR0912, PLR0913, PLR0915
     Fetch current state with get_work_item BEFORE updating; PATCHes then GETs.
     description_html is raw Polarion HTML, sent verbatim — source from
     get_work_item(include_description_html=True); greenfield bodies use
-    create_work_items Markdown, formats never mix. New table/caption HTML must
-    be adapted from get_html_recipes templates, never hand-written.
+    create_work_items Markdown, formats never mix. New table, caption, link,
+    or widget HTML must be adapted from get_html_recipes templates, never
+    hand-written.
 
     hyperlinks/assignee_ids REPLACE the stored list — resubmit every existing
     entry plus the change or omissions are deleted. custom_fields is partial,

--- a/src/mcp_server_polarion/utils/__init__.py
+++ b/src/mcp_server_polarion/utils/__init__.py
@@ -6,6 +6,7 @@ from mcp_server_polarion.utils.html import (
     first_anchorless_block,
     html_to_markdown,
     markdown_to_html,
+    polarionify_html,
     sanitize_html,
     stamp_block_ids,
 )
@@ -14,6 +15,7 @@ __all__: list[str] = [
     "first_anchorless_block",
     "html_to_markdown",
     "markdown_to_html",
+    "polarionify_html",
     "sanitize_html",
     "stamp_block_ids",
 ]

--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -267,6 +267,120 @@ def markdown_to_html(text: str) -> str:
     return result.strip()
 
 
+# Polarion house style, copied from UI-generated tables (testdrive 2506).
+_POLARION_TABLE_STYLE: Final[str] = (
+    "width: 100%;max-width: 1280px;margin-left: 0px;margin-right: auto;"
+    "border: 1px solid #CCCCCC;empty-cells: show;border-collapse: collapse;"
+)
+_POLARION_TH_STYLE: Final[str] = (
+    "font-weight: bold;background-color: #F0F0F0;text-align: left;"
+    "vertical-align: top;border: 1px solid #CCCCCC;padding: 5px;"
+)
+_POLARION_TD_STYLE: Final[str] = (
+    "text-align: left;vertical-align: top;border: 1px solid #CCCCCC;padding: 5px;"
+)
+
+# Caption prefix → data-sequence value (pandoc-style convention).
+_CAPTION_KINDS: Final[dict[str, str]] = {"Table:": "Table", "Figure:": "Figure"}
+
+
+def polarionify_html(html: str) -> str:
+    """Style class-less tables and convert adjacent ``Table:``/``Figure:``
+    paragraphs into caption widgets. Must run AFTER ``sanitize_html`` (every
+    injected attribute is a fixed constant); unmatched input returned verbatim.
+    """
+    if not html or not html.strip():
+        return ""
+    if "<table" not in html.lower() and "Table:" not in html and "Figure:" not in html:
+        return html
+
+    soup = BeautifulSoup(html, "html.parser")
+    changed = _style_bare_tables(soup)
+    changed = _convert_caption_paragraphs(soup) or changed
+    return str(soup) if changed else html
+
+
+def _style_bare_tables(soup: BeautifulSoup) -> bool:
+    """House-style class-less tables (cells with a ``style`` kept); ``True`` if
+    any changed.
+    """
+    changed = False
+    for table in soup.find_all("table"):
+        if table.attrs.get("class"):
+            continue
+        table["class"] = "polarion-Document-table"
+        table["style"] = _POLARION_TABLE_STYLE
+        changed = True
+        for cell in table.find_all(["th", "td"]):
+            if cell.attrs.get("style"):
+                continue
+            cell["style"] = (
+                _POLARION_TH_STYLE if cell.name == "th" else _POLARION_TD_STYLE
+            )
+    return changed
+
+
+def _convert_caption_paragraphs(soup: BeautifulSoup) -> bool:
+    """Convert caption-candidate paragraphs to widgets; ``True`` if any did."""
+    changed = False
+    for paragraph in soup.find_all("p"):
+        kind = _caption_kind_for(paragraph)
+        if kind is None:
+            continue
+        paragraph.replace_with(_build_caption(soup, paragraph, kind))
+        changed = True
+    return changed
+
+
+def _caption_kind_for(paragraph: Tag) -> str | None:
+    """``data-sequence`` value for a caption candidate, or ``None``. Adjacency
+    required — previous sibling must be a ``<table>`` (Table) or a ``<p>`` with
+    an ``<img>`` (Figure) — so ordinary prose starting ``Table:`` stays prose.
+    """
+    first_text = paragraph.find(string=True)
+    if first_text is None:
+        return None
+    prefix = next(
+        (p for p in _CAPTION_KINDS if str(first_text).lstrip().startswith(p)), None
+    )
+    if prefix is None:
+        return None
+    anchor = paragraph.find_previous_sibling(lambda tag: isinstance(tag, Tag))
+    if anchor is None:
+        return None
+    kind = _CAPTION_KINDS[prefix]
+    if kind == "Table" and anchor.name == "table":
+        return kind
+    if kind == "Figure" and anchor.name == "p" and anchor.find("img") is not None:
+        return kind
+    return None
+
+
+def _build_caption(soup: BeautifulSoup, paragraph: Tag, kind: str) -> Tag:
+    """Caption widget ``<p>``: prefix stripped, inline children preserved."""
+    caption = soup.new_tag(
+        "p",
+        attrs={
+            "class": "polarion-rte-caption-paragraph",
+            "style": "text-align: left;",
+        },
+    )
+    caption.append(f"{kind} ")
+    number = soup.new_tag(
+        "span", attrs={"data-sequence": kind, "class": "polarion-rte-caption"}
+    )
+    number.string = "#"
+    caption.append(number)
+
+    first_text = paragraph.find(string=True)
+    if first_text is not None:
+        stripped = str(first_text).lstrip().removeprefix(f"{kind}:").lstrip()
+        first_text.replace_with(f" {stripped}" if stripped else "")
+    for child in list(paragraph.children):
+        caption.append(child.extract())
+    return caption
+
+
 def sanitize_html(html: str) -> str:
     """Restrict HTML to ``ALLOWED_TAGS``/``ALLOWED_ATTRS``.
 

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -654,6 +654,64 @@ class TestResolveObservedPath:
         assert checks._resolve_observed_path(None, "items[].id") == []
 
 
+class TestCheckTableHtmlRecipeSourced:
+    def test_recipe_then_table_update_passes(self) -> None:
+        trajectory = [
+            _call("get_html_recipes"),
+            _call(
+                "update_work_item",
+                {"work_item_id": "MCPT-200", "description_html": "<p>x</p><table>"},
+            ),
+        ]
+        passed, _ = checks.check_table_html_recipe_sourced(trajectory, {})
+        assert passed is True
+
+    def test_table_update_without_recipes_fails(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_item",
+                {"work_item_id": "MCPT-200", "description_html": "<TABLE><tr>"},
+            )
+        ]
+        passed, reason = checks.check_table_html_recipe_sourced(trajectory, {})
+        assert passed is False
+        assert "get_html_recipes" in reason
+
+    def test_document_body_table_also_constrained(self) -> None:
+        trajectory = [
+            _call(
+                "update_document",
+                {"document_name": "D", "home_page_content_html": "<table></table>"},
+            )
+        ]
+        passed, _ = checks.check_table_html_recipe_sourced(trajectory, {})
+        assert passed is False
+
+    def test_no_table_update_at_all_fails(self) -> None:
+        # The task demands a table; a refusal must not pass vacuously.
+        trajectory = [
+            _call("get_work_item", {"work_item_id": "MCPT-200"}),
+            _call(
+                "update_work_item",
+                {"work_item_id": "MCPT-200", "description_html": "<p>plain</p>"},
+            ),
+        ]
+        passed, reason = checks.check_table_html_recipe_sourced(trajectory, {})
+        assert passed is False
+        assert "table" in reason.lower()
+
+    def test_recipe_after_table_update_fails(self) -> None:
+        trajectory = [
+            _call(
+                "update_work_item",
+                {"work_item_id": "MCPT-200", "description_html": "<table>"},
+            ),
+            _call("get_html_recipes"),
+        ]
+        passed, _ = checks.check_table_html_recipe_sourced(trajectory, {})
+        assert passed is False
+
+
 class TestCheckOrderedTrajectory:
     def test_canonical_spec_sequence_passes(self) -> None:
         trajectory = [

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -33,6 +33,7 @@ _READ_TOOL_NAMES: frozenset[str] = frozenset(
         "list_work_items",
         "list_test_runs",
         "get_sql_query_recipes",
+        "get_html_recipes",
         "get_work_item",
         "read_work_item",
         "list_work_item_links",
@@ -98,6 +99,19 @@ class TestSqlRecipeGallery:
         recipes = body["recipes"]
         assert "list_work_items SQL recipes" in recipes
         assert "POLARION.STRUCT_WORKITEM_LINKEDWORKITEMS" in recipes
+
+
+class TestHtmlRecipeGallery:
+    """The HTML recipe gallery reaches the transport as a callable tool."""
+
+    async def test_get_html_recipes_reads(self, mcp_client: _MCPClient) -> None:
+        # The update tools point the LLM here, so the payload must not be empty.
+        result = await mcp_client.call_tool("get_html_recipes", {})
+        body = result.structured_content
+        assert body is not None
+        recipes = body["recipes"]
+        assert "polarion-Document-table" in recipes
+        assert "polarion-rte-caption" in recipes
 
 
 @pytest.mark.parametrize("tool_name", sorted(EXPECTED_TOOL_NAMES))

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -8,6 +8,7 @@ from typing import Annotated, cast, get_type_hints
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from bs4 import BeautifulSoup
 from pydantic import TypeAdapter, ValidationError
 
 from mcp_server_polarion.core.exceptions import (
@@ -3209,6 +3210,39 @@ class TestCreateDocumentHappyPath:
         assert body["type"] == "text/html"
         assert "<strong>bold</strong>" in body["value"]
         assert 'href="https://example.com"' in body["value"]
+
+    async def test_home_page_content_table_and_caption_polarionified(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "documents", "id": "MyProj/_default/MySpec"}]
+        }
+
+        await create_document(
+            mock_ctx,
+            project_id="MyProj",
+            space_id="_default",
+            module_name="MySpec",
+            title="t",
+            type="generic",
+            status=None,
+            home_page_content="| a |\n| --- |\n| 1 |\n\nTable: 표 캡션\n",
+            custom_fields=None,
+            dry_run=False,
+        )
+
+        _, kwargs = mock_client.post.call_args
+        value = kwargs["json"]["data"][0]["attributes"]["homePageContent"]["value"]
+        assert 'class="polarion-Document-table"' in value
+        assert 'data-sequence="Table"' in value
+        soup = BeautifulSoup(value, "html.parser")
+        caption = soup.find("p", class_="polarion-rte-caption-paragraph")
+        assert caption is not None
+        table = soup.find("table")
+        assert table is not None
+        # Stamping runs after polarionify, so both new blocks are anchored.
+        assert str(caption.get("id", "")).strip()
+        assert str(table.get("id", "")).strip()
 
     async def test_home_page_content_stamps_unique_block_ids(
         self, mock_ctx: MagicMock, mock_client: AsyncMock

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -15,6 +15,7 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
+    HtmlRecipeGallery,
     Hyperlink,
     PaginatedResult,
     WorkItemCreateSpec,
@@ -24,15 +25,22 @@ from mcp_server_polarion.models import (
     WorkItemUpdateResult,
 )
 from mcp_server_polarion.tools._shared import cache as _cache_mod
+from mcp_server_polarion.tools._shared.cache import store_work_item_custom_keys
 from mcp_server_polarion.tools.work_items import (
     _build_create_work_items_payload,
     _build_update_work_item_payload,
     _build_work_item_resource,
     create_work_items,
+    get_html_recipes,
     get_work_item,
     list_work_items,
     read_work_item,
     update_work_item,
+)
+from mcp_server_polarion.utils.html import (
+    _POLARION_TABLE_STYLE,
+    _POLARION_TD_STYLE,
+    _POLARION_TH_STYLE,
 )
 
 
@@ -568,6 +576,102 @@ class TestCreateWorkItemsHappyPath:
         # No usable javascript: href in either quote style.
         assert 'href="javascript:' not in desc_html
         assert "href='javascript:" not in desc_html
+
+    async def test_markdown_table_and_caption_polarionified(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {
+            "data": [{"type": "workitems", "id": "MyProj/MCPT-1"}]
+        }
+
+        await create_work_items(
+            mock_ctx,
+            project_id="MyProj",
+            items=[
+                WorkItemCreateSpec(
+                    title="t",
+                    type="task",
+                    description=(
+                        "| a | b |\n| --- | --- |\n| 1 | 2 |\n\nTable: 캡션\n"
+                    ),
+                )
+            ],
+            dry_run=False,
+        )
+
+        _, kwargs = mock_client.post.call_args
+        desc_html = kwargs["json"]["data"][0]["attributes"]["description"]["value"]
+        assert 'class="polarion-Document-table"' in desc_html
+        assert 'data-sequence="Table"' in desc_html
+        assert "캡션" in desc_html
+
+    async def test_rich_text_custom_field_value_not_polarionified(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # polarionify applies to description only, never custom_fields.
+        store_work_item_custom_keys(
+            "MyProj", "task", frozenset({"verification_criteria"})
+        )
+        mock_client.post.return_value = {
+            "data": [{"type": "workitems", "id": "MyProj/MCPT-1"}]
+        }
+        rich = {"type": "text/html", "value": "<table><tr><td>x</td></tr></table>"}
+
+        await create_work_items(
+            mock_ctx,
+            project_id="MyProj",
+            items=[
+                WorkItemCreateSpec(
+                    title="t",
+                    type="task",
+                    custom_fields={"verification_criteria": rich},
+                )
+            ],
+            dry_run=False,
+        )
+
+        _, kwargs = mock_client.post.call_args
+        attributes = kwargs["json"]["data"][0]["attributes"]
+        assert attributes["verification_criteria"] == rich
+
+
+class TestGetHtmlRecipes:
+    """``get_html_recipes`` serves raw-HTML templates for update tools."""
+
+    async def test_returns_gallery_with_core_templates(self) -> None:
+        result = await get_html_recipes()
+        assert isinstance(result, HtmlRecipeGallery)
+        assert "polarion-Document-table" in result.recipes
+        assert "polarion-rte-caption-paragraph" in result.recipes
+        assert 'data-sequence="Table"' in result.recipes
+        assert 'data-sequence="Figure"' in result.recipes
+
+    async def test_returns_link_and_widget_templates(self) -> None:
+        result = await get_html_recipes()
+        for marker in (
+            'data-type="workItem"',
+            'data-type="crossReference"',
+            'data-type="richPage"',
+            "polarion_wiki macro name=toc",
+            "polarion_wiki macro name=tof",
+            "polarion_wiki macro name=page_break",
+        ):
+            assert marker in result.recipes
+
+    async def test_recipes_warn_about_scope_and_macro_ids(self) -> None:
+        result = await get_html_recipes()
+        assert "custom field" in result.recipes.lower()
+        assert "polarion_wiki" in result.recipes
+
+    async def test_recipes_stay_in_sync_with_pipeline_constants(self) -> None:
+        # Guide must quote the exact styles polarionify_html injects.
+        result = await get_html_recipes()
+        for constant in (
+            _POLARION_TABLE_STYLE,
+            _POLARION_TH_STYLE,
+            _POLARION_TD_STYLE,
+        ):
+            assert constant in result.recipes
 
 
 class TestCreateWorkItemsErrorMapping:

--- a/tests/mcp_server_polarion/utils/test_html.py
+++ b/tests/mcp_server_polarion/utils/test_html.py
@@ -10,6 +10,7 @@ from mcp_server_polarion.utils.html import (
     first_anchorless_block,
     html_to_markdown,
     markdown_to_html,
+    polarionify_html,
     sanitize_html,
     stamp_block_ids,
 )
@@ -833,3 +834,130 @@ class TestFirstAnchorlessBlock:
         # <span>/<strong> are not in the block set, so an anchored <p>
         # wrapping them passes even though the inline tags lack ids.
         assert first_anchorless_block('<p id="a">x <span>y</span></p>') is None
+
+
+class TestPolarionifyTables:
+    """Verify bare-table styling injection."""
+
+    def test_bare_table_gets_polarion_class(self) -> None:
+        result = polarionify_html("<table><tr><td>x</td></tr></table>")
+        assert 'class="polarion-Document-table"' in result
+
+    def test_bare_table_gets_table_style(self) -> None:
+        result = polarionify_html("<table><tr><td>x</td></tr></table>")
+        assert "border-collapse: collapse" in result
+        assert "max-width: 1280px" in result
+
+    def test_th_and_td_get_cell_styles(self) -> None:
+        html = "<table><tr><th>h</th></tr><tr><td>d</td></tr></table>"
+        result = polarionify_html(html)
+        assert 'th style="' in result and "background-color: #F0F0F0" in result
+        assert 'td style="' in result and "padding: 5px" in result
+
+    def test_classed_table_untouched(self) -> None:
+        html = '<table class="custom"><tr><td>x</td></tr></table>'
+        assert polarionify_html(html) == html
+
+    def test_cell_with_existing_style_kept(self) -> None:
+        html = '<table><tr><td style="color: red;">x</td></tr></table>'
+        result = polarionify_html(html)
+        assert 'style="color: red;"' in result
+
+    def test_colspan_rowspan_survive(self) -> None:
+        html = '<table><tr><td colspan="2" rowspan="3">x</td></tr></table>'
+        result = polarionify_html(html)
+        assert 'colspan="2"' in result and 'rowspan="3"' in result
+
+    def test_no_table_returns_input_verbatim(self) -> None:
+        html = "<p>no&nbsp;tables here</p>"
+        assert polarionify_html(html) is html
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert polarionify_html("") == ""
+        assert polarionify_html("   ") == ""
+
+    def test_thead_structure_preserved(self) -> None:
+        html = (
+            "<table><thead><tr><th>h</th></tr></thead>"
+            "<tbody><tr><td>d</td></tr></tbody></table>"
+        )
+        result = polarionify_html(html)
+        assert "<thead>" in result and "<tbody>" in result
+
+    def test_no_macro_id_added(self) -> None:
+        result = polarionify_html("<table><tr><td>x</td></tr></table>")
+        assert "polarion_wiki" not in result
+
+
+class TestPolarionifyCaptions:
+    """Verify Table:/Figure: paragraph → native caption widget."""
+
+    def test_table_caption_converted(self) -> None:
+        html = "<table><tr><td>x</td></tr></table><p>Table: 병합 테스트</p>"
+        result = polarionify_html(html)
+        assert 'class="polarion-rte-caption-paragraph"' in result
+        assert 'data-sequence="Table"' in result
+        assert 'class="polarion-rte-caption"' in result
+        assert "병합 테스트" in result
+        assert "Table:" not in result
+
+    def test_caption_paragraph_shape(self) -> None:
+        html = "<table><tr><td>x</td></tr></table><p>Table: cap</p>"
+        result = polarionify_html(html)
+        # BS4 serializes class before data-*; Polarion accepts either order.
+        assert (
+            '<p class="polarion-rte-caption-paragraph" style="text-align: left;">'
+            'Table <span class="polarion-rte-caption" data-sequence="Table">#</span>'
+            " cap</p>" in result
+        )
+
+    def test_figure_caption_after_image_paragraph(self) -> None:
+        html = '<p><img src="x.png" alt="x"/></p><p>Figure: 다이어그램</p>'
+        result = polarionify_html(html)
+        assert 'data-sequence="Figure"' in result
+        assert "다이어그램" in result
+
+    def test_non_adjacent_table_paragraph_untouched(self) -> None:
+        html = "<p>Table: just prose</p><p>other</p>"
+        assert polarionify_html(html) is html
+
+    def test_paragraph_between_table_and_caption_blocks_conversion(self) -> None:
+        html = "<table><tr><td>x</td></tr></table><p>gap</p><p>Table: cap</p>"
+        result = polarionify_html(html)
+        assert "polarion-rte-caption" not in result
+
+    def test_figure_prefix_after_table_not_converted(self) -> None:
+        html = "<table><tr><td>x</td></tr></table><p>Figure: wrong kind</p>"
+        result = polarionify_html(html)
+        assert "polarion-rte-caption" not in result
+
+    def test_inline_formatting_in_caption_preserved(self) -> None:
+        html = "<table><tr><td>x</td></tr></table><p>Table: with <b>bold</b> text</p>"
+        result = polarionify_html(html)
+        assert "<b>bold</b>" in result
+        assert 'data-sequence="Table"' in result
+
+    def test_whitespace_between_table_and_caption_skipped(self) -> None:
+        html = "<table><tr><td>x</td></tr></table>\n  <p>Table: cap</p>"
+        result = polarionify_html(html)
+        assert 'data-sequence="Table"' in result
+
+
+class TestPolarionifyPipeline:
+    """Markdown → sanitize → polarionify full greenfield chain."""
+
+    def test_markdown_table_with_caption_end_to_end(self) -> None:
+        markdown = (
+            "intro\n\n| 도구 | 결과 |\n| --- | --- |\n| a | b |\n\nTable: 테스트 표\n"
+        )
+        result = polarionify_html(sanitize_html(markdown_to_html(markdown)))
+        assert 'class="polarion-Document-table"' in result
+        assert 'data-sequence="Table"' in result
+        assert "테스트 표" in result
+
+    def test_markdown_image_stripped_so_figure_caption_stays_prose(self) -> None:
+        # sanitize_html drops <img>, so the Figure: paragraph loses its anchor.
+        markdown = "![alt](https://example.com/x.png)\n\nFigure: 그림 캡션\n"
+        result = polarionify_html(sanitize_html(markdown_to_html(markdown)))
+        assert "polarion-rte-caption" not in result
+        assert "Figure: 그림 캡션" in result


### PR DESCRIPTION
## Summary

Markdown-created tables rendered bare (no borders/header shading) in the Polarion UI, and native numbered captions were impossible through the greenfield path -- `sanitize_html` strips `class`/`style`/`data-*`. Verified live on testdrive by comparing a markdown-created item (MCPT-609) against a UI-created one (MCPT-611).

This PR adds a `polarionify_html` step that runs strictly **after** `sanitize_html` in the greenfield pipeline (`create_work_items` / `create_document`):

- class-less tables get the Polarion house style (`polarion-Document-table` + fixed inline styles, extracted from UI-generated tables);
- a paragraph starting `Table:` directly after a table (pandoc-style) becomes a native numbered caption widget (`polarion-rte-caption-paragraph` + `data-sequence` span), feeding the Table of Tables widget.

Every injected attribute is a fixed constant, so user input cannot smuggle styles or classes through sanitization. Raw-HTML update paths stay verbatim (untouched by design); for those, a new `get_html_recipes` guide tool serves copy-paste templates: styled tables, Table/Figure captions, `polarion-rte-link` spans (workItem / crossReference / richPage), TOC / Table-of-Figures widgets, page breaks, macro-id and metadata-scope caveats -- all extracted from live testdrive HTML.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Markdown-created tables rendered unstyled and captions could not reach the native numbered widget.
- Add post-sanitize polarionify step plus get_html_recipes templates with a recipe-sourced eval case.

## Testing

- TDD throughout: new/updated tests across `test_html.py`, `test_work_items.py`, `test_documents.py`, `test_mcp_transport.py`, `test_checks.py`; full suite 1521 passed.
- `ruff check` / `ruff format --check` / `mypy` clean; total coverage 94%, `diff-cover` 100% on changed lines.
- New eval case `EFF-TABLE-RECIPE-SOURCED` (efficiency, 0.8): a table written via `update_work_item`/`update_document` must be preceded by `get_html_recipes`; passes 5/5 on gpt-4o-mini after tool-description keyword tuning. `get_html_recipes` removed from eval-coverage deferral.
- E2E on testdrive: MCPT-612 created from markdown -- stored HTML carries the house style and caption widget; placed in the SRS document next to the pre-fix MCPT-609 for visual comparison.

## Notes for Reviewers

- `Figure:` caption conversion is unreachable on the greenfield chain today (`sanitize_html` drops `<img>`); it is covered at unit level and documented in the recipes for the raw-HTML path.
- Guide/pipeline drift is test-enforced: `html_recipes.md` must quote the exact style constants `polarionify_html` injects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)