### PR TITLE
refactor(tools): extract recipes module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
 ## Architecture
 
 - `core/` — `client.py` (async httpx, retries 429/5xx → `PolarionError`/`PolarionAuthError`/`PolarionNotFoundError`), `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only; loggers `mcp_server_polarion.<module>`).
-- `tools/` — domain modules; `_build_*_payload` = unit-test seam; `tools/__init__.py` import registers `@mcp.tool`s. `_shared/`: `helpers.py`, `parse.py` (JSON:API→models), `pagination.py` (`make_page`), `fields.py`/`custom_fields.py` (sparse-fieldset + custom-field policy), `cache.py` (`TTLCache`), `guard.py` (write guards), `sql.py` (recipes). `tools/guides/` = on-demand data.
+- `tools/` — domain modules; `_build_*_payload` = unit-test seam; `tools/__init__.py` import registers `@mcp.tool`s. `_shared/`: `helpers.py`, `parse.py` (JSON:API→models), `pagination.py` (`make_page`), `fields.py`/`custom_fields.py` (sparse-fieldset + custom-field policy), `cache.py` (`TTLCache`), `guard.py` (write guards), `sql.py` (recipes). `tools/guides/` = on-demand data served by `recipes.py`.
 - `utils/html.py` — Markdown↔HTML, `stamp_block_ids`, `first_anchorless_block`.
 - `models/` — Pydantic v2, re-exported from `models/__init__.py`; `PaginatedResult[T]` wrap list responses.
 - `server.py` — FastMCP instance; lifespan owns `PolarionClient`.

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -36,15 +36,17 @@ from mcp_server_polarion.models.links import (
     WorkItemLinkUpdateSpec,
 )
 from mcp_server_polarion.models.projects import ProjectSummary
+from mcp_server_polarion.models.recipes import (
+    HtmlRecipeGallery,
+    SqlRecipeGallery,
+)
 from mcp_server_polarion.models.test_runs import (
     TestRunCreateSpec,
     TestRunsCreateResult,
     TestRunSummary,
 )
 from mcp_server_polarion.models.work_items import (
-    HtmlRecipeGallery,
     Hyperlink,
-    SqlRecipeGallery,
     WorkItemCreateSpec,
     WorkItemDetail,
     WorkItemMoveResult,

--- a/src/mcp_server_polarion/models/recipes.py
+++ b/src/mcp_server_polarion/models/recipes.py
@@ -1,0 +1,17 @@
+"""Recipe gallery models served by the static guide tools."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SqlRecipeGallery(BaseModel):
+    """Copy-paste SQL recipe gallery returned by ``get_sql_query_recipes``."""
+
+    recipes: str
+
+
+class HtmlRecipeGallery(BaseModel):
+    """Copy-paste Polarion HTML templates returned by ``get_html_recipes``."""
+
+    recipes: str

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -9,18 +9,6 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from mcp_server_polarion.models.common import MAX_BODY_HTML_LEN
 
 
-class SqlRecipeGallery(BaseModel):
-    """Copy-paste SQL recipe gallery returned by ``get_sql_query_recipes``."""
-
-    recipes: str
-
-
-class HtmlRecipeGallery(BaseModel):
-    """Copy-paste Polarion HTML templates returned by ``get_html_recipes``."""
-
-    recipes: str
-
-
 class WorkItemSummary(BaseModel):
     """Compact work-item representation for list and search results."""
 

--- a/src/mcp_server_polarion/tools/__init__.py
+++ b/src/mcp_server_polarion/tools/__init__.py
@@ -11,6 +11,7 @@ import mcp_server_polarion.tools.enum
 import mcp_server_polarion.tools.links
 import mcp_server_polarion.tools.moves
 import mcp_server_polarion.tools.projects
+import mcp_server_polarion.tools.recipes
 import mcp_server_polarion.tools.test_runs
 import mcp_server_polarion.tools.work_items  # noqa: F401
 

--- a/src/mcp_server_polarion/tools/recipes.py
+++ b/src/mcp_server_polarion/tools/recipes.py
@@ -1,0 +1,53 @@
+"""Static recipe tools — copy-paste SQL queries and Polarion HTML templates
+served from ``tools/guides/``.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from typing import Final
+
+from mcp_server_polarion.models import HtmlRecipeGallery, SqlRecipeGallery
+from mcp_server_polarion.server import mcp
+
+_SQL_QUERY_RECIPES: Final[str] = (
+    resources.files("mcp_server_polarion.tools")
+    .joinpath("guides", "sql_query_recipes.md")
+    .read_text(encoding="utf-8")
+)
+
+_HTML_RECIPES: Final[str] = (
+    resources.files("mcp_server_polarion.tools")
+    .joinpath("guides", "html_recipes.md")
+    .read_text(encoding="utf-8")
+)
+
+
+@mcp.tool(
+    tags={"read"},
+    annotations={"readOnlyHint": True},
+)
+async def get_sql_query_recipes() -> SqlRecipeGallery:
+    """Fetch copy-paste SQL recipes for the list_work_items SQL:(...) prefix.
+
+    Call before writing any SQL query (document scope, custom-field,
+    traceability); adapt a recipe instead of hand-writing joins. Includes the
+    table schema.
+    """
+    return SqlRecipeGallery(recipes=_SQL_QUERY_RECIPES)
+
+
+@mcp.tool(
+    tags={"read"},
+    annotations={"readOnlyHint": True},
+)
+async def get_html_recipes() -> HtmlRecipeGallery:
+    """Fetch the required HTML templates for tables, captions, links, and
+    widgets written via update_work_items / update_document.
+
+    Any new <table>, numbered caption, work-item / cross-reference / wiki-page
+    link, or TOC / Table-of-Figures widget must be adapted from these
+    templates — plain hand-written markup renders unstyled and breaks
+    numbering. Also covers macro-id and metadata-scope caveats.
+    """
+    return HtmlRecipeGallery(recipes=_HTML_RECIPES)

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -1,10 +1,9 @@
-"""Work item tools — query, create, update, and SQL recipes."""
+"""Work item tools — query, create, and update."""
 
 from __future__ import annotations
 
 import logging
-from importlib import resources
-from typing import Final, cast
+from typing import cast
 from urllib.parse import urlencode
 
 from fastmcp import Context
@@ -16,10 +15,8 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
-    HtmlRecipeGallery,
     JsonValue,
     PaginatedResult,
-    SqlRecipeGallery,
     WorkItemCreateSpec,
     WorkItemDetail,
     WorkItemRead,
@@ -208,19 +205,6 @@ def _update_query_params(
     if change_type_to:
         params["changeTypeTo"] = change_type_to
     return params
-
-
-_SQL_QUERY_RECIPES: Final[str] = (
-    resources.files("mcp_server_polarion.tools")
-    .joinpath("guides", "sql_query_recipes.md")
-    .read_text(encoding="utf-8")
-)
-
-_HTML_RECIPES: Final[str] = (
-    resources.files("mcp_server_polarion.tools")
-    .joinpath("guides", "html_recipes.md")
-    .read_text(encoding="utf-8")
-)
 
 
 @mcp.tool(
@@ -477,36 +461,6 @@ async def update_work_items(  # noqa: PLR0913
         work_item_ids=[spec.work_item_id for spec in items],
         payload_preview=None,
     )
-
-
-@mcp.tool(
-    tags={"read"},
-    annotations={"readOnlyHint": True},
-)
-async def get_sql_query_recipes() -> SqlRecipeGallery:
-    """Fetch copy-paste SQL recipes for the list_work_items SQL:(...) prefix.
-
-    Call before writing any SQL query (document scope, custom-field,
-    traceability); adapt a recipe instead of hand-writing joins. Includes the
-    table schema.
-    """
-    return SqlRecipeGallery(recipes=_SQL_QUERY_RECIPES)
-
-
-@mcp.tool(
-    tags={"read"},
-    annotations={"readOnlyHint": True},
-)
-async def get_html_recipes() -> HtmlRecipeGallery:
-    """Fetch the required HTML templates for tables, captions, links, and
-    widgets written via update_work_items / update_document.
-
-    Any new <table>, numbered caption, work-item / cross-reference / wiki-page
-    link, or TOC / Table-of-Figures widget must be adapted from these
-    templates — plain hand-written markup renders unstyled and breaks
-    numbering. Also covers macro-id and metadata-scope caveats.
-    """
-    return HtmlRecipeGallery(recipes=_HTML_RECIPES)
 
 
 @mcp.tool(

--- a/tests/mcp_server_polarion/models/test_recipes.py
+++ b/tests/mcp_server_polarion/models/test_recipes.py
@@ -1,0 +1,21 @@
+"""Tests for the recipe gallery models."""
+
+from __future__ import annotations
+
+from mcp_server_polarion.models import HtmlRecipeGallery, SqlRecipeGallery
+
+
+class TestRecipeGalleries:
+    """Galleries are plain string carriers that round-trip through JSON."""
+
+    def test_sql_gallery_round_trip(self) -> None:
+        gallery = SqlRecipeGallery(recipes="SELECT wi.c_uri FROM workitem wi")
+        assert (
+            SqlRecipeGallery.model_validate_json(gallery.model_dump_json()) == gallery
+        )
+
+    def test_html_gallery_round_trip(self) -> None:
+        gallery = HtmlRecipeGallery(recipes="<table></table>")
+        assert (
+            HtmlRecipeGallery.model_validate_json(gallery.model_dump_json()) == gallery
+        )

--- a/tests/mcp_server_polarion/tools/test_recipes.py
+++ b/tests/mcp_server_polarion/tools/test_recipes.py
@@ -1,0 +1,66 @@
+"""Tests for the static SQL and HTML recipe gallery tools."""
+
+from __future__ import annotations
+
+from mcp_server_polarion.models import HtmlRecipeGallery, SqlRecipeGallery
+from mcp_server_polarion.tools.recipes import get_html_recipes, get_sql_query_recipes
+from mcp_server_polarion.utils.html import (
+    _POLARION_TABLE_STYLE,
+    _POLARION_TD_STYLE,
+    _POLARION_TH_STYLE,
+)
+
+
+class TestGetSqlQueryRecipes:
+    """``get_sql_query_recipes`` serves the SQL:(...) recipe gallery."""
+
+    async def test_returns_gallery_with_schema_and_core_recipes(self) -> None:
+        result = await get_sql_query_recipes()
+        assert isinstance(result, SqlRecipeGallery)
+        for marker in (
+            "## Schema",
+            "work items belonging to a document",
+            "custom-field value search",
+            "back-traceability",
+            "forward-traceability",
+        ):
+            assert marker in result.recipes
+
+
+class TestGetHtmlRecipes:
+    """``get_html_recipes`` serves raw-HTML templates for update tools."""
+
+    async def test_returns_gallery_with_core_templates(self) -> None:
+        result = await get_html_recipes()
+        assert isinstance(result, HtmlRecipeGallery)
+        assert "polarion-Document-table" in result.recipes
+        assert "polarion-rte-caption-paragraph" in result.recipes
+        assert 'data-sequence="Table"' in result.recipes
+        assert 'data-sequence="Figure"' in result.recipes
+
+    async def test_returns_link_and_widget_templates(self) -> None:
+        result = await get_html_recipes()
+        for marker in (
+            'data-type="workItem"',
+            'data-type="crossReference"',
+            'data-type="richPage"',
+            "polarion_wiki macro name=toc",
+            "polarion_wiki macro name=tof",
+            "polarion_wiki macro name=page_break",
+        ):
+            assert marker in result.recipes
+
+    async def test_recipes_warn_about_scope_and_macro_ids(self) -> None:
+        result = await get_html_recipes()
+        assert "custom field" in result.recipes.lower()
+        assert "polarion_wiki" in result.recipes
+
+    async def test_recipes_stay_in_sync_with_pipeline_constants(self) -> None:
+        # Guide must quote the exact styles polarionify_html injects.
+        result = await get_html_recipes()
+        for constant in (
+            _POLARION_TABLE_STYLE,
+            _POLARION_TH_STYLE,
+            _POLARION_TD_STYLE,
+        ):
+            assert constant in result.recipes

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -15,7 +15,6 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import (
-    HtmlRecipeGallery,
     Hyperlink,
     PaginatedResult,
     WorkItemCreateSpec,
@@ -34,16 +33,10 @@ from mcp_server_polarion.tools.work_items import (
     _build_update_work_items_payload,
     _build_work_item_resource,
     create_work_items,
-    get_html_recipes,
     get_work_item,
     list_work_items,
     read_work_item,
     update_work_items,
-)
-from mcp_server_polarion.utils.html import (
-    _POLARION_TABLE_STYLE,
-    _POLARION_TD_STYLE,
-    _POLARION_TH_STYLE,
 )
 
 
@@ -607,45 +600,6 @@ class TestCreateWorkItemsHappyPath:
         _, kwargs = mock_client.post.call_args
         attributes = kwargs["json"]["data"][0]["attributes"]
         assert attributes["verification_criteria"] == rich
-
-
-class TestGetHtmlRecipes:
-    """``get_html_recipes`` serves raw-HTML templates for update tools."""
-
-    async def test_returns_gallery_with_core_templates(self) -> None:
-        result = await get_html_recipes()
-        assert isinstance(result, HtmlRecipeGallery)
-        assert "polarion-Document-table" in result.recipes
-        assert "polarion-rte-caption-paragraph" in result.recipes
-        assert 'data-sequence="Table"' in result.recipes
-        assert 'data-sequence="Figure"' in result.recipes
-
-    async def test_returns_link_and_widget_templates(self) -> None:
-        result = await get_html_recipes()
-        for marker in (
-            'data-type="workItem"',
-            'data-type="crossReference"',
-            'data-type="richPage"',
-            "polarion_wiki macro name=toc",
-            "polarion_wiki macro name=tof",
-            "polarion_wiki macro name=page_break",
-        ):
-            assert marker in result.recipes
-
-    async def test_recipes_warn_about_scope_and_macro_ids(self) -> None:
-        result = await get_html_recipes()
-        assert "custom field" in result.recipes.lower()
-        assert "polarion_wiki" in result.recipes
-
-    async def test_recipes_stay_in_sync_with_pipeline_constants(self) -> None:
-        # Guide must quote the exact styles polarionify_html injects.
-        result = await get_html_recipes()
-        for constant in (
-            _POLARION_TABLE_STYLE,
-            _POLARION_TH_STYLE,
-            _POLARION_TD_STYLE,
-        ):
-            assert constant in result.recipes
 
 
 class TestCreateWorkItemsErrorMapping:


### PR DESCRIPTION
## Summary

`get_sql_query_recipes` and `get_html_recipes` are static guide-serving tools, not work-item CRUD - `get_html_recipes` backs both `update_work_items` and `update_document`, and the guide data already lives in `tools/guides/`. This extracts them into a `recipes` domain module pair (`tools/recipes.py` + `models/recipes.py`), preserving the tools/ <-> models/ one-to-one domain mirror. MCP tool names, docstrings, and behavior are unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- get_html_recipes serves documents too; static guide tools misplaced in work_items
- Move both recipe tools and gallery models to new recipes.py domain pair

## Testing

ruff + mypy + pytest all green locally (1494 passed). diff-cover 100% on changed lines. Transport tests (`test_get_sql_query_recipes_reads` / `test_get_html_recipes_reads`) verify both tools still register over MCP stdio via the new `tools/__init__.py` import. Added a previously missing unit test for `get_sql_query_recipes` content markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)