### PR TITLE
chore(src): compress comments caveman-style

### DIFF
--- a/src/mcp_server_polarion/__main__.py
+++ b/src/mcp_server_polarion/__main__.py
@@ -1,4 +1,4 @@
-"""Entry point for the MCP server — ``python -m mcp_server_polarion``."""
+"""Entry point — ``python -m mcp_server_polarion``."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from mcp_server_polarion.server import mcp
 
 
 def main() -> None:
-    """Run the Polarion MCP server over stdio transport."""
+    """Run Polarion MCP server over stdio."""
     mcp.run(transport="stdio")
 
 

--- a/src/mcp_server_polarion/core/client.py
+++ b/src/mcp_server_polarion/core/client.py
@@ -1,9 +1,9 @@
-"""Async HTTP client for the Polarion REST API v1.
+"""Async HTTP client for Polarion REST API v1.
 
-``PolarionClient`` wraps :class:`httpx.AsyncClient` with bearer auth,
-JSON:API error mapping (401/403 → ``PolarionAuthError``, 404 →
+``PolarionClient`` wrap :class:`httpx.AsyncClient`: bearer auth, JSON:API
+error mapping (401/403 → ``PolarionAuthError``, 404 →
 ``PolarionNotFoundError``, else ``PolarionError``), 429/5xx
-exponential-backoff retry, and a post-mutation delay.
+exponential-backoff retry, post-mutation delay.
 """
 
 from __future__ import annotations
@@ -30,10 +30,9 @@ _INITIAL_BACKOFF_SECONDS: Final[float] = 1.0
 _BACKOFF_MULTIPLIER: Final[float] = 2.0
 _RETRYABLE_STATUS_CODES: Final[frozenset[int]] = frozenset({429, 500, 502, 503, 504})
 
-# Pause after each mutation (Polarion forbids concurrent writes).
+# Pause after each mutation (Polarion forbid concurrent writes).
 _WRITE_DELAY_SECONDS: Final[float] = 1.5
-# Min gap between request starts → ≤3 req/s; start-based, so slow
-# requests add no extra wait.
+# Start-based min gap → ≤3 req/s; slow request add no extra wait.
 _MIN_REQUEST_INTERVAL_SECONDS: Final[float] = 1.0 / 3.0
 _DEFAULT_TIMEOUT_SECONDS: Final[float] = 30.0
 
@@ -46,9 +45,7 @@ _MAX_ERROR_DETAIL_LEN: Final[int] = 200
 
 
 def _extract_json_api_detail(body: object) -> str:
-    """Concise detail from a JSON:API body: ``errors[*].detail``/``title``,
-    else truncated body.
-    """
+    """Detail from JSON:API body: ``errors[*].detail``/``title``, else truncated."""
     if not isinstance(body, dict):
         return str(body)[:_MAX_ERROR_DETAIL_LEN]
     errors = body.get("errors")
@@ -65,7 +62,7 @@ def _extract_json_api_detail(body: object) -> str:
 
 
 def _sanitize_error_text(raw: str) -> str:
-    """Strip HTML tags and truncate raw error text for safe display."""
+    """Strip HTML tags + truncate for safe display."""
     clean = re.sub(r"<[^>]+>", " ", raw)
     clean = " ".join(clean.split())
     if len(clean) > _MAX_ERROR_DETAIL_LEN:
@@ -74,9 +71,7 @@ def _sanitize_error_text(raw: str) -> str:
 
 
 class PolarionClient:
-    """Async HTTP client for the Polarion REST API; created once and reused
-    for the MCP server lifetime (``lifespan`` context in ``server.py``).
-    """
+    """Async Polarion REST client; one instance per server ``lifespan``."""
 
     def __init__(
         self,
@@ -88,7 +83,7 @@ class PolarionClient:
         self.base_url: str = config.base_api_url
         self._write_delay = write_delay
         self._min_interval = min_interval
-        # -inf: first request never waits, whatever the clock epoch.
+        # -inf: first request never wait, any clock epoch.
         self._last_request_monotonic: float = float("-inf")
         self._client = httpx.AsyncClient(
             base_url=self.base_url,
@@ -100,8 +95,7 @@ class PolarionClient:
             timeout=httpx.Timeout(_DEFAULT_TIMEOUT_SECONDS),
             verify=config.polarion_verify_ssl,
         )
-        # Lazily bound to running loop; serializes all calls
-        # (no concurrency); not reentrant.
+        # Lazy-bound to running loop; serialize all calls; not reentrant.
         self._request_lock: asyncio.Lock | None = None
 
     def _get_request_lock(self) -> asyncio.Lock:
@@ -110,9 +104,7 @@ class PolarionClient:
         return self._request_lock
 
     async def _pace(self) -> None:
-        """Block until ``_min_interval`` since the previous request issued. Caller
-        holds the lock; :meth:`_request` stamps each attempt's issue time.
-        """
+        """Block until ``_min_interval`` since previous request (caller hold lock)."""
         loop = asyncio.get_running_loop()
         wait = self._min_interval - (loop.time() - self._last_request_monotonic)
         if wait > 0:
@@ -131,11 +123,11 @@ class PolarionClient:
 
     @property
     def is_closed(self) -> bool:
-        """Whether the underlying HTTP transport has been closed."""
+        """Whether underlying HTTP transport closed."""
         return self._client.is_closed
 
     async def close(self) -> None:
-        """Close the underlying ``httpx.AsyncClient``."""
+        """Close underlying ``httpx.AsyncClient``."""
         await self._client.aclose()
 
     async def get(
@@ -144,7 +136,7 @@ class PolarionClient:
         *,
         params: dict[str, str | int] | None = None,
     ) -> dict[str, object]:
-        """``GET``; raises ``PolarionAuthError`` (401/403),
+        """``GET``; raise ``PolarionAuthError`` (401/403),
         ``PolarionNotFoundError`` (404), ``PolarionError`` (other non-2xx).
         """
         async with self._get_request_lock():
@@ -156,8 +148,8 @@ class PolarionClient:
         *,
         json: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        """``POST``; sleeps ``_write_delay`` after success, inside the lock,
-        for cluster propagation before the next call.
+        """``POST``; sleep ``_write_delay`` in-lock after success —
+        cluster propagation before next call.
         """
         async with self._get_request_lock():
             result = await self._request("POST", path, json=json)
@@ -182,9 +174,9 @@ class PolarionClient:
         *,
         json: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        """``DELETE``; same delay contract as :meth:`post`. ``json`` carries
-        bulk-delete ids — non-standard for DELETE, but httpx and Polarion's
-        gateway both accept it. ``{}`` for 204 No Content.
+        """``DELETE``; same delay contract as :meth:`post`. ``json`` carry
+        bulk-delete ids — non-standard for DELETE, httpx + Polarion gateway
+        both accept. ``{}`` for 204 No Content.
         """
         async with self._get_request_lock():
             result = await self._request("DELETE", path, json=json)
@@ -199,19 +191,18 @@ class PolarionClient:
         params: dict[str, str | int] | None = None,
         json: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        """Execute with error mapping; retries 429/5xx up to ``_MAX_RETRIES``
+        """Execute with error mapping; retry 429/5xx up to ``_MAX_RETRIES``
         with exponential backoff, other errors raise immediately.
         """
-        # Lock held across retries — releasing mid-backoff would let another caller
-        # slip in and hit the same 429. Pace before first attempt; backoffs widen gap.
+        # Lock held across retries — release mid-backoff = other caller hit same 429.
+        # Pace before first attempt; backoffs widen gap.
         await self._pace()
         last_exception: PolarionError | None = None
         backoff = _INITIAL_BACKOFF_SECONDS
         loop = asyncio.get_running_loop()
 
         for attempt in range(_MAX_RETRIES + 1):
-            # Stamp per attempt so the next request paces from the last one
-            # sent, not the stale first.
+            # Stamp per attempt — next request pace from last sent, not stale first.
             self._last_request_monotonic = loop.time()
             try:
                 response = await self._client.request(
@@ -264,7 +255,7 @@ class PolarionClient:
 
     @staticmethod
     def _map_status_to_error(response: httpx.Response) -> PolarionError:
-        """Map a non-2xx response to the matching ``PolarionError`` subclass."""
+        """Map non-2xx response to matching ``PolarionError`` subclass."""
         status = response.status_code
         try:
             detail: str = _extract_json_api_detail(response.json())

--- a/src/mcp_server_polarion/core/config.py
+++ b/src/mcp_server_polarion/core/config.py
@@ -1,6 +1,4 @@
-"""Polarion configuration from environment variables; secrets live in ``.env``
-or real env vars, never hardcoded.
-"""
+"""Polarion configuration from env vars; secrets never hardcoded."""
 
 from __future__ import annotations
 
@@ -9,13 +7,12 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class PolarionConfig(BaseSettings):
-    """Environment-based configuration for the Polarion MCP server."""
+    """Env-based configuration for Polarion MCP server."""
 
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
-        # A shared .env may hold unrelated secrets (e.g. OPENAI_API_KEY for the
-        # eval gate); ignore extras instead of failing client construction.
+        # Shared .env may hold unrelated secrets (eval OPENAI_API_KEY); ignore extras.
         extra="ignore",
     )
 
@@ -37,5 +34,5 @@ class PolarionConfig(BaseSettings):
 
     @property
     def base_api_url(self) -> str:
-        """Return the full REST API v1 base URL."""
+        """Full REST API v1 base URL."""
         return f"{self.polarion_url.rstrip('/')}/polarion/rest/v1"

--- a/src/mcp_server_polarion/core/exceptions.py
+++ b/src/mcp_server_polarion/core/exceptions.py
@@ -1,12 +1,10 @@
-"""Polarion API exceptions; each carries the HTTP ``status_code`` so tool-level
-handlers can produce actionable messages for the LLM.
-"""
+"""Polarion API exceptions; each carry HTTP ``status_code`` for tool handlers."""
 
 from __future__ import annotations
 
 
 class PolarionError(Exception):
-    """Base exception for all Polarion REST API errors."""
+    """Base for Polarion REST API errors."""
 
     def __init__(self, message: str, *, status_code: int = 0) -> None:
         super().__init__(message)

--- a/src/mcp_server_polarion/core/logging.py
+++ b/src/mcp_server_polarion/core/logging.py
@@ -1,4 +1,4 @@
-"""Logging setup — all output goes to stderr (stdout is reserved for MCP)."""
+"""Logging setup — stderr only (stdout reserved for MCP)."""
 
 from __future__ import annotations
 
@@ -7,10 +7,7 @@ import sys
 
 
 def setup_logging(*, level: int = logging.INFO) -> logging.Logger:
-    """Configure and return the package-level logger — single
-    ``StreamHandler(sys.stderr)`` so log messages never pollute the MCP
-    JSON-RPC channel on stdout.
-    """
+    """Package logger — single ``StreamHandler(sys.stderr)``, never MCP stdout."""
     logger = logging.getLogger("mcp_server_polarion")
 
     if not logger.handlers:

--- a/src/mcp_server_polarion/middleware.py
+++ b/src/mcp_server_polarion/middleware.py
@@ -1,10 +1,9 @@
 """FastMCP middleware compacting tool-argument validation errors.
 
-FastMCP validates tool arguments via Pydantic before the tool body runs, so a
-per-tool wrapper can't catch the failure; the raw ``ValidationError`` dump
-(per-error ``input_value`` reprs + pydantic.dev URLs) would otherwise become the
-tool-result text the LLM pays for. ``on_call_tool`` wraps the call and rewrites
-it to a one-line field summary.
+FastMCP validate tool args via Pydantic before tool body run — per-tool
+wrapper can't catch. Raw ``ValidationError`` dump (``input_value`` reprs +
+pydantic.dev URLs) would become tool-result text LLM pay for.
+``on_call_tool`` wrap call, rewrite to one-line field summary.
 """
 
 from __future__ import annotations
@@ -19,9 +18,9 @@ from pydantic import ValidationError
 def compact_validation_error(
     tool_name: str, exc: ValidationError, *, max_errors: int = 20
 ) -> str:
-    """One-line ``<loc.path>: <msg>`` summary of a tool-argument
-    ``ValidationError``; drops ``input_value`` reprs and pydantic.dev URLs, caps
-    at *max_errors* entries with a ``(+N more)`` suffix.
+    """One-line ``<loc.path>: <msg>`` summary of tool-arg ``ValidationError``;
+    drop ``input_value`` reprs + pydantic.dev URLs, cap at *max_errors* with
+    ``(+N more)`` suffix.
     """
     errors = exc.errors(include_url=False)
     parts = [
@@ -37,8 +36,8 @@ def compact_validation_error(
 class CompactValidationErrorMiddleware(Middleware):
     """Rewrite tool-argument ``ValidationError``s into compact ``ToolError``s.
 
-    Also catches a ``ValidationError`` raised inside a tool body (e.g. result
-    model construction); the compacted message still names the offending paths.
+    Also catch ``ValidationError`` from inside tool body (e.g. result model
+    construction); compacted message still name offending paths.
     """
 
     async def on_call_tool(

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -1,6 +1,6 @@
-"""Pydantic models for MCP tool I/O, grouped by domain and re-exported here as
-the single import surface. Class docstrings and ``Field(description=...)`` ship
-in the JSON Schema — omit a description when name + type say everything.
+"""Pydantic models for MCP tool I/O, grouped by domain, re-exported here as
+single import surface. Class docstrings + ``Field(description=...)`` ship in
+JSON Schema — omit description when name + type say everything.
 """
 
 from __future__ import annotations

--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -1,4 +1,4 @@
-"""Comment models — shared comment view, create specs, and update results."""
+"""Comment models — shared view, create specs, update results."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class Comment(BaseModel):
-    """A single comment returned by the comment list tools."""
+    """Single comment from comment list tools."""
 
     id: str
     created: str
@@ -23,9 +23,9 @@ class Comment(BaseModel):
 
 
 class CommentSpec(BaseModel):
-    """Common fields for a comment to create; base for type-specific specs."""
+    """Common create fields; base for type-specific specs."""
 
-    # LLM input model: reject typo keys instead of silently dropping them.
+    # LLM input model: reject typo keys, not silent-drop.
     model_config = ConfigDict(extra="forbid")
 
     text: str = Field(min_length=1)
@@ -42,7 +42,7 @@ class WorkItemCommentSpec(CommentSpec):
 
 
 class CommentsCreateResult(BaseModel):
-    """Result of a comment-create operation."""
+    """Comment-create result."""
 
     created: bool
     dry_run: bool
@@ -51,7 +51,7 @@ class CommentsCreateResult(BaseModel):
 
 
 class CommentUpdateResult(BaseModel):
-    """Shared result of a comment-resolve update, across all comment types."""
+    """Comment-resolve update result, shared across comment types."""
 
     updated: bool
     dry_run: bool

--- a/src/mcp_server_polarion/models/common.py
+++ b/src/mcp_server_polarion/models/common.py
@@ -1,4 +1,4 @@
-"""Shared wrappers and constants used across model groups."""
+"""Shared wrappers + constants across model groups."""
 
 from __future__ import annotations
 
@@ -6,8 +6,8 @@ from typing import Final
 
 from pydantic import BaseModel
 
-# Internal payload-builder alias only — result models expose previews as
-# `Mapping[str, object]` because the recursive self-reference breaks FastMCP's
+# Payload-builder alias only — result models expose previews as
+# `Mapping[str, object]`: recursive self-reference break FastMCP
 # `json_schema_to_type` (unresolved `ForwardRef('Root')`).
 type JsonValue = (
     str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
@@ -18,7 +18,7 @@ MAX_BODY_HTML_LEN: Final[int] = 2_000_000
 
 
 class PaginatedResult[T](BaseModel):
-    """Paginated response wrapper used by all list tools."""
+    """Paginated response wrapper for all list tools."""
 
     items: list[T]
     total_count: int

--- a/src/mcp_server_polarion/models/documents.py
+++ b/src/mcp_server_polarion/models/documents.py
@@ -1,4 +1,4 @@
-"""Document models — summaries, details, parts, and write results."""
+"""Document models — summaries, details, parts, write results."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 
 
 class DocumentSummary(BaseModel):
-    """Summary of a Polarion document returned by ``list_documents``."""
+    """Polarion document summary from ``list_documents``."""
 
     space_id: str
     document_name: str
@@ -21,7 +21,7 @@ class DocumentSummary(BaseModel):
 
 
 class DocumentDetail(BaseModel):
-    """Full details of a Polarion document returned by ``get_document``."""
+    """Full Polarion document detail from ``get_document``."""
 
     title: str
     type: str = ""
@@ -36,7 +36,7 @@ class DocumentDetail(BaseModel):
 
 
 class DocumentPart(BaseModel):
-    """A single part (heading or work item) within a Polarion document."""
+    """Single part (heading or work item) within Polarion document."""
 
     id: str
     title: str
@@ -72,7 +72,7 @@ class DocumentReadResult(BaseModel):
 
 
 class DocumentCreateResult(BaseModel):
-    """Result of a ``create_document`` operation."""
+    """``create_document`` result."""
 
     created: bool
     dry_run: bool
@@ -81,7 +81,7 @@ class DocumentCreateResult(BaseModel):
 
 
 class DocumentUpdateResult(BaseModel):
-    """Result of an ``update_document`` operation."""
+    """``update_document`` result."""
 
     updated: bool
     dry_run: bool

--- a/src/mcp_server_polarion/models/enum.py
+++ b/src/mcp_server_polarion/models/enum.py
@@ -1,4 +1,4 @@
-"""Enum option model — the valid option set returned by list_*_enum_options."""
+"""Enum option model — valid option set from list_*_enum_options."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 
 class EnumOption(BaseModel):
-    """Single enum option returned by ``list_*_enum_options``."""
+    """Single enum option from ``list_*_enum_options``."""
 
     id: str
     name: str

--- a/src/mcp_server_polarion/models/links.py
+++ b/src/mcp_server_polarion/models/links.py
@@ -1,4 +1,4 @@
-"""Work item link models — link views, create/delete/update specs and results."""
+"""Work item link models — views, create/delete/update specs + results."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class WorkItemLink(BaseModel):
-    """A work item link with the target's summary metadata."""
+    """Work item link with target summary metadata."""
 
     id: str
     title: str
@@ -25,7 +25,7 @@ class WorkItemLink(BaseModel):
 class WorkItemLinkSpec(BaseModel):
     """One link to create under a source work item."""
 
-    # LLM input model: reject typo keys instead of silently dropping them.
+    # LLM input model: reject typo keys, not silent-drop.
     model_config = ConfigDict(extra="forbid")
 
     role: str = Field(min_length=1)
@@ -46,7 +46,7 @@ class WorkItemLinkRef(BaseModel):
 
 
 class WorkItemLinksCreateResult(BaseModel):
-    """Result of a ``create_work_item_links`` operation."""
+    """``create_work_item_links`` result."""
 
     created: bool
     dry_run: bool
@@ -55,7 +55,7 @@ class WorkItemLinksCreateResult(BaseModel):
 
 
 class WorkItemLinksDeleteResult(BaseModel):
-    """Result of a ``delete_work_item_links`` operation."""
+    """``delete_work_item_links`` result."""
 
     deleted: bool
     dry_run: bool
@@ -88,7 +88,7 @@ class WorkItemLinkUpdateSpec(BaseModel):
 
 
 class WorkItemLinkUpdateResult(BaseModel):
-    """Result of an ``update_work_item_link`` operation."""
+    """``update_work_item_link`` result."""
 
     updated: bool
     dry_run: bool

--- a/src/mcp_server_polarion/models/projects.py
+++ b/src/mcp_server_polarion/models/projects.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 
 class ProjectSummary(BaseModel):
-    """Summary of a Polarion project returned by ``list_projects``."""
+    """Polarion project summary from ``list_projects``."""
 
     id: str
     name: str

--- a/src/mcp_server_polarion/models/recipes.py
+++ b/src/mcp_server_polarion/models/recipes.py
@@ -6,12 +6,12 @@ from pydantic import BaseModel
 
 
 class SqlRecipeGallery(BaseModel):
-    """Copy-paste SQL recipe gallery returned by ``get_sql_query_recipes``."""
+    """Copy-paste SQL recipe gallery from ``get_sql_query_recipes``."""
 
     recipes: str
 
 
 class HtmlRecipeGallery(BaseModel):
-    """Copy-paste Polarion HTML templates returned by ``get_html_recipes``."""
+    """Copy-paste Polarion HTML templates from ``get_html_recipes``."""
 
     recipes: str

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -1,4 +1,4 @@
-"""Test run models — summaries, create specs, and write results."""
+"""Test run models — summaries, create specs, write results."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class TestRunSummary(BaseModel):
     """Compact test-run representation for list results."""
 
-    # pytest collects Test*-named classes as tests on import; opt out here.
+    # pytest collect Test*-named classes on import; opt out.
     __test__ = False
 
     id: str
@@ -28,7 +28,7 @@ class TestRunCreateSpec(BaseModel):
 
     __test__ = False
 
-    # LLM input model: reject typo keys instead of silently dropping them.
+    # LLM input model: reject typo keys, not silent-drop.
     model_config = ConfigDict(extra="forbid")
 
     id: str = Field(min_length=1)
@@ -43,7 +43,7 @@ class TestRunCreateSpec(BaseModel):
 
 
 class TestRunsCreateResult(BaseModel):
-    """Result of a ``create_test_runs`` operation."""
+    """``create_test_runs`` result."""
 
     __test__ = False
 

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -1,4 +1,4 @@
-"""Work item models — summaries, details, create specs, and write results."""
+"""Work item models — summaries, details, create specs, write results."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from mcp_server_polarion.models.common import MAX_BODY_HTML_LEN
 
 
 class WorkItemSummary(BaseModel):
-    """Compact work-item representation for list and search results."""
+    """Compact work-item view for list + search results."""
 
     id: str
     title: str
@@ -24,9 +24,9 @@ class WorkItemSummary(BaseModel):
 
 
 class Hyperlink(BaseModel):
-    """A single external hyperlink attached to a work item."""
+    """Single external hyperlink on a work item."""
 
-    # LLM input model: reject typo keys instead of silently dropping them.
+    # LLM input model: reject typo keys, not silent-drop.
     model_config = ConfigDict(extra="forbid")
 
     role: str
@@ -35,7 +35,7 @@ class Hyperlink(BaseModel):
 
 
 class WorkItemDetail(WorkItemSummary):
-    """Full work-item details returned by ``get_work_item``."""
+    """Full work-item detail from ``get_work_item``."""
 
     description_html: str = ""
     project_id: str
@@ -49,7 +49,7 @@ class WorkItemDetail(WorkItemSummary):
 
 
 class WorkItemRead(WorkItemSummary):
-    """LLM-friendly work-item view returned by ``read_work_item``."""
+    """LLM-friendly work-item view from ``read_work_item``."""
 
     description: str = ""
     project_id: str
@@ -81,7 +81,7 @@ class WorkItemCreateSpec(BaseModel):
 
 
 class WorkItemsCreateResult(BaseModel):
-    """Result of a ``create_work_items`` operation."""
+    """``create_work_items`` result."""
 
     created: bool
     dry_run: bool
@@ -139,8 +139,7 @@ class WorkItemUpdateSpec(BaseModel):
 
     @model_validator(mode="after")
     def _require_effective_change(self) -> WorkItemUpdateSpec:
-        # None-valued custom entries are dropped at payload build; an item
-        # reduced to an attribute-less resource would 400 the whole batch.
+        # None custom entries drop at payload build; attribute-less item 400 the batch.
         effective = (
             self.title
             or self.description_html
@@ -169,7 +168,7 @@ class WorkItemUpdateSpec(BaseModel):
 
 
 class WorkItemsUpdateResult(BaseModel):
-    """Result of an ``update_work_items`` operation."""
+    """``update_work_items`` result."""
 
     updated: bool
     dry_run: bool
@@ -178,7 +177,7 @@ class WorkItemsUpdateResult(BaseModel):
 
 
 class WorkItemMoveResult(BaseModel):
-    """Result of a ``move_work_item_to_document`` or sibling move-document call."""
+    """Result of ``move_work_item_to_document`` or sibling move call."""
 
     moved: bool
     dry_run: bool

--- a/src/mcp_server_polarion/server.py
+++ b/src/mcp_server_polarion/server.py
@@ -1,4 +1,4 @@
-"""FastMCP server instance and lifespan management."""
+"""FastMCP server instance + lifespan management."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ ICON_URL = (
 
 
 class LifespanContext(TypedDict):
-    """Typed context yielded by the server lifespan."""
+    """Typed context yielded by server lifespan."""
 
     polarion_client: PolarionClient
 
@@ -62,5 +62,5 @@ mcp = FastMCP(
 )
 mcp.add_middleware(CompactValidationErrorMiddleware())
 
-# Register tool modules — must be at bottom to avoid circular imports.
+# Register tool modules — bottom to avoid circular import.
 import mcp_server_polarion.tools  # noqa: E402, F401

--- a/src/mcp_server_polarion/tools/__init__.py
+++ b/src/mcp_server_polarion/tools/__init__.py
@@ -1,6 +1,6 @@
 """MCP tool definitions — domain-grouped tools for Polarion ALM.
 
-Importing each module registers its ``@mcp.tool`` functions as a side effect.
+Import of each module register its ``@mcp.tool``s as side effect.
 """
 
 from __future__ import annotations
@@ -15,5 +15,5 @@ import mcp_server_polarion.tools.recipes
 import mcp_server_polarion.tools.test_runs
 import mcp_server_polarion.tools.work_items  # noqa: F401
 
-# Intentionally empty: tools register via import side effect, not by name export.
+# Empty: tools register via import side effect, not name export.
 __all__: list[str] = []

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -1,6 +1,6 @@
-"""In-process TTL caches for near-static project facts, sparing the server's
-tight budget (<=3 req/s, no concurrency). Owns ALL cache state; tool logic
-reaches it only through the typed get / store wrappers.
+"""In-process TTL caches for near-static project facts — spare server's
+tight budget (<=3 req/s, no concurrency). Own ALL cache state; tool logic
+reach it only via typed get / store wrappers.
 """
 
 from __future__ import annotations
@@ -22,9 +22,7 @@ class _Entry[V]:
 
 
 class TTLCache[K, V]:
-    """Single-threaded TTL cache; lazy expiry, so a bounded key space never
-    grows past its bound.
-    """
+    """Single-threaded TTL cache; lazy expiry — bounded key space stay bounded."""
 
     def __init__(self, ttl_seconds: float) -> None:
         self._ttl = ttl_seconds
@@ -40,7 +38,7 @@ class TTLCache[K, V]:
         return entry.value
 
     def set(self, key: K, value: V, ttl_seconds: float | None = None) -> None:
-        """Store *value*; *ttl_seconds* overrides the cache default for this entry."""
+        """Store *value*; *ttl_seconds* override cache default for this entry."""
         ttl = self._ttl if ttl_seconds is None else ttl_seconds
         self._entries[key] = _Entry(expires_at=_now() + ttl, value=value)
 
@@ -55,7 +53,7 @@ Resource = Literal["workitems", "documents"]
 
 
 class DiscoveredDocument(NamedTuple):
-    """One document found by the ``list_documents`` discovery scan."""
+    """One document from ``list_documents`` discovery scan."""
 
     space_id: str
     document_name: str
@@ -66,14 +64,14 @@ class DiscoveredDocument(NamedTuple):
     updated_by_name: str = ""
 
 
-# 60s caps the window in which a stale entry accepts an admin-removed option.
+# 60s cap window where stale entry accept admin-removed option.
 _GUARD_TTL_SECONDS: Final[float] = 60.0
 
-# 404 "not an Enumeration field" is a stable schema fact whose stale worst
-# case is merely deferring to Polarion — safe to outlive positive option sets.
+# 404 "not an Enumeration field" = stable schema fact; stale worst case
+# just defer to Polarion — safe to outlive positive option sets.
 _ENUM_NOT_FOUND_TTL_SECONDS: Final[float] = 600.0
 
-# New documents must surface within ~1 min (create also invalidates on write).
+# New documents surface within ~1 min (create also invalidate on write).
 _DOCUMENT_LIST_TTL_SECONDS: Final[float] = 60.0
 
 
@@ -84,7 +82,7 @@ _document_list_cache: TTLCache[str, tuple[DiscoveredDocument, ...]] = TTLCache(
 
 
 def get_cached_documents(project_id: str) -> list[DiscoveredDocument] | None:
-    """Return the cached document list for *project_id* or ``None``."""
+    """Cached document list for *project_id*, or ``None``."""
     cached = _document_list_cache.get(project_id)
     return list(cached) if cached is not None else None
 
@@ -93,12 +91,12 @@ def store_cached_documents(
     project_id: str,
     documents: list[DiscoveredDocument],
 ) -> None:
-    """Cache *documents* for *project_id* for ``_DOCUMENT_LIST_TTL_SECONDS``."""
+    """Cache *documents* for ``_DOCUMENT_LIST_TTL_SECONDS``."""
     _document_list_cache.set(project_id, tuple(documents))
 
 
 def invalidate_documents_cache(project_id: str) -> None:
-    """Drop the cached document list for *project_id*, if any."""
+    """Drop cached document list for *project_id*, if any."""
     _document_list_cache.invalidate(project_id)
 
 
@@ -114,7 +112,7 @@ def get_cached_enum_options(
     field_id: str,
     type_id: str,
 ) -> frozenset[str] | None:
-    """Return cached valid option ids for the field/type, or ``None`` on miss."""
+    """Cached valid option ids for field/type, or ``None`` on miss."""
     return _enum_option_cache.get((project_id, resource, field_id, type_id))
 
 
@@ -127,8 +125,8 @@ def store_cached_enum_options(  # noqa: PLR0913
     *,
     not_found: bool = False,
 ) -> None:
-    """Cache option ids for the field/type; ``not_found=True`` (404 result)
-    uses the longer ``_ENUM_NOT_FOUND_TTL_SECONDS``.
+    """Cache option ids for field/type; ``not_found=True`` (404 result)
+    use longer ``_ENUM_NOT_FOUND_TTL_SECONDS``.
     """
     _enum_option_cache.set(
         (project_id, resource, field_id, type_id),
@@ -147,7 +145,7 @@ def get_cached_project_enum(
     project_id: str,
     enum_name: str,
 ) -> frozenset[str] | None:
-    """Return cached valid option ids for the project enum, or ``None`` on miss."""
+    """Cached valid option ids for project enum, or ``None`` on miss."""
     return _project_enum_cache.get((project_id, enum_name))
 
 
@@ -156,7 +154,7 @@ def store_cached_project_enum(
     enum_name: str,
     option_ids: frozenset[str],
 ) -> None:
-    """Cache the valid option ids for the project enum for ``_GUARD_TTL_SECONDS``."""
+    """Cache valid option ids for project enum for ``_GUARD_TTL_SECONDS``."""
     _project_enum_cache.set((project_id, enum_name), option_ids)
 
 
@@ -170,7 +168,7 @@ def get_work_item_custom_keys(
     project_id: str,
     work_item_type: str,
 ) -> frozenset[str] | None:
-    """Return the cached complete key schema for ``(project, type)``, or ``None``."""
+    """Cached complete key schema for ``(project, type)``, or ``None``."""
     return _work_item_custom_key_cache.get((project_id, work_item_type))
 
 
@@ -179,14 +177,14 @@ def store_work_item_custom_keys(
     work_item_type: str,
     keys: frozenset[str],
 ) -> None:
-    """Replace any prior set — each sample is the full key set, so an admin
-    removal shrinks the schema on expiry.
+    """Replace prior set — each sample = full key set, admin removal
+    shrink schema on expiry.
     """
     _work_item_custom_key_cache.set((project_id, work_item_type), keys)
 
 
 def invalidate_work_item_custom_keys(project_id: str, work_item_type: str) -> None:
-    """Drop the cached schema for ``(project, type)`` (used by the bypass-retry)."""
+    """Drop cached schema for ``(project, type)`` (bypass-retry)."""
     _work_item_custom_key_cache.invalidate((project_id, work_item_type))
 
 
@@ -200,7 +198,7 @@ def get_document_type_custom_keys(
     project_id: str,
     document_type: str,
 ) -> frozenset[str] | None:
-    """Return the cached key schema for ``(project, document_type)``, or ``None``."""
+    """Cached key schema for ``(project, document_type)``, or ``None``."""
     return _document_type_custom_key_cache.get((project_id, document_type))
 
 
@@ -209,14 +207,14 @@ def store_document_type_custom_keys(
     document_type: str,
     keys: frozenset[str],
 ) -> None:
-    """Replace any prior set — each sample is the full key set, so an admin
-    removal shrinks the schema on expiry.
+    """Replace prior set — each sample = full key set, admin removal
+    shrink schema on expiry.
     """
     _document_type_custom_key_cache.set((project_id, document_type), keys)
 
 
 def invalidate_document_type_custom_keys(project_id: str, document_type: str) -> None:
-    """Drop the cached schema for ``(project, document_type)`` (bypass-retry)."""
+    """Drop cached schema for ``(project, document_type)`` (bypass-retry)."""
     _document_type_custom_key_cache.invalidate((project_id, document_type))
 
 
@@ -225,19 +223,19 @@ _test_run_custom_key_cache: TTLCache[str, frozenset[str]] = TTLCache(_GUARD_TTL_
 
 
 def get_test_run_custom_keys(project_id: str) -> frozenset[str] | None:
-    """Return the cached testrun custom-field key schema, or ``None`` on miss."""
+    """Cached testrun custom-field key schema, or ``None`` on miss."""
     return _test_run_custom_key_cache.get(project_id)
 
 
 def store_test_run_custom_keys(project_id: str, keys: frozenset[str]) -> None:
-    """Replace any prior set — each sample is the full key set, so an admin
-    removal shrinks the schema on expiry.
+    """Replace prior set — each sample = full key set, admin removal
+    shrink schema on expiry.
     """
     _test_run_custom_key_cache.set(project_id, keys)
 
 
 def invalidate_test_run_custom_keys(project_id: str) -> None:
-    """Drop the cached testrun schema for *project_id* (used by the bypass-retry)."""
+    """Drop cached testrun schema for *project_id* (bypass-retry)."""
     _test_run_custom_key_cache.invalidate(project_id)
 
 

--- a/src/mcp_server_polarion/tools/_shared/custom_fields.py
+++ b/src/mcp_server_polarion/tools/_shared/custom_fields.py
@@ -1,6 +1,5 @@
-"""Custom-field policy: the standard-attribute allowlists plus the read
-(extract) and write (merge) helpers that split inline customs from standard
-Polarion attributes.
+"""Custom-field policy: standard-attribute allowlists + read (extract) and
+write (merge) helpers splitting inline customs from standard Polarion attrs.
 """
 
 from __future__ import annotations
@@ -9,8 +8,8 @@ from typing import Final, cast
 
 from mcp_server_polarion.models import JsonValue
 
-# Standard-attribute allowlist (REST OpenAPI schema); anything outside is
-# treated as a custom field, so new standard attrs misclassify until added.
+# Standard-attribute allowlist (REST OpenAPI schema); anything outside =
+# custom field, so new standard attrs misclassify until added.
 STANDARD_WORK_ITEM_ATTRIBUTES: Final[frozenset[str]] = frozenset(
     {
         "id",
@@ -60,7 +59,7 @@ STANDARD_DOCUMENT_ATTRIBUTES: Final[frozenset[str]] = frozenset(
 )
 
 
-# Testrun custom fields sit inline under attributes, like work items.
+# Testrun custom fields inline under attributes, like work items.
 STANDARD_TEST_RUN_ATTRIBUTES: Final[frozenset[str]] = frozenset(
     {
         "id",
@@ -86,8 +85,8 @@ def extract_custom_fields(
     attributes: dict[str, object],
     standard: frozenset[str],
 ) -> dict[str, object]:
-    """Inline custom-field subset of ``attributes`` (keys outside *standard*),
-    returned verbatim so rich-text values round-trip unchanged.
+    """Custom-field subset of ``attributes`` (keys outside *standard*),
+    verbatim so rich-text values round-trip unchanged.
     """
     return {k: v for k, v in attributes.items() if k not in standard}
 
@@ -97,9 +96,9 @@ def merge_custom_fields(
     customs: dict[str, object] | None,
     standard: frozenset[str],
 ) -> None:
-    """Merge custom-field key/values into *attributes* in place; a key in
-    *standard* raises ``ValueError`` (would shadow a tool parameter), ``None``
-    values skipped. Values stored by reference — callers must NOT mutate
+    """Merge custom-field key/values into *attributes* in place; key in
+    *standard* raise ``ValueError`` (would shadow tool parameter), ``None``
+    values skipped. Values stored by reference — caller must NOT mutate
     *customs* before serialisation.
     """
     if not customs:

--- a/src/mcp_server_polarion/tools/_shared/fields.py
+++ b/src/mcp_server_polarion/tools/_shared/fields.py
@@ -11,8 +11,8 @@ MAX_BULK_ITEMS: Final[int] = 50
 WORK_ITEM_LIST_FIELDS: Final[str] = "title,type,status,priority,updated,module,assignee"
 WORK_ITEM_DETAIL_FIELDS: Final[str] = "@all"
 WORK_ITEM_PART_FIELDS: Final[str] = "title,type,status,description,outlineNumber"
-# camelCase finishedOn/isTemplate are Polarion attr names; author keeps the
-# relationship block alive under the sparse fieldset.
+# camelCase finishedOn/isTemplate = Polarion attr names; author keep
+# relationship block alive under sparse fieldset.
 TEST_RUN_LIST_FIELDS: Final[str] = (
     "title,type,status,finishedOn,updated,author,isTemplate"
 )

--- a/src/mcp_server_polarion/tools/_shared/guard/__init__.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/__init__.py
@@ -1,13 +1,12 @@
-"""Pre-write guards: Polarion persists unknown enum ids / custom-field keys as
-silent ghosts (HTTP 200, invisible to UI and Lucene), so each guard fetches the
-real options and raises before the write. Fail-closed — validation error blocks
-the write (auth → ``PermissionError``, else ``RuntimeError``); only a
-*successful* empty option set and a 404 defer to Polarion. Caching in
-:mod:`...tools._shared.cache`.
+"""Pre-write guards: Polarion persist unknown enum ids / custom-field keys as
+silent ghosts (HTTP 200, invisible to UI and Lucene) — each guard fetch real
+options and raise before write. Fail-closed — validation error block write
+(auth → ``PermissionError``, else ``RuntimeError``); only *successful* empty
+option set and 404 defer to Polarion. Caching in :mod:`...tools._shared.cache`.
 
 Naming: ``guard_*`` = pure validators (return ``None``, raise on invalid);
 ``resolve_*``/``partition_*`` = fail-closed helpers whose validation result
-the caller also needs as data.
+caller also need as data.
 """
 
 from __future__ import annotations

--- a/src/mcp_server_polarion/tools/_shared/guard/_custom_keys.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/_custom_keys.py
@@ -1,6 +1,6 @@
-"""Custom-field key validation shared by the work-item / document / test-run
-guards: one control-flow engine over axis-supplied cache and fetch closures —
-the sampling strategies differ per axis, the check algorithm must not.
+"""Custom-field key validation shared by work-item / document / test-run
+guards: one control-flow engine over axis-supplied cache + fetch closures —
+sampling strategies differ per axis, check algorithm must not.
 """
 
 from __future__ import annotations
@@ -20,10 +20,10 @@ async def check_custom_keys(  # noqa: PLR0913
     discovery_tool: str,
     empty_schema_error: str,
 ) -> None:
-    """Reject ``custom_fields`` keys absent from the axis's sampled schema.
+    """Reject ``custom_fields`` keys absent from axis's sampled schema.
 
-    Unknown key vs *cached* schema forces one fresh re-fetch before rejecting;
-    empty schema fails closed with ``RuntimeError(empty_schema_error)`` (ghost
+    Unknown key vs *cached* schema force one fresh re-fetch before reject;
+    empty schema fail closed with ``RuntimeError(empty_schema_error)`` (ghost
     write unrecoverable).
     """
     schema = get_cached()
@@ -34,7 +34,7 @@ async def check_custom_keys(  # noqa: PLR0913
     if all(key in schema for key in custom_fields):
         return
 
-    # Unknown key may be admin-added since caching; refetch once before rejecting.
+    # Unknown key may be admin-added since caching; refetch once before reject.
     if not fetched_fresh:
         invalidate()
         schema = await fetch()

--- a/src/mcp_server_polarion/tools/_shared/guard/_errors.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/_errors.py
@@ -1,5 +1,5 @@
-"""Fail-closed write blocks: a guard that cannot validate raises instead of
-letting the write through (unknown ids/keys persist as silent ghosts).
+"""Fail-closed write blocks: guard that cannot validate raise instead of
+letting write through (unknown ids/keys persist as silent ghosts).
 """
 
 from __future__ import annotations
@@ -29,8 +29,8 @@ def unreachable_write_block(
 
 
 def unauthorized_write_block(what: str, project_id: str) -> PermissionError:
-    """Mirrors the tool layer's ``PolarionAuthError -> PermissionError``
-    (fixable token scope, not a backend to retry).
+    """Mirror tool layer ``PolarionAuthError -> PermissionError``
+    (fixable token scope, not backend to retry).
     """
     logger.warning(
         "guard blocking write: not authorized to validate %s for project=%s",

--- a/src/mcp_server_polarion/tools/_shared/guard/_http.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/_http.py
@@ -1,5 +1,5 @@
-"""Request-layer building blocks shared by guard submodules: fail-closed GET
-translation and page iteration, kept orthogonal so call sites compose only
+"""Request-layer building blocks for guard submodules: fail-closed GET
+translation + page iteration, kept orthogonal — call sites compose only
 what their error semantics need.
 """
 
@@ -24,8 +24,8 @@ GUARD_PAGE_SIZE: int = 100
 def _translate_error(
     exc: PolarionError, what: str, project_id: str
 ) -> PermissionError | RuntimeError:
-    """Single source of the fail-closed mapping (auth → ``PermissionError``,
-    else ``RuntimeError``); 404 policy stays at each call site.
+    """Single source of fail-closed mapping (auth → ``PermissionError``,
+    else ``RuntimeError``); 404 policy stay at each call site.
     """
     if isinstance(exc, PolarionAuthError):
         return unauthorized_write_block(what, project_id)
@@ -41,8 +41,8 @@ async def guarded_get(
     project_id: str,
 ) -> dict[str, object]:
     """GET with fail-closed translation (auth → ``PermissionError``, else
-    ``RuntimeError``). 404 always re-raises — its meaning is per-call-site
-    (defer, map to ``ValueError``, ...), so every caller handles it locally.
+    ``RuntimeError``). 404 always re-raise — meaning is per-call-site
+    (defer, map to ``ValueError``, ...), every caller handle it locally.
     """
     try:
         return await client.get(path, params=params)
@@ -57,12 +57,11 @@ async def paged_responses(
     path: str,
     base_params: dict[str, str | int],
 ) -> AsyncIterator[tuple[list[object], dict[str, object]]]:
-    """Yield each page as ``(data, response)`` — ``data`` already narrowed to
-    a list, ``response`` kept whole for ``included`` readers; stop on non-list
-    ``data`` or a short page. No error translation — compose with
-    :func:`guarded_pages` for fail-closed semantics. ``page[size]`` is forced
-    to ``GUARD_PAGE_SIZE`` here because the short-page stop compares against
-    it.
+    """Yield each page as ``(data, response)`` — ``data`` narrowed to list,
+    ``response`` kept whole for ``included`` readers; stop on non-list
+    ``data`` or short page. No error translation — compose with
+    :func:`guarded_pages` for fail-closed semantics. ``page[size]`` forced
+    to ``GUARD_PAGE_SIZE`` because short-page stop compare against it.
     """
     page_number = 1
     while True:
@@ -91,9 +90,9 @@ async def guarded_pages(
     what: str,
     project_id: str,
 ) -> AsyncIterator[tuple[list[object], dict[str, object]]]:
-    """:func:`paged_responses` with fail-closed translation around the
-    fetches. Unlike :func:`guarded_get`, 404 folds into the unreachable block:
-    paged sampling has no per-site 404 semantics to preserve.
+    """:func:`paged_responses` with fail-closed translation around fetches.
+    Unlike :func:`guarded_get`, 404 fold into unreachable block: paged
+    sampling has no per-site 404 semantics to preserve.
     """
     try:
         async for page in paged_responses(client, path, base_params):

--- a/src/mcp_server_polarion/tools/_shared/guard/documents.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/documents.py
@@ -47,13 +47,13 @@ async def _fetch_document_type_custom_keys(
     project_id: str,
     document_type: str,
 ) -> frozenset[str]:
-    """Sample the project's documents and return *document_type*'s key schema.
+    """Sample project documents, return *document_type*'s key schema.
 
-    Heading-discovery SQL + ``include=module`` surfaces each document's type and
-    inline customs — works on every build, unlike ``GET /documents``. All types'
-    schemas are stored (later writes hit cache); target type stored even when
-    empty so a no-customs type fails closed without re-probing. Headingless
-    documents are invisible to this sample.
+    Heading-discovery SQL + ``include=module`` surface each document's type +
+    inline customs — work on every build, unlike ``GET /documents``. All
+    types' schemas stored (later writes hit cache); target type stored even
+    when empty so no-customs type fail closed without re-probe. Headingless
+    documents invisible to this sample.
     """
     path = f"/projects/{encode_path_segment(project_id)}/workitems"
     base_params: dict[str, str | int] = {

--- a/src/mcp_server_polarion/tools/_shared/guard/enums.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/enums.py
@@ -42,7 +42,7 @@ async def fetch_enum_option_ids(
     type_id: str,
 ) -> frozenset[str]:
     """Valid option ids for ``(project, resource, field, type)``; cached,
-    fail-closed, 404 defers (empty set).
+    fail-closed, 404 defer (empty set).
     """
     cached = get_cached_enum_options(project_id, resource, field_id, type_id)
     if cached is not None:
@@ -64,7 +64,7 @@ async def fetch_enum_option_ids(
         )
     except PolarionNotFoundError:
         # 404 = non-enum field or endpoint absent; cache empty set (long TTL —
-        # stale worst case is the same deferral).
+        # stale worst case = same deferral).
         logger.warning(
             "getAvailableOptions returned 404 for field=%s (resource=%s, "
             "project=%s); skipping enum validation for this field -- the "
@@ -123,10 +123,10 @@ async def fetch_project_enum_option_ids(
     enum_name: str,
     context: str = "~",
 ) -> frozenset[str]:
-    """Valid option ids for a project-level enum not in ``getAvailableOptions``
-    (link/hyperlink role, testrun type/status). ``context`` is the enumeration
+    """Valid option ids for project-level enum not in ``getAvailableOptions``
+    (link/hyperlink role, testrun type/status). ``context`` = enumeration
     context path segment (``testing`` for testrun enums; ``~`` does NOT
-    resolve them). Response ``data`` is a dict (not list), options at
+    resolve them). Response ``data`` = dict (not list), options at
     ``data.attributes.options[].id``. Cached; fail-closed like
     :func:`fetch_enum_option_ids`.
     """
@@ -242,11 +242,10 @@ async def check_custom_field_enum_values(
 ) -> None:
     """Validate enum-typed ``custom_fields`` values against ``getAvailableOptions``.
 
-    Non-empty option set proves the field is an enum (the endpoint is the only
-    API mapping key → options) → value must be an option-id string or list of
-    them; empty set defers. Arity unchecked — endpoint can't distinguish
-    single/multi-enum, but wrong arity 400s loudly at Polarion, so only wrong
-    option-id strings ghost.
+    Non-empty option set prove field is enum (endpoint = only API mapping
+    key → options) → value must be option-id string or list of them; empty
+    set defer. Arity unchecked — endpoint can't distinguish single/multi-enum,
+    wrong arity 400 loudly at Polarion, only wrong option-id strings ghost.
     """
     for field_id in sorted(custom_fields):
         value = custom_fields[field_id]

--- a/src/mcp_server_polarion/tools/_shared/guard/links.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/links.py
@@ -33,8 +33,8 @@ async def guard_work_item_link_roles(
     project_id: str,
     roles: Iterable[str],
 ) -> None:
-    """Reject link roles not in ``workitem-link-role`` — an unknown role stores
-    verbatim (HTTP 201) as a ghost link.
+    """Reject link roles not in ``workitem-link-role`` — unknown role store
+    verbatim (HTTP 201) as ghost link.
     """
     await check_project_enum_roles(
         client,
@@ -54,7 +54,7 @@ async def guard_hyperlink_roles(
     project_id: str,
     roles: Iterable[str],
 ) -> None:
-    """Reject hyperlink roles not in the project's ``hyperlink-role`` enum
+    """Reject hyperlink roles not in project ``hyperlink-role`` enum
     (typically ``ref_int``/``ref_ext``) — unknown roles ghost silently.
     """
     await check_project_enum_roles(
@@ -74,8 +74,8 @@ async def _existing_target_ids(
     project_id: str,
     target_ids: frozenset[str],
 ) -> frozenset[str]:
-    """Subset of *target_ids* that exist in *project_id*, via chunked
-    ``id:(...)`` queries. 404 (project missing) propagates to caller;
+    """Subset of *target_ids* existing in *project_id*, via chunked
+    ``id:(...)`` queries. 404 (project missing) propagate to caller;
     auth/other failures translate fail-closed.
     """
     ordered = sorted(target_ids)
@@ -105,8 +105,8 @@ async def guard_work_item_link_targets(
     source_project_id: str,
     links: list[WorkItemLinkSpec],
 ) -> None:
-    """Reject links whose target work item does not exist — Polarion stores a
-    nonexistent target as a silent dangling link (HTTP 201, empty
+    """Reject links whose target work item not exist — Polarion store
+    nonexistent target as silent dangling link (HTTP 201, empty
     title/type/status). One ``id:(...)`` query per target project.
     """
     by_project: dict[str, set[str]] = {}
@@ -138,9 +138,9 @@ async def _existing_forward_link_ids(
     project_id: str,
     work_item_id: str,
 ) -> frozenset[str]:
-    """Composite ids of every outgoing link on the source work item — each
-    ``data[].id`` is the 5-segment composite the delete payload reconstructs,
-    so it is set-membership-testable directly. 404 propagates.
+    """Composite ids of every outgoing link on source work item — each
+    ``data[].id`` = the 5-segment composite the delete payload reconstruct,
+    so set-membership-testable directly. 404 propagate.
     """
     path = (
         f"/projects/{encode_path_segment(project_id)}"
@@ -165,8 +165,8 @@ async def partition_delete_links(
     work_item_id: str,
     link_ids: list[str],
 ) -> tuple[list[str], list[str]]:
-    """Pre-read existing links and split *link_ids* into ``(matched, not_found)``
-    — the only way to surface the no-ops Polarion's 204 hides. Fail-closed:
+    """Pre-read existing links, split *link_ids* into ``(matched, not_found)``
+    — only way to surface the no-ops Polarion's 204 hide. Fail-closed:
     missing source → ``ValueError``, auth → ``PermissionError``, else
     ``RuntimeError``.
     """

--- a/src/mcp_server_polarion/tools/_shared/guard/test_runs.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/test_runs.py
@@ -38,9 +38,9 @@ async def guard_test_run_enums(
     type: str | None = None,
     status: str | None = None,
 ) -> None:
-    """Validate test-run ``type``/``status`` against the ``testing``-context
+    """Validate test-run ``type``/``status`` against ``testing``-context
     project enumerations — testruns have no ``getAvailableOptions`` endpoint,
-    and the ``~`` wildcard context does not resolve these enums.
+    and ``~`` wildcard context not resolve these enums.
     """
     await check_project_enum_roles(
         client,
@@ -67,8 +67,8 @@ async def guard_test_run_templates(
     project_id: str,
     template_ids: Iterable[str],
 ) -> None:
-    """Resolve each template id before the write — Polarion doesn't validate
-    relationship targets. Run instances are rejected too: ``isTemplate`` is
+    """Resolve each template id before write — Polarion not validate
+    relationship targets. Run instances rejected too: ``isTemplate``
     served only (as ``true``) on templates, absent on instances.
     """
     for template_id in sorted({t for t in template_ids if t}):
@@ -108,9 +108,9 @@ async def _fetch_test_run_custom_keys(
     client: PolarionClient,
     project_id: str,
 ) -> frozenset[str]:
-    """Union of custom-field keys sampled from the project's runs and
-    templates — testrun custom fields are project config (no type axis, no
-    SQL needed). Cached even if empty.
+    """Union of custom-field keys sampled from project's runs + templates —
+    testrun custom fields = project config (no type axis, no SQL needed).
+    Cached even if empty.
     """
     path = f"/projects/{encode_path_segment(project_id)}/testruns"
     keys: set[str] = set()
@@ -158,9 +158,9 @@ async def guard_test_run_custom_fields(
     project_id: str,
     custom_fields: dict[str, object],
 ) -> None:
-    """Validate ``custom_fields`` keys before a test-run write. Keys only —
-    testruns have no ``getAvailableOptions``, so enum-typed *values* defer to
-    Polarion (wrong option ids there ghost; keys are the guardable axis).
+    """Validate ``custom_fields`` keys before test-run write. Keys only —
+    testruns have no ``getAvailableOptions``, enum-typed *values* defer to
+    Polarion (wrong option ids there ghost; keys = the guardable axis).
     """
     if not custom_fields:
         return

--- a/src/mcp_server_polarion/tools/_shared/guard/work_items.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/work_items.py
@@ -52,9 +52,9 @@ async def guard_work_item_enums(  # noqa: PLR0913
 ) -> None:
     """Validate supplied work-item enum args against ``getAvailableOptions``.
 
-    ``work_item_type`` scopes status/severity/resolution/priority (``'~'`` =
-    type-agnostic); ``type`` checked first so an invalid type raises before
-    being reused as the scoping axis.
+    ``work_item_type`` scope status/severity/resolution/priority (``'~'`` =
+    type-agnostic); ``type`` checked first so invalid type raise before
+    reuse as scoping axis.
     """
     if type is not None and type != "":
         await check_enum(client, project_id, "workitems", "type", "~", type)
@@ -83,8 +83,8 @@ async def _fetch_work_item_type_custom_keys(
 ) -> frozenset[str]:
     """Union of custom-field keys sampled from existing items of a type.
 
-    MIN-per-key SQL, paged for >100 distinct keys. SQL rejection fails closed —
-    a partial Lucene sample would silently false-reject real keys. Cached even
+    MIN-per-key SQL, paged for >100 distinct keys. SQL rejection fail closed —
+    partial Lucene sample would silently false-reject real keys. Cached even
     if empty.
     """
     path = f"/projects/{encode_path_segment(project_id)}/workitems"
@@ -135,9 +135,9 @@ async def guard_work_item_custom_fields(
     work_item_type: str,
     custom_fields: dict[str, object],
 ) -> None:
-    """Validate ``custom_fields`` keys then enum-typed values before a write.
+    """Validate ``custom_fields`` keys then enum-typed values before write.
 
-    Keys-first order keeps ghost keys out of the enum probe's long-lived 404
+    Keys-first order keep ghost keys out of enum probe's long-lived 404
     cache. Wrong key, option id, or value shape → ``ValueError``; fail-closed
     otherwise.
     """
@@ -156,9 +156,9 @@ async def resolve_work_item_types(
     project_id: str,
     work_item_ids: Iterable[str],
 ) -> dict[str, str]:
-    """Existence check plus short id -> type map for a bulk batch, via chunked
+    """Existence check + short id -> type map for bulk batch, via chunked
     ``id:(...)`` queries (enum guards scope options by type). Fail-closed:
-    raises ``ValueError`` naming every missing id before any write.
+    raise ``ValueError`` naming every missing id before any write.
     """
     requested = sorted({wi for wi in work_item_ids if wi})
     if not requested:

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -15,13 +15,13 @@ from fastmcp import Context
 
 from mcp_server_polarion.core.client import PolarionClient
 
-# Ceiling for option lists in guard errors: showing the full set beats a
-# list_*_enum_options re-call, but a pathological enum must not flood context.
+# Ceiling for option lists in guard errors: full set beat list_*_enum_options
+# re-call, but pathological enum must not flood context.
 OPTION_LIST_LIMIT: Final[int] = 50
 
 
 def get_client(ctx: Context) -> PolarionClient:
-    """Extract the active ``PolarionClient`` from the lifespan context."""
+    """Active ``PolarionClient`` from lifespan context."""
     lifespan_ctx = ctx.lifespan_context
     if "polarion_client" not in lifespan_ctx:  # pragma: no cover
         msg = "polarion_client is missing from lifespan_context"
@@ -38,8 +38,8 @@ def get_client(ctx: Context) -> PolarionClient:
 
 
 def format_option_list(options: Iterable[str], limit: int = OPTION_LIST_LIMIT) -> str:
-    """Sorted option list for an error message; past *limit*, truncates to the
-    first *limit* items plus a ``(+N more)`` suffix.
+    """Sorted option list for error message; past *limit*, truncate to
+    first *limit* items + ``(+N more)`` suffix.
     """
     ordered = sorted(options)
     if len(ordered) <= limit:
@@ -48,14 +48,14 @@ def format_option_list(options: Iterable[str], limit: int = OPTION_LIST_LIMIT) -
 
 
 def safe_str(value: object) -> str:
-    """Convert a value to ``str``, returning ``""`` for ``None``."""
+    """``str(value)``; ``""`` for ``None``."""
     if value is None:
         return ""
     return str(value)
 
 
 def encode_path_segment(segment: str) -> str:
-    """URL-encode a single path segment (e.g. a document name with spaces)."""
+    """URL-encode single path segment (e.g. document name with spaces)."""
     return quote(segment, safe="")
 
 
@@ -64,8 +64,8 @@ _WORK_ITEM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def validate_work_item_id_for_lucene(work_item_id: str) -> None:
-    """Reject ids outside ``[A-Za-z0-9_-]`` — Lucene treats punctuation as
-    operators, so an unescaped id could reshape the query.
+    """Reject ids outside ``[A-Za-z0-9_-]`` — Lucene treat punctuation as
+    operators; unescaped id could reshape query.
     """
     if not _WORK_ITEM_ID_PATTERN.match(work_item_id):
         msg = (
@@ -76,8 +76,8 @@ def validate_work_item_id_for_lucene(work_item_id: str) -> None:
 
 
 def ensure_unique_ids(ids: Iterable[str], *, label: str) -> None:
-    """Reject duplicate ids within one bulk batch — the server's apply order
-    for duplicate resources in a single request is undefined.
+    """Reject duplicate ids in one bulk batch — server apply order for
+    duplicate resources in single request undefined.
     """
     duplicates = sorted(id_ for id_, count in Counter(ids).items() if count > 1)
     if duplicates:
@@ -90,8 +90,8 @@ def ensure_unique_ids(ids: Iterable[str], *, label: str) -> None:
 
 @contextmanager
 def reraise_with_item_context(index: int, item_id: str) -> Iterator[None]:
-    """Prefix a per-item guard ``ValueError`` with the batch position and id so
-    bulk-tool errors name the offending item; other exceptions (project-level
+    """Prefix per-item guard ``ValueError`` with batch position + id so
+    bulk-tool errors name offending item; other exceptions (project-level
     auth/backend failures) pass through unwrapped.
     """
     try:

--- a/src/mcp_server_polarion/tools/_shared/pagination.py
+++ b/src/mcp_server_polarion/tools/_shared/pagination.py
@@ -1,5 +1,5 @@
 """Pagination math for list tools: total-count extraction, has-more decision,
-and the shared ``make_page`` wrapper every list response ends in.
+shared ``make_page`` wrapper every list response end in.
 """
 
 from __future__ import annotations
@@ -8,12 +8,12 @@ from typing import Final
 
 from mcp_server_polarion.models import PaginatedResult
 
-# Polarion enforces a hard cap of 100 server-side.
+# Polarion hard cap 100 server-side.
 DEFAULT_PAGE_SIZE: Final[int] = 100
 
 
 def extract_total_count(response: dict[str, object]) -> int:
-    """Return ``meta.totalCount`` from a JSON:API response, or 0 if missing."""
+    """``meta.totalCount`` from JSON:API response, or 0 if missing."""
     meta = response.get("meta")
     if isinstance(meta, dict):
         total = meta.get("totalCount", 0)
@@ -23,7 +23,7 @@ def extract_total_count(response: dict[str, object]) -> int:
 
 
 def has_links_next(response: dict[str, object]) -> bool:
-    """Return whether the JSON:API response carries a ``links.next`` key."""
+    """Whether JSON:API response carry ``links.next`` key."""
     links = response.get("links")
     if isinstance(links, dict):
         return "next" in links
@@ -38,7 +38,7 @@ def compute_has_more(
     items_count: int,
 ) -> bool:
     """Whether more pages exist: ``total`` when reliable (>0), else
-    ``links.next`` (Polarion sometimes omits ``meta.totalCount``), else
+    ``links.next`` (Polarion sometimes omit ``meta.totalCount``), else
     full-page heuristic.
     """
     if total > 0:
@@ -54,9 +54,9 @@ def make_page[T](
     page_number: int,
     page_size: int,
 ) -> PaginatedResult[T]:
-    """Wrap parsed items in a ``PaginatedResult``. ``total`` falls back to an
-    offset estimate when Polarion omits ``meta.totalCount`` (non-empty page
-    only, else out-of-range pages inflate it); ``has_more`` via ``compute_has_more``.
+    """Wrap parsed items in ``PaginatedResult``. ``total`` fall back to offset
+    estimate when Polarion omit ``meta.totalCount`` (non-empty page only,
+    else out-of-range pages inflate it); ``has_more`` via ``compute_has_more``.
     """
     raw_total = extract_total_count(response)
     total = raw_total

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -1,6 +1,6 @@
-"""JSON:API response -> Pydantic model parsers, plus the relationship/id
-extractors they build on. Read side only; description/text values pass through
-as raw HTML so they round-trip unchanged.
+"""JSON:API response -> Pydantic model parsers + relationship/id extractors.
+Read side only; description/text values pass through as raw HTML for
+unchanged round-trip.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from mcp_server_polarion.tools._shared.pagination import make_page
 
 
 class WorkItemSummaryKwargs(TypedDict):
-    """Kwargs shape produced by ``parse_work_item_summary_kwargs``."""
+    """Kwargs shape from ``parse_work_item_summary_kwargs``."""
 
     id: str
     title: str
@@ -43,7 +43,7 @@ def extract_relationship_id(
     relationships: dict[str, object],
     rel_name: str,
 ) -> str:
-    """Return a named relationship's ``data.id``, or ``""`` if absent."""
+    """Named relationship ``data.id``, or ``""`` if absent."""
     rel = relationships.get(rel_name, {})
     if isinstance(rel, dict):
         inner = rel.get("data")
@@ -56,7 +56,7 @@ def extract_relationship_ids(
     relationships: dict[str, object],
     rel_name: str,
 ) -> list[str]:
-    """Return a to-many relationship's ``data[].id`` list (declaration order)."""
+    """To-many relationship ``data[].id`` list (declaration order)."""
     rel = relationships.get(rel_name, {})
     if not isinstance(rel, dict):
         return []
@@ -86,16 +86,16 @@ def split_module_id(module_full_id: str) -> tuple[str, str]:
 
 
 def extract_short_id(full_id: str) -> str:
-    """Strip the path prefix from a JSON:API id (``"p/MCPT-001"`` → ``"MCPT-001"``)."""
+    """Strip path prefix from JSON:API id (``"p/MCPT-001"`` → ``"MCPT-001"``)."""
     if "/" not in full_id:
         return full_id
     return full_id.rsplit("/", maxsplit=1)[-1]
 
 
 def extract_created_short_ids(response: dict[str, object]) -> list[str]:
-    """Short resource ids from a bulk 201 response, relying on Polarion echoing
-    ``data`` in submission order (call-site count check catches missing ids,
-    not reordered ones).
+    """Short resource ids from bulk 201 response; rely on Polarion echoing
+    ``data`` in submission order (call-site count check catch missing ids,
+    not reordered).
     """
     data = response.get("data")
     if not isinstance(data, list):
@@ -112,7 +112,7 @@ def extract_created_short_ids(response: dict[str, object]) -> list[str]:
 def parse_included_work_item_map(
     response: dict[str, object],
 ) -> dict[str, dict[str, object]]:
-    """Map full work-item ID to its included resource dict from a response."""
+    """Full work-item ID → included resource dict from response."""
     work_item_map: dict[str, dict[str, object]] = {}
     included = response.get("included", [])
     if isinstance(included, list):
@@ -123,7 +123,7 @@ def parse_included_work_item_map(
 
 
 def parse_included_user_name_map(response: dict[str, object]) -> dict[str, str]:
-    """Map user ID to display name from a response's included ``users`` resources."""
+    """User ID → display name from included ``users`` resources."""
     user_map: dict[str, str] = {}
     included = response.get("included", [])
     if isinstance(included, list):
@@ -142,8 +142,8 @@ def parse_included_user_name_map(response: dict[str, object]) -> dict[str, str]:
 def parse_work_item_summary_kwargs(
     item: dict[str, object],
 ) -> WorkItemSummaryKwargs:
-    """``WorkItemSummary`` kwargs from a JSON:API resource; shared so
-    ``WorkItemDetail`` stays a strict superset of ``WorkItemSummary``.
+    """``WorkItemSummary`` kwargs from JSON:API resource; shared so
+    ``WorkItemDetail`` stay strict superset of ``WorkItemSummary``.
     """
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
@@ -199,9 +199,9 @@ def parse_work_item_detail(
     project_id: str,
     fallback_id: str = "",
 ) -> WorkItemDetail:
-    """JSON:API work-item resource → ``WorkItemDetail``. Expects
-    ``WORK_ITEM_DETAIL_FIELDS`` + ``include=assignee``; description passes
-    through as raw HTML so it round-trips unchanged.
+    """JSON:API work-item resource → ``WorkItemDetail``. Expect
+    ``WORK_ITEM_DETAIL_FIELDS`` + ``include=assignee``; description pass
+    through as raw HTML, round-trip unchanged.
     """
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
@@ -234,8 +234,8 @@ def parse_work_item_detail(
 
 
 def summary_to_back_link(summary: WorkItemSummary) -> WorkItemLink:
-    """Lift a ``linkedWorkItems:`` query result to a back link; the query
-    exposes no role/suspect → ``role=None``, ``suspect=False``.
+    """Lift ``linkedWorkItems:`` query result to back link; query expose
+    no role/suspect → ``role=None``, ``suspect=False``.
     """
     return WorkItemLink(
         id=summary.id,
@@ -253,7 +253,7 @@ def summary_to_back_link(summary: WorkItemSummary) -> WorkItemLink:
 def parse_work_item_summaries(
     data: object,
 ) -> list[WorkItemSummary]:
-    """Parse a JSON:API ``data`` array into ``WorkItemSummary`` models."""
+    """JSON:API ``data`` array → ``WorkItemSummary`` models."""
     items: list[WorkItemSummary] = []
     if not isinstance(data, list):
         return items
@@ -266,7 +266,7 @@ def parse_work_item_summaries(
 
 
 class TestRunSummaryKwargs(TypedDict):
-    """Kwargs shape produced by ``parse_test_run_summary_kwargs``."""
+    """Kwargs shape from ``parse_test_run_summary_kwargs``."""
 
     id: str
     title: str
@@ -282,8 +282,8 @@ def parse_test_run_summary_kwargs(
     item: dict[str, object],
     user_names: dict[str, str],
 ) -> TestRunSummaryKwargs:
-    """``TestRunSummary`` kwargs from a JSON:API resource; ``user_names`` maps the
-    full author id to a display name (from the response's included ``users``).
+    """``TestRunSummary`` kwargs from JSON:API resource; ``user_names`` map
+    full author id → display name (from included ``users``).
     """
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
@@ -306,9 +306,9 @@ def parse_test_run_summary_kwargs(
 
 
 def parse_test_run_summaries(response: dict[str, object]) -> list[TestRunSummary]:
-    """Parse a test-runs list response into ``TestRunSummary`` models. Takes the
-    whole response (not just ``data``) to resolve author display names from the
-    included ``users`` resources.
+    """Test-runs list response → ``TestRunSummary`` models. Take whole
+    response (not just ``data``) to resolve author names from included
+    ``users``.
     """
     user_names = parse_included_user_name_map(response)
     data = response.get("data", [])
@@ -324,7 +324,7 @@ def parse_test_run_summaries(response: dict[str, object]) -> list[TestRunSummary
 
 
 def _parse_comment(item: dict[str, object]) -> Comment:
-    """Build a ``Comment`` from a JSON:API resource (short relationship IDs)."""
+    """``Comment`` from JSON:API resource (short relationship IDs)."""
     attributes_raw = item.get("attributes")
     attributes: dict[str, object] = (
         attributes_raw if isinstance(attributes_raw, dict) else {}
@@ -362,8 +362,8 @@ def _parse_comment(item: dict[str, object]) -> Comment:
 def parse_comments_page(
     response: dict[str, object], page_number: int, page_size: int
 ) -> PaginatedResult[Comment]:
-    """Parse a JSON:API comments response into a ``PaginatedResult`` page; shared
-    by the document- and work-item comment list tools.
+    """JSON:API comments response → ``PaginatedResult`` page; shared by
+    document- and work-item comment list tools.
     """
     raw_data = response.get("data", [])
     comment_items: list[Comment] = []

--- a/src/mcp_server_polarion/tools/_shared/sql.py
+++ b/src/mcp_server_polarion/tools/_shared/sql.py
@@ -1,7 +1,7 @@
 """REST-SQL ``query`` builders (not public API). No bind parameters — ids
-escaped inline by doubling ``'``. A ``SELECT`` over ``workitem`` always yields
-work-item resources (column list ignored); callers pair with
-``include=``/``fields=`` for the attributes they need.
+escaped inline by doubling ``'``. ``SELECT`` over ``workitem`` always yield
+work-item resources (column list ignored); caller pair with
+``include=``/``fields=`` for needed attributes.
 """
 
 from __future__ import annotations
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 def one_heading_per_document_sql(project_id: str) -> str:
     """One representative heading per document (``MIN`` per ``module`` URI).
-    ``c_deleted IS NOT TRUE`` excludes the recycle bin (``= 0`` 500s).
+    ``c_deleted IS NOT TRUE`` exclude recycle bin (``= 0`` 500s).
     """
     project = project_id.replace("'", "''")
     return (
@@ -23,7 +23,7 @@ def one_heading_per_document_sql(project_id: str) -> str:
 
 def one_item_per_custom_field_sql(project_id: str, type_id: str) -> str:
     """One representative item per custom-field key (``MIN`` per indexed
-    ``cf.c_name``) — catches single-item keys a fixed-N sample misses.
+    ``cf.c_name``) — catch single-item keys a fixed-N sample miss.
     """
     project = project_id.replace("'", "''")
     type_value = type_id.replace("'", "''")

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -49,8 +49,8 @@ def _build_comment_create_payload(
     parent_prefix: str,
 ) -> dict[str, JsonValue]:
     """JSON:API POST body (``data`` list); ``None``/empty fields omitted, short
-    ``parent_comment_id`` expanded to the full path the API requires. ``title``
-    emitted only when the spec carries a non-empty one (WorkItemCommentSpec);
+    ``parent_comment_id`` expanded to full path API require. ``title``
+    emitted only when spec carry non-empty one (WorkItemCommentSpec);
     base CommentSpec has no title, so document comments never send it.
     """
     items: list[JsonValue] = []
@@ -93,7 +93,7 @@ def _build_document_comments_payload(
     space_id: str,
     document_name: str,
 ) -> dict[str, JsonValue]:
-    """POST body for .../documents/{d}/comments; parent ids are 4-segment."""
+    """POST body for .../documents/{d}/comments; parent ids 4-segment."""
     return _build_comment_create_payload(
         specs=specs,
         comment_type="document_comments",
@@ -107,7 +107,7 @@ def _build_work_item_comments_payload(
     project_id: str,
     work_item_id: str,
 ) -> dict[str, JsonValue]:
-    """POST body for .../workitems/{wi}/comments; parent ids are 3-segment."""
+    """POST body for .../workitems/{wi}/comments; parent ids 3-segment."""
     return _build_comment_create_payload(
         specs=specs,
         comment_type="workitem_comments",
@@ -116,7 +116,7 @@ def _build_work_item_comments_payload(
 
 
 def _extract_created_comment_ids(response: object) -> list[str]:
-    """Short ids from a comment-create POST response (``data`` list)."""
+    """Short ids from comment-create POST response (``data`` list)."""
     raw_data = response.get("data", []) if isinstance(response, dict) else []
     comment_ids: list[str] = []
     if isinstance(raw_data, list):
@@ -135,7 +135,7 @@ def _build_comment_update_payload(
     resolved: bool,
 ) -> dict[str, JsonValue]:
     """Single-resource PATCH body (``data`` dict, not list). Only ``resolved``
-    is patchable; ``id`` is the full resource path the API expects.
+    patchable; ``id`` = full resource path API expect.
     """
     return {
         "data": {
@@ -156,7 +156,7 @@ def _build_document_comment_update_payload(
     comment_id: str,
     resolved: bool,
 ) -> dict[str, JsonValue]:
-    """PATCH body for a document comment; ``id`` is the full 4-segment path."""
+    """PATCH body for document comment; ``id`` = full 4-segment path."""
     full_id = f"{project_id}/{space_id}/{document_name}/{comment_id}"
     return _build_comment_update_payload(
         full_id=full_id,
@@ -172,7 +172,7 @@ def _build_work_item_comment_update_payload(
     comment_id: str,
     resolved: bool,
 ) -> dict[str, JsonValue]:
-    """PATCH body for a work item comment; ``id`` is the full 3-segment path."""
+    """PATCH body for work item comment; ``id`` = full 3-segment path."""
     full_id = f"{project_id}/{work_item_id}/{comment_id}"
     return _build_comment_update_payload(
         full_id=full_id,
@@ -212,7 +212,7 @@ async def list_document_comments(  # noqa: PLR0913
             path,
             params={
                 "fields[document_comments]": DOCUMENT_COMMENT_LIST_FIELDS,
-                # To-many ``childComments.data`` is only inlined when included.
+                # To-many ``childComments.data`` inlined only when included.
                 "include": "childComments",
                 "page[size]": page_size,
                 "page[number]": page_number,
@@ -264,7 +264,7 @@ async def list_work_item_comments(
             path,
             params={
                 "fields[workitem_comments]": WORK_ITEM_COMMENT_LIST_FIELDS,
-                # To-many ``childComments.data`` is only inlined when included.
+                # To-many ``childComments.data`` inlined only when included.
                 "include": "childComments",
                 "page[size]": page_size,
                 "page[number]": page_number,
@@ -291,7 +291,7 @@ async def list_work_item_comments(
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Additive: non-destructive, but non-idempotent (a retry duplicates comments).
+        # Additive: non-destructive, non-idempotent (retry duplicate comments).
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
@@ -382,7 +382,7 @@ async def create_document_comments(  # noqa: PLR0913
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Additive: non-destructive, but non-idempotent (a retry duplicates comments).
+        # Additive: non-destructive, non-idempotent (retry duplicate comments).
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -104,7 +104,7 @@ class _LinkedWorkItem:
 
 
 def _extract_html_value(field: object) -> str:
-    """Extract HTML from a Polarion text field (``{type,value}`` dict or str)."""
+    """Extract HTML from Polarion text field (``{type,value}`` dict or str)."""
     if isinstance(field, dict):
         return safe_str(field.get("value", ""))
     if isinstance(field, str):
@@ -113,7 +113,7 @@ def _extract_html_value(field: object) -> str:
 
 
 def _resolve_heading_level(attributes: dict[str, object]) -> int:
-    """Return a heading part's level: ``attributes.level``, else parsed ``<hN>``."""
+    """Heading part level: ``attributes.level``, else parsed ``<hN>``."""
     attr_level = attributes.get("level")
     if isinstance(attr_level, int):
         return attr_level
@@ -126,7 +126,7 @@ def _resolve_linked_work_item(
     relationships: dict[str, object],
     work_item_map: dict[str, dict[str, object]],
 ) -> _LinkedWorkItem:
-    """Return metadata for the work item linked from a document part."""
+    """Metadata for work item linked from document part."""
     work_item_full_id = extract_relationship_id(relationships, "workItem")
     if not work_item_full_id:
         return _LinkedWorkItem()
@@ -154,7 +154,7 @@ def _parse_document_part(
     item: object,
     work_item_map: dict[str, dict[str, object]],
 ) -> DocumentPart | None:
-    """Parse a JSON:API document-part resource into a model; ``None`` if invalid."""
+    """JSON:API document-part resource → model; ``None`` if invalid."""
     if not isinstance(item, dict):
         return None
     attributes = item.get("attributes", {})
@@ -169,15 +169,15 @@ def _parse_document_part(
         _PartType,
         raw_type if raw_type in _POLARION_PART_TYPES else "normal",
     )
-    # Polarion reports TOF / page-break as ``normal``; kind is in the ID prefix.
+    # Polarion report TOF / page-break as ``normal``; kind live in ID prefix.
     if part_type == "normal":
         if short_id.startswith("tof_"):
             part_type = "tof"
         elif short_id.startswith("pagebreak_"):
             part_type = "page_break"
 
-    # Heading/workitem body lives in title/description; content is an empty
-    # <hN> stub — skip conversion to avoid "#" noise.
+    # Heading/workitem body live in title/description; content = empty <hN>
+    # stub — skip conversion, avoid "#" noise.
     content_html = (
         _extract_html_value(attributes.get("content"))
         if part_type not in {"heading", "workitem"}
@@ -231,7 +231,7 @@ _FENCED_MIN_LINES: Final[int] = 2
 
 
 def _render_parts_to_markdown(parts: list[DocumentPart]) -> str:
-    """Interleave a page of parts into one Markdown string; chunks join on a
+    """Interleave page of parts into one Markdown string; chunks join on
     blank line, runs of 3+ newlines collapse to 2.
     """
     chunks: list[str] = []
@@ -245,7 +245,7 @@ def _render_parts_to_markdown(parts: list[DocumentPart]) -> str:
 
 
 def _render_part(part: DocumentPart) -> str:
-    """Return the Markdown chunk for one part, or ``""`` to skip it."""
+    """Markdown chunk for one part, or ``""`` to skip."""
     constant = _CONSTANT_CHUNKS.get(part.type)
     if constant is not None:
         return constant
@@ -265,7 +265,7 @@ def _render_part(part: DocumentPart) -> str:
 
 
 def _render_workitem_part(part: DocumentPart) -> str:
-    """Format a ``workitem`` part's lead-in line and optional body."""
+    """``workitem`` part lead-in line + optional body."""
     if not part.title and not part.description:
         return f"`{part.work_item_id}`"
     if not part.description:
@@ -274,8 +274,8 @@ def _render_workitem_part(part: DocumentPart) -> str:
 
 
 def _decorate_wikiblock(content: str) -> str:
-    """Lift the Velocity macro name (``#name(``) into the fenced-code
-    info-string; raw fence when none detectable.
+    """Lift Velocity macro name (``#name(``) into fenced-code info-string;
+    raw fence when none detectable.
     """
     stripped = content.strip()
     if not stripped:
@@ -312,8 +312,8 @@ def _extract_document_from_module(
 ) -> None:
     """Record an included ``module`` resource as (space_id, document_name) → meta.
 
-    Attributes/relationships only present because discovery names them in
-    ``fields[documents]``; a plain ``module`` relationship carries id only.
+    Attributes/relationships only present because discovery name them in
+    ``fields[documents]``; plain ``module`` relationship carry id only.
     """
     if not isinstance(resource, dict) or resource.get("type") != "documents":
         return
@@ -341,9 +341,9 @@ async def _discover_documents(
 ) -> list[DiscoveredDocument]:
     """Discover every document in *project_id* with display metadata; TTL-cached.
 
-    ``GROUP BY mod.c_uri`` SQL collapses headings to one per document (pages of
+    ``GROUP BY mod.c_uri`` SQL collapse headings to one per document (pages of
     documents, not headings). ``module`` must be listed alongside its dot-path
-    includes — a dot-path alone drops the intermediate resource.
+    includes — dot-path alone drop the intermediate resource.
     """
     cached = get_cached_documents(project_id)
     if cached is not None:
@@ -401,7 +401,7 @@ async def _discover_documents(
 
 
 def _extract_first_resource_id(response: dict[str, object]) -> str | None:
-    """First resource id from a JSON:API ``{"data": [...]}`` body, else ``None``."""
+    """First resource id from JSON:API ``{"data": [...]}`` body, else ``None``."""
     data = response.get("data")
     if not isinstance(data, list) or not data:
         return None
@@ -413,7 +413,7 @@ def _extract_first_resource_id(response: dict[str, object]) -> str | None:
 
 
 def _extract_created_module_name(response: dict[str, object]) -> str | None:
-    """Document name from a 201 create response (name may contain ``/``);
+    """Document name from 201 create response (name may contain ``/``);
     ``None`` on unexpected shape.
     """
     full_id = _extract_first_resource_id(response)
@@ -436,7 +436,7 @@ def _build_update_document_payload(  # noqa: PLR0913
     uses_outline_numbering: bool | None = None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
-    """JSON:API PATCH body for ``.../documents/{d}``; skips unset.
+    """JSON:API PATCH body for ``.../documents/{d}``; skip unset.
     ``home_page_content_html`` wrapped verbatim (empty guard in tool layer).
     """
     attributes: dict[str, JsonValue] = {}
@@ -478,7 +478,7 @@ def _build_create_document_payload(  # noqa: PLR0913
     uses_outline_numbering: bool | None = None,
     custom_fields: dict[str, object] | None = None,
 ) -> dict[str, JsonValue]:
-    """JSON:API POST body for ``.../spaces/{s}/documents``; skips unset."""
+    """JSON:API POST body for ``.../spaces/{s}/documents``; skip unset."""
     attributes: dict[str, JsonValue] = {
         "moduleName": module_name,
         "title": title,
@@ -605,7 +605,7 @@ async def get_document(
         f"/documents/{encode_path_segment(document_name)}"
     )
 
-    # ``@all`` token: an explicit field list silently drops inline customs here.
+    # ``@all`` token: explicit field list silently drop inline customs here.
     try:
         response = await client.get(
             path,
@@ -639,12 +639,12 @@ async def get_document(
     relationships = data.get("relationships", {})
     if not isinstance(relationships, dict):
         relationships = {}
-    # Output carries display names only; ids are join keys into included users.
+    # Output carry display names only; ids = join keys into included users.
     user_names = parse_included_user_name_map(response)
 
     content_html = ""
     if include_homepage_content_html:
-        # Verbatim {type,value} so it round-trips through update_document.
+        # Verbatim {type,value} so it round-trip through update_document.
         content_obj = attributes.get("homePageContent", {})
         if isinstance(content_obj, dict):
             content_html = safe_str(content_obj.get("value", ""))
@@ -697,7 +697,7 @@ async def read_document_parts(  # noqa: PLR0913
             path,
             params={
                 "fields[document_parts]": "@all",
-                # Narrow workitem fields — ``@all`` ships unused inline customs.
+                # Narrow workitem fields — ``@all`` ship unused inline customs.
                 "fields[workitems]": WORK_ITEM_PART_FIELDS,
                 "include": "workItem",
                 "page[size]": page_size,
@@ -752,7 +752,7 @@ async def read_document(  # noqa: PLR0913
     round-trip via get_document(include_homepage_content_html=True). For
     metadata-only extraction prefer list_work_items SQL.
     """
-    # read_document_parts handles fetch + error mapping (@mcp.tool returns the
+    # read_document_parts handle fetch + error mapping (@mcp.tool return
     # original function).
     page = await read_document_parts(
         ctx,
@@ -778,8 +778,8 @@ async def _resolve_document_type(
     space_id: str,
     document_name: str,
 ) -> str:
-    """Resolve the ``type`` axis the custom-field guard keys on. Runs on dry_run
-    too, so the preview raises the same not-found / auth errors as the real write.
+    """Resolve the ``type`` axis the custom-field guard key on. Run on dry_run
+    too, so preview raise same not-found / auth errors as real write.
     """
     path = (
         f"/projects/{encode_path_segment(project_id)}"
@@ -937,7 +937,7 @@ async def update_document(  # noqa: PLR0913
         )
 
     client = get_client(ctx)
-    # Type-agnostic enum guard: avoids an extra GET, still catches ghost ids.
+    # Type-agnostic enum guard: avoid extra GET, still catch ghost ids.
     await guard_document_enums(
         client,
         project_id,
@@ -946,7 +946,7 @@ async def update_document(  # noqa: PLR0913
         status=status,
     )
 
-    # Build first: merge_custom_fields collision check is cheaper than guard GET.
+    # Build first: merge_custom_fields collision check cheaper than guard GET.
     payload = _build_update_document_payload(
         project_id=project_id,
         space_id=space_id,
@@ -959,7 +959,7 @@ async def update_document(  # noqa: PLR0913
         uses_outline_numbering=uses_outline_numbering,
         custom_fields=custom_fields,
     )
-    # A type change keys the custom-field schema on the new type, else current.
+    # Type change key custom-field schema on new type, else current.
     if custom_fields:
         effective_type = type or await _resolve_document_type(
             client, project_id, space_id, document_name
@@ -1011,7 +1011,7 @@ async def update_document(  # noqa: PLR0913
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Additive: non-destructive, but non-idempotent (duplicate module_name 409s).
+        # Additive: non-destructive, non-idempotent (duplicate module_name 409s).
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
@@ -1149,7 +1149,7 @@ async def create_document(  # noqa: PLR0913
             "The document may or may not exist; verify with list_documents."
         )
 
-    # Drop the stale list_documents cache so the new doc shows on the next call.
+    # Drop stale list_documents cache so new doc show on next call.
     invalidate_documents_cache(project_id)
 
     return DocumentCreateResult(

--- a/src/mcp_server_polarion/tools/enum.py
+++ b/src/mcp_server_polarion/tools/enum.py
@@ -1,7 +1,7 @@
 """Enum option tools — list valid option ids via Polarion getAvailableOptions.
 
-One module for both resources: getAvailableOptions applies to work items and
-documents alike, mirroring the resource-parameterized guard layer.
+One module for both resources: getAvailableOptions apply to work items and
+documents alike, mirror the resource-parameterized guard layer.
 """
 
 from __future__ import annotations

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -58,7 +58,7 @@ logger = logging.getLogger("mcp_server_polarion.tools.links")
 
 
 def _extract_created_link_ids(response: dict[str, object]) -> list[str]:
-    """Composite link ids verbatim, input order, from a bulk create response —
+    """Composite link ids verbatim, input order, from bulk create response —
     the path ids for later PATCH / DELETE. Empty on malformed shapes.
     """
     data = response.get("data")
@@ -79,7 +79,7 @@ def _build_create_links_payload(
     links: list[WorkItemLinkSpec],
 ) -> dict[str, JsonValue]:
     """JSON:API body for bulk create-link POST; ``revision`` skipped when
-    unset, ``target_project_id`` defaults to source.
+    unset, ``target_project_id`` default to source.
     """
     data: list[JsonValue] = []
     for spec in links:
@@ -182,7 +182,7 @@ def _parse_work_item_links(
     direction: Literal["forward", "back"],
 ) -> list[WorkItemLink]:
     """Parse linked work items into ``WorkItemLink``s; target id from
-    ``relationships.workItem.data.id``, never by parsing the composite id.
+    ``relationships.workItem.data.id``, never parse composite id.
     """
     work_item_map = parse_included_work_item_map(response)
 
@@ -201,7 +201,7 @@ def _parse_work_item_links(
         role = safe_str(attributes.get("role", ""))
         suspect = bool(attributes.get("suspect", False))
 
-        # Derive the target via relationships, never by parsing the 5-segment id.
+        # Derive target via relationships, never parse 5-segment id.
         relationships = item.get("relationships", {})
         if not isinstance(relationships, dict):
             relationships = {}
@@ -251,7 +251,7 @@ async def _get_forward_link_page(
     page_size: int,
     page_number: int,
 ) -> PaginatedResult[WorkItemLink]:
-    """Fetch a single page of forward (outgoing) links."""
+    """Fetch one page of forward (outgoing) links."""
     path = (
         f"/projects/{encode_path_segment(project_id)}"
         f"/workitems/{encode_path_segment(work_item_id)}/linkedworkitems"
@@ -295,7 +295,7 @@ async def _get_back_link_page(
     page_size: int,
     page_number: int,
 ) -> PaginatedResult[WorkItemLink]:
-    """Fetch a single page of back (incoming) links via Lucene query."""
+    """Fetch one page of back (incoming) links via Lucene query."""
     validate_work_item_id_for_lucene(work_item_id)
     try:
         response = await client.get(
@@ -370,7 +370,7 @@ async def list_work_item_links(  # noqa: PLR0913
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Additive: non-destructive, non-idempotent (a duplicate role+target 409s).
+        # Additive: non-destructive, non-idempotent (duplicate role+target 409s).
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
@@ -462,7 +462,7 @@ async def create_work_item_links(
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Destructive but idempotent: unmatched ids are ignored, 204 regardless.
+        # Destructive but idempotent: unmatched ids ignored, 204 regardless.
         "readOnlyHint": False,
         "destructiveHint": True,
         "idempotentHint": True,
@@ -550,7 +550,7 @@ async def delete_work_item_links(
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Non-destructive, non-idempotent (a re-PATCH still bumps the revision).
+        # Non-destructive, non-idempotent (re-PATCH still bump revision).
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,

--- a/src/mcp_server_polarion/tools/moves.py
+++ b/src/mcp_server_polarion/tools/moves.py
@@ -35,7 +35,7 @@ def _build_move_to_document_payload(
     next_part_id: str | None,
 ) -> dict[str, JsonValue]:
     """Flat ``moveToDocument`` action body (not JSON:API): ``targetDocument``
-    plus at most one of ``previousPart``/``nextPart`` (both omitted = append);
+    + at most one of ``previousPart``/``nextPart`` (both omitted = append);
     at-most-one re-checked here to fail closed.
     """
     if previous_part_id is not None and next_part_id is not None:
@@ -59,7 +59,7 @@ def _build_move_to_document_payload(
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Non-idempotent: re-moving an already-moved item may 400, not no-op.
+        # Non-idempotent: re-move already-moved item may 400, not no-op.
         "readOnlyHint": False,
         "destructiveHint": True,
         "idempotentHint": False,
@@ -164,7 +164,7 @@ async def move_work_item_to_document(  # noqa: PLR0913
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Non-idempotent: a second moveFromDocument 400s (already free-floating).
+        # Non-idempotent: second moveFromDocument 400s (already free-floating).
         "readOnlyHint": False,
         "destructiveHint": True,
         "idempotentHint": False,
@@ -204,7 +204,7 @@ async def move_work_item_from_document(
         "/actions/moveFromDocument"
     )
     try:
-        # moveFromDocument takes no body.
+        # moveFromDocument take no body.
         await client.post(path)
     except PolarionAuthError as exc:
         raise PermissionError(

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -53,8 +53,8 @@ def _build_test_run_resource(
     project_id: str,
     spec: TestRunCreateSpec,
 ) -> dict[str, JsonValue]:
-    """One ``testruns`` resource for a bulk create POST; skips unset so the
-    template (or Polarion default) fills them.
+    """One ``testruns`` resource for bulk create POST; skip unset so
+    template (or Polarion default) fill them.
     """
     attributes: dict[str, JsonValue] = {"id": spec.id}
     if spec.title:
@@ -97,7 +97,7 @@ def _build_create_test_runs_payload(
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Additive: non-destructive; a retry 409s on the same explicit id.
+        # Additive: non-destructive; retry 409s on same explicit id.
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -72,8 +72,8 @@ def _build_work_item_resource(
     spec: WorkItemCreateSpec,
     description_html: str,
 ) -> dict[str, JsonValue]:
-    """One ``workitems`` resource for a bulk create POST; skips unset (no
-    overwriting defaults). ``description_html`` arrives pre-converted.
+    """One ``workitems`` resource for bulk create POST; skip unset (no
+    overwriting defaults). ``description_html`` arrive pre-converted.
     """
     attributes: dict[str, JsonValue] = {
         "title": spec.title,
@@ -134,9 +134,9 @@ def _build_update_work_item_resource(
     project_id: str,
     spec: WorkItemUpdateSpec,
 ) -> dict[str, JsonValue]:
-    """One ``workitems`` resource for the bulk PATCH; skips unset so an
-    update never blanks an existing attribute. The spec validator guarantees
-    at least one attribute or relationship survives.
+    """One ``workitems`` resource for bulk PATCH; skip unset so update
+    never blank existing attribute. Spec validator guarantee at least one
+    attribute or relationship survive.
     """
     attributes: dict[str, JsonValue] = {}
     if spec.title:
@@ -211,7 +211,7 @@ def _update_query_params(
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Additive: non-destructive, but non-idempotent (a retry duplicates).
+        # Additive: non-destructive, non-idempotent (retry duplicate).
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
@@ -377,28 +377,27 @@ async def update_work_items(  # noqa: PLR0913
     """
     client = get_client(ctx)
 
-    # Ids are embedded into the id:(...) existence query below.
+    # Ids embed into the id:(...) existence query below.
     for spec in items:
         validate_work_item_id_for_lucene(spec.work_item_id)
     ensure_unique_ids((spec.work_item_id for spec in items), label="work_item_id")
     payload = _build_update_work_items_payload(project_id=project_id, specs=items)
 
-    # One batched query resolves existence + type for every item (on dry_run
-    # too, so preview raises the same errors); enum options are type-scoped.
+    # One batched query resolve existence + type for every item (on dry_run
+    # too, so preview raise same errors); enum options type-scoped.
     types_by_id = await resolve_work_item_types(
         client, project_id, (spec.work_item_id for spec in items)
     )
 
     if change_type_to:
-        # Request-wide param: validate once on its own axis, unprefixed — a
-        # bad value is not any single item's fault.
+        # Request-wide param: validate once on own axis, unprefixed — bad
+        # value is no single item's fault.
         await guard_work_item_enums(
             client, project_id, work_item_type=change_type_to, type=change_type_to
         )
 
     for index, spec in enumerate(items):
-        # change_type_to retypes in the same PATCH — enums and customs are
-        # scoped to the new type.
+        # change_type_to retype in same PATCH — enums + customs scope to new type.
         effective_type = change_type_to or types_by_id.get(spec.work_item_id, "")
         with reraise_with_item_context(index, spec.work_item_id):
             if spec.status or spec.severity or spec.priority or spec.resolution:
@@ -416,8 +415,8 @@ async def update_work_items(  # noqa: PLR0913
                     client, project_id, effective_type, spec.custom_fields
                 )
             if spec.hyperlinks:
-                # Per item (option cache makes repeats free) so a bad role is
-                # attributed to its batch position like the other guards.
+                # Per item (option cache make repeats free) so bad role
+                # attribute to its batch position like other guards.
                 await guard_hyperlink_roles(
                     client, project_id, [h.role for h in spec.hyperlinks]
                 )
@@ -446,8 +445,8 @@ async def update_work_items(  # noqa: PLR0913
             "Cannot update work items -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionNotFoundError as exc:
-        # Race fallback: existence was verified above, so a PATCH 404 means
-        # the batch changed under us.
+        # Race fallback: existence verified above — PATCH 404 = batch changed
+        # under us.
         raise ValueError(
             f"A work item in the batch was not found in project '{project_id}': "
             f"{exc.message} Use `list_work_items` to discover valid IDs."
@@ -495,7 +494,7 @@ async def list_work_items(
     client = get_client(ctx)
     params: dict[str, str | int] = {
         "fields[workitems]": WORK_ITEM_LIST_FIELDS,
-        # To-many ``assignee.data`` is only inlined when explicitly included.
+        # To-many ``assignee.data`` inlined only when explicitly included.
         "include": "assignee",
         "page[size]": page_size,
         "page[number]": page_number,
@@ -583,7 +582,7 @@ async def get_work_item(
         fallback_id=work_item_id,
     )
     if not include_description_html:
-        # Body always travels over the wire; blank it per the False contract.
+        # Body always travel over wire; blank it per the False contract.
         detail = detail.model_copy(update={"description_html": ""})
     return detail
 
@@ -604,7 +603,7 @@ async def read_work_item(
     Polarion anchors) — NEVER feed to update_work_items; round-trip via the HTML
     pair instead.
     """
-    # Pull raw HTML from get_work_item so conversion needs no second round trip.
+    # Pull raw HTML from get_work_item — conversion need no second round trip.
     detail = await get_work_item(
         ctx,
         project_id=project_id,

--- a/src/mcp_server_polarion/utils/html.py
+++ b/src/mcp_server_polarion/utils/html.py
@@ -42,7 +42,7 @@ ALLOWED_TAGS: Final[frozenset[str]] = frozenset(
     }
 )
 
-# Per-tag attr allowlist (absent tag = none); blocks on* handlers → stored XSS.
+# Per-tag attr allowlist (absent tag = none); block on* handlers → stored XSS.
 ALLOWED_ATTRS: Final[dict[str, frozenset[str]]] = {
     "a": frozenset({"href", "title"}),
     "td": frozenset({"colspan", "rowspan"}),
@@ -55,7 +55,7 @@ _DECOMPOSE_TAGS: Final[frozenset[str]] = frozenset({"script", "style"})
 # Safe href schemes; others (javascript:, data:, vbscript:) stripped (XSS).
 _SAFE_URL_SCHEMES: Final[frozenset[str]] = frozenset({"http", "https", "mailto"})
 
-# Bounds adversarial colspan*rowspan (1M clones); covers realistic tables.
+# Bound adversarial colspan*rowspan (1M clones); cover realistic tables.
 _MAX_CELLS_PER_MERGE: Final[int] = 10_000
 
 # html_block/html_inline disabled so raw HTML can't bypass sanitization.
@@ -79,9 +79,9 @@ def html_to_markdown(html: str) -> str:
 
 def _render_polarion_rte_links(html: str) -> str:
     """Lift ``span.polarion-rte-link`` (empty span, target on ``data-*``) into
-    ``<a href="polarion:...">`` — markdownify drops empty spans, losing the
-    link. ``polarion:`` is intentionally absent from ``_SAFE_URL_SCHEMES`` so a
-    round-trip through ``sanitize_html`` strips the unresolvable href.
+    ``<a href="polarion:...">`` — markdownify drop empty spans, lose the
+    link. ``polarion:`` intentionally absent from ``_SAFE_URL_SCHEMES`` so
+    round-trip through ``sanitize_html`` strip the unresolvable href.
     """
     if "polarion-rte-link" not in html:
         return html
@@ -119,8 +119,8 @@ def _resolve_rte_link(span: Tag) -> tuple[str, str]:
     if item_id:
         scope_raw = span.attrs.get("data-scope", "")
         scope = scope_raw if isinstance(scope_raw, str) else ""
-        # Bare ``polarion:workitem/MCPT-7`` resolves against current project;
-        # ``polarion:project/Proj/workitem/MCPT-7`` carries cross-project scope.
+        # Bare ``polarion:workitem/MCPT-7`` resolve against current project;
+        # ``polarion:project/Proj/workitem/MCPT-7`` carry cross-project scope.
         if scope:
             href = (
                 f"polarion:project/{quote(scope, safe='')}"
@@ -140,7 +140,7 @@ def _escape_md_link_label(text: str) -> str:
 
 def _fill_empty_img_alt(html: str) -> str:
     """Promote ``<img title>`` (or post-colon ``src`` filename) to ``alt`` —
-    Polarion puts attachment filenames on ``title``, so markdownify emits a
+    Polarion put attachment filenames on ``title``, so markdownify emit
     label-less ``![](src)``.
     """
     if "<img" not in html.lower():
@@ -168,8 +168,8 @@ def _fill_empty_img_alt(html: str) -> str:
 
 def _expand_merged_table_cells(html: str) -> str:
     """Duplicate ``colspan``/``rowspan`` cells into every covered grid position
-    — markdownify 1.2.2 renders colspan as empty cells and drops rowspan,
-    breaking GFM cell counts.
+    — markdownify 1.2.2 render colspan as empty cells, drop rowspan,
+    break GFM cell counts.
     """
     if "<table" not in html.lower():
         return html
@@ -229,14 +229,14 @@ def _rectangularize_table(table: Tag) -> None:
                 for placed_col in placed_cols:
                     reservations[target][placed_col] = _clone_cell(cell)
 
-        # clear() drops inter-cell whitespace (markdownify ignores it anyway).
+        # clear() drop inter-cell whitespace (markdownify ignore it anyway).
         row.clear()
         for col in sorted(layout):
             row.append(layout[col])
 
 
 def _get_span(cell: Tag, attr_name: str) -> int:
-    """colspan/rowspan as int in ``[1, 1000]`` (mirrors markdownify); invalid → 1."""
+    """colspan/rowspan as int in ``[1, 1000]`` (mirror markdownify); invalid → 1."""
     raw = cell.attrs.get(attr_name)
     if isinstance(raw, list):
         raw = raw[0] if raw else ""
@@ -285,9 +285,9 @@ _CAPTION_KINDS: Final[dict[str, str]] = {"Table:": "Table", "Figure:": "Figure"}
 
 
 def polarionify_html(html: str) -> str:
-    """Style class-less tables and convert adjacent ``Table:``/``Figure:``
+    """Style class-less tables + convert adjacent ``Table:``/``Figure:``
     paragraphs into caption widgets. Must run AFTER ``sanitize_html`` (every
-    injected attribute is a fixed constant); unmatched input returned verbatim.
+    injected attribute = fixed constant); unmatched input returned verbatim.
     """
     if not html or not html.strip():
         return ""
@@ -386,7 +386,7 @@ def sanitize_html(html: str) -> str:
 
     ``script``/``style`` decomposed (content too — never visible text); other
     disallowed tags unwrapped (children kept). Surviving tags lose non-allowed
-    attrs (kills ``on*`` → stored XSS); ``href`` outside ``_SAFE_URL_SCHEMES``
+    attrs (kill ``on*`` → stored XSS); ``href`` outside ``_SAFE_URL_SCHEMES``
     (``javascript:``, ``data:``) removed.
     """
     if not html or not html.strip():
@@ -407,7 +407,7 @@ def sanitize_html(html: str) -> str:
         else:
             tag.unwrap()
 
-    # Fresh find_all visits only still-attached tags.
+    # Fresh find_all visit only still-attached tags.
     for tag in soup.find_all(True):
         allowed_attrs: frozenset[str] = ALLOWED_ATTRS.get(tag.name, frozenset())
         for attr in list(tag.attrs):
@@ -433,12 +433,11 @@ _BLOCK_TAGS_NEEDING_IDS: Final[frozenset[str]] = frozenset(
 
 def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
     """Stamp unique ``id="{prefix}_{N}"`` on anchorless ``_BLOCK_TAGS_NEEDING_IDS``
-    blocks — an anchorless block saves fine but makes the next ``GET .../parts``
-    return HTTP 500. Headings skipped (Polarion rewrites their ids on save).
+    blocks — anchorless block save fine but make next ``GET .../parts``
+    return HTTP 500. Headings skipped (Polarion rewrite their ids on save).
     Existing non-blank ids preserved; generated ids skip in-document values
-    (Polarion 400s on duplicates). Input returned verbatim (not reserialized)
-    when nothing needs stamping, so an anchored round-trip body is never
-    perturbed.
+    (Polarion 400 on duplicates). Input returned verbatim (not reserialized)
+    when nothing need stamping — anchored round-trip body never perturbed.
     """
     if not html or not html.strip():
         return ""
@@ -468,9 +467,9 @@ def stamp_block_ids(html: str, prefix: str = "polarion_mcp") -> str:
 
 
 def first_anchorless_block(html: str) -> str | None:
-    """Name of the first block lacking a non-empty ``id=`` (whitespace-only
+    """Name of first block lacking non-empty ``id=`` (whitespace-only
     counts), or ``None``. Defensive counterpart to :func:`stamp_block_ids` —
-    document tools run it post-stamping so a stamping regression cannot reach
+    document tools run it post-stamping so stamping regression cannot reach
     Polarion (anchorless block ⇒ ``GET .../parts`` HTTP 500).
     """
     if not html or not html.strip():


### PR DESCRIPTION
## Summary

Compress developer comments and dev docstrings across `src/` to full-caveman style: drop articles and filler, compress verbs, one line per point, "why" over "what". Comment/docstring-only diff -- no executable line changed (verified per file with the `assert_comment_only.py` AST gate). LLM-facing surfaces (`@mcp.tool` docstrings, `Field(description=...)`) and functional directives (`# noqa`, `# type: ignore`, `# pragma`) are byte-identical.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Comments and dev docstrings in src/ drifted verbose; caveman style cuts token cost and re-sync burden
- Compress comments + module/class/helper docstrings; @mcp.tool docstrings and Field descriptions untouched

## Testing

- Per-file `assert_comment_only.py` gate: all 42 changed files pass (comment/docstring-only AST diff vs main)
- `ruff check` + `ruff format --check` + `mypy src/` + `pytest` all green (1597 passed)
- `diff-cover --fail-under=90`: pass ("No lines with coverage information in this diff" -- comment-only)
- `git diff main -- src/ | grep -E 'Field\(|description='`: no Field description changes

## Notes for Reviewers

Docstrings compressed, never deleted (AST gate treats docstring removal as a code change). Already-dense one-line comments left as-is; load-bearing multi-line docstrings (guards, html.py) kept multi-line where each line carries a distinct fact.

Generated with [Claude Code](https://claude.com/claude-code)
