### PR TITLE
chore(tests): compress comments caveman-style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
 - Guards fail closed: validation GET error block write; only successful empty option set defer to Polarion.
 - Docstrings = LLM manual, Google-style; only prose above `Args:` ship — keep tight; return-field bullets sync with model. Field descriptions one line, skip when name + type say all.
 - No `WARNING:`/`NOTE:` prefixes, no dev-narrative, no banner dividers. CLAUDE.md dev-only — MCP-user info live in `@mcp.tool` docstring. Module docstrings = why module exists; constraints inline next to what they constrain.
-- Comments: one line, explain why not what; never restate self-evident code. No dead code, no stray `TODO`s; keep comments sync when code change.
+- Comments + dev docstrings caveman-style: drop articles/filler, compress verbs — `# Custom key match standard attr = silent shadow.` One line per point, why not what; never restate self-evident code; multi-line only when each line carry distinct fact. Technical terms/ids/API names/numbers exact; no invented abbreviations. Exempt (LLM-facing, eval-gated): `@mcp.tool` docstrings + `Field(description=...)` — normal prose per Docstrings rule above. `TODO` = `# TODO(#issue): concrete action`, never stray. No dead code; keep comments sync when code change.
 
 ## Polarion API Gotchas
 

--- a/tests/claude_hooks/test_validate_pr_body.py
+++ b/tests/claude_hooks/test_validate_pr_body.py
@@ -1,5 +1,5 @@
-"""Unit tests for the `validate_pr_body` hook, loaded by path via importlib
-(script lives outside any package). Pure helpers only; `main()` left to e2e.
+"""`validate_pr_body` hook tests, loaded by path via importlib (script live
+outside any package). Pure helpers only; `main()` left to e2e.
 """
 
 from __future__ import annotations
@@ -44,7 +44,7 @@ class TestBodyClassify:
         [
             "gh pr list",
             "git commit -m x",
-            # PR review/comment API endpoints are not full-body PR edits
+            # PR review/comment API endpoints are not full-body PR edits.
             "gh api /repos/o/r/pulls/5/comments -f body=z",
             "gh api /repos/o/r/pulls/5/reviews -f body=z",
         ],
@@ -123,7 +123,7 @@ class TestMissingTemplateBoxes:
 
     def test_all_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         self._template(tmp_path, monkeypatch)
-        # state flipped, all labels present
+        # State flipped, all labels present.
         full = "- [x] Bug fix\n- [ ] New feature\n- [ ] CI / tooling\n"
         assert body.missing_template_boxes(full) == []
 
@@ -147,7 +147,7 @@ class TestChangesFormatErrors:
         assert body.changes_format_errors(text) == []
 
     def test_section_ends_at_next_header(self) -> None:
-        # bullets under a later section must not be counted toward Changes
+        # Bullets under later section must not count toward Changes.
         text = "## Changes\n\n- one\n- two\n\n## Testing\n\n- not counted\n"
         assert body.changes_format_errors(text) == []
 
@@ -157,7 +157,7 @@ class TestChangesFormatErrors:
         assert any("exactly 2" in e for e in errs)
 
     def test_empty_template_stub_fails(self) -> None:
-        # the unfilled "- \n- " stub has no text, so it counts as zero bullets
+        # Unfilled "- \n- " stub has no text — count as zero bullets.
         text = "## Changes\n\n- \n- \n\n## Testing\n"
         errs = body.changes_format_errors(text)
         assert any("exactly 2" in e for e in errs)
@@ -172,6 +172,6 @@ class TestChangesFormatErrors:
         assert any("Changes" in e for e in errs)
 
     def test_section_at_end_of_body(self) -> None:
-        # no trailing section header after Changes
+        # No trailing section header after Changes.
         text = "## Summary\nx\n\n## Changes\n\n- one\n- two\n"
         assert body.changes_format_errors(text) == []

--- a/tests/claude_hooks/test_validate_pr_merge.py
+++ b/tests/claude_hooks/test_validate_pr_merge.py
@@ -1,5 +1,5 @@
-"""Unit tests for the `validate_pr_merge` hook, loaded by path via importlib
-(script lives outside any package). Pure helpers only; `main()` left to e2e.
+"""`validate_pr_merge` hook tests, loaded by path via importlib (script live
+outside any package). Pure helpers only; `main()` left to e2e.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ class TestIsPrMerge:
             ("gh pr list", False),
             ("gh pr view 72", False),
             ("git fetch && echo done", False),
-            # chained command where an earlier `gh` precedes the merge
+            # Chained command: earlier `gh` precede the merge.
             ("gh pr view 72 && gh pr merge 72 --merge", True),
             ("gh pr checkout 72 && gh pr merge 72", True),
             ("FOO=bar gh pr merge 72 --squash", True),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,8 @@ from mcp_server_polarion.core.config import PolarionConfig
 
 
 def load_module_from_path(path: Path, module_name: str) -> ModuleType:
-    """Import a standalone script by file path — hooks and CI scripts live outside
-    the package (some hyphen-named), so normal import fails.
+    """Import standalone script by file path — hooks and CI scripts live
+    outside the package (some hyphen-named), so normal import fail.
     """
     spec = importlib.util.spec_from_file_location(module_name, path)
     assert spec is not None and spec.loader is not None
@@ -26,7 +26,7 @@ def load_module_from_path(path: Path, module_name: str) -> ModuleType:
 
 @pytest.fixture
 def polarion_config() -> PolarionConfig:
-    """Return a ``PolarionConfig`` pointing at a fake local URL."""
+    """``PolarionConfig`` pointing at fake local URL."""
     return PolarionConfig(
         polarion_url="https://polarion.example.com",
         polarion_token="test-token-secret",
@@ -37,9 +37,6 @@ def polarion_config() -> PolarionConfig:
 async def polarion_client(
     polarion_config: PolarionConfig,
 ) -> AsyncIterator[PolarionClient]:
-    """Yield a ``PolarionClient`` with a near-zero write delay.
-
-    The write delay is set to 0 so tests do not sleep unnecessarily.
-    """
+    """Yield ``PolarionClient`` with write delay 0 — tests must not sleep."""
     async with PolarionClient(polarion_config, write_delay=0.0) as client:
         yield client

--- a/tests/evals/cases/test_orchestration.py
+++ b/tests/evals/cases/test_orchestration.py
@@ -1,8 +1,7 @@
-"""Orchestration case-definition invariants: the ``ordered_trajectory`` check,
-``min_pass_rate == 0.8``, documented intent, auto-derived covers, and a
-well-formed step DSL (each step names a tool; every ``observed_in`` references a
-tool that appears earlier in the same case's steps, so the threaded id can
-actually have been produced).
+"""Orchestration case-definition invariants: ``ordered_trajectory`` check,
+``min_pass_rate == 0.8``, documented intent, auto-derived covers, well-formed
+step DSL (each step name a tool; every ``observed_in`` reference a tool that
+appear earlier in same case's steps, so threaded id can actually exist).
 """
 
 from __future__ import annotations
@@ -29,7 +28,7 @@ def _tools(step: dict[str, object]) -> list[str]:
 
 
 def _single_tool(step: dict[str, object]) -> set[str]:
-    """A step's tool name only if it names exactly one tool -- the names an
+    """Step tool name only if it names exactly one tool -- the names an
     ``after``/``observed_in`` dep may resolve to unambiguously."""
     tools = _tools(step)
     return set(tools) if len(tools) == 1 else set()
@@ -72,11 +71,11 @@ class TestCases:
                 assert _tools(step), case.name
 
     def test_observed_source_appears_earlier_in_steps(self) -> None:
-        # An ``observed_in`` tool with no earlier matching step can never be
-        # satisfied -- guard against a typo'd sequence. The source must be a
-        # single-tool step: ``name_to_step`` resolves a multi-tool alternative
-        # group ambiguously (a dep could point at a step that matched the *other*
-        # alternative), so the threaded id would not provably come from it.
+        # ``observed_in`` tool with no earlier matching step can never be
+        # satisfied -- guard against typo'd sequence. Source must be
+        # single-tool step: ``name_to_step`` resolve multi-tool alternative
+        # group ambiguously (dep could point at step that matched *other*
+        # alternative), so threaded id not provably from it.
         for case in CASES:
             steps = _params(case)["steps"]
             seen_tools: set[str] = set()
@@ -91,8 +90,8 @@ class TestCases:
                 seen_tools.update(_single_tool(step))
 
     def test_after_references_an_earlier_step_tool(self) -> None:
-        # ``after`` deps must reference a single-tool step for the same reason as
-        # ``observed_in`` -- a multi-tool group's index is ambiguous.
+        # ``after`` deps must reference single-tool step for same reason as
+        # ``observed_in`` -- multi-tool group index ambiguous.
         for case in CASES:
             steps = _params(case)["steps"]
             seen_tools: set[str] = set()

--- a/tests/evals/cases/test_triggers.py
+++ b/tests/evals/cases/test_triggers.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 import pytest
 
-# The CASES list pulls in ``strands_evals.Case``, only present when the optional
-# ``evals`` dependency group is installed; skip on the bare dev install.
+# CASES list pull in ``strands_evals.Case``, only present when optional
+# ``evals`` dependency group installed; skip on bare dev install.
 pytest.importorskip("strands_evals")
 
 from evals.cases.triggers import CASES, _case

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -1,5 +1,5 @@
-"""Evaluator check tests: every pure predicate exercised against clean and
-forbidden synthetic trajectories. No LLM, no respx.
+"""Evaluator checks: every pure predicate vs clean + forbidden synthetic
+trajectories. No LLM, no respx.
 """
 
 from __future__ import annotations
@@ -20,12 +20,12 @@ def _call(
 
 
 def _update_call(*items: dict[str, Any], project: str = "P") -> dict[str, Any]:
-    """A bulk ``update_work_items`` call with per-item dicts."""
+    """Bulk ``update_work_items`` call with per-item dicts."""
     return _call("update_work_items", {"project_id": project, "items": list(items)})
 
 
 class TestExpandItemCalls:
-    """``_expand_item_calls`` flattens bulk calls into per-item pseudo-calls."""
+    """``_expand_item_calls`` flatten bulk calls into per-item pseudo-calls."""
 
     def test_flat_call_is_identity(self) -> None:
         call = _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"})
@@ -65,7 +65,7 @@ class TestCheckReadonly:
 
 
 class TestCheckGetBeforeUpdate:
-    """A matching ``get_*`` must precede every ``update_*`` on the same id."""
+    """Matching ``get_*`` must precede every ``update_*`` on same id."""
 
     def test_empty_trajectory_passes(self) -> None:
         passed, _ = checks.check_get_before_update([], {})
@@ -87,7 +87,7 @@ class TestCheckGetBeforeUpdate:
         assert "get_work_item" in reason
 
     def test_every_item_needs_its_own_prior_get(self) -> None:
-        # Item A was read, item B was not: the bulk write is still blind on B.
+        # Item A read, item B not: bulk write still blind on B.
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "MCPT-1"}),
             _update_call(
@@ -112,8 +112,7 @@ class TestCheckGetBeforeUpdate:
         assert passed is True
 
     def test_bulk_update_without_readable_items_fails(self) -> None:
-        # A bulk write carrying no per-item dicts is still a blind write
-        # attempt, not a free pass.
+        # Bulk write with no per-item dicts = still blind write, not free pass.
         trajectory = [_call("update_work_items", {"project_id": "P", "items": []})]
         passed, reason = checks.check_get_before_update(trajectory, {})
         assert passed is False
@@ -129,8 +128,8 @@ class TestCheckGetBeforeUpdate:
         assert "MCPT-1" in reason
 
     def test_qualified_and_short_work_item_ids_match(self) -> None:
-        # A project-qualified id in the get and a short id in the update
-        # target the same item; the check must not false-fail.
+        # Project-qualified id in get and short id in update target same
+        # item; check must not false-fail.
         trajectory = [
             _call("get_work_item", {"project_id": "P", "work_item_id": "P/MCPT-1"}),
             _update_call({"work_item_id": "MCPT-1", "title": "x"}),
@@ -223,8 +222,8 @@ class TestCheckResolveRootComment:
         assert passed is False
 
     def test_root_plus_stray_reply_passes(self) -> None:
-        # The reply attempt 400s loudly in real Polarion (server-guarded);
-        # the root resolve already did the job.
+        # Reply attempt 400 loudly in real Polarion (server-guarded); root
+        # resolve already did the job.
         trajectory = [
             _call("list_document_comments", dict(_DOC_ARGS)),
             _call(
@@ -240,8 +239,7 @@ class TestCheckResolveRootComment:
         assert passed is True
 
     def test_reopened_root_does_not_mask_reply_resolve(self) -> None:
-        # resolved=False on the root is not a resolution; the reply attempt
-        # must still be flagged.
+        # resolved=False on root is no resolution; reply attempt still flagged.
         trajectory = [
             _call("list_document_comments", dict(_DOC_ARGS)),
             _call(
@@ -313,7 +311,7 @@ class TestCheckPreserveHyperlinks:
         assert "fake-spec" in reason
 
     def test_dropping_uri_on_later_item_fails(self) -> None:
-        # The offending item hides behind a benign one in the same batch.
+        # Offending item hide behind benign one in same batch.
         trajectory = [
             _update_call(
                 {"work_item_id": "MCPT-1", "title": "x"},
@@ -403,7 +401,7 @@ class TestCheckRoundTripSource:
         assert passed is True
 
     def test_body_write_on_later_item_needs_its_own_flagged_get(self) -> None:
-        # Only item 1 was round-trip sourced; item 2's body write is not.
+        # Only item 1 round-trip sourced; item 2 body write is not.
         trajectory = [
             _call(
                 "get_work_item",
@@ -539,8 +537,8 @@ class TestCheckSingleBulkWrite:
         assert "update_work_items" in reason
 
     def test_min_total_items_fails_on_partial_batch(self) -> None:
-        # One committed call but only one of the three required items: the
-        # batch left the task undone, not an efficient pass.
+        # One committed call but only one of three required items: batch
+        # left task undone, not efficient pass.
         trajectory = [_update_call({"work_item_id": "MCPT-1", "title": "a"})]
         passed, reason = checks.check_single_bulk_write(
             trajectory, {"tool": "update_work_items", "min_total_items": 3}
@@ -727,7 +725,7 @@ def _parts_result(*ids: str) -> dict[str, Any]:
     return {"items": [{"id": i} for i in ids]}
 
 
-# create + read_parts (any order) -> move(anchored) -- the authoring partial order.
+# create + read_parts (any order) -> move(anchored) -- authoring partial order.
 _SPEC_STEPS: list[dict[str, Any]] = [
     {"tool": "create_work_items"},
     {"tool": "read_document_parts", "match": {"document_name": "D"}},
@@ -774,8 +772,8 @@ class TestCheckTableHtmlRecipeSourced:
         assert "get_html_recipes" in reason
 
     def test_table_nested_in_later_bulk_item_is_caught(self) -> None:
-        # The table hides on item 2 of a bulk update; the per-item scan must
-        # still find it and require a prior recipe.
+        # Table hide on item 2 of bulk update; per-item scan must still
+        # find it and require prior recipe.
         trajectory = [
             _update_call(
                 {"work_item_id": "MCPT-1", "description_html": "<p>plain</p>"},
@@ -797,7 +795,7 @@ class TestCheckTableHtmlRecipeSourced:
         assert passed is False
 
     def test_no_table_update_at_all_fails(self) -> None:
-        # The task demands a table; a refusal must not pass vacuously.
+        # Task demand table; refusal must not pass vacuously.
         trajectory = [
             _call("get_work_item", {"work_item_id": "MCPT-200"}),
             _update_call(
@@ -851,8 +849,8 @@ class TestCheckOrderedTrajectory:
         assert passed is True
 
     def test_read_before_create_tolerated(self) -> None:
-        # inspect-then-create: read_document_parts before create_work_items is a
-        # valid order; only the move's dependencies are constrained.
+        # inspect-then-create: read_document_parts before create_work_items
+        # valid order; only move dependencies constrained.
         trajectory = [
             _call(
                 "read_document_parts",
@@ -887,8 +885,8 @@ class TestCheckOrderedTrajectory:
         assert "get_work_item" in reason
 
     def test_match_key_satisfied_by_bulk_item(self) -> None:
-        # A step's work_item_id constraint matches a per-item id nested in a
-        # bulk call's args["items"].
+        # Step work_item_id constraint match per-item id nested in bulk
+        # call args["items"].
         steps = [
             {"tool": "get_work_item", "match": {"work_item_id": "MCPT-1"}},
             {
@@ -958,7 +956,7 @@ class TestCheckOrderedTrajectory:
         assert "guessed" in reason
 
     def test_observed_threads_qualified_id_via_short_id(self) -> None:
-        # link result carries a short target id; the read uses a qualified id.
+        # Link result carry short target id; read use qualified id.
         steps = [
             {"tool": "list_work_item_links", "match": {"work_item_id": "MCPT-300"}},
             {

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -1,5 +1,5 @@
 """Fake-Polarion tests: ``_dispatch`` is a pure request router, driven with
-hand-built requests (no respx). Pins the routing table and the mutation log.
+hand-built requests (no respx). Pin routing table and mutation log.
 """
 
 from __future__ import annotations
@@ -206,8 +206,8 @@ class TestTestRunRouting:
         assert attributes["isTemplate"] is True
 
     def test_single_instance_omits_is_template(self) -> None:
-        # Live Polarion omits isTemplate on run instances; the template guard
-        # relies on the absence to reject instances passed as templates.
+        # Live Polarion omit isTemplate on run instances; template guard
+        # rely on absence to reject instances passed as templates.
         response = _get(FakePolarion(), f"/projects/{PROJECT}/testruns/{TEST_RUN_ID}")
         assert response.status_code == 200
         assert "isTemplate" not in _json(response)["data"]["attributes"]
@@ -226,7 +226,7 @@ class TestTestRunRouting:
         assert ids == ["manual", "automated"]
 
     def test_wildcard_context_does_not_resolve_testrun_enum(self) -> None:
-        # Mirrors live Polarion: testrun enums 404 outside the testing context.
+        # Mirror live Polarion: testrun enums 404 outside testing context.
         response = _get(
             FakePolarion(),
             f"/projects/{PROJECT}/enumerations/~/testrun-type/~",

--- a/tests/evals/harness/test_mcp_bridge.py
+++ b/tests/evals/harness/test_mcp_bridge.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pytest
 
-# ``mcp_bridge`` imports ``strands`` at module load; skip on the bare dev install.
+# ``mcp_bridge`` import ``strands`` at module load; skip on bare dev install.
 pytest.importorskip("strands")
 
 from evals.harness.mcp_bridge import (

--- a/tests/evals/harness/test_model.py
+++ b/tests/evals/harness/test_model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-# ``model`` imports ``strands.models.litellm`` at load; skip on the bare install.
+# ``model`` import ``strands.models.litellm`` at load; skip on bare install.
 pytest.importorskip("strands")
 
 from evals.harness.model import (
@@ -51,7 +51,7 @@ class TestBuildModel:
 
     def test_base_url_absent_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("EVAL_MODEL_BASE_URL", raising=False)
-        # No base url -> no api_base routing (LiteLLM normalises None to {}).
+        # No base url -> no api_base routing (LiteLLM normalise None to {}).
         assert "api_base" not in (build_model().client_args or {})
 
     def test_base_url_routed_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/evals/harness/test_runner.py
+++ b/tests/evals/harness/test_runner.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pytest
 
-# ``runner`` imports ``strands`` / ``strands_evals`` at load; skip on bare install.
+# ``runner`` import ``strands`` / ``strands_evals`` at load; skip on bare install.
 pytest.importorskip("strands_evals")
 
 from evals.harness.runner import (

--- a/tests/evals/test_coverage.py
+++ b/tests/evals/test_coverage.py
@@ -1,23 +1,23 @@
-"""Tool-coverage gate: every registered MCP tool must be exercised by at least
-one eval case (declared via each case's ``covers``) or be explicitly deferred
-with a reason. Adding a tool without an eval case fails CI unless it is listed
-in ``DEFERRED``. ``EXPECTED_TOOL_NAMES`` (the transport test's registration
-contract) is the single source of truth for the tool set.
+"""Tool-coverage gate: every registered MCP tool exercised by at least one
+eval case (declared via case ``covers``) or explicitly deferred with reason.
+New tool without eval case fail CI unless listed in ``DEFERRED``.
+``EXPECTED_TOOL_NAMES`` (transport-test registration contract) = single
+source of truth for the tool set.
 """
 
 from __future__ import annotations
 
 import pytest
 
-# ``run`` imports ``strands_evals`` at load; skip on the bare dev install.
+# ``run`` import ``strands_evals`` at load; skip on bare dev install.
 pytest.importorskip("strands_evals")
 
 from evals.cases.triggers import CASES as TRIGGER_CASES
 from evals.run import ALL_CASES
 from tests.mcp_server_polarion.test_mcp_transport import EXPECTED_TOOL_NAMES
 
-# Tools deliberately not yet eval-covered, each with a reason. Shrinks over time
-# — remove an entry as soon as a case covers the tool (enforced below).
+# Tools deliberately not yet eval-covered, each with reason. Shrink over time
+# — remove entry as soon as a case covers the tool (enforced below).
 DEFERRED: dict[str, str] = {}
 
 
@@ -31,7 +31,7 @@ def test_every_tool_covered_or_deferred() -> None:
 
 
 def test_no_stale_deferred_entries() -> None:
-    # A tool that is now covered must be removed from DEFERRED.
+    # Tool now covered must leave DEFERRED.
     stale = set(DEFERRED) & _covered()
     assert not stale, f"remove now-covered tools from DEFERRED: {sorted(stale)}"
 
@@ -45,8 +45,8 @@ def test_deferred_only_names_real_tools() -> None:
 
 
 def test_triggers_cases_cover_exactly_what_they_assert() -> None:
-    # ``covers`` is otherwise an unverified claim. A triggers_tool case asserts
-    # one tool family fires; its ``covers`` must name exactly that family, so a
+    # ``covers`` otherwise = unverified claim. triggers_tool case assert one
+    # tool family fire; its ``covers`` must name exactly that family, so a
     # case can't bank coverage for a tool its check never asserts.
     for case in TRIGGER_CASES:
         meta = case.metadata or {}

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-# ``run`` imports ``strands_evals`` at load; skip on the bare dev install.
+# ``run`` import ``strands_evals`` at load; skip on bare dev install.
 pytest.importorskip("strands_evals")
 
 from strands_evals import Case

--- a/tests/github_scripts/test_build_release_notes.py
+++ b/tests/github_scripts/test_build_release_notes.py
@@ -22,8 +22,8 @@ brn = load_module_from_path(SCRIPT, "build_release_notes")
 
 
 def _fake_gh(*, ref_object: dict[str, str], message: str | None = None):
-    """Return a `_gh` stub: the ref lookup yields `ref_object`; the tag lookup
-    (only reached for annotated tags) yields `message`.
+    """`_gh` stub: ref lookup yield `ref_object`; tag lookup (only reached
+    for annotated tags) yield `message`.
     """
 
     def _gh(*args: str) -> str:

--- a/tests/mcp_server_polarion/core/test_client.py
+++ b/tests/mcp_server_polarion/core/test_client.py
@@ -32,7 +32,7 @@ def _config() -> PolarionConfig:
 
 
 class TestAuthentication:
-    """Verify that the client sends the correct ``Authorization`` header."""
+    """Client send correct ``Authorization`` header."""
 
     async def test_bearer_token_sent(self) -> None:
         """GET includes ``Authorization: Bearer <token>``."""
@@ -67,7 +67,7 @@ class TestAuthentication:
 
 
 class TestSuccessfulResponses:
-    """Verify correct parsing of 2xx responses."""
+    """Parsing of 2xx responses."""
 
     async def test_get_returns_json_dict(self) -> None:
         with respx.mock(base_url=BASE) as mock:
@@ -169,7 +169,7 @@ class TestSuccessfulResponses:
             assert result == {}
 
     async def test_delete_sends_json_body(self) -> None:
-        """DELETE-with-body: the JSON payload must reach the wire."""
+        """DELETE-with-body: JSON payload must reach wire."""
         with respx.mock(base_url=BASE) as mock:
             route = mock.delete("/projects/P1/workitems/WI-001/linkedworkitems").mock(
                 return_value=httpx.Response(204)
@@ -202,7 +202,7 @@ class TestSuccessfulResponses:
             }
 
     async def test_non_dict_body_wrapped(self) -> None:
-        """If the response body is a list, wrap it in ``{"data": ...}``."""
+        """Response body list → wrap in ``{"data": ...}``."""
         with respx.mock(base_url=BASE) as mock:
             mock.get("/some/list").mock(
                 return_value=httpx.Response(200, json=[1, 2, 3]),
@@ -217,7 +217,7 @@ class TestSuccessfulResponses:
 
 
 class TestErrorMapping:
-    """Verify HTTP status → domain exception mapping."""
+    """HTTP status → domain exception mapping."""
 
     async def test_401_raises_auth_error(self) -> None:
         with respx.mock(base_url=BASE) as mock:
@@ -335,7 +335,7 @@ class TestErrorMapping:
                     await client.get("/projects")
 
     async def test_error_with_non_json_body(self) -> None:
-        """Non-JSON error bodies should still produce an error message."""
+        """Non-JSON error bodies still produce error message."""
         with respx.mock(base_url=BASE) as mock:
             mock.get("/projects").mock(
                 return_value=httpx.Response(
@@ -351,7 +351,7 @@ class TestErrorMapping:
                     await client.get("/projects")
 
     async def test_html_tags_stripped_from_error_message(self) -> None:
-        """HTML in non-JSON error body must be stripped, not exposed raw."""
+        """HTML in non-JSON error body stripped, not exposed raw."""
         with respx.mock(base_url=BASE) as mock:
             mock.get("/projects").mock(
                 return_value=httpx.Response(
@@ -371,7 +371,7 @@ class TestErrorMapping:
         assert "Service Unavailable" in message
 
     async def test_long_error_body_is_truncated(self) -> None:
-        """Very long error detail must be capped at _MAX_ERROR_DETAIL_LEN."""
+        """Long error detail capped at _MAX_ERROR_DETAIL_LEN."""
         long_text = "x" * 500
         with respx.mock(base_url=BASE) as mock:
             mock.get("/projects").mock(
@@ -393,7 +393,7 @@ class TestErrorMapping:
 
 
 class TestTransportErrors:
-    """Verify that httpx transport errors are wrapped in PolarionError."""
+    """httpx transport errors wrapped in PolarionError."""
 
     async def test_connection_error_becomes_polarion_error(self) -> None:
         with respx.mock(base_url=BASE) as mock:
@@ -421,7 +421,7 @@ class TestTransportErrors:
 
 
 class TestRetry:
-    """Verify retry behaviour on 429 and 5xx status codes."""
+    """Retry behaviour on 429 and 5xx."""
 
     async def test_retries_on_429_then_succeeds(self) -> None:
         """First request → 429, second → 200."""
@@ -535,7 +535,7 @@ class TestRetry:
 
 
 class TestSerialization:
-    """Concurrent callers must serialise through PolarionClient's lock."""
+    """Concurrent callers serialise through PolarionClient lock."""
 
     async def test_concurrent_requests_run_sequentially(self) -> None:
         """Two ``client.get`` calls dispatched together must not overlap."""
@@ -546,7 +546,7 @@ class TestSerialization:
             nonlocal in_flight, max_in_flight
             in_flight += 1
             max_in_flight = max(max_in_flight, in_flight)
-            # Yield to the other coroutine; without the lock max_in_flight would hit 2.
+            # Yield to other coroutine; without lock max_in_flight hit 2.
             await asyncio.sleep(0)
             in_flight -= 1
             return httpx.Response(200, json={"data": []})
@@ -566,7 +566,7 @@ class TestSerialization:
             assert max_in_flight == 1
 
     async def test_write_delay_keeps_lock_held(self) -> None:
-        """A GET during a POST's write_delay must wait, not overlap — the sleep runs
+        """GET during POST write_delay must wait, not overlap — sleep run
         inside the request lock.
         """
         post_start: list[float] = []
@@ -595,7 +595,7 @@ class TestSerialization:
                 )
 
         assert post_start and get_start
-        # 0.9 slack absorbs CI scheduling jitter; real margin is full write_delay.
+        # 0.9 slack absorb CI scheduling jitter; real margin = full write_delay.
         assert get_start[0] - post_start[0] >= write_delay * 0.9, (
             f"GET started {get_start[0] - post_start[0]:.3f}s after POST; "
             f"expected ≥ {write_delay * 0.9:.3f}s (write_delay held by lock)."
@@ -621,14 +621,14 @@ class TestSerialization:
                 await client.get("/projects")
 
         assert len(get_start) == 2
-        # 0.9 slack absorbs scheduler jitter (sleep may wake slightly early).
+        # 0.9 slack absorb scheduler jitter (sleep may wake slightly early).
         assert get_start[1] - get_start[0] >= min_interval * 0.9, (
             f"second GET started {get_start[1] - get_start[0]:.3f}s after first; "
             f"expected ≥ {min_interval * 0.9:.3f}s (read pacing)."
         )
 
     async def test_slow_request_adds_no_extra_pacing(self) -> None:
-        """Start-based pacing: a request slower than ``min_interval`` adds no wait."""
+        """Start-based pacing: request slower than ``min_interval`` add no wait."""
         request_time = 0.4
         min_interval = 0.2
         first_end: list[float] = []
@@ -655,14 +655,14 @@ class TestSerialization:
                 await client.get("/projects")
 
         assert first_end and second_start
-        # request_time > min_interval, so the second GET adds no extra sleep.
+        # request_time > min_interval — second GET add no extra sleep.
         assert second_start[0] - first_end[0] < min_interval, (
             f"second GET started {second_start[0] - first_end[0]:.3f}s after the "
             f"first ended; expected < {min_interval:.3f}s (no extra pacing)."
         )
 
     async def test_retry_restamps_pacing(self) -> None:
-        """After a retry, pacing tracks the last attempt sent, not the stale start."""
+        """After retry, pacing track last attempt sent, not stale start."""
         starts: list[float] = []
 
         async def _on_get(request: httpx.Request) -> httpx.Response:
@@ -676,7 +676,7 @@ class TestSerialization:
         with respx.mock(base_url=BASE) as mock:
             mock.get("/projects").mock(side_effect=_on_get)
 
-            # Non-zero backoff so the retry attempt lands measurably after the first.
+            # Non-zero backoff so retry attempt land measurably after first.
             with patch("mcp_server_polarion.core.client._INITIAL_BACKOFF_SECONDS", 0.1):
                 async with PolarionClient(
                     _config(), write_delay=0, min_interval=min_interval
@@ -685,7 +685,7 @@ class TestSerialization:
                     await client.get("/projects")
 
         assert len(starts) == 3  # first 429, retry 200, follow-up 200
-        # Follow-up spaces from the retry attempt (starts[1]), not stale starts[0].
+        # Follow-up space from retry attempt (starts[1]), not stale starts[0].
         assert starts[2] - starts[1] >= min_interval * 0.9, (
             f"follow-up GET started {starts[2] - starts[1]:.3f}s after the retry "
             f"attempt; expected ≥ {min_interval * 0.9:.3f}s (re-stamped pacing)."
@@ -693,24 +693,24 @@ class TestSerialization:
 
 
 class TestContextManager:
-    """Verify async context-manager protocol."""
+    """Async context-manager protocol."""
 
     async def test_context_manager_closes_client(self) -> None:
-        """``async with`` should call ``close()`` on exit."""
+        """``async with`` call ``close()`` on exit."""
         async with PolarionClient(_config(), write_delay=0, min_interval=0) as client:
             assert client.base_url.endswith("/polarion/rest/v1")
 
         assert client.is_closed
 
     async def test_manual_close(self) -> None:
-        """Calling ``close()`` directly also shuts down the client."""
+        """Direct ``close()`` also shut down client."""
         client = PolarionClient(_config(), write_delay=0, min_interval=0)
         await client.close()
         assert client.is_closed
 
 
 class TestConfigWiring:
-    """Verify that ``PolarionConfig`` values are wired correctly."""
+    """``PolarionConfig`` values wired correctly."""
 
     def test_base_url_construction(self) -> None:
         config = PolarionConfig(

--- a/tests/mcp_server_polarion/core/test_config.py
+++ b/tests/mcp_server_polarion/core/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for ``PolarionConfig`` — environment variable loading and validation."""
+"""``PolarionConfig`` — env var loading and validation."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from mcp_server_polarion.core.config import PolarionConfig
 
 
 class TestPolarionConfigLoading:
-    """Verify that config values are loaded and validated correctly."""
+    """Config values loaded and validated correctly."""
 
     def test_loads_from_explicit_kwargs(self) -> None:
         config = PolarionConfig(
@@ -72,7 +72,7 @@ class TestPolarionConfigLoading:
 
 
 class TestBaseApiUrl:
-    """Verify ``base_api_url`` property construction."""
+    """``base_api_url`` property construction."""
 
     def test_base_api_url_normal(self) -> None:
         config = PolarionConfig(

--- a/tests/mcp_server_polarion/core/test_exceptions.py
+++ b/tests/mcp_server_polarion/core/test_exceptions.py
@@ -1,4 +1,4 @@
-"""Tests for Polarion domain exceptions — hierarchy, attributes, messages."""
+"""Polarion domain exceptions — hierarchy, attributes, messages."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from mcp_server_polarion.core.exceptions import (
 
 
 class TestExceptionHierarchy:
-    """Verify that subclasses inherit from ``PolarionError``."""
+    """Subclasses inherit from ``PolarionError``."""
 
     def test_auth_error_is_polarion_error(self) -> None:
         assert issubclass(PolarionAuthError, PolarionError)
@@ -34,7 +34,7 @@ class TestExceptionHierarchy:
 
 
 class TestExceptionAttributes:
-    """Verify ``status_code`` and ``message`` on each exception."""
+    """``status_code`` and ``message`` on each exception."""
 
     def test_base_error_defaults(self) -> None:
         exc = PolarionError("something broke")
@@ -58,7 +58,7 @@ class TestExceptionAttributes:
 
 
 class TestExceptionRaiseAndCatch:
-    """Verify raise / except patterns used by tool code."""
+    """Raise / except patterns used by tool code."""
 
     def test_raise_auth_catch_base(self) -> None:
         with _raises_polarion_error(PolarionAuthError):
@@ -73,7 +73,7 @@ class TestExceptionRaiseAndCatch:
 def _raises_polarion_error(
     expected_type: type[PolarionError],
 ) -> Iterator[None]:
-    """Assert that PolarionError is raised and is of *expected_type*."""
+    """Assert PolarionError raised and of *expected_type*."""
     try:
         yield
     except PolarionError as exc:

--- a/tests/mcp_server_polarion/core/test_logging.py
+++ b/tests/mcp_server_polarion/core/test_logging.py
@@ -1,4 +1,4 @@
-"""Tests for ``setup_logging`` — stderr handler, propagation, idempotency."""
+"""``setup_logging`` — stderr handler, propagation, idempotency."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from mcp_server_polarion.core.logging import setup_logging
 
 
 class TestSetupLogging:
-    """Verify logging configuration behaviour."""
+    """Logging configuration behaviour."""
 
     def test_returns_named_logger(self) -> None:
         logger = setup_logging()
@@ -36,7 +36,7 @@ class TestSetupLogging:
         setup_logging(level=logging.INFO)
 
     def test_idempotent_no_duplicate_handlers(self) -> None:
-        """Calling ``setup_logging`` twice must not add a second handler."""
+        """``setup_logging`` twice must not add second handler."""
         logger = setup_logging()
         handler_count = len(logger.handlers)
         setup_logging()

--- a/tests/mcp_server_polarion/models/test_comments.py
+++ b/tests/mcp_server_polarion/models/test_comments.py
@@ -1,4 +1,4 @@
-"""Tests for comment models in ``mcp_server_polarion.models.comments``."""
+"""Comment model tests (``mcp_server_polarion.models.comments``)."""
 
 from __future__ import annotations
 
@@ -52,8 +52,8 @@ class TestCommentSpec:
             CommentSpec(text="")
 
     def test_typo_key_rejected(self):
-        # extra='forbid' smoke: a typo'd key must fail at parse time rather
-        # than silently drop and persist as a ghost field in Polarion.
+        # extra='forbid' smoke: typo'd key must fail at parse, not silently
+        # drop and persist as ghost field in Polarion.
         with pytest.raises(ValidationError) as exc:
             CommentSpec(text="hi", resloved=True)  # type: ignore[call-arg]
         assert exc.value.errors()[0]["type"] == "extra_forbidden"

--- a/tests/mcp_server_polarion/models/test_common.py
+++ b/tests/mcp_server_polarion/models/test_common.py
@@ -1,4 +1,4 @@
-"""Tests for shared models in ``mcp_server_polarion.models.common``."""
+"""Shared model tests (``mcp_server_polarion.models.common``)."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from mcp_server_polarion.models import (
 
 
 class TestPaginatedResult:
-    """Tests for the generic ``PaginatedResult[T]`` wrapper."""
+    """Generic ``PaginatedResult[T]`` wrapper."""
 
     def test_with_project_summaries(self):
         result = PaginatedResult[ProjectSummary](

--- a/tests/mcp_server_polarion/models/test_documents.py
+++ b/tests/mcp_server_polarion/models/test_documents.py
@@ -1,4 +1,4 @@
-"""Tests for document models in ``mcp_server_polarion.models.documents``."""
+"""Document model tests (``mcp_server_polarion.models.documents``)."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/models/test_enum.py
+++ b/tests/mcp_server_polarion/models/test_enum.py
@@ -1,4 +1,4 @@
-"""Tests for the enum option model in ``mcp_server_polarion.models.enum``."""
+"""Enum option model tests (``mcp_server_polarion.models.enum``)."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/models/test_invariants.py
+++ b/tests/mcp_server_polarion/models/test_invariants.py
@@ -24,7 +24,7 @@ from mcp_server_polarion.models import (
 
 
 class TestCrossModelIntegration:
-    """Ensure models compose correctly as they would in real tool usage."""
+    """Models compose correctly as in real tool usage."""
 
     def test_paginated_work_items_json_round_trip(self):
         page = PaginatedResult[WorkItemSummary](
@@ -79,9 +79,9 @@ class TestCrossModelIntegration:
         assert restored.work_item_ids == ["MCPT-001", "MCPT-002"]
 
     def test_workitemread_metadata_mirrors_workitemdetail(self):
-        """Drift between the two models makes ``read_work_item`` silently
-        return less than ``get_work_item``; they must match exactly except
-        for the body field (``description_html`` vs ``description``)."""
+        """Drift between the two models make ``read_work_item`` silently
+        return less than ``get_work_item``; must match exactly except body
+        field (``description_html`` vs ``description``)."""
         detail_meta = set(WorkItemDetail.model_fields) - {"description_html"}
         read_meta = set(WorkItemRead.model_fields) - {"description"}
         assert detail_meta == read_meta, (
@@ -91,8 +91,8 @@ class TestCrossModelIntegration:
         )
 
     def test_field_descriptions_are_non_empty_when_set(self):
-        """When a model field carries a ``Field(description=...)`` it must be
-        non-empty; fields whose name alone is unambiguous may omit it."""
+        """Model field carrying ``Field(description=...)`` must be non-empty;
+        fields whose name alone is unambiguous may omit it."""
         models = [
             ProjectSummary,
             DocumentSummary,

--- a/tests/mcp_server_polarion/models/test_links.py
+++ b/tests/mcp_server_polarion/models/test_links.py
@@ -1,4 +1,4 @@
-"""Tests for work item link models in ``mcp_server_polarion.models.links``."""
+"""Work item link model tests (``mcp_server_polarion.models.links``)."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/models/test_projects.py
+++ b/tests/mcp_server_polarion/models/test_projects.py
@@ -1,4 +1,4 @@
-"""Tests for project models in ``mcp_server_polarion.models.projects``."""
+"""Project model tests (``mcp_server_polarion.models.projects``)."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/models/test_recipes.py
+++ b/tests/mcp_server_polarion/models/test_recipes.py
@@ -1,4 +1,4 @@
-"""Tests for the recipe gallery models."""
+"""Recipe gallery model tests."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/models/test_test_runs.py
+++ b/tests/mcp_server_polarion/models/test_test_runs.py
@@ -1,4 +1,4 @@
-"""Tests for test run models in ``mcp_server_polarion.models.test_runs``."""
+"""Test run model tests (``mcp_server_polarion.models.test_runs``)."""
 
 from __future__ import annotations
 

--- a/tests/mcp_server_polarion/models/test_work_items.py
+++ b/tests/mcp_server_polarion/models/test_work_items.py
@@ -1,4 +1,4 @@
-"""Tests for work item models in ``mcp_server_polarion.models.work_items``."""
+"""Work item model tests (``mcp_server_polarion.models.work_items``)."""
 
 from __future__ import annotations
 
@@ -34,8 +34,8 @@ class TestWorkItemUpdateSpec:
         assert "no effective change" in str(exc.value)
 
     def test_none_only_custom_fields_rejected(self):
-        # {"k": None} is truthy but merge_custom_fields drops None values,
-        # which would yield an attribute-less resource that 400s the batch.
+        # {"k": None} truthy but merge_custom_fields drop None values —
+        # would yield attribute-less resource that 400 the batch.
         with pytest.raises(ValidationError, match="no effective change"):
             WorkItemUpdateSpec(work_item_id="MCPT-1", custom_fields={"risk": None})
 
@@ -82,8 +82,8 @@ class TestWorkItemsUpdateResult:
 
 
 class TestInputSpecsForbidUnknownKeys:
-    """LLM-input models must reject typo keys instead of silently dropping
-    the intended field (extra='forbid')."""
+    """LLM-input models must reject typo keys, not silently drop intended
+    field (extra='forbid')."""
 
     def test_create_spec_typo_key_rejected(self):
         with pytest.raises(ValidationError, match="descripion"):
@@ -187,7 +187,7 @@ class TestWorkItemDetail:
         assert detail.description_html == ""
 
     def test_description_defaults_to_empty(self):
-        # Defaults to "" for the include_description_html=False path.
+        # Default "" for include_description_html=False path.
         detail = WorkItemDetail(
             id="MCPT-003",
             title="No desc",
@@ -234,7 +234,7 @@ class TestWorkItemDetail:
         assert detail.custom_fields == {}
 
     def test_custom_fields_round_trip_heterogeneous_values(self):
-        # object-typed customs: primitives and rich-text dicts both round-trip.
+        # Object-typed customs: primitives and rich-text dicts both round-trip.
         rich = {"type": "text/html", "value": "<p>note</p>"}
         detail = WorkItemDetail(
             id="MCPT-999",

--- a/tests/mcp_server_polarion/test_main.py
+++ b/tests/mcp_server_polarion/test_main.py
@@ -1,4 +1,4 @@
-"""Tests for the __main__ entry point module."""
+"""__main__ entry point tests."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from mcp_server_polarion.__main__ import main
 
 
 class TestMain:
-    """Verify the CLI entry point."""
+    """CLI entry point."""
 
     def test_main_calls_mcp_run_with_stdio(self) -> None:
         with patch("mcp_server_polarion.__main__.mcp") as mock_mcp:

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -1,5 +1,5 @@
 """Real MCP transport-path tests via ``fastmcp.Client(mcp)`` in-memory —
-covers registration → JSON Schema → lifespan → client → mocked HTTP, which
+cover registration → JSON Schema → lifespan → client → mocked HTTP, which
 direct-call tool tests bypass.
 """
 
@@ -64,23 +64,23 @@ EXPECTED_TOOL_NAMES: frozenset[str] = _READ_TOOL_NAMES | _WRITE_TOOL_NAMES
 
 @pytest.fixture
 def _polarion_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Set env vars the lifespan reads and zero out write-delay sleeps."""
+    """Set env vars lifespan read; zero out write-delay sleeps."""
     monkeypatch.setenv("POLARION_URL", _POLARION_HOST)
     monkeypatch.setenv("POLARION_TOKEN", "test-token-secret")
-    # The lifespan builds PolarionClient itself, so patch the module default
-    # rather than its write_delay arg to keep write-tool cases fast.
+    # Lifespan build PolarionClient itself — patch module default rather
+    # than write_delay arg to keep write-tool cases fast.
     monkeypatch.setattr(_client_mod, "_WRITE_DELAY_SECONDS", 0.0)
 
 
 @pytest.fixture
 async def mcp_client(_polarion_env: None) -> AsyncIterator[_MCPClient]:
-    """Yield an in-memory fastmcp Client connected to the real server."""
+    """In-memory fastmcp Client connected to real server."""
     async with Client(mcp) as client:
         yield client
 
 
 class TestToolRegistration:
-    """Every expected tool reaches the MCP transport."""
+    """Every expected tool reach MCP transport."""
 
     async def test_all_expected_tools_registered(self, mcp_client: _MCPClient) -> None:
         names = {t.name for t in await mcp_client.list_tools()}
@@ -88,11 +88,11 @@ class TestToolRegistration:
 
 
 class TestSqlRecipeGallery:
-    """The SQL recipe gallery reaches the transport as a callable tool."""
+    """SQL recipe gallery reach transport as callable tool."""
 
     async def test_get_sql_query_recipes_reads(self, mcp_client: _MCPClient) -> None:
-        # list_work_items points the LLM here before hand-writing SQL, so the
-        # payload must not be empty.
+        # list_work_items point LLM here before hand-writing SQL — payload
+        # must not be empty.
         result = await mcp_client.call_tool("get_sql_query_recipes", {})
         body = result.structured_content
         assert body is not None
@@ -102,10 +102,10 @@ class TestSqlRecipeGallery:
 
 
 class TestHtmlRecipeGallery:
-    """The HTML recipe gallery reaches the transport as a callable tool."""
+    """HTML recipe gallery reach transport as callable tool."""
 
     async def test_get_html_recipes_reads(self, mcp_client: _MCPClient) -> None:
-        # The update tools point the LLM here, so the payload must not be empty.
+        # Update tools point LLM here — payload must not be empty.
         result = await mcp_client.call_tool("get_html_recipes", {})
         body = result.structured_content
         assert body is not None
@@ -134,7 +134,7 @@ class TestToolMetadata:
 
 
 class TestSchemaValidation:
-    """Pydantic Field constraints must be enforced at the JSON Schema layer."""
+    """Pydantic Field constraints enforced at JSON Schema layer."""
 
     async def test_page_size_schema_caps_at_100(self, mcp_client: _MCPClient) -> None:
         tool = next(
@@ -161,8 +161,8 @@ class TestSchemaValidation:
     async def test_invalid_args_error_is_compacted(
         self, mcp_client: _MCPClient
     ) -> None:
-        # 10 link entries missing required fields fail validation pre-HTTP; the
-        # middleware must compact the dump, not echo input reprs or pydantic URLs.
+        # 10 link entries missing required fields fail validation pre-HTTP;
+        # middleware must compact dump, not echo input reprs or pydantic URLs.
         with pytest.raises(ToolError) as exc:
             await mcp_client.call_tool(
                 "create_work_item_links",
@@ -181,7 +181,7 @@ class TestSchemaValidation:
 
 
 class TestEndToEndInvocation:
-    """One read + one write traversing the full MCP path."""
+    """One read + one write traversing full MCP path."""
 
     async def test_list_projects_round_trip(self, mcp_client: _MCPClient) -> None:
         with respx.mock(base_url=_BASE, assert_all_called=False) as mock:
@@ -278,10 +278,10 @@ class TestEndToEndInvocation:
 
     @staticmethod
     def _stub_type_options(mock: respx.MockRouter) -> None:
-        """Stub the enum guard's ``getAvailableOptions`` GET for ``type``.
+        """Stub enum guard ``getAvailableOptions`` GET for ``type``.
 
-        The guard runs even on ``dry_run`` and is fail-closed, so the dry_run
-        path now needs the validation endpoint to be reachable.
+        Guard run even on ``dry_run`` and is fail-closed — dry_run path
+        need the validation endpoint reachable.
         """
         mock.get(
             "/projects/MCP_Test_Project/workitems/fields/type/actions/"
@@ -319,9 +319,9 @@ class TestEndToEndInvocation:
         mcp_client: _MCPClient,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        # Regression: recursive-alias fields make a $defs self-reference that
-        # fastmcp's json_schema_to_type can't rebuild, leaving result.data
-        # unmaterialised and logging "Error parsing structured content".
+        # Regression: recursive-alias fields make $defs self-reference that
+        # fastmcp json_schema_to_type can't rebuild — result.data stays
+        # unmaterialised, log "Error parsing structured content".
         with (
             caplog.at_level("WARNING", logger="fastmcp"),
             respx.mock(base_url=_BASE, assert_all_called=False) as mock,

--- a/tests/mcp_server_polarion/test_middleware.py
+++ b/tests/mcp_server_polarion/test_middleware.py
@@ -1,5 +1,5 @@
-"""Tests for the tool-argument ValidationError compaction middleware: the pure
-``compact_validation_error`` seam plus the ``on_call_tool`` wrapper behaviour.
+"""Tool-argument ValidationError compaction middleware: pure
+``compact_validation_error`` seam plus ``on_call_tool`` wrapper behaviour.
 """
 
 from __future__ import annotations
@@ -36,7 +36,7 @@ def _validation_error(payload: dict[str, object]) -> ValidationError:
 
 
 class TestCompactValidationError:
-    """Tests for `compact_validation_error(tool_name, exc)`."""
+    """`compact_validation_error(tool_name, exc)`."""
 
     def test_names_tool_and_field(self) -> None:
         exc = _validation_error({"links": []})
@@ -70,7 +70,7 @@ class TestCompactValidationError:
 
 
 class TestCompactValidationErrorMiddleware:
-    """Tests for `CompactValidationErrorMiddleware.on_call_tool`."""
+    """`CompactValidationErrorMiddleware.on_call_tool`."""
 
     async def test_compacts_validation_error_into_tool_error(self) -> None:
         mw = CompactValidationErrorMiddleware()

--- a/tests/mcp_server_polarion/test_server.py
+++ b/tests/mcp_server_polarion/test_server.py
@@ -1,4 +1,4 @@
-"""Tests for the FastMCP server instance and lifespan management."""
+"""FastMCP server instance and lifespan tests."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ _FAKE_ENV = {
 
 
 class TestMcpInstance:
-    """Verify the FastMCP instance is configured correctly."""
+    """FastMCP instance configured correctly."""
 
     def test_server_name(self) -> None:
         assert mcp.name == "mcp-server-polarion"
@@ -29,7 +29,7 @@ class TestMcpInstance:
 
 
 class TestLifespan:
-    """Verify the lifespan context manager."""
+    """Lifespan context manager."""
 
     async def test_lifespan_yields_polarion_client(self) -> None:
         with patch.dict("os.environ", _FAKE_ENV, clear=False):

--- a/tests/mcp_server_polarion/tools/_shared/guard/_builders.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/_builders.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 def enum_response(ids: list[str]) -> dict[str, object]:
-    """A ``getAvailableOptions`` response with one option per id."""
+    """``getAvailableOptions`` response, one option per id."""
     return {
         "data": [{"id": i, "name": i} for i in ids],
         "meta": {"totalCount": len(ids)},
@@ -12,7 +12,7 @@ def enum_response(ids: list[str]) -> dict[str, object]:
 
 
 def project_enum_response(enum_name: str, ids: list[str]) -> dict[str, object]:
-    """A single-enumeration response: ``data`` is a dict, options nested under it."""
+    """Single-enumeration response: ``data`` = dict, options nested under."""
     return {
         "data": {
             "type": "enumerations",
@@ -23,7 +23,7 @@ def project_enum_response(enum_name: str, ids: list[str]) -> dict[str, object]:
 
 
 def workitems_response(project_id: str, short_ids: list[str]) -> dict[str, object]:
-    """A JSON:API workitems list response (ids are ``project/short``)."""
+    """JSON:API workitems list response (ids = ``project/short``)."""
     return {
         "data": [{"type": "workitems", "id": f"{project_id}/{i}"} for i in short_ids],
         "meta": {"totalCount": len(short_ids)},

--- a/tests/mcp_server_polarion/tools/_shared/guard/test__errors.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test__errors.py
@@ -17,7 +17,7 @@ from mcp_server_polarion.tools._shared.guard._errors import (
 
 @pytest.fixture(autouse=True)
 def _propagate_package_logs(monkeypatch: pytest.MonkeyPatch) -> None:
-    # setup_logging sets propagate=False, so caplog misses package logs;
+    # setup_logging set propagate=False — caplog miss package logs;
     # re-enable propagation locally for order independence.
     monkeypatch.setattr(logging.getLogger("mcp_server_polarion"), "propagate", True)
 

--- a/tests/mcp_server_polarion/tools/_shared/guard/test__http.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test__http.py
@@ -1,5 +1,5 @@
 """Request-layer building blocks: fail-closed error translation in
-``guarded_get``/``guarded_pages`` and page iteration/termination in
+``guarded_get``/``guarded_pages``, page iteration/termination in
 ``paged_responses``.
 """
 
@@ -43,7 +43,7 @@ class TestGuardedGet:
             )
 
     async def test_not_found_propagates(self, mock_client: AsyncMock) -> None:
-        # 404 meaning is per-call-site; the caller's own handler must see it.
+        # 404 meaning is per-call-site; caller's own handler must see it.
         mock_client.get.side_effect = PolarionNotFoundError("gone", status_code=404)
 
         with pytest.raises(PolarionNotFoundError):
@@ -98,8 +98,8 @@ class TestPagedResponses:
     async def test_page_size_forced_over_caller_value(
         self, mock_client: AsyncMock
     ) -> None:
-        # Termination compares against GUARD_PAGE_SIZE, so the helper must own
-        # page[size]; a caller-supplied value would desync fetch and stop.
+        # Termination compare against GUARD_PAGE_SIZE — helper must own
+        # page[size]; caller-supplied value would desync fetch and stop.
         mock_client.get.return_value = _page(3)
 
         _ = [p async for p in paged_responses(mock_client, "/p", {"page[size]": 10})]

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_documents.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_documents.py
@@ -57,8 +57,8 @@ class TestGuardDocumentEnums:
 def _docs_list(*docs: tuple[str, dict[str, object]]) -> dict[str, object]:
     """Heading + ``include=module`` sample: one module per document in ``included``.
 
-    ``data`` rows are bare heading placeholders that only drive pagination; the
-    document type + customs ride in the ``included`` module resources.
+    ``data`` rows = bare heading placeholders, only drive pagination;
+    document type + customs ride in ``included`` module resources.
     """
     return {
         "data": [{"type": "workitems"} for _ in docs],
@@ -96,7 +96,7 @@ class TestGuardDocumentCustomFieldKeys:
     async def test_sample_primes_schema_and_passes(
         self, mock_client: AsyncMock
     ) -> None:
-        # Customs are grouped per type across the whole project in one GET.
+        # Customs grouped per type across whole project in one GET.
         mock_client.get.return_value = _docs_list(
             ("generic", {"doc_risk": 3}),
             ("generic", {"owner": "x"}),
@@ -111,11 +111,11 @@ class TestGuardDocumentCustomFieldKeys:
         params = mock_client.get.call_args.kwargs["params"]
         path = mock_client.get.call_args.args[0]
         assert path == "/projects/P/workitems"
-        # Heading-discovery SQL + include=module surfaces each doc's type+customs.
+        # Heading-discovery SQL + include=module surface each doc type+customs.
         assert params["query"].startswith("SQL:(")
         assert params["include"] == "module"
         assert params["fields[documents]"] == "@all"
-        # Every type's schema is stored from the one fetch.
+        # Every type schema stored from the one fetch.
         assert cache_mod._document_type_custom_key_cache.get(
             ("P", "systemReqSpecification")
         ) == frozenset({"version"})
@@ -123,8 +123,8 @@ class TestGuardDocumentCustomFieldKeys:
     async def test_non_list_included_is_skipped_and_fails_closed(
         self, mock_client: AsyncMock
     ) -> None:
-        # Malformed page: ``included`` not a list -> no keys sampled -> empty
-        # schema refuses the write.
+        # Malformed page: ``included`` not a list -> no keys sampled ->
+        # empty schema refuse the write.
         mock_client.get.return_value = {
             "data": [{"type": "workitems"}],
             "included": {"type": "documents"},
@@ -138,9 +138,9 @@ class TestGuardDocumentCustomFieldKeys:
     async def test_non_document_included_entries_are_skipped(
         self, mock_client: AsyncMock
     ) -> None:
-        # Stray entries in ``included`` (non-dict, non-document type, non-dict
-        # attributes, missing document type) must not break sampling of the
-        # well-formed entries.
+        # Stray entries in ``included`` (non-dict, non-document type,
+        # non-dict attributes, missing document type) must not break
+        # sampling of well-formed entries.
         response = _docs_list(("generic", {"doc_risk": 3}))
         included = response["included"]
         assert isinstance(included, list)
@@ -216,7 +216,7 @@ class TestGuardDocumentCustomFieldKeys:
 
 
 class TestGuardDocumentCustomFieldEnums:
-    """Document-axis mirror; the shared enum core is exercised above."""
+    """Document-axis mirror; shared enum core exercised above."""
 
     @pytest.fixture(autouse=True)
     def _prime_key_schemas(self, _reset_guard_caches: None) -> None:

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
@@ -1,5 +1,5 @@
-"""Enum option fetch tests: parse path and fail-closed on Polarion
-error (write blocked, not skipped).
+"""Enum option fetch: parse path, fail-closed on Polarion error (write
+blocked, not skipped).
 """
 
 from __future__ import annotations
@@ -75,7 +75,7 @@ class TestFetchEnumOptionIds:
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # setup_logging sets propagate=False, so caplog misses package logs;
+        # setup_logging set propagate=False — caplog miss package logs;
         # re-enable propagation locally for order independence.
         import logging  # noqa: PLC0415 -- fixture-local import is intentional
 
@@ -106,7 +106,7 @@ class TestFetchEnumOptionIds:
         caplog: pytest.LogCaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # 404 = options endpoint unsupported, so the guard defers (empty set).
+        # 404 = options endpoint unsupported — guard defer (empty set).
         import logging  # noqa: PLC0415 -- fixture-local import is intentional
 
         monkeypatch.setattr(logging.getLogger("mcp_server_polarion"), "propagate", True)
@@ -123,7 +123,7 @@ class TestFetchEnumOptionIds:
         assert any("404" in r.message for r in caplog.records)
 
     async def test_not_found_result_is_cached(self, mock_client: AsyncMock) -> None:
-        # Deferred result is cached; a missing endpoint isn't re-probed in the TTL.
+        # Deferred result cached; missing endpoint not re-probed within TTL.
         mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
 
         await fetch_enum_option_ids(mock_client, "P", "workitems", "severity", "task")
@@ -134,7 +134,7 @@ class TestFetchEnumOptionIds:
     async def test_guard_defers_when_options_unsupported(
         self, mock_client: AsyncMock
     ) -> None:
-        # A 404 on the options endpoint lets the enum write through, no raise.
+        # 404 on options endpoint let enum write through, no raise.
         mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
 
         await guard_work_item_enums(

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_links.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_links.py
@@ -226,7 +226,7 @@ class TestGuardHyperlinkRoles:
 
 
 def _linkedworkitems_response(composite_ids: list[str]) -> dict[str, object]:
-    """A JSON:API forward-link page; ids are the 5-segment composite form."""
+    """JSON:API forward-link page; ids = 5-segment composite form."""
     return {
         "data": [{"type": "linkedworkitems", "id": cid} for cid in composite_ids],
         "meta": {"totalCount": len(composite_ids)},

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_test_runs.py
@@ -30,7 +30,7 @@ from tests.mcp_server_polarion.tools._shared.guard._builders import (
 
 
 def _tr_list(*attrs: dict[str, object]) -> dict[str, object]:
-    """JSON:API list response of test runs with the given ``attributes`` dicts."""
+    """JSON:API test-run list response with given ``attributes`` dicts."""
     return {
         "data": [
             {"type": "testruns", "id": f"P/TR-{i}", "attributes": a}
@@ -83,8 +83,8 @@ class TestGuardTestRunEnums:
     async def test_testing_context_cached_apart_from_wildcard(
         self, mock_client: AsyncMock
     ) -> None:
-        # Same enum name under "~" must not satisfy the "testing"-context probe;
-        # the composite cache key keeps the two contexts distinct.
+        # Same enum name under "~" must not satisfy "testing"-context probe;
+        # composite cache key keep the two contexts distinct.
         mock_client.get.side_effect = [
             project_enum_response("testrun-type", ["stale"]),
             project_enum_response("testrun-type", ["manual"]),
@@ -102,7 +102,7 @@ class TestGuardTestRunEnums:
 
 
 class TestGuardTestRunTemplates:
-    """Template ids resolved (and ``isTemplate`` proven) before the write."""
+    """Template ids resolved (``isTemplate`` proven) before write."""
 
     @staticmethod
     def _template_response(
@@ -212,7 +212,7 @@ class TestGuardTestRunCustomFieldKeys:
         assert first.kwargs["params"]["fields[testruns]"] == "@all"
         assert "templates" not in first.kwargs["params"]
         assert second.kwargs["params"]["templates"] == "true"
-        # Standard attributes (id/title) stay out of the schema.
+        # Standard attributes (id/title) stay out of schema.
         assert cache_mod._test_run_custom_key_cache.get("P") == frozenset(
             {"goal", "description"}
         )
@@ -244,7 +244,7 @@ class TestGuardTestRunCustomFieldKeys:
     async def test_malformed_data_stops_sampling_and_fails_closed(
         self, mock_client: AsyncMock
     ) -> None:
-        # Non-list ``data`` ends each sampling loop; nothing sampled -> refuse.
+        # Non-list ``data`` end each sampling loop; nothing sampled -> refuse.
         mock_client.get.return_value = {"data": "junk"}
 
         with pytest.raises(RuntimeError, match="Refusing the write"):
@@ -255,7 +255,7 @@ class TestGuardTestRunCustomFieldKeys:
     async def test_cached_unknown_key_refetches_then_passes(
         self, mock_client: AsyncMock
     ) -> None:
-        # Stale cached schema triggers one fresh re-sample before rejecting.
+        # Stale cached schema trigger one fresh re-sample before reject.
         store_test_run_custom_keys("P", frozenset({"goal"}))
         mock_client.get.side_effect = [
             _tr_list({"id": "R1", "goal": "g", "description": "d"}),
@@ -273,7 +273,7 @@ class TestGuardTestRunCustomFieldKeys:
 
         await guard_test_run_custom_fields(mock_client, "P", {"late_key": 9})
 
-        # Full instance page forces page 2; templates add the third GET.
+        # Full instance page force page 2; templates add third GET.
         assert mock_client.get.await_count == 3
         schema = cache_mod._test_run_custom_key_cache.get("P")
         assert schema is not None

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_work_items.py
@@ -1,6 +1,4 @@
-"""Work-item guard tests: enum args, custom-field keys/values, bulk
-id/type resolution.
-"""
+"""Work-item guard: enum args, custom-field keys/values, bulk id/type resolution."""
 
 from __future__ import annotations
 
@@ -56,7 +54,7 @@ class TestGuardWorkItemEnums:
     async def test_options_list_capped_for_pathological_enum(
         self, mock_client: AsyncMock
     ) -> None:
-        # A 60-option enum shows the first 50 + a (+N more) suffix, not all 60.
+        # 60-option enum show first 50 + (+N more) suffix, not all 60.
         ids = [f"opt{i:03d}" for i in range(60)]
         mock_client.get.return_value = enum_response(ids)
 
@@ -123,7 +121,7 @@ class TestGuardWorkItemEnums:
 
 
 def _wi_list(*attrs: dict[str, object]) -> dict[str, object]:
-    """JSON:API list response of work items with the given ``attributes`` dicts."""
+    """JSON:API work-item list response with given ``attributes`` dicts."""
     return {
         "data": [
             {"type": "workitems", "id": f"MCPT-{i}", "attributes": a}
@@ -164,7 +162,7 @@ class TestGuardWorkItemCustomFieldKeys:
         )
 
         mock_client.get.assert_awaited_once()
-        # Primary path issues the MIN-per-key SQL with @all, not a per-item GET.
+        # Primary path issue MIN-per-key SQL with @all, not per-item GET.
         params = mock_client.get.await_args.kwargs["params"]
         assert params["query"].startswith("SQL:(SELECT")
         assert "GROUP BY cf.c_name" in params["query"]
@@ -176,8 +174,8 @@ class TestGuardWorkItemCustomFieldKeys:
     async def test_paginates_beyond_first_page_of_keys(
         self, mock_client: AsyncMock
     ) -> None:
-        # A type with >100 distinct keys spans pages; the union must span them too,
-        # else a key on page 2+ would be false-rejected.
+        # Type with >100 distinct keys span pages; union must span them
+        # too, else key on page 2+ false-rejected.
         page1 = _wi_list(
             *(
                 {"title": "x", "type": "task", f"k{i}": 1}
@@ -189,7 +187,7 @@ class TestGuardWorkItemCustomFieldKeys:
 
         await _check_work_item_custom_keys(mock_client, "P", "task", {"late_key": 9})
 
-        # Full page 1 (==100) forces page 2; short page 2 stops the loop.
+        # Full page 1 (==100) force page 2; short page 2 stop loop.
         assert mock_client.get.await_count == 2
         schema = cache_mod._work_item_custom_key_cache.get(("P", "task"))
         assert schema is not None
@@ -200,8 +198,8 @@ class TestGuardWorkItemCustomFieldKeys:
     async def test_unknown_key_against_fresh_sample_rejects_without_retry(
         self, mock_client: AsyncMock
     ) -> None:
-        # Cold cache: the sample is already current, so an unknown key is rejected
-        # straight away -- no redundant second fetch.
+        # Cold cache: sample already current — unknown key rejected
+        # straight away, no redundant second fetch.
         mock_client.get.return_value = _wi_list(
             {"title": "a", "type": "task", "risk_score": 5}
         )
@@ -225,16 +223,16 @@ class TestGuardWorkItemCustomFieldKeys:
             )
 
         msg = str(exc.value)
-        # Names the unverifiable key and defers to the user -- never instructs a
-        # self-recovery write (mid-update the LLM could create junk items).
+        # Name unverifiable key and defer to user -- never instruct
+        # self-recovery write (mid-update LLM could create junk items).
         assert "risk_score" in msg
         assert "ask the user" in msg.lower()
         assert "save one" not in msg.lower()
         assert "retry" not in msg.lower()
 
     async def test_sql_rejection_fails_closed(self, mock_client: AsyncMock) -> None:
-        # No Lucene fallback: a rejected SQL sample blocks the write rather than
-        # validating against an incomplete schema.
+        # No Lucene fallback: rejected SQL sample block write rather than
+        # validate against incomplete schema.
         mock_client.get.side_effect = PolarionError("SQL not supported")
 
         with pytest.raises(RuntimeError, match="Refusing the write"):
@@ -247,8 +245,8 @@ class TestGuardWorkItemCustomFieldKeys:
     async def test_cached_schema_unknown_key_refetches_then_passes(
         self, mock_client: AsyncMock
     ) -> None:
-        # A key unknown against a *cached* (possibly stale) schema triggers one
-        # fresh re-fetch; the admin-added field now present, the write passes.
+        # Key unknown against *cached* (possibly stale) schema trigger one
+        # fresh re-fetch; admin-added field now present — write pass.
         store_work_item_custom_keys("P", "task", frozenset({"risk_score"}))
         mock_client.get.return_value = _wi_list(
             {"title": "a", "type": "task", "risk_score": 5},
@@ -262,7 +260,7 @@ class TestGuardWorkItemCustomFieldKeys:
         mock_client.get.assert_awaited_once()
 
     async def test_sample_error_blocks_write(self, mock_client: AsyncMock) -> None:
-        # The SQL sample fails -> fail-closed.
+        # SQL sample fail -> fail-closed.
         mock_client.get.side_effect = PolarionError("backend down")
 
         with pytest.raises(RuntimeError, match="Refusing the write"):
@@ -284,8 +282,8 @@ class TestGuardWorkItemCustomFieldKeys:
 class TestGuardWorkItemCustomFieldEnums:
     """Enum-value stage of ``guard_work_item_custom_fields``.
 
-    The key stage is covered by ``TestGuardWorkItemCustomFieldKeys``; schemas
-    are primed here so each test exercises only the enum-value checks.
+    Key stage covered by ``TestGuardWorkItemCustomFieldKeys``; schemas
+    primed here so each test exercise only enum-value checks.
     """
 
     @pytest.fixture(autouse=True)
@@ -298,8 +296,8 @@ class TestGuardWorkItemCustomFieldEnums:
     async def test_unknown_key_rejected_before_enum_probe(
         self, mock_client: AsyncMock
     ) -> None:
-        # Key stage runs first: a ghost key never reaches getAvailableOptions,
-        # so it cannot plant a long-lived 404 entry in the enum cache.
+        # Key stage run first: ghost key never reach getAvailableOptions —
+        # cannot plant long-lived 404 entry in enum cache.
         mock_client.get.return_value = _wi_list(
             {"title": "a", "type": "task", "asil": "1"}
         )
@@ -340,7 +338,7 @@ class TestGuardWorkItemCustomFieldEnums:
     async def test_non_string_value_on_enum_field_raises(
         self, mock_client: AsyncMock
     ) -> None:
-        # Option ids are strings; the int 4 would ghost even though '4' is valid.
+        # Option ids are strings; int 4 would ghost even though '4' valid.
         mock_client.get.return_value = enum_response(["1", "2", "3", "4"])
 
         with pytest.raises(ValueError, match="int 4"):
@@ -388,8 +386,8 @@ class TestGuardWorkItemCustomFieldEnums:
     async def test_empty_values_skip_probe_entirely(
         self, mock_client: AsyncMock
     ) -> None:
-        # Payload builders drop empties; nothing reaches Polarion to ghost,
-        # so the guard must not even spend the probe GET.
+        # Payload builders drop empties; nothing reach Polarion to ghost —
+        # guard must not even spend the probe GET.
         await guard_work_item_custom_fields(
             mock_client, "P", "task", {"asil": "", "other": None, "platform": []}
         )
@@ -413,15 +411,14 @@ class TestGuardWorkItemCustomFieldEnums:
         mock_client.get.side_effect = PolarionNotFoundError("not enum", status_code=404)
         clock = [1000.0]
         monkeypatch.setattr(cache_mod, "_now", lambda: clock[0])
-        # The fixture primed the key schema under the real monotonic clock; on
-        # a freshly booted host its expiry can precede 1000.0. Re-prime under
-        # the patched clock so only the enum cache's expiry is measured.
+        # Fixture primed key schema under real monotonic clock; on freshly
+        # booted host its expiry can precede 1000.0. Re-prime under patched
+        # clock so only enum cache expiry measured.
         store_work_item_custom_keys("P", "task", frozenset({"f"}))
 
         await guard_work_item_custom_fields(mock_client, "P", "task", {"f": "x"})
         clock[0] += 61.0  # past _GUARD_TTL_SECONDS, within not_found TTL
-        # The key schema shares the 60s TTL; re-prime so only the enum
-        # cache's expiry is measured.
+        # Key schema share 60s TTL; re-prime so only enum cache expiry measured.
         store_work_item_custom_keys("P", "task", frozenset({"f"}))
         await guard_work_item_custom_fields(mock_client, "P", "task", {"f": "x"})
         assert mock_client.get.await_count == 1
@@ -449,7 +446,7 @@ class TestGuardWorkItemCustomFieldEnums:
 def _typed_workitems_response(
     project_id: str, pairs: list[tuple[str, str]]
 ) -> dict[str, object]:
-    """A JSON:API workitems list response carrying each item's ``type``."""
+    """JSON:API workitems list response carrying each item ``type``."""
     return {
         "data": [
             {
@@ -511,7 +508,7 @@ class TestResolveWorkItemTypes:
     async def test_missing_type_attribute_maps_to_empty(
         self, mock_client: AsyncMock
     ) -> None:
-        # Defensive: entry without attributes still counts as existing.
+        # Defensive: entry without attributes still count as existing.
         mock_client.get.return_value = {
             "data": [{"type": "workitems", "id": "P/A"}, "not-a-dict"]
         }
@@ -521,7 +518,7 @@ class TestResolveWorkItemTypes:
     async def test_non_list_data_treated_as_missing(
         self, mock_client: AsyncMock
     ) -> None:
-        # Defensive: a malformed reply must not pass the existence check.
+        # Defensive: malformed reply must not pass existence check.
         mock_client.get.return_value = {"data": {"type": "workitems"}}
 
         with pytest.raises(ValueError, match="not found"):

--- a/tests/mcp_server_polarion/tools/_shared/test_cache.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_cache.py
@@ -1,4 +1,4 @@
-"""``TTLCache`` + typed wrapper tests; expiry driven by patching the
+"""``TTLCache`` + typed wrapper tests; expiry driven by patching
 module-level ``_now`` clock seam.
 """
 
@@ -38,14 +38,14 @@ def _reset_caches() -> None:
 
 @pytest.fixture
 def clock(monkeypatch: pytest.MonkeyPatch) -> list[float]:
-    """Patch the cache clock to a controllable list-wrapped value."""
+    """Patch cache clock to controllable list-wrapped value."""
     now = [1000.0]
     monkeypatch.setattr(cache_mod, "_now", lambda: now[0])
     return now
 
 
 class TestTTLCachePrimitive:
-    """Behaviour of the generic ``TTLCache`` independent of any wrapper."""
+    """Generic ``TTLCache`` behaviour independent of any wrapper."""
 
     def test_miss_returns_none(self) -> None:
         cache: TTLCache[str, int] = TTLCache(60.0)
@@ -127,7 +127,7 @@ class TestTTLCachePrimitive:
 
 
 class TestDocumentListCache:
-    """The mutable document-discovery listing wrappers."""
+    """Mutable document-discovery listing wrappers."""
 
     def test_store_then_get_returns_a_list_copy(self) -> None:
         doc = DiscoveredDocument("_default", "Doc")
@@ -135,7 +135,7 @@ class TestDocumentListCache:
 
         cached = get_cached_documents("P")
         assert cached == [doc]
-        # A mutation of the returned list must not corrupt the cache.
+        # Mutation of returned list must not corrupt cache.
         assert cached is not None
         cached.append(DiscoveredDocument("_default", "Other"))
         assert get_cached_documents("P") == [doc]
@@ -226,7 +226,7 @@ class TestProjectEnumCache:
 
 
 class TestWorkItemCustomKeys:
-    """``store/get/invalidate_work_item_custom_keys`` — the type's key schema."""
+    """``store/get/invalidate_work_item_custom_keys`` — type key schema."""
 
     def test_store_then_get(self) -> None:
         store_work_item_custom_keys("P", "task", frozenset({"a", "b"}))

--- a/tests/mcp_server_polarion/tools/_shared/test_custom_fields.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_custom_fields.py
@@ -1,6 +1,5 @@
-"""Direct tests for custom-field policy worth pinning beyond the transitive
-per-tool coverage — `extract_custom_fields` / `merge_custom_fields` allowlist
-semantics.
+"""Custom-field policy worth pinning beyond transitive per-tool coverage —
+`extract_custom_fields` / `merge_custom_fields` allowlist semantics.
 """
 
 from __future__ import annotations
@@ -73,7 +72,7 @@ class TestExtractCustomFields:
         }
 
     def test_document_allowlist_filters_document_attrs(self) -> None:
-        # Document allowlist filters document-only keys (homePageContent, moduleFolder).
+        # Document allowlist filter document-only keys (homePageContent, moduleFolder).
         attributes: dict[str, object] = {
             "title": "Doc",
             "type": "req_specification",
@@ -90,8 +89,8 @@ class TestExtractCustomFields:
         }
 
     def test_allowlist_swap_changes_classification(self) -> None:
-        # autoSuspect is standard for documents but custom for work items;
-        # swapping the allowlist flips its classification.
+        # autoSuspect standard for documents but custom for work items;
+        # swapping allowlist flip its classification.
         attributes: dict[str, object] = {"autoSuspect": False}
         assert extract_custom_fields(attributes, STANDARD_DOCUMENT_ATTRIBUTES) == {}
         assert extract_custom_fields(attributes, STANDARD_WORK_ITEM_ATTRIBUTES) == {
@@ -112,7 +111,7 @@ class TestMergeCustomFields:
         assert attributes == {"riskLevel": "high", "effortHours": 8.0}
 
     def test_merges_into_pre_populated_attributes(self) -> None:
-        # Existing standard fields stay; customs are appended.
+        # Existing standard fields stay; customs appended.
         attributes: dict[str, JsonValue] = {"title": "T", "status": "open"}
         merge_custom_fields(
             attributes, {"riskLevel": "high"}, STANDARD_WORK_ITEM_ATTRIBUTES
@@ -152,7 +151,7 @@ class TestMergeCustomFields:
         assert "skip_me" not in attributes
 
     def test_rich_text_dict_passes_through_identity(self) -> None:
-        # {type, value} dict round-trips by identity, no defensive copy.
+        # {type, value} dict round-trip by identity, no defensive copy.
         rich = {"type": "text/html", "value": "<p>x</p>"}
         attributes: dict[str, JsonValue] = {}
         merge_custom_fields(
@@ -163,7 +162,7 @@ class TestMergeCustomFields:
         assert attributes["reviewerNote"] is rich
 
     def test_collision_with_standard_attr_raises(self) -> None:
-        # A custom key overlapping the allowlist would shadow a standard param.
+        # Custom key overlap allowlist = shadow standard param.
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             merge_custom_fields(
                 {},
@@ -172,7 +171,7 @@ class TestMergeCustomFields:
             )
 
     def test_collision_message_lists_offending_keys_sorted(self) -> None:
-        # Collisions reported sorted for a predictable message.
+        # Collisions reported sorted — predictable message.
         with pytest.raises(ValueError) as exc_info:
             merge_custom_fields(
                 {},
@@ -182,7 +181,7 @@ class TestMergeCustomFields:
         assert "['status', 'title']" in str(exc_info.value)
 
     def test_document_allowlist_recognises_document_collisions(self) -> None:
-        # moduleFolder is standard for documents but custom for work items.
+        # moduleFolder standard for documents but custom for work items.
         merge_custom_fields(
             {}, {"moduleFolder": "Design"}, STANDARD_WORK_ITEM_ATTRIBUTES
         )  # OK for work items
@@ -194,7 +193,7 @@ class TestMergeCustomFields:
             )
 
     def test_returns_none_mutates_in_place(self) -> None:
-        # Mutates attributes in place and returns None, like _build_*_payload.
+        # Mutate attributes in place, return None, like _build_*_payload.
         attributes: dict[str, JsonValue] = {}
         result = merge_custom_fields(
             attributes, {"riskLevel": "high"}, STANDARD_WORK_ITEM_ATTRIBUTES

--- a/tests/mcp_server_polarion/tools/_shared/test_helpers.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_helpers.py
@@ -1,6 +1,6 @@
-"""Direct tests for core helpers worth pinning beyond transitive per-tool
-coverage — `format_option_list` rendering, `safe_str` coercion, the slash-encoding
-contract of `encode_path_segment`, the Lucene-id guard, and `get_client` lookup.
+"""Core helpers worth pinning beyond transitive per-tool coverage —
+`format_option_list` rendering, `safe_str` coercion, slash-encoding contract
+of `encode_path_segment`, Lucene-id guard, `get_client` lookup.
 """
 
 from __future__ import annotations
@@ -31,7 +31,7 @@ class TestFormatOptionList:
         assert format_option_list(["a"]) == repr(["a"])
 
     def test_under_limit_identical_to_repr_sorted(self) -> None:
-        # Byte-identical to the old `sorted(option_ids)` interpolation.
+        # Byte-identical to old `sorted(option_ids)` interpolation.
         ids = ["3", "1", "2", "4"]
         assert format_option_list(ids) == repr(["1", "2", "3", "4"])
 
@@ -65,7 +65,7 @@ class TestSafeStr:
     """Tests for `safe_str`."""
 
     def test_none_becomes_empty_string(self) -> None:
-        # None → "" so absent attributes don't surface as the literal "None".
+        # None → "" so absent attributes not surface as literal "None".
         assert safe_str(None) == ""
 
     def test_str_passes_through(self) -> None:
@@ -87,7 +87,7 @@ class TestEncodePathSegment:
         assert encode_path_segment("My Doc") == "My%20Doc"
 
     def test_encodes_slash(self) -> None:
-        # safe="" is the whole point: a document name with "/" must not split
+        # safe="" is the whole point: document name with "/" must not split
         # into extra path segments.
         assert encode_path_segment("a/b") == "a%2Fb"
 
@@ -102,7 +102,7 @@ class TestValidateWorkItemIdForLucene:
     """Tests for `validate_work_item_id_for_lucene`."""
 
     def test_accepts_alphanumeric_hyphen_underscore(self) -> None:
-        # Returns None (no raise) for the allowed character set.
+        # Return None (no raise) for allowed character set.
         assert validate_work_item_id_for_lucene("MCPT-001_a9") is None
 
     @pytest.mark.parametrize(

--- a/tests/mcp_server_polarion/tools/_shared/test_pagination.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_pagination.py
@@ -1,6 +1,6 @@
-"""Direct tests for pagination math — `make_page` total/has_more derivation,
-`compute_has_more`, `extract_total_count`, and `has_links_next` branch coverage.
-Behavior shared by every list tool.
+"""Pagination math — `make_page` total/has_more derivation, `compute_has_more`,
+`extract_total_count`, `has_links_next` branch coverage. Behavior shared by
+every list tool.
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ class TestMakePage:
         assert page.has_more is False  # 2 <= 1 * 10
 
     def test_missing_total_offset_fallback_on_nonempty_page(self) -> None:
-        # No meta.totalCount → estimate from offset + len on a non-empty page.
+        # No meta.totalCount → estimate from offset + len on non-empty page.
         page = make_page(["x", "y", "z"], {}, page_number=2, page_size=10)
         assert page.total_count == 13  # (2 - 1) * 10 + 3
         # raw_total stays 0 → no links.next, 3 != page_size → no more.
@@ -49,12 +49,12 @@ class TestMakePage:
         assert page.has_more is True
 
     def test_has_more_via_full_page_heuristic(self) -> None:
-        # No meta, no links, but a full page implies another may follow.
+        # No meta, no links, but full page imply another may follow.
         page = make_page(["a"] * 10, {}, page_number=1, page_size=10)
         assert page.has_more is True
 
     def test_generic_round_trips_model(self) -> None:
-        # Exercises the PaginatedResult[T] subscript at construction.
+        # Exercise PaginatedResult[T] subscript at construction.
         items = [ProjectSummary(id="p1", name="Proj 1", active=True)]
         page = make_page(items, {"meta": {"totalCount": 1}}, 1, 10)
         assert isinstance(page, PaginatedResult)
@@ -96,7 +96,7 @@ class TestExtractTotalCount:
         assert extract_total_count({"meta": "nope"}) == 0
 
     def test_non_int_total_count_is_zero(self) -> None:
-        # A non-int totalCount (e.g. null/str) coerces to 0, not a raise.
+        # Non-int totalCount (e.g. null/str) coerce to 0, not raise.
         assert extract_total_count({"meta": {"totalCount": None}}) == 0
         assert extract_total_count({"meta": {"totalCount": "12"}}) == 0
 

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -1,6 +1,6 @@
-"""Direct tests for JSON:API parsers worth pinning beyond the transitive
-per-tool coverage — relationship/id extraction edge cases, raw-HTML passthrough,
-comment text-format branches, and the phantom-editor skip.
+"""JSON:API parsers worth pinning beyond transitive per-tool coverage —
+relationship/id extraction edge cases, raw-HTML passthrough, comment
+text-format branches, phantom-editor skip.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ class TestExtractRelationshipId:
         assert extract_relationship_id({}, "author") == ""
 
     def test_to_many_data_list_is_empty(self) -> None:
-        # A to-many `data` is a list, not a dict → no scalar id.
+        # To-many `data` is a list, not dict → no scalar id.
         rels = {"assignee": {"data": [{"id": "proj/u1"}]}}
         assert extract_relationship_id(rels, "assignee") == ""
 
@@ -71,7 +71,7 @@ class TestSplitModuleId:
         assert split_module_id("proj/Design/Spec") == ("Design", "Spec")
 
     def test_document_name_keeps_extra_slashes(self) -> None:
-        # `doc` may contain `/`; only the first two splits are structural.
+        # `doc` may contain `/`; only first two splits structural.
         assert split_module_id("proj/Design/Spec/v2") == ("Design", "Spec/v2")
 
     def test_under_three_segments_is_empty(self) -> None:
@@ -153,7 +153,7 @@ class TestParseIncludedUserNameMap:
         assert parse_included_user_name_map(response) == {"proj/jdoe": "J Doe"}
 
     def test_skips_empty_user_id(self) -> None:
-        # "" key would join with absent-author "" → phantom editor; must be dropped.
+        # "" key would join absent-author "" → phantom editor; must drop.
         response: dict[str, object] = {
             "included": [{"type": "users", "id": "", "attributes": {"name": "Ghost"}}]
         }
@@ -398,7 +398,7 @@ class TestParseEnumOption:
     """Tests for `parse_enum_option` bool coercion."""
 
     def test_coerces_non_bool_flags_to_false(self) -> None:
-        # Non-bool flag values default to False rather than raising.
+        # Non-bool flag values default to False rather than raise.
         option = parse_enum_option(
             {"id": "open", "name": "Open", "default": "yes", "hidden": 1}
         )

--- a/tests/mcp_server_polarion/tools/conftest.py
+++ b/tests/mcp_server_polarion/tools/conftest.py
@@ -1,5 +1,5 @@
-"""Shared fixtures: tools called directly with a mock ``PolarionClient``
-injected via a mock ``Context``.
+"""Shared fixtures: tools called direct with mock ``PolarionClient``
+injected via mock ``Context``.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ from mcp_server_polarion.tools._shared import cache as _cache_mod
 
 
 def _clear_guard_caches() -> None:
-    """Drop the enum / custom-field guard caches owned by ``_shared/cache.py``."""
+    """Drop enum / custom-field guard caches owned by ``_shared/cache.py``."""
     _cache_mod._enum_option_cache.clear()
     _cache_mod._project_enum_cache.clear()
     _cache_mod._work_item_custom_key_cache.clear()
@@ -23,7 +23,7 @@ def _clear_guard_caches() -> None:
 
 @pytest.fixture(autouse=True)
 def _reset_guard_caches() -> None:
-    """Cold guard caches per test — a key primed by one test would leak into the
+    """Cold guard caches per test — key primed by one test would leak into
     next and mask a missing priming GET.
     """
     _clear_guard_caches()
@@ -31,11 +31,11 @@ def _reset_guard_caches() -> None:
 
 @pytest.fixture
 def mock_client() -> AsyncMock:
-    """Return a mock PolarionClient with async methods."""
+    """Mock PolarionClient with async methods."""
     client = AsyncMock(spec=PolarionClient)
-    # Default to an empty dict: an unstubbed GET (e.g. an enum-options probe a
-    # test doesn't care about) then defers cleanly instead of returning a nested
-    # AsyncMock whose ``.get`` leaks an unawaited coroutine.
+    # Default empty dict: unstubbed GET (e.g. enum-options probe a test
+    # doesn't care about) then defer cleanly instead of returning nested
+    # AsyncMock whose ``.get`` leak an unawaited coroutine.
     client.get = AsyncMock(return_value={})
     client.post = AsyncMock()
     client.patch = AsyncMock()
@@ -45,7 +45,7 @@ def mock_client() -> AsyncMock:
 
 @pytest.fixture
 def mock_ctx(mock_client: AsyncMock) -> MagicMock:
-    """Return a mock FastMCP Context with the mock client."""
+    """Mock FastMCP Context with the mock client."""
     ctx = MagicMock()
     ctx.lifespan_context = {
         "polarion_client": mock_client,

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -1,4 +1,4 @@
-"""Tests for the comment tools."""
+"""Comment tool tests."""
 
 from __future__ import annotations
 
@@ -36,7 +36,7 @@ from mcp_server_polarion.tools.comments import (
 
 
 class TestListDocumentComments:
-    """Tests for the ``list_document_comments`` tool."""
+    """``list_document_comments`` tool."""
 
     async def test_returns_paginated_result(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -349,7 +349,7 @@ class TestListDocumentComments:
 
 
 class TestListWorkItemComments:
-    """Tests for the ``list_work_item_comments`` tool."""
+    """``list_work_item_comments`` tool."""
 
     async def test_returns_paginated_result(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -651,7 +651,7 @@ class TestListWorkItemComments:
 
 
 class TestBuildDocumentCommentsPayload:
-    """Unit tests for the private ``_build_document_comments_payload`` helper."""
+    """Private ``_build_document_comments_payload`` helper."""
 
     def test_single_plain_text_spec(self) -> None:
         payload = _build_document_comments_payload(
@@ -729,7 +729,7 @@ class TestBuildDocumentCommentsPayload:
         }
 
     def test_parent_comment_full_path_composed(self) -> None:
-        """Short parent_comment_id is expanded to the full 4-segment path."""
+        """Short parent_comment_id expanded to full 4-segment path."""
         payload = _build_document_comments_payload(
             specs=[CommentSpec(text="t", parent_comment_id="c1")],
             project_id="Proj",
@@ -775,7 +775,7 @@ class TestBuildDocumentCommentsPayload:
         assert len(payload["data"]) == 1  # type: ignore[arg-type]
 
     def test_no_title_for_documents(self) -> None:
-        """Base CommentSpec has no title field, so it never reaches attributes."""
+        """Base CommentSpec has no title field — never reach attributes."""
         spec = CommentSpec(text="t")
         assert not hasattr(spec, "title")
         payload = _build_document_comments_payload(
@@ -789,7 +789,7 @@ class TestBuildDocumentCommentsPayload:
 
 
 class TestCreateDocumentCommentsDryRun:
-    """Verify dry_run returns preview without calling Polarion."""
+    """dry_run return preview without calling Polarion."""
 
     async def test_dry_run_no_post_call(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -846,7 +846,7 @@ class TestCreateDocumentCommentsDryRun:
 
 
 class TestCreateDocumentCommentsHappyPath:
-    """Verify successful creation extracts and returns short comment IDs."""
+    """Successful creation extract and return short comment IDs."""
 
     async def test_returns_short_comment_ids(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -951,7 +951,7 @@ class TestCreateDocumentCommentsHappyPath:
 
 
 class TestCreateDocumentCommentsErrors:
-    """Verify domain exceptions map to the correct public exceptions."""
+    """Domain exceptions map to correct public exceptions."""
 
     async def test_auth_error_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1000,7 +1000,7 @@ class TestCreateDocumentCommentsErrors:
     async def test_empty_response_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """201 with no IDs must raise rather than silently return created=True."""
+        """201 with no IDs must raise, not silently return created=True."""
         mock_client.post.return_value = {}
         with pytest.raises(RuntimeError, match="no comment IDs"):
             await create_document_comments(
@@ -1015,8 +1015,8 @@ class TestCreateDocumentCommentsErrors:
 
 class TestCreateDocumentCommentsFieldValidation:
     """Field constraints on create_document_comments / CommentSpec — direct
-    calls bypass FastMCP's JSON Schema gate, so rebuild a ``TypeAdapter`` per
-    parameter to prove the constraint is wired.
+    calls bypass FastMCP JSON Schema gate; rebuild ``TypeAdapter`` per
+    parameter to prove constraint wired.
     """
 
     @staticmethod
@@ -1064,7 +1064,7 @@ class TestCreateDocumentCommentsFieldValidation:
 
 
 class TestBuildWorkItemCommentsPayload:
-    """Unit tests for the private ``_build_work_item_comments_payload`` helper."""
+    """Private ``_build_work_item_comments_payload`` helper."""
 
     def test_single_plain_text_spec(self) -> None:
         payload = _build_work_item_comments_payload(
@@ -1095,7 +1095,7 @@ class TestBuildWorkItemCommentsPayload:
         assert attrs["title"] == "Heads up"  # type: ignore[index]
 
     def test_empty_title_omitted(self) -> None:
-        """Empty title is dropped, not sent as a blank heading."""
+        """Empty title dropped, not sent as blank heading."""
         payload = _build_work_item_comments_payload(
             specs=[WorkItemCommentSpec(text="t", title="")],
             project_id="P",
@@ -1136,7 +1136,7 @@ class TestBuildWorkItemCommentsPayload:
         }
 
     def test_parent_comment_full_path_composed(self) -> None:
-        """Short parent_comment_id is expanded to the full 3-segment path."""
+        """Short parent_comment_id expanded to full 3-segment path."""
         payload = _build_work_item_comments_payload(
             specs=[WorkItemCommentSpec(text="t", parent_comment_id="c1")],
             project_id="Proj",
@@ -1160,7 +1160,7 @@ class TestBuildWorkItemCommentsPayload:
 
 
 class TestCreateWorkItemCommentsDryRun:
-    """Verify dry_run returns preview without calling Polarion."""
+    """dry_run return preview without calling Polarion."""
 
     async def test_dry_run_no_post_call(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1196,7 +1196,7 @@ class TestCreateWorkItemCommentsDryRun:
 
 
 class TestCreateWorkItemCommentsHappyPath:
-    """Verify successful creation extracts and returns short comment IDs."""
+    """Successful creation extract and return short comment IDs."""
 
     async def test_returns_short_comment_ids(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1271,7 +1271,7 @@ class TestCreateWorkItemCommentsHappyPath:
 
 
 class TestCreateWorkItemCommentsErrors:
-    """Verify domain exceptions map to the correct public exceptions."""
+    """Domain exceptions map to correct public exceptions."""
 
     async def test_auth_error_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1317,7 +1317,7 @@ class TestCreateWorkItemCommentsErrors:
     async def test_empty_response_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """201 with no IDs must raise rather than silently return created=True."""
+        """201 with no IDs must raise, not silently return created=True."""
         mock_client.post.return_value = {}
         with pytest.raises(RuntimeError, match="no comment IDs"):
             await create_work_item_comments(
@@ -1331,8 +1331,8 @@ class TestCreateWorkItemCommentsErrors:
 
 class TestCreateWorkItemCommentsFieldValidation:
     """Field constraints on create_work_item_comments — direct calls bypass
-    FastMCP's JSON Schema gate, so rebuild a ``TypeAdapter`` per parameter to
-    prove the constraint is wired.
+    FastMCP JSON Schema gate; rebuild ``TypeAdapter`` per parameter to
+    prove constraint wired.
     """
 
     @staticmethod
@@ -1364,7 +1364,7 @@ class TestCreateWorkItemCommentsFieldValidation:
 
 
 class TestBuildDocumentCommentUpdatePayload:
-    """Unit tests for _build_document_comment_update_payload (no I/O)."""
+    """_build_document_comment_update_payload (no I/O)."""
 
     def _build(
         self,
@@ -1651,7 +1651,7 @@ class TestUpdateDocumentCommentErrors:
 
 
 class TestBuildWorkItemCommentUpdatePayload:
-    """Unit tests for _build_work_item_comment_update_payload (no I/O)."""
+    """_build_work_item_comment_update_payload (no I/O)."""
 
     def _build(
         self,

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -1,4 +1,4 @@
-"""Tests for the document query/read/create/update tools."""
+"""Document query/read/create/update tool tests."""
 
 from __future__ import annotations
 
@@ -50,7 +50,7 @@ def _make_part(
     work_item_id: str = "",
     outline_number: str = "",
 ) -> DocumentPart:
-    """Build a ``DocumentPart`` with sensible defaults for render-rule tests."""
+    """``DocumentPart`` with sensible defaults for render-rule tests."""
     return DocumentPart(
         id=part_id,
         title=title,
@@ -70,8 +70,8 @@ def _make_part(
 def _stub_parts(
     monkeypatch: pytest.MonkeyPatch, parts: list[DocumentPart]
 ) -> AsyncMock:
-    """Replace ``read_document_parts`` with an AsyncMock returning *parts*; page
-    metadata derived from the list. Returns the mock for call assertions.
+    """Replace ``read_document_parts`` with AsyncMock returning *parts*; page
+    metadata derived from list. Return mock for call assertions.
     """
     stub = AsyncMock(
         return_value=PaginatedResult[DocumentPart](
@@ -87,7 +87,7 @@ def _stub_parts(
 
 
 def _enum_get_response(ids: list[str]) -> dict[str, object]:
-    """Shape a ``getAvailableOptions`` reply for the guard tests."""
+    """``getAvailableOptions`` reply for guard tests."""
     return {
         "data": [{"id": i, "name": i} for i in ids],
         "meta": {"totalCount": len(ids)},
@@ -95,7 +95,7 @@ def _enum_get_response(ids: list[str]) -> dict[str, object]:
 
 
 async def _call_create_doc(mock_ctx: MagicMock, **overrides: object) -> object:
-    """Invoke ``create_document`` with explicit defaults for every Field."""
+    """Invoke ``create_document``, explicit defaults for every Field."""
     defaults: dict[str, object] = {
         "project_id": "MyProj",
         "space_id": "_default",
@@ -112,7 +112,7 @@ async def _call_create_doc(mock_ctx: MagicMock, **overrides: object) -> object:
 
 
 async def _call_update_doc(mock_ctx: MagicMock, **overrides: object) -> object:
-    """Invoke ``update_document`` with explicit defaults for every Field."""
+    """Invoke ``update_document``, explicit defaults for every Field."""
     defaults: dict[str, object] = {
         "project_id": "MyProj",
         "space_id": "_default",
@@ -131,7 +131,7 @@ async def _call_update_doc(mock_ctx: MagicMock, **overrides: object) -> object:
 
 @pytest.fixture
 def reset_enum_guard_caches() -> None:
-    """Drop guard caches between integration tests so each scenario starts cold."""
+    """Drop guard caches between tests — each scenario start cold."""
     _cache_mod._enum_option_cache.clear()
     _cache_mod._project_enum_cache.clear()
     _cache_mod._work_item_custom_key_cache.clear()
@@ -147,7 +147,7 @@ def _module_resource(
     author_id: str = "",
     updated_by_id: str = "",
 ) -> dict:
-    """An ``included`` document resource as returned by ``include=module``."""
+    """``included`` document resource as returned by ``include=module``."""
     attributes: dict = {"type": doc_type}
     if status:
         attributes["status"] = status
@@ -165,7 +165,7 @@ def _module_resource(
 
 
 def _user_resource(user_id: str, name: str) -> dict:
-    """An ``included`` user resource as returned by an ``include=`` user path."""
+    """``included`` user resource from ``include=`` user path."""
     return {"type": "users", "id": user_id, "attributes": {"name": name}}
 
 
@@ -175,10 +175,10 @@ def _discovery_response(
     total: int | None = None,
     data_count: int | None = None,
 ) -> dict:
-    """Build a discovery page: ``data`` drives pagination, ``included`` the docs.
+    """Discovery page: ``data`` drive pagination, ``included`` the docs.
 
-    Discovery reads documents from ``included``; ``data`` (one heading per doc)
-    only feeds the page-walk loop, so its rows are bare placeholders.
+    Discovery read documents from ``included``; ``data`` (one heading per
+    doc) only feed page-walk loop — rows are bare placeholders.
     """
     rows = data_count if data_count is not None else len(included)
     response: dict = {
@@ -191,14 +191,14 @@ def _discovery_response(
 
 
 class TestListDocuments:
-    """Tests for the ``list_documents`` tool."""
+    """``list_documents`` tool."""
 
     @pytest.fixture(autouse=True)
     def _clear_doc_cache(self) -> Iterator[None]:
-        """Reset the module-level TTL cache around every test.
+        """Reset module-level TTL cache around every test.
 
-        Several tests reuse ``project_id='proj1'``, so without this the
-        first test would poison subsequent tests via cache hits.
+        Several tests reuse ``project_id='proj1'`` — without reset, first
+        test poison later ones via cache hits.
         """
         _cache_mod._document_list_cache.clear()
         yield
@@ -269,7 +269,7 @@ class TestListDocuments:
     async def test_unresolved_user_yields_empty_name(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """A relationship pointing at a user missing from ``included`` → ``""``."""
+        """Relationship point at user missing from ``included`` → ``""``."""
         included = [
             _module_resource("proj1/_default/Doc1", author_id="ghost"),
         ]
@@ -289,7 +289,7 @@ class TestListDocuments:
     async def test_id_less_included_user_never_matches(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """An id-less included user must not join with an absent relationship."""
+        """Id-less included user must not join with absent relationship."""
         included = [
             _module_resource("proj1/_default/Doc1"),
             {"type": "users", "attributes": {"name": "Phantom"}},
@@ -390,7 +390,7 @@ class TestListDocuments:
     async def test_linear_scan_walks_all_pages(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Discovery walks every document page exactly once."""
+        """Discovery walk every document page exactly once."""
         page = {
             1: ([_module_resource("p/S/DocA")], 100),
             2: ([_module_resource("p/S/DocA"), _module_resource("p/S/DocB")], 100),
@@ -419,8 +419,8 @@ class TestListDocuments:
     async def test_linear_scan_stops_on_partial_page(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """A short final page (without totalCount/links.next) ends the loop."""
-        # Partial page 2 (50 < 100) with no totalCount stops the scan.
+        """Short final page (no totalCount/links.next) end the loop."""
+        # Partial page 2 (50 < 100), no totalCount — stop scan.
         page = {
             1: ([_module_resource("p/S/DocA")], 100),
             2: ([_module_resource("p/S/DocB")], 50),
@@ -445,7 +445,7 @@ class TestListDocuments:
     async def test_single_page_uses_one_call(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Multiple documents on a single page → one API call."""
+        """Multiple documents on single page → one API call."""
         included = [
             _module_resource("p/S/Alpha"),
             _module_resource("p/S/Bravo"),
@@ -471,7 +471,7 @@ class TestListDocuments:
     async def test_cache_hit_skips_api_calls(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """A second call with the same project_id is served from cache."""
+        """Second call with same project_id served from cache."""
         mock_client.get.return_value = _discovery_response(
             [_module_resource("proj1/_default/Doc1")], total=1
         )
@@ -496,7 +496,7 @@ class TestListDocuments:
         """Different project IDs do not share cache entries."""
 
         async def _mock_get(_path, *, params=None):
-            # Return a distinct document per call so cross-project sharing shows up.
+            # Distinct document per call — cross-project sharing show up.
             return _discovery_response(
                 [_module_resource(f"x/S/Doc{mock_client.get.call_count}")], total=1
             )
@@ -505,7 +505,7 @@ class TestListDocuments:
 
         await list_documents(mock_ctx, project_id="projA", page_size=100, page_number=1)
         await list_documents(mock_ctx, project_id="projB", page_size=100, page_number=1)
-        # Each project triggered its own fetch — no cross-project cache hit.
+        # Each project trigger own fetch — no cross-project cache hit.
         assert mock_client.get.call_count == 2
 
     async def test_cache_expires_after_ttl(
@@ -514,7 +514,7 @@ class TestListDocuments:
         mock_client: AsyncMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """After TTL elapses, the next call re-fetches from the API."""
+        """After TTL elapse, next call re-fetch from API."""
         mock_client.get.return_value = _discovery_response(
             [_module_resource("proj1/_default/Doc1")], total=1
         )
@@ -529,7 +529,6 @@ class TestListDocuments:
         await list_documents(mock_ctx, project_id="proj1", page_size=100, page_number=1)
         first_calls = mock_client.get.call_count
 
-        # Advance time past the TTL.
         fake_now[0] += _cache_mod._DOCUMENT_LIST_TTL_SECONDS + 1.0
 
         await list_documents(mock_ctx, project_id="proj1", page_size=100, page_number=1)
@@ -556,20 +555,20 @@ class TestListDocuments:
             call_args[0][1] if len(call_args[0]) > 1 else {},
         )
         query = params["query"]
-        # SQL GROUP BY collapses every heading to one row per document.
+        # SQL GROUP BY collapse headings to one row per document.
         assert query.startswith("SQL:(")
         assert "GROUP BY mod.c_uri" in query
         assert "wi.c_type = 'heading'" in query
-        # Recycle-bin exclusion mirrors the Lucene type:heading default.
+        # Recycle-bin exclusion mirror Lucene type:heading default.
         assert "wi.c_deleted IS NOT TRUE" in query
         assert "p.c_id = 'proj1'" in query
-        # module pulls document attributes, the dot-paths the editors' names;
-        # the intermediate ``module`` must stay listed or documents drop out.
+        # module pull document attrs, dot-paths the editor names;
+        # intermediate ``module`` must stay listed or documents drop out.
         assert params["include"] == "module,module.author,module.updatedBy"
         # Relationship names listed explicitly: sparse fieldsets drop them.
         assert params["fields[documents]"] == "type,status,updated,author,updatedBy"
         assert params["fields[users]"] == "name"
-        # No sort=module: server-side sort costs more than client-side dedup.
+        # No sort=module: server-side sort cost more than client-side dedup.
         assert "sort" not in params
 
     async def test_not_found_raises_value_error(
@@ -602,7 +601,7 @@ class TestListDocuments:
 
 
 class TestGetDocument:
-    """Tests for the ``get_document`` tool."""
+    """``get_document`` tool."""
 
     async def test_returns_document_detail(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -646,10 +645,10 @@ class TestGetDocument:
         assert result.type == "req_specification"
         assert result.status == "approved"
         assert result.updated == "2026-02-22T14:53:03.244Z"
-        # Editor names resolved from the included users; ids never surface.
+        # Editor names resolved from included users; ids never surface.
         assert result.author == "System Administrator"
         assert result.last_updated_by == "Dev Member"
-        # Raw HTML round-trip: <p> and <strong> tags survive verbatim.
+        # Raw HTML round-trip: <p>/<strong> survive verbatim.
         assert result.content_html == (
             "<p>This is the <strong>SRS</strong> document.</p>"
         )
@@ -719,7 +718,7 @@ class TestGetDocument:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         """include_homepage_content_html=False → body hidden even though ``@all``
-        always carries it on the wire.
+        always carry it on wire.
         """
         mock_client.get.return_value = {
             "data": {
@@ -752,7 +751,7 @@ class TestGetDocument:
     async def test_include_homepage_content_html_returns_raw_html(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """include_homepage_content_html=True → raw HTML in content_html (no markdownify)."""  # noqa: E501
+        """include_homepage_content_html=True → raw HTML, no markdownify."""
         mock_client.get.return_value = {
             "data": {
                 "attributes": {
@@ -781,8 +780,8 @@ class TestGetDocument:
     async def test_polarion_specific_markup_round_trips(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Core round-trip guarantee: Polarion spans / data-* attrs survive read, so
-        the string can go back into update_document unchanged.
+        """Core round-trip guarantee: Polarion spans / data-* attrs survive read —
+        string can go back into update_document unchanged.
         """
         raw = (
             '<p>See <span class="polarion-rte-link" '
@@ -871,7 +870,7 @@ class TestGetDocument:
     async def test_no_content_field(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Missing homePageContent → content stays empty even when requested."""
+        """Missing homePageContent → content stay empty even when requested."""
         mock_client.get.return_value = {
             "data": {
                 "attributes": {
@@ -894,7 +893,7 @@ class TestGetDocument:
     async def test_custom_fields_populated_from_response(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Inline non-standard attributes flow through as ``custom_fields``."""
+        """Inline non-standard attrs flow through as ``custom_fields``."""
         rich_value = {"type": "text/html", "value": "<p>note</p>"}
         mock_client.get.return_value = {
             "data": {
@@ -956,7 +955,7 @@ class TestGetDocument:
     async def test_sparse_fieldset_uses_all_token(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``fields[documents]=@all`` is sent regardless of the include flag."""
+        """``fields[documents]=@all`` sent regardless of include flag."""
         mock_client.get.return_value = {
             "data": {
                 "attributes": {"title": "x", "type": "generic", "status": "draft"},
@@ -972,7 +971,7 @@ class TestGetDocument:
         )
         _, kwargs_a = mock_client.get.call_args
         assert kwargs_a["params"]["fields[documents]"] == "@all"
-        # Editor names ride along on the same request.
+        # Editor names ride same request.
         assert kwargs_a["params"]["include"] == "author,updatedBy"
         assert kwargs_a["params"]["fields[users]"] == "name"
 
@@ -988,7 +987,7 @@ class TestGetDocument:
 
 
 class TestReadDocumentParts:
-    """Tests for the ``read_document_parts`` tool."""
+    """``read_document_parts`` tool."""
 
     async def test_returns_document_parts(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1179,8 +1178,8 @@ class TestReadDocumentParts:
     async def test_uses_tight_workitem_fieldset(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Embedded work items use WORK_ITEM_PART_FIELDS, not ``@all`` — ``@all`` ships
-        KBs of unused inline customs per page.
+        """Embedded work items use WORK_ITEM_PART_FIELDS, not ``@all`` — ``@all``
+        ship KBs of unused inline customs per page.
         """
         mock_client.get.return_value = {
             "data": [],
@@ -1223,7 +1222,7 @@ class TestReadDocumentParts:
     async def test_string_content_field(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Plain string content (not dict) is handled for normal parts."""
+        """Plain string content (not dict) handled for normal parts."""
         mock_client.get.return_value = {
             "data": [
                 {
@@ -1255,7 +1254,7 @@ class TestReadDocumentParts:
     async def test_tof_part_reclassified_from_id_prefix(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Polarion reports TOF as ``type=normal``; the ID prefix wins."""
+        """Polarion report TOF as ``type=normal``; ID prefix win."""
         mock_client.get.return_value = {
             "data": [
                 {
@@ -1285,7 +1284,7 @@ class TestReadDocumentParts:
     async def test_page_break_part_reclassified_from_id_prefix(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``pagebreak_*`` IDs are surfaced as ``page_break`` parts."""
+        """``pagebreak_*`` IDs surface as ``page_break`` parts."""
         mock_client.get.return_value = {
             "data": [
                 {
@@ -1468,13 +1467,13 @@ class TestReadDocumentParts:
 
 
 class TestReadDocument:
-    """Tests for the ``read_document`` tool."""
+    """``read_document`` tool."""
 
-    # End-to-end wiring: exercises read_document_parts via client.get.
+    # End-to-end wiring: exercise read_document_parts via client.get.
     async def test_end_to_end_renders_document(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Real fetch path: stub the HTTP layer, verify the rendered Markdown."""
+        """Real fetch path: stub HTTP layer, verify rendered Markdown."""
         mock_client.get.return_value = {
             "data": [
                 {
@@ -1526,7 +1525,7 @@ class TestReadDocument:
                     "id": "proj1/_default/SRS/polarion_2",
                     "attributes": {
                         "id": "polarion_2",
-                        # Empty paragraph — should not appear in the render.
+                        # Empty paragraph — must not appear in render.
                         "content": "<p></p>",
                         "type": "normal",
                     },
@@ -1590,7 +1589,7 @@ class TestReadDocument:
     async def test_pagination_params_forwarded_to_http(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``page_size`` / ``page_number`` reach the underlying client.get call."""
+        """``page_size``/``page_number`` reach underlying client.get call."""
         mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
 
         await read_document(
@@ -1628,7 +1627,7 @@ class TestReadDocument:
     async def test_not_found_propagates_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Delegation to ``read_document_parts`` surfaces its ValueError verbatim."""
+        """Delegation to ``read_document_parts`` surface its ValueError verbatim."""
         mock_client.get.side_effect = PolarionNotFoundError(
             "Not found", status_code=404
         )
@@ -1728,7 +1727,7 @@ class TestReadDocument:
     async def test_empty_normal_parts_skipped(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Polarion's empty placeholder paragraphs (polarion_3, _4, ...) drop out."""
+        """Polarion empty placeholder paragraphs (polarion_3, _4, ...) drop out."""
         _stub_parts(
             monkeypatch,
             [
@@ -1852,7 +1851,7 @@ class TestReadDocument:
     async def test_wikiblock_without_macro_falls_back_to_plain_fence(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A wikiblock that doesn't start with ``#name(`` keeps its plain fence."""
+        """Wikiblock not starting with ``#name(`` keep plain fence."""
         _stub_parts(
             monkeypatch,
             [_make_part(type_="wikiblock", content="```\njust text\n```")],
@@ -1872,7 +1871,7 @@ class TestReadDocument:
     async def test_empty_wikiblock_skipped(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Whitespace-only wikiblock is dropped, mirroring empty normal parts."""
+        """Whitespace-only wikiblock dropped, mirror empty normal parts."""
         _stub_parts(
             monkeypatch,
             [
@@ -1896,7 +1895,7 @@ class TestReadDocument:
     async def test_heading_level_clamp_low(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``level=0`` (the model default for non-headings) becomes ``#``."""
+        """``level=0`` (model default for non-headings) become ``#``."""
         _stub_parts(
             monkeypatch,
             [_make_part(type_="heading", title="Corrupt", level=0)],
@@ -1916,7 +1915,7 @@ class TestReadDocument:
     async def test_heading_level_clamp_high(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``level`` above 6 clamps to ``######`` to stay valid Markdown."""
+        """``level`` above 6 clamp to ``######`` — stay valid Markdown."""
         _stub_parts(
             monkeypatch,
             [_make_part(type_="heading", title="Deep", level=10)],
@@ -1936,7 +1935,7 @@ class TestReadDocument:
     async def test_heading_with_outline_number_prefix(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Outline number is prefixed before the heading title."""
+        """Outline number prefixed before heading title."""
         _stub_parts(
             monkeypatch,
             [
@@ -1960,7 +1959,7 @@ class TestReadDocument:
     async def test_heading_without_outline_number_unchanged(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Headings without an outline number render as before."""
+        """Headings without outline number render as before."""
         _stub_parts(
             monkeypatch,
             [_make_part(type_="heading", title="Standalone", level=2)],
@@ -1980,7 +1979,7 @@ class TestReadDocument:
     async def test_newline_collapse(
         self, mock_ctx: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Runs of 3+ blank lines from joined chunks collapse to a single blank."""
+        """Runs of 3+ blank lines from joined chunks collapse to one blank."""
         _stub_parts(
             monkeypatch,
             [
@@ -2032,8 +2031,8 @@ class TestReadDocument:
 
 
 class TestReadDocumentFieldValidation:
-    """Field constraints on ``read_document`` — direct calls bypass FastMCP's JSON
-    Schema gate, so rebuild a ``TypeAdapter`` per parameter.
+    """Field constraints on ``read_document`` — direct calls bypass FastMCP JSON
+    Schema gate, so rebuild ``TypeAdapter`` per parameter.
     """
 
     @staticmethod
@@ -2063,10 +2062,10 @@ class TestReadDocumentFieldValidation:
 
 
 class TestBuildUpdateDocumentPayload:
-    """Tests for the private ``_build_update_document_payload`` helper."""
+    """Private ``_build_update_document_payload`` helper."""
 
     def test_only_set_fields_appear_in_attributes(self) -> None:
-        # None fields stay unserialized so JSON:API omit-preserve applies.
+        # None fields stay unserialized — JSON:API omit-preserve apply.
         payload = _build_update_document_payload(
             project_id="MyProj",
             space_id="Requirements",
@@ -2105,7 +2104,7 @@ class TestBuildUpdateDocumentPayload:
         }
 
     def test_no_attributes_when_all_fields_are_none(self) -> None:
-        # All-None yields no attributes key; the tool rejects this upstream.
+        # All-None yield no attributes key; tool reject upstream.
         payload = _build_update_document_payload(
             project_id="MyProj",
             space_id="S",
@@ -2120,7 +2119,7 @@ class TestBuildUpdateDocumentPayload:
         assert data["id"] == "MyProj/S/D"
 
     def test_homepagecontent_omitted_when_not_passed(self) -> None:
-        # Omitting home_page_content_html leaves the body untouched.
+        # Omit home_page_content_html leave body untouched.
         payload = _build_update_document_payload(
             project_id="MyProj",
             space_id="S",
@@ -2179,7 +2178,7 @@ class TestBuildUpdateDocumentPayload:
         assert attributes == {"complianceLevel": "L3", "reviewerName": "alice"}
 
     def test_custom_fields_collision_raises_for_document_standard(self) -> None:
-        # ``moduleFolder`` is in the document standard set — collision.
+        # ``moduleFolder`` in document standard set — collision.
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             _build_update_document_payload(
                 project_id="MyProj",
@@ -2225,7 +2224,7 @@ class TestBuildUpdateDocumentPayload:
         assert "usesOutlineNumbering" not in body_str
 
     def test_false_autosuspect_and_outline_are_serialised(self) -> None:
-        # False (unlike None) clears the values server-side.
+        # False (unlike None) clear values server-side.
         payload = _build_update_document_payload(
             project_id="MyProj",
             space_id="S",
@@ -2246,7 +2245,7 @@ class TestBuildUpdateDocumentPayload:
 
 
 class TestUpdateDocumentValidation:
-    """Tool-layer validation that protects against empty / no-op PATCHes."""
+    """Tool-layer validation against empty / no-op PATCHes."""
 
     async def test_no_fields_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -2293,8 +2292,8 @@ class TestUpdateDocumentValidation:
     async def test_custom_fields_unresolvable_type_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Doc exists but carries no type attr: cannot key the schema guard, so the
-        # write is refused rather than validated against an empty "" schema.
+        # Doc exists but no type attr: cannot key schema guard, so write
+        # refused rather than validated against empty "" schema.
         mock_client.get.return_value = {"data": {"attributes": {"title": "D"}}}
         with pytest.raises(RuntimeError, match="no resolvable type"):
             await update_document(
@@ -2315,7 +2314,7 @@ class TestUpdateDocumentValidation:
     async def test_workflow_action_with_status_passes(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # workflow_action paired with at least one attribute is OK.
+        # workflow_action paired with at least one attribute = OK.
         result = await update_document(
             mock_ctx,
             project_id="MyProj",
@@ -2334,7 +2333,7 @@ class TestUpdateDocumentValidation:
     async def test_custom_fields_alone_satisfies_at_least_one_check(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # custom_fields counts as a body field; the type sample knows the key.
+        # custom_fields count as body field; type sample know the key.
         mock_client.get.return_value = {
             "data": {"attributes": {"title": "D", "type": "generic"}}
         }
@@ -2359,7 +2358,7 @@ class TestUpdateDocumentValidation:
     async def test_workflow_action_with_custom_fields_passes(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # workflow_action + custom_fields-only satisfies the body-field check.
+        # workflow_action + custom_fields-only satisfy body-field check.
         mock_client.get.return_value = {
             "data": {"attributes": {"title": "D", "type": "generic"}}
         }
@@ -2386,8 +2385,8 @@ class TestUpdateDocumentValidation:
     ) -> None:
         """workflow_action + home_page_content_html-only is OK.
 
-        home_page_content_html counts as the required attribute, so the
-        body-field check must not regress to title/status/type/customs only.
+        home_page_content_html count as required attribute — body-field
+        check must not regress to title/status/type/customs only.
         """
         result = await update_document(
             mock_ctx,
@@ -2403,7 +2402,7 @@ class TestUpdateDocumentValidation:
             dry_run=True,
         )
         assert result.dry_run is True
-        # Payload carries both the body and the workflow query param.
+        # Payload carry both body and workflow query param.
         assert result.payload_preview is not None
         item = cast(dict[str, object], result.payload_preview["data"])
         attributes = cast(dict[str, object], item["attributes"])
@@ -2434,8 +2433,8 @@ class TestUpdateDocumentValidation:
     async def test_custom_fields_homepagecontent_collision_raises(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """`homePageContent` collision raises — allowing it via custom_fields would
-        bypass the explicit parameter and its empty-string guard.
+        """`homePageContent` collision raise — allow via custom_fields would
+        bypass explicit parameter and its empty-string guard.
         """
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             await update_document(
@@ -2460,7 +2459,7 @@ class TestUpdateDocumentValidation:
 
 
 class TestUpdateDocumentDryRun:
-    """Tests for ``update_document`` with ``dry_run=True``."""
+    """``update_document`` with ``dry_run=True``."""
 
     async def test_dry_run_returns_payload_without_calling_patch(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -2493,7 +2492,7 @@ class TestUpdateDocumentDryRun:
 
 
 class TestUpdateDocumentHappyPath:
-    """Tests for a successful ``update_document`` call."""
+    """Successful ``update_document`` call."""
 
     async def test_returns_updated_true_on_204(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -2575,7 +2574,7 @@ class TestUpdateDocumentHappyPath:
     async def test_home_page_content_html_is_sent_verbatim(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """home_page_content_html passes through with no sanitization."""
+        """home_page_content_html pass through, no sanitization."""
         mock_client.patch.return_value = {}
 
         raw = (
@@ -2631,7 +2630,7 @@ class TestUpdateDocumentHappyPath:
     async def test_home_page_content_html_empty_string_raises(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Empty string is rejected at the tool layer (body-wipe guard)."""
+        """Empty string rejected at tool layer (body-wipe guard)."""
         with pytest.raises(ValueError, match="would wipe"):
             await update_document(
                 mock_ctx,
@@ -2655,7 +2654,7 @@ class TestUpdateDocumentHappyPath:
         mock_client: AsyncMock,
         whitespace: str,
     ) -> None:
-        """Whitespace-only strings strip to '' on the server, so reject too."""
+        """Whitespace-only strings strip to '' server-side — reject too."""
         with pytest.raises(ValueError, match="would wipe"):
             await update_document(
                 mock_ctx,
@@ -2675,7 +2674,7 @@ class TestUpdateDocumentHappyPath:
     async def test_home_page_content_html_alone_passes_has_attrs_guard(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """home_page_content_html alone counts as a body field."""
+        """home_page_content_html alone count as body field."""
         result = await update_document(
             mock_ctx,
             project_id="MyProj",
@@ -2694,7 +2693,7 @@ class TestUpdateDocumentHappyPath:
     async def test_outline_param_alone_passes_has_attrs_guard(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """An outline/suspect param alone satisfies the has_attrs guard."""
+        """Outline/suspect param alone satisfy has_attrs guard."""
         result = await update_document(
             mock_ctx,
             project_id="MyProj",
@@ -2718,7 +2717,7 @@ class TestUpdateDocumentHappyPath:
     async def test_explicit_empty_title_is_serialized(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # title="" (unlike None) is sent in attributes, clearing it server-side.
+        # title="" (unlike None) sent in attributes — clear it server-side.
         mock_client.patch.return_value = {}
 
         await update_document(
@@ -2785,14 +2784,14 @@ class TestUpdateDocumentHappyPath:
 
         args, _ = mock_client.patch.call_args
         path = args[0]
-        # Space encodes to "+" or "%20"; Polarion accepts either.
+        # Space encode to "+" or "%20"; Polarion accept either.
         assert "workflowAction=needs+review" in path or (
             "workflowAction=needs%20review" in path
         )
 
 
 class TestUpdateDocumentErrorMapping:
-    """Tests that domain exceptions are mapped at the tool layer."""
+    """Domain exceptions mapped at tool layer."""
 
     async def test_401_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -2859,7 +2858,7 @@ class TestUpdateDocumentErrorMapping:
 
 
 class TestUpdateDocumentFieldValidation:
-    """Verify ``min_length=1`` constraints on required path parameters."""
+    """``min_length=1`` constraints on required path parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
@@ -2881,7 +2880,7 @@ class TestUpdateDocumentFieldValidation:
             assert self._adapter_for(name).validate_python(None) is None
 
     def test_home_page_content_html_rejects_overlong_input(self) -> None:
-        """``max_length=MAX_BODY_HTML_LEN`` defends against runaway HTML."""
+        """``max_length=MAX_BODY_HTML_LEN`` defend against runaway HTML."""
         adapter = self._adapter_for("home_page_content_html")
         assert adapter.validate_python("<p>ok</p>") == "<p>ok</p>"
         with pytest.raises(ValidationError):
@@ -2889,13 +2888,13 @@ class TestUpdateDocumentFieldValidation:
 
 
 class TestUpdateDocumentPitfallDocumentation:
-    """Lock the macro-div pitfall into ``update_document.__doc__`` — reproduced on
-    the live testdrive server, user-facing (other MCP hosts never load CLAUDE.md).
+    """Lock macro-div pitfall into ``update_document.__doc__`` — reproduced on
+    live testdrive server, user-facing (other MCP hosts never load CLAUDE.md).
     Anchorless-block pitfall intentionally absent: ids now auto-stamped.
     """
 
     def test_docstring_warns_about_macro_div_module_relationship_gap(self) -> None:
-        """Macro <div> reference injected via update_document leaves module unset."""
+        """Macro <div> reference via update_document leave module unset."""
         document = update_document.__doc__ or ""
         assert "polarion_wiki macro" in document, (
             "update_document docstring must mention the polarion_wiki macro pitfall"
@@ -2918,7 +2917,7 @@ class TestUpdateDocumentPitfallDocumentation:
 
 
 class TestBuildCreateDocumentPayload:
-    """Tests for the private ``_build_create_document_payload`` helper."""
+    """Private ``_build_create_document_payload`` helper."""
 
     def test_minimal_payload_has_only_required_attrs(self) -> None:
         payload = _build_create_document_payload(
@@ -3061,7 +3060,7 @@ class TestBuildCreateDocumentPayload:
 
 
 class TestCreateDocumentDryRun:
-    """Tests for ``create_document`` with ``dry_run=True``."""
+    """``create_document`` with ``dry_run=True``."""
 
     async def test_dry_run_returns_payload_without_calling_post(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -3098,7 +3097,7 @@ class TestCreateDocumentDryRun:
 
 
 class TestCreateDocumentHappyPath:
-    """Tests for a successful ``create_document`` call."""
+    """Successful ``create_document`` call."""
 
     async def test_returns_document_name_on_201(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -3240,16 +3239,16 @@ class TestCreateDocumentHappyPath:
         assert caption is not None
         table = soup.find("table")
         assert table is not None
-        # Stamping runs after polarionify, so both new blocks are anchored.
+        # Stamping run after polarionify — both new blocks anchored.
         assert str(caption.get("id", "")).strip()
         assert str(table.get("id", "")).strip()
 
     async def test_home_page_content_stamps_unique_block_ids(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Every block-level element from the target set gets a unique
-        ``polarion_mcp_N`` id; headings are intentionally left bare so
-        Polarion can rewrite them to the macro form on save.
+        """Every block-level element from target set get unique
+        ``polarion_mcp_N`` id; headings intentionally left bare so
+        Polarion can rewrite them to macro form on save.
         """
         mock_client.post.return_value = {
             "data": [{"type": "documents", "id": "MyProj/_default/MySpec"}]
@@ -3282,8 +3281,8 @@ class TestCreateDocumentHappyPath:
         mock_client: AsyncMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A stamp_block_ids regression that leaves a block anchorless is
-        caught by the trailing first_anchorless_block guard before POST.
+        """stamp_block_ids regression leaving block anchorless caught by
+        trailing first_anchorless_block guard before POST.
         """
         monkeypatch.setattr(_mod, "stamp_block_ids", lambda html: html)
         with pytest.raises(RuntimeError, match="anchorless block"):
@@ -3329,7 +3328,7 @@ class TestCreateDocumentHappyPath:
     async def test_document_name_with_slashes_extracted_correctly(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``split_module_id`` preserves slashes in the document_name segment."""
+        """``split_module_id`` preserve slashes in document_name segment."""
         mock_client.post.return_value = {
             "data": [{"type": "documents", "id": "MyProj/_default/Folder/Sub/Doc"}]
         }
@@ -3352,7 +3351,7 @@ class TestCreateDocumentHappyPath:
     async def test_invalidates_documents_cache_on_success(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``create_document`` drops the project's docs cache entry on 201."""
+        """``create_document`` drop project docs cache entry on 201."""
         _cache_mod.store_cached_documents("MyProj", [("_default", "OldDoc")])
         mock_client.post.return_value = {
             "data": [{"type": "documents", "id": "MyProj/_default/MySpec"}]
@@ -3376,7 +3375,7 @@ class TestCreateDocumentHappyPath:
     async def test_does_not_invalidate_cache_on_failure(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Cache is preserved when the POST raises — no half-state change."""
+        """Cache preserved when POST raise — no half-state change."""
         _cache_mod.store_cached_documents("MyProj", [("_default", "OldDoc")])
         mock_client.post.side_effect = PolarionError("boom", status_code=500)
 
@@ -3400,7 +3399,7 @@ class TestCreateDocumentHappyPath:
 
 
 class TestCreateDocumentErrorMapping:
-    """Tests that domain exceptions are mapped at the tool layer."""
+    """Domain exceptions mapped at tool layer."""
 
     async def test_401_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -3465,7 +3464,7 @@ class TestCreateDocumentErrorMapping:
 
 
 class TestCreateDocumentResponseParsing:
-    """Tests for unexpected 2xx response shapes from Polarion."""
+    """Unexpected 2xx response shapes from Polarion."""
 
     async def test_empty_data_array_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -3508,7 +3507,7 @@ class TestCreateDocumentResponseParsing:
     async def test_two_segment_id_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``split_module_id`` returns ``('','')`` for under-3-segment IDs."""
+        """``split_module_id`` return ``('','')`` for under-3-segment IDs."""
         mock_client.post.return_value = {
             "data": [{"type": "documents", "id": "MyProj/MySpec"}]
         }
@@ -3529,7 +3528,7 @@ class TestCreateDocumentResponseParsing:
 
 
 class TestCreateDocumentFieldValidation:
-    """Verify ``min_length`` / ``max_length`` constraints on parameters."""
+    """``min_length``/``max_length`` constraints on parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
@@ -3569,7 +3568,7 @@ class TestCreateDocumentFieldValidation:
 
 
 class TestCreateDocumentRegistration:
-    """The tool must be registered on the FastMCP server instance."""
+    """Tool must be registered on FastMCP server instance."""
 
     async def test_create_document_tool_registered(self) -> None:
         tools = await mcp.list_tools()
@@ -3577,10 +3576,10 @@ class TestCreateDocumentRegistration:
 
 
 class TestCreateDocumentDocstringGuidance:
-    """Lock load-bearing steers into the public docstring.
+    """Lock load-bearing steers into public docstring.
 
-    Enum values (standard and custom-field) are tool-guarded, so no
-    enum-resolution steer is needed; uniqueness is not.
+    Enum values (standard and custom-field) tool-guarded, so no
+    enum-resolution steer needed; uniqueness is not.
     """
 
     def test_docstring_mentions_module_name_uniqueness(self) -> None:
@@ -3590,7 +3589,7 @@ class TestCreateDocumentDocstringGuidance:
 
 
 class TestEnumGuardCreateDocument:
-    """Integration: ``create_document`` rejects ghost document types."""
+    """Integration: ``create_document`` reject ghost document types."""
 
     async def test_unlisted_type_raises_before_post(
         self,
@@ -3616,8 +3615,8 @@ class TestEnumGuardCreateDocument:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: type options, the heading + include=module sample, then the
-        # enum-value probe for the key (404 = not an enum field, defers).
+        # GETs: type options, heading + include=module sample, enum-value
+        # probe (404 = not enum field, defer).
         dtype = "systemRequirementSpecification"
         mock_client.get.side_effect = [
             _enum_get_response([dtype]),
@@ -3646,8 +3645,8 @@ class TestEnumGuardCreateDocument:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: type options, heading sample (knows docRisk), then the
-        # enum-value probe -- 'severe' is not among the field's options.
+        # GETs: type options, heading sample (know docRisk), enum-value
+        # probe -- 'severe' not among field options.
         dtype = "generic"
         mock_client.get.side_effect = [
             _enum_get_response([dtype]),
@@ -3720,7 +3719,7 @@ class TestEnumGuardCreateDocument:
 
 
 class TestEnumGuardUpdateDocument:
-    """Integration: ``update_document`` rejects ghost type / status."""
+    """Integration: ``update_document`` reject ghost type / status."""
 
     async def test_unlisted_status_raises_before_patch(
         self,
@@ -3740,8 +3739,8 @@ class TestEnumGuardUpdateDocument:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: resolve the doc's type, then the type sample (+ bypass-retry).
-        # The sample knows only doc_risk, so ghost_key is rejected.
+        # GETs: resolve doc type, then type sample (+ bypass-retry).
+        # Sample know only doc_risk — ghost_key rejected.
         type_resp = {"data": {"attributes": {"title": "x", "type": "generic"}}}
         sample = {
             "data": [{"type": "workitems"}],
@@ -3761,7 +3760,7 @@ class TestEnumGuardUpdateDocument:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: resolve the doc's type, type sample (knows doc_risk), enum probe.
+        # GETs: resolve doc type, type sample (know doc_risk), enum probe.
         type_resp = {"data": {"attributes": {"title": "x", "type": "generic"}}}
         sample = {
             "data": [{"type": "workitems"}],
@@ -3788,7 +3787,7 @@ class TestEnumGuardUpdateDocument:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Resolve the doc's type; the cached type schema knows doc_risk.
+        # Resolve doc type; cached type schema know doc_risk.
         mock_client.get.return_value = {
             "data": {"attributes": {"title": "x", "type": "generic"}}
         }
@@ -3803,7 +3802,7 @@ class TestEnumGuardUpdateDocument:
 
 
 def _doc_body_value(result: object) -> str:
-    """Pull ``homePageContent.value`` out of an update_document dry-run preview."""
+    """Pull ``homePageContent.value`` from update_document dry-run preview."""
     preview = result.payload_preview  # type: ignore[attr-defined]
     assert preview is not None
     data = cast(dict[str, object], preview["data"])
@@ -3813,7 +3812,7 @@ def _doc_body_value(result: object) -> str:
 
 
 class TestUpdateDocumentAnchorlessGuard:
-    """Integration: ``update_document`` auto-stamps anchorless body blocks."""
+    """Integration: ``update_document`` auto-stamp anchorless body blocks."""
 
     async def test_anchorless_paragraph_is_stamped(
         self,
@@ -3835,8 +3834,8 @@ class TestUpdateDocumentAnchorlessGuard:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        """An already-anchored body round-trips byte-for-byte: stamp_block_ids
-        short-circuits before reserializing, so ``&nbsp;`` is not mangled.
+        """Already-anchored body round-trip byte-for-byte: stamp_block_ids
+        short-circuit before reserializing, so ``&nbsp;`` not mangled.
         """
         raw = '<p id="polarion_mcp_1">Note&nbsp;here</p>'
         result = await _call_update_doc(
@@ -3862,8 +3861,8 @@ class TestUpdateDocumentAnchorlessGuard:
         reset_enum_guard_caches: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """If a future stamp_block_ids regression leaves a block anchorless,
-        the trailing first_anchorless_block guard blocks the PATCH.
+        """Future stamp_block_ids regression leaving block anchorless —
+        trailing first_anchorless_block guard block the PATCH.
         """
         monkeypatch.setattr(_mod, "stamp_block_ids", lambda html: html)
         with pytest.raises(RuntimeError, match="anchorless block"):

--- a/tests/mcp_server_polarion/tools/test_enum.py
+++ b/tests/mcp_server_polarion/tools/test_enum.py
@@ -1,4 +1,4 @@
-"""Tests for the enum option tools (work item + document)."""
+"""Enum option tool tests (work item + document)."""
 
 from __future__ import annotations
 
@@ -47,7 +47,7 @@ _STATUS_DATA: list[dict[str, object]] = [
 
 
 class TestListWorkItemEnumOptions:
-    """Tests for the ``list_work_item_enum_options`` tool."""
+    """``list_work_item_enum_options`` tool."""
 
     async def test_returns_enum_options(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -257,7 +257,7 @@ class TestListWorkItemEnumOptions:
 
 
 class TestListWorkItemEnumOptionsFieldValidation:
-    """Verify Field constraints on ``list_work_item_enum_options`` parameters."""
+    """Field constraints on ``list_work_item_enum_options`` parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
@@ -283,7 +283,7 @@ class TestListWorkItemEnumOptionsFieldValidation:
 
 
 class TestListDocumentEnumOptions:
-    """Tests for the ``list_document_enum_options`` tool."""
+    """``list_document_enum_options`` tool."""
 
     async def test_returns_enum_options(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -493,7 +493,7 @@ class TestListDocumentEnumOptions:
 
 
 class TestListDocumentEnumOptionsFieldValidation:
-    """Verify Field constraints on ``list_document_enum_options`` parameters."""
+    """Field constraints on ``list_document_enum_options`` parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:

--- a/tests/mcp_server_polarion/tools/test_links.py
+++ b/tests/mcp_server_polarion/tools/test_links.py
@@ -1,4 +1,4 @@
-"""Tests for the work item link tools."""
+"""Work item link tool tests."""
 
 from __future__ import annotations
 
@@ -38,7 +38,7 @@ from mcp_server_polarion.tools.links import (
 
 
 def _project_enum_get_response(enum_name: str, ids: list[str]) -> dict[str, object]:
-    """Single-enumeration response: ``data`` is a dict, options nested under it."""
+    """Single-enumeration response: ``data`` = dict, options nested under."""
     return {
         "data": {
             "type": "enumerations",
@@ -51,7 +51,7 @@ def _project_enum_get_response(enum_name: str, ids: list[str]) -> dict[str, obje
 def _echo_targets_exist(
     path: str, *, params: dict[str, object] | None = None, **_: object
 ) -> dict[str, object]:
-    """Guard GET stub: report every id in the ``id:(...)`` query as existing."""
+    """Guard GET stub: report every id in ``id:(...)`` query as existing."""
     project = path.split("/")[2]
     query = str((params or {}).get("query", ""))
     ids = query.removeprefix("id:(").removesuffix(")").split()
@@ -59,7 +59,7 @@ def _echo_targets_exist(
 
 
 def _forward_links_response(composite_ids: list[str]) -> dict[str, object]:
-    """A JSON:API forward-link page used by the delete pre-read."""
+    """JSON:API forward-link page used by delete pre-read."""
     return {
         "data": [{"type": "linkedworkitems", "id": cid} for cid in composite_ids],
         "meta": {"totalCount": len(composite_ids)},
@@ -67,10 +67,10 @@ def _forward_links_response(composite_ids: list[str]) -> dict[str, object]:
 
 
 class TestListWorkItemLinks:
-    """Tests for the ``list_work_item_links`` tool.
+    """``list_work_item_links`` tool.
 
-    Each call returns a single page in a single direction (``forward`` or
-    ``back``). Pagination matches the convention used by other list tools.
+    Each call return single page in single direction (``forward`` or
+    ``back``). Pagination match other list tools' convention.
     """
 
     async def test_forward_returns_paginated_result(
@@ -387,8 +387,8 @@ class TestListWorkItemLinks:
     async def test_direction_default_is_forward_in_registered_schema(
         self,
     ) -> None:
-        """Guard the JSON-Schema default for ``direction`` — direct calls can't exercise
-        FastMCP default-injection, so the registered schema is authoritative.
+        """Guard JSON-Schema default for ``direction`` — direct calls can't
+        exercise FastMCP default-injection; registered schema authoritative.
         """
         tools = await mcp.list_tools()
         tool = next(t for t in tools if t.name == "list_work_item_links")
@@ -414,7 +414,7 @@ class TestListWorkItemLinks:
         mock_client: AsyncMock,
         bad_id: str,
     ) -> None:
-        """Back-link Lucene query is built from the raw id; bad chars must abort."""
+        """Back-link Lucene query built from raw id; bad chars must abort."""
         with pytest.raises(ValueError, match="Lucene"):
             await list_work_item_links(
                 mock_ctx,
@@ -428,7 +428,7 @@ class TestListWorkItemLinks:
 
 
 class TestBuildCreateLinksPayload:
-    """Tests for the private ``_build_create_links_payload`` helper."""
+    """Private ``_build_create_links_payload`` helper."""
 
     def test_single_spec_minimal_skips_revision(self) -> None:
         payload = _build_create_links_payload(
@@ -519,7 +519,7 @@ class TestBuildCreateLinksPayload:
 
 
 class TestExtractCreatedLinkIds:
-    """Tests for the private ``_extract_created_link_ids`` helper."""
+    """Private ``_extract_created_link_ids`` helper."""
 
     def test_extracts_in_order(self) -> None:
         response: dict[str, object] = {
@@ -550,7 +550,7 @@ class TestExtractCreatedLinkIds:
 
 
 class TestCreateWorkItemLinksDryRun:
-    """Tests for ``create_work_item_links`` with ``dry_run=True``."""
+    """``create_work_item_links`` with ``dry_run=True``."""
 
     @pytest.fixture(autouse=True)
     def _stub_target_existence(self, mock_client: AsyncMock) -> None:
@@ -578,12 +578,12 @@ class TestCreateWorkItemLinksDryRun:
         assert attrs == {"role": "parent", "suspect": False}
         rels = cast(dict[str, object], item["relationships"])
         wi_rel = cast(dict[str, object], rels["workItem"])
-        # target_project_id defaults to source project_id when None.
+        # target_project_id default to source project_id when None.
         assert wi_rel["data"] == {"type": "workitems", "id": "MyProj/MCPT-2"}
 
 
 class TestCreateWorkItemLinksTargetGuard:
-    """The target-existence guard runs before the write, on dry-run too."""
+    """Target-existence guard run before write, on dry-run too."""
 
     async def test_dry_run_missing_target_raises_without_post(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -619,11 +619,11 @@ class TestCreateWorkItemLinksTargetGuard:
 
 
 class TestCreateWorkItemLinksRoleGuard:
-    """The link-role guard runs after the target guard, before the write."""
+    """Link-role guard run after target guard, before write."""
 
     @staticmethod
     def _stub(valid_roles: list[str]) -> object:
-        """GET stub: echo targets as existing, serve the role enumeration."""
+        """GET stub: echo targets as existing, serve role enumeration."""
 
         def fake_get(
             path: str, *, params: dict[str, object] | None = None, **_: object
@@ -677,7 +677,7 @@ class TestCreateWorkItemLinksRoleGuard:
     async def test_target_guard_runs_before_role_guard(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Target guard runs first, so its error surfaces before role enumeration.
+        # Target guard run first — its error surface before role enumeration.
         def fake_get(
             path: str, *, params: dict[str, object] | None = None, **_: object
         ) -> dict[str, object]:
@@ -702,7 +702,7 @@ class TestCreateWorkItemLinksRoleGuard:
 
 
 class TestCreateWorkItemLinksHappyPath:
-    """Tests for a successful ``create_work_item_links`` call."""
+    """Successful ``create_work_item_links`` call."""
 
     @pytest.fixture(autouse=True)
     def _stub_target_existence(self, mock_client: AsyncMock) -> None:
@@ -810,7 +810,7 @@ class TestCreateWorkItemLinksHappyPath:
 
 
 class TestCreateWorkItemLinksErrorMapping:
-    """Tests that domain exceptions are mapped at the tool layer."""
+    """Domain exceptions mapped at tool layer."""
 
     @pytest.fixture(autouse=True)
     def _stub_target_existence(self, mock_client: AsyncMock) -> None:
@@ -868,7 +868,7 @@ class TestCreateWorkItemLinksErrorMapping:
 
 
 class TestCreateWorkItemLinksResponseParsing:
-    """Tests for unexpected 2xx response shapes from Polarion."""
+    """Unexpected 2xx response shapes from Polarion."""
 
     @pytest.fixture(autouse=True)
     def _stub_target_existence(self, mock_client: AsyncMock) -> None:
@@ -909,7 +909,7 @@ class TestCreateWorkItemLinksResponseParsing:
     async def test_id_count_mismatch_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Fewer returned ids than submitted links flags a partial create."""
+        """Fewer returned ids than submitted links flag partial create."""
         mock_client.post.return_value = {
             "data": [
                 {
@@ -933,7 +933,7 @@ class TestCreateWorkItemLinksResponseParsing:
 
 
 class TestCreateWorkItemLinksFieldValidation:
-    """Verify ``min_length=1`` constraints on the required parameters."""
+    """``min_length=1`` constraints on required parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
@@ -984,7 +984,7 @@ class TestCreateWorkItemLinksFieldValidation:
 
 
 class TestBuildDeleteLinksPayload:
-    """Tests for the private ``_build_delete_links_payload`` helper."""
+    """Private ``_build_delete_links_payload`` helper."""
 
     def test_single_ref_composite_id_same_project(self) -> None:
         link_ids, payload = _build_delete_links_payload(
@@ -1039,7 +1039,7 @@ class TestBuildDeleteLinksPayload:
 
 
 class TestDeleteWorkItemLinksDryRun:
-    """Tests for ``delete_work_item_links`` with ``dry_run=True``."""
+    """``delete_work_item_links`` with ``dry_run=True``."""
 
     async def test_dry_run_returns_payload_without_calling_delete(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1063,12 +1063,12 @@ class TestDeleteWorkItemLinksDryRun:
         assert isinstance(result, WorkItemLinksDeleteResult)
         assert result.dry_run is True
         assert result.deleted is False
-        # link_ids are always populated since they are reconstructed from input.
+        # link_ids always populated — reconstructed from input.
         assert result.link_ids == [
             "MyProj/MCPT-1/parent/MyProj/MCPT-2",
             "MyProj/MCPT-1/verifies/MyProj/MCPT-3",
         ]
-        # The pre-read runs on dry_run so the preview's split is accurate.
+        # Pre-read run on dry_run so preview split accurate.
         assert result.deleted_link_ids == ["MyProj/MCPT-1/parent/MyProj/MCPT-2"]
         assert result.not_found_link_ids == ["MyProj/MCPT-1/verifies/MyProj/MCPT-3"]
         assert result.payload_preview is not None
@@ -1080,7 +1080,7 @@ class TestDeleteWorkItemLinksDryRun:
 
 
 class TestDeleteWorkItemLinksHappyPath:
-    """Tests for a successful ``delete_work_item_links`` call."""
+    """Successful ``delete_work_item_links`` call."""
 
     async def test_returns_deleted_true_on_204(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1190,7 +1190,7 @@ class TestDeleteWorkItemLinksHappyPath:
 
 
 class TestDeleteWorkItemLinksErrorMapping:
-    """Tests that domain exceptions are mapped at the tool layer."""
+    """Domain exceptions mapped at tool layer."""
 
     async def test_401_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1214,8 +1214,8 @@ class TestDeleteWorkItemLinksErrorMapping:
     async def test_404_raises_value_error_about_source_wi(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Path-level 404 = source WI missing; body-level 'link not found' is silently
-        ignored by Polarion (confirmed on testdrive, 2026-05-22).
+        """Path-level 404 = source WI missing; body-level 'link not found'
+        silently ignored by Polarion (confirmed on testdrive, 2026-05-22).
         """
         mock_client.get.return_value = _forward_links_response(
             ["MyProj/MCPT-1/parent/MyProj/MCPT-2"]
@@ -1289,7 +1289,7 @@ class TestDeleteWorkItemLinksErrorMapping:
     async def test_preread_unreachable_blocks_before_delete(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """A 5xx pre-read fails closed -- the delete is never attempted."""
+        """5xx pre-read fail closed -- delete never attempted."""
         mock_client.get.side_effect = PolarionError("server error", status_code=500)
 
         with pytest.raises(RuntimeError, match="Refusing the delete"):
@@ -1304,7 +1304,7 @@ class TestDeleteWorkItemLinksErrorMapping:
 
 
 class TestDeleteWorkItemLinksFieldValidation:
-    """Verify ``min_length=1`` constraints on the required parameters."""
+    """``min_length=1`` constraints on required parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
@@ -1355,7 +1355,7 @@ class TestDeleteWorkItemLinksFieldValidation:
 
 
 class TestBuildUpdateLinkPayload:
-    """Tests for the private ``_build_update_link_payload`` helper."""
+    """Private ``_build_update_link_payload`` helper."""
 
     def test_composite_id_same_project(self) -> None:
         link_id, path, payload = _build_update_link_payload(
@@ -1434,7 +1434,7 @@ class TestBuildUpdateLinkPayload:
         assert attributes == {"revision": "HEAD", "suspect": False}
 
     def test_suspect_false_is_emitted(self) -> None:
-        """``suspect=False`` is a real value (clearing the flag), not omitted."""
+        """``suspect=False`` is a real value (clear the flag), not omitted."""
         _link_id, _path, payload = _build_update_link_payload(
             source_project_id="MyProj",
             source_work_item_id="MCPT-1",
@@ -1449,7 +1449,7 @@ class TestBuildUpdateLinkPayload:
 
 
 class TestUpdateWorkItemLinkDryRun:
-    """Tests for ``update_work_item_link`` with ``dry_run=True``."""
+    """``update_work_item_link`` with ``dry_run=True``."""
 
     async def test_dry_run_returns_preview_without_calling_patch(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1477,7 +1477,7 @@ class TestUpdateWorkItemLinkDryRun:
 
 
 class TestUpdateWorkItemLinkHappyPath:
-    """Tests for a successful ``update_work_item_link`` call."""
+    """Successful ``update_work_item_link`` call."""
 
     async def test_returns_updated_true_and_link_id(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1530,7 +1530,7 @@ class TestUpdateWorkItemLinkHappyPath:
 
 
 class TestUpdateWorkItemLinkErrors:
-    """Domain exceptions are raised, not returned in the result."""
+    """Domain exceptions raised, not returned in result."""
 
     async def test_not_found_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1594,7 +1594,7 @@ class TestUpdateWorkItemLinkAuthError:
 
 
 class TestUpdateWorkItemLinkFieldValidation:
-    """Verify ``min_length=1`` constraints and at-least-one-attribute check."""
+    """``min_length=1`` constraints + at-least-one-attribute check."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
@@ -1622,7 +1622,7 @@ class TestUpdateWorkItemLinkFieldValidation:
     async def test_both_attributes_none_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """suspect=None and revision=None must be rejected before any PATCH."""
+        """suspect=None and revision=None rejected before any PATCH."""
         with pytest.raises(ValueError, match="at least one"):
             await update_work_item_link(
                 mock_ctx,

--- a/tests/mcp_server_polarion/tools/test_moves.py
+++ b/tests/mcp_server_polarion/tools/test_moves.py
@@ -1,4 +1,4 @@
-"""Tests for the work item document-membership move tools."""
+"""Work item document-membership move tool tests."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from mcp_server_polarion.tools.moves import (
 
 
 class TestBuildMoveToDocumentPayload:
-    """Tests for the private ``_build_move_to_document_payload`` helper."""
+    """Private ``_build_move_to_document_payload`` helper."""
 
     def test_minimal_payload_with_previous_part(self) -> None:
         payload = _build_move_to_document_payload(
@@ -55,7 +55,7 @@ class TestBuildMoveToDocumentPayload:
             "targetDocument": "MyProj/_default/My Doc",
             "nextPart": "MyProj/_default/My Doc/heading_MCPT-9",
         }
-        # previousPart and nextPart are mutually exclusive in the body.
+        # previousPart and nextPart mutually exclusive in body.
         assert "previousPart" not in payload
 
     def test_document_name_with_slashes_preserved_verbatim(self) -> None:
@@ -72,7 +72,7 @@ class TestBuildMoveToDocumentPayload:
         assert payload["previousPart"] == "MyProj/Design/Folder/Sub Doc/workitem_MCPT-2"
 
     def test_payload_omits_position_keys_when_both_none(self) -> None:
-        # Omitting both position keys appends at the end of the target document.
+        # Omit both position keys = append at end of target document.
         payload = _build_move_to_document_payload(
             project_id="MyProj",
             target_space_id="S",
@@ -97,7 +97,7 @@ class TestBuildMoveToDocumentPayload:
 
 
 class TestMoveWorkItemToDocumentPositionValidation:
-    """Tests for the at-most-one-of-position rule."""
+    """At-most-one-of-position rule."""
 
     async def test_neither_position_appends_at_end(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -166,7 +166,7 @@ class TestMoveWorkItemToDocumentPositionValidation:
 
 
 class TestMoveWorkItemToDocumentDryRun:
-    """Tests for ``move_work_item_to_document`` with ``dry_run=True``."""
+    """``move_work_item_to_document`` with ``dry_run=True``."""
 
     async def test_dry_run_returns_payload_without_calling_post(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -192,12 +192,12 @@ class TestMoveWorkItemToDocumentDryRun:
 
 
 class TestMoveWorkItemToDocumentHappyPath:
-    """Tests for a successful ``move_work_item_to_document`` call."""
+    """Successful ``move_work_item_to_document`` call."""
 
     async def test_returns_moved_true_on_204(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # client.post returns {} on 204 No Content.
+        # client.post return {} on 204 No Content.
         mock_client.post.return_value = {}
 
         result = await move_work_item_to_document(
@@ -233,7 +233,7 @@ class TestMoveWorkItemToDocumentHappyPath:
         )
 
         args, kwargs = mock_client.post.call_args
-        # Path uses the work item ID, with URL-encoded segments.
+        # Path use work item ID, URL-encoded segments.
         expected_path = "/projects/MyProj/workitems/MCPT-42/actions/moveToDocument"
         assert args == (expected_path,)
         body = kwargs["json"]
@@ -245,7 +245,7 @@ class TestMoveWorkItemToDocumentHappyPath:
     async def test_path_url_encodes_special_chars_in_project_id(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # project_id is run through encode_path_segment.
+        # project_id run through encode_path_segment.
         mock_client.post.return_value = {}
 
         await move_work_item_to_document(
@@ -264,7 +264,7 @@ class TestMoveWorkItemToDocumentHappyPath:
 
 
 class TestMoveWorkItemToDocumentErrorMapping:
-    """Tests that domain exceptions are mapped at the tool layer."""
+    """Domain exceptions mapped at tool layer."""
 
     async def test_401_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -321,7 +321,7 @@ class TestMoveWorkItemToDocumentErrorMapping:
 
 
 class TestMoveWorkItemToDocumentFieldValidation:
-    """Verify ``min_length=1`` constraints attached to required parameters."""
+    """``min_length=1`` constraints on required parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
@@ -347,7 +347,7 @@ class TestMoveWorkItemToDocumentFieldValidation:
 
 
 class TestMoveWorkItemFromDocumentDryRun:
-    """Tests for ``move_work_item_from_document`` with ``dry_run=True``."""
+    """``move_work_item_from_document`` with ``dry_run=True``."""
 
     async def test_dry_run_returns_empty_payload_without_calling_post(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -363,12 +363,12 @@ class TestMoveWorkItemFromDocumentDryRun:
         assert isinstance(result, WorkItemMoveResult)
         assert result.moved is False
         assert result.dry_run is True
-        # moveFromDocument has no body — payload preview is an empty dict.
+        # moveFromDocument has no body — payload preview = empty dict.
         assert result.payload_preview == {}
 
 
 class TestMoveWorkItemFromDocumentHappyPath:
-    """Tests for a successful ``move_work_item_from_document`` call."""
+    """Successful ``move_work_item_from_document`` call."""
 
     async def test_returns_moved_true_on_204(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -424,7 +424,7 @@ class TestMoveWorkItemFromDocumentHappyPath:
 
 
 class TestMoveWorkItemFromDocumentErrorMapping:
-    """Tests that domain exceptions are mapped at the tool layer."""
+    """Domain exceptions mapped at tool layer."""
 
     async def test_401_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -457,7 +457,7 @@ class TestMoveWorkItemFromDocumentErrorMapping:
     async def test_400_already_detached_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Detaching an already free-floating item 400s → RuntimeError.
+        # Detach already free-floating item 400 → RuntimeError.
         mock_client.post.side_effect = PolarionError(
             "Work item is not in a Document", status_code=400
         )
@@ -485,7 +485,7 @@ class TestMoveWorkItemFromDocumentErrorMapping:
 
 
 class TestMoveWorkItemFromDocumentFieldValidation:
-    """Verify ``min_length=1`` on the required ``work_item_id`` parameter."""
+    """``min_length=1`` on required ``work_item_id`` parameter."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:

--- a/tests/mcp_server_polarion/tools/test_path_encoding.py
+++ b/tests/mcp_server_polarion/tools/test_path_encoding.py
@@ -22,9 +22,9 @@ from mcp_server_polarion.tools.work_items import (
 
 
 class TestReadPathEncoding:
-    """Every read tool must URL-encode each path segment — unencoded reserved chars
-    malform the URL or allow ``../`` traversal. Pins ``encode_path_segment()`` so
-    a refactor cannot silently drop it.
+    """Every read tool must URL-encode each path segment — unencoded reserved
+    chars malform URL or allow ``../`` traversal. Pin ``encode_path_segment()``
+    so a refactor cannot silently drop it.
     """
 
     @pytest.fixture(autouse=True)
@@ -145,8 +145,8 @@ class TestReadPathEncoding:
     async def test_list_work_item_links_back_encodes_project_id(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # work_item_id is rejected by the Lucene allowlist before encoding;
-        # use a safe id and verify only project_id is encoded.
+        # work_item_id rejected by Lucene allowlist before encoding; use
+        # safe id and verify only project_id encoded.
         mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
 
         await list_work_item_links(

--- a/tests/mcp_server_polarion/tools/test_projects.py
+++ b/tests/mcp_server_polarion/tools/test_projects.py
@@ -1,4 +1,4 @@
-"""Tests for the ``list_projects`` tool."""
+"""``list_projects`` tool tests."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ from mcp_server_polarion.tools.projects import list_projects
 
 
 class TestListProjects:
-    """Tests for the ``list_projects`` tool."""
+    """``list_projects`` tool."""
 
     async def test_returns_projects(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -256,7 +256,7 @@ class TestListProjects:
     async def test_total_count_floor_when_api_returns_zero(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """totalCount=0 with items present uses item count."""
+        """totalCount=0 with items present use item count."""
         mock_client.get.return_value = {
             "data": [
                 {

--- a/tests/mcp_server_polarion/tools/test_recipes.py
+++ b/tests/mcp_server_polarion/tools/test_recipes.py
@@ -1,4 +1,4 @@
-"""Tests for the static SQL and HTML recipe gallery tools."""
+"""Static SQL and HTML recipe gallery tool tests."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from mcp_server_polarion.utils.html import (
 
 
 class TestGetSqlQueryRecipes:
-    """``get_sql_query_recipes`` serves the SQL:(...) recipe gallery."""
+    """``get_sql_query_recipes`` serve the SQL:(...) recipe gallery."""
 
     async def test_returns_gallery_with_schema_and_core_recipes(self) -> None:
         result = await get_sql_query_recipes()
@@ -28,7 +28,7 @@ class TestGetSqlQueryRecipes:
 
 
 class TestGetHtmlRecipes:
-    """``get_html_recipes`` serves raw-HTML templates for update tools."""
+    """``get_html_recipes`` serve raw-HTML templates for update tools."""
 
     async def test_returns_gallery_with_core_templates(self) -> None:
         result = await get_html_recipes()

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -1,5 +1,5 @@
-"""Tests for the test run tools — list parsing/param forwarding, bulk create
-payloads and guards, error mapping, and field bounds.
+"""Test run tools — list parsing/param forwarding, bulk create payloads and
+guards, error mapping, field bounds.
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ from mcp_server_polarion.tools.test_runs import (
 
 
 def _template_response(run_id: str) -> dict[str, object]:
-    """Single-testrun GET body the template guard accepts."""
+    """Single-testrun GET body template guard accept."""
     return {
         "data": {
             "type": "testruns",
@@ -36,7 +36,7 @@ def _template_response(run_id: str) -> dict[str, object]:
 
 
 class TestListTestRuns:
-    """Tests for the ``list_test_runs`` tool."""
+    """``list_test_runs`` tool."""
 
     async def test_returns_test_runs(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -324,9 +324,9 @@ class TestListTestRuns:
 
 
 class TestListTestRunsQueryDocumentation:
-    """Lock the query docs to Lucene-only — ``SQL:(...)`` on ``/testruns`` 400s
-    on the live server (the endpoint wraps the query verbatim into Lucene), so
-    even a "no SQL" disclaimer must not reintroduce the token an LLM could copy.
+    """Lock query docs to Lucene-only — ``SQL:(...)`` on ``/testruns`` 400 on
+    live server (endpoint wrap query verbatim into Lucene), so even a "no SQL"
+    disclaimer must not reintroduce the token an LLM could copy.
     """
 
     def test_query_docs_promise_lucene_only(self) -> None:
@@ -414,13 +414,13 @@ class TestBuildCreateTestRunsPayload:
 
 
 class TestCreateTestRuns:
-    """Tests for the ``create_test_runs`` tool."""
+    """``create_test_runs`` tool."""
 
     async def test_duplicate_ids_rejected_before_any_request(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Client-supplied ids can collide; the server would 409 after
-        # partially creating the batch.
+        # Client-supplied ids can collide; server would 409 after partially
+        # creating the batch.
         with pytest.raises(ValueError, match=r"Duplicate id\(s\) \['TR-1'\]"):
             await create_test_runs(
                 mock_ctx,
@@ -452,7 +452,7 @@ class TestCreateTestRuns:
         assert result.dry_run is False
         assert result.test_run_ids == ["TR-1"]
         assert result.payload_preview is None
-        # No enums / template / custom fields supplied -> no guard traffic.
+        # No enums / template / custom fields -> no guard traffic.
         mock_client.get.assert_not_awaited()
         path = mock_client.post.await_args.args[0]
         assert path == "/projects/proj1/testruns"
@@ -546,7 +546,7 @@ class TestCreateTestRuns:
         )
 
         assert result.test_run_ids == ["TR-5"]
-        # Sampled instances then templates before the POST.
+        # Sampled instances then templates before POST.
         assert mock_client.get.await_count == 2
 
     async def test_project_not_found_raises_value_error(
@@ -640,7 +640,7 @@ class TestCreateTestRunsFieldValidation:
 
 class TestListTestRunsFieldValidation:
     """``page_size`` bounds — direct calls bypass JSON Schema; proven via
-    ``TypeAdapter`` rebuild from the signature.
+    ``TypeAdapter`` rebuild from signature.
     """
 
     @staticmethod

--- a/tests/mcp_server_polarion/tools/test_tool_annotations.py
+++ b/tests/mcp_server_polarion/tools/test_tool_annotations.py
@@ -8,8 +8,8 @@ from mcp_server_polarion.server import mcp
 
 
 class TestWriteToolAnnotations:
-    """Write tools must advertise destructive/idempotent/openWorld hints — MCP
-    clients use them for risk display and auto-approval policies.
+    """Write tools must advertise destructive/idempotent/openWorld hints —
+    MCP clients use them for risk display and auto-approval policies.
     """
 
     @staticmethod

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -1,4 +1,4 @@
-"""Tests for the work item query/create/update tools."""
+"""Work item query/create/update tool tests."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ from mcp_server_polarion.tools.work_items import (
 
 
 def _project_enum_get_response(enum_name: str, ids: list[str]) -> dict[str, object]:
-    """Single-enumeration response: ``data`` is a dict, options nested under it."""
+    """Single-enumeration response: ``data`` = dict, options nested under."""
     return {
         "data": {
             "type": "enumerations",
@@ -52,7 +52,7 @@ def _project_enum_get_response(enum_name: str, ids: list[str]) -> dict[str, obje
 
 
 def _spec(**overrides: object) -> WorkItemUpdateSpec:
-    """One update spec with a default id; tests override what they need."""
+    """Update spec with default id; tests override as needed."""
     fields: dict[str, object] = {"work_item_id": "MCPT-1"}
     fields.update(overrides)
     return WorkItemUpdateSpec(**fields)  # type: ignore[arg-type]
@@ -61,10 +61,10 @@ def _spec(**overrides: object) -> WorkItemUpdateSpec:
 async def _call_update(
     mock_ctx: MagicMock, **overrides: object
 ) -> WorkItemsUpdateResult:
-    """Call update_work_items with all params explicit.
+    """Call update_work_items, all params explicit.
 
-    Field(...) defaults stay FieldInfo objects outside FastMCP, so every
-    param must be passed; tests override only what they care about.
+    Field(...) defaults stay FieldInfo outside FastMCP — must pass every
+    param; tests override as needed.
     """
     defaults: dict[str, object] = {
         "project_id": "MyProj",
@@ -78,7 +78,7 @@ async def _call_update(
 
 
 def _existence_response(*pairs: tuple[str, str]) -> dict[str, object]:
-    """Reply to the batched ``id:(...)`` existence/type query."""
+    """Reply to batched ``id:(...)`` existence/type query."""
     return {
         "data": [
             {
@@ -92,7 +92,7 @@ def _existence_response(*pairs: tuple[str, str]) -> dict[str, object]:
 
 
 def _enum_get_response(ids: list[str]) -> dict[str, object]:
-    """Shape a ``getAvailableOptions`` reply for the guard tests."""
+    """``getAvailableOptions`` reply for guard tests."""
     return {
         "data": [{"id": i, "name": i} for i in ids],
         "meta": {"totalCount": len(ids)},
@@ -100,7 +100,7 @@ def _enum_get_response(ids: list[str]) -> dict[str, object]:
 
 
 def _wi_sample_response(*custom_dicts: dict[str, object]) -> dict[str, object]:
-    """Shape a MIN-per-key list reply: representative items with inline customs."""
+    """MIN-per-key list reply: representative items, inline customs."""
     return {
         "data": [
             {
@@ -114,10 +114,10 @@ def _wi_sample_response(*custom_dicts: dict[str, object]) -> dict[str, object]:
 
 
 async def _call_create_wi(mock_ctx: MagicMock, **overrides: object) -> object:
-    """Invoke ``create_work_items`` with a single-spec default batch.
+    """Invoke ``create_work_items`` with single-spec default batch.
 
-    ``project_id`` / ``dry_run`` are top-level tool params; all other
-    overrides are per-item and fold into one ``WorkItemCreateSpec``.
+    ``project_id``/``dry_run`` = top-level tool params; other overrides
+    fold into one ``WorkItemCreateSpec``.
     """
     project_id = cast(str, overrides.pop("project_id", "MyProj"))
     dry_run = cast(bool, overrides.pop("dry_run", False))
@@ -131,7 +131,7 @@ async def _call_create_wi(mock_ctx: MagicMock, **overrides: object) -> object:
 
 @pytest.fixture
 def reset_enum_guard_caches() -> None:
-    """Drop guard caches between integration tests so each scenario starts cold."""
+    """Drop guard caches between tests — each scenario start cold."""
     _cache_mod._enum_option_cache.clear()
     _cache_mod._project_enum_cache.clear()
     _cache_mod._work_item_custom_key_cache.clear()
@@ -139,7 +139,7 @@ def reset_enum_guard_caches() -> None:
 
 
 class TestBuildWorkItemResource:
-    """Tests for the private ``_build_work_item_resource`` helper (one resource)."""
+    """Private ``_build_work_item_resource`` helper (one resource)."""
 
     def test_minimal_item_has_only_required_attrs(self) -> None:
         item = _build_work_item_resource(
@@ -262,11 +262,11 @@ class TestBuildWorkItemResource:
         attributes = cast(dict[str, object], item["attributes"])
         assert attributes["riskLevel"] == "high"
         assert attributes["effortHours"] == 12.0
-        # Customs land flat; Polarion drops a customFields container.
+        # Customs land flat; Polarion drop customFields container.
         assert "customFields" not in attributes
 
     def test_custom_fields_collision_with_standard_attr_raises(self) -> None:
-        # A custom key matching a standard attr would silently shadow it.
+        # Custom key match standard attr = silent shadow.
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             _build_work_item_resource(
                 spec=WorkItemCreateSpec(
@@ -291,7 +291,7 @@ class TestBuildWorkItemResource:
 
 
 class TestBuildCreateWorkItemsPayload:
-    """Tests for the bulk ``_build_create_work_items_payload`` wrapper."""
+    """Bulk ``_build_create_work_items_payload`` wrapper."""
 
     def test_single_spec_wraps_in_data_list(self) -> None:
         payload = _build_create_work_items_payload(
@@ -322,7 +322,7 @@ class TestBuildCreateWorkItemsPayload:
         assert "description" not in second
 
     def test_mismatched_lengths_raise(self) -> None:
-        # zip(strict=True) guards the spec/html pairing.
+        # zip(strict=True) guard spec/html pairing.
         with pytest.raises(ValueError):
             _build_create_work_items_payload(
                 specs=[WorkItemCreateSpec(title="a", type="task")],
@@ -331,7 +331,7 @@ class TestBuildCreateWorkItemsPayload:
 
 
 class TestCreateWorkItemsDryRun:
-    """Tests for ``create_work_items`` with ``dry_run=True``."""
+    """``create_work_items`` with ``dry_run=True``."""
 
     async def test_dry_run_returns_payload_without_calling_post(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -349,7 +349,7 @@ class TestCreateWorkItemsDryRun:
         assert result.created is False
         assert result.work_item_ids == []
         assert result.payload_preview is not None
-        # Plain dict, no Pydantic objects leaked.
+        # Plain dict, no Pydantic leak.
         assert isinstance(result.payload_preview, dict)
         item = cast(list[dict[str, object]], result.payload_preview["data"])[0]
         attributes = cast(dict[str, object], item["attributes"])
@@ -357,7 +357,7 @@ class TestCreateWorkItemsDryRun:
 
 
 class TestCreateWorkItemsHyperlinkRoleGuard:
-    """``create_work_items`` validates each hyperlink role before writing."""
+    """``create_work_items`` validate each hyperlink role before write."""
 
     async def test_unknown_hyperlink_role_raises_without_post(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -411,7 +411,7 @@ class TestCreateWorkItemsHyperlinkRoleGuard:
 
 
 class TestCreateWorkItemsHappyPath:
-    """Tests for a successful ``create_work_items`` call."""
+    """Successful ``create_work_items`` call."""
 
     async def test_single_item_returns_short_id_on_201(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -456,7 +456,7 @@ class TestCreateWorkItemsHappyPath:
         )
 
         assert result.work_item_ids == ["MCPT-1", "MCPT-2"]
-        # A single POST creates the whole batch.
+        # Single POST create whole batch.
         assert mock_client.post.call_count == 1
 
     async def test_post_called_with_correct_path_and_body(
@@ -512,15 +512,15 @@ class TestCreateWorkItemsHappyPath:
         desc = kwargs["json"]["data"][0]["attributes"]["description"]
         assert desc["type"] == "text/html"
         assert "<strong>bold</strong>" in desc["value"]
-        # Safe https link survives sanitize.
+        # Safe https link survive sanitize.
         assert 'href="https://example.com"' in desc["value"]
 
     async def test_description_strips_dangerous_link_schemes(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """No javascript: anchor reaches the payload.
+        """No javascript: anchor reach payload.
 
-        markdown-it leaves it unrendered; sanitize_html strips it as a
+        markdown-it leave it unrendered; sanitize_html strip it as
         second layer.
         """
         mock_client.post.return_value = {
@@ -575,7 +575,7 @@ class TestCreateWorkItemsHappyPath:
     async def test_rich_text_custom_field_value_not_polarionified(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # polarionify applies to description only, never custom_fields.
+        # polarionify apply to description only, never custom_fields.
         store_work_item_custom_keys(
             "MyProj", "task", frozenset({"verification_criteria"})
         )
@@ -603,7 +603,7 @@ class TestCreateWorkItemsHappyPath:
 
 
 class TestCreateWorkItemsErrorMapping:
-    """Tests that domain exceptions are mapped at the tool layer."""
+    """Domain exceptions mapped at tool layer."""
 
     async def test_401_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -648,7 +648,7 @@ class TestCreateWorkItemsErrorMapping:
 
 
 class TestCreateWorkItemsResponseParsing:
-    """Tests for unexpected / partial 2xx response shapes from Polarion."""
+    """Unexpected / partial 2xx response shapes from Polarion."""
 
     async def test_id_count_mismatch_raises_runtime_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -697,8 +697,8 @@ class TestCreateWorkItemsResponseParsing:
 
 
 class TestCreateWorkItemsFieldValidation:
-    """Constraints on ``items`` + ``WorkItemCreateSpec`` — direct calls bypass the
-    JSON Schema gate; collection-level bounds proven via ``TypeAdapter`` rebuild.
+    """Constraints on ``items`` + ``WorkItemCreateSpec`` — direct calls bypass
+    JSON Schema gate; collection bounds proven via ``TypeAdapter`` rebuild.
     """
 
     @staticmethod
@@ -732,7 +732,7 @@ class TestCreateWorkItemsFieldValidation:
             WorkItemCreateSpec(title="t", type="")
 
     def test_spec_description_rejects_overlong_input(self) -> None:
-        """``max_length`` on the spec defends against runaway Markdown."""
+        """``max_length`` on spec defend against runaway Markdown."""
         WorkItemCreateSpec(title="t", type="task", description="hello")
         with pytest.raises(ValidationError):
             WorkItemCreateSpec(
@@ -741,7 +741,7 @@ class TestCreateWorkItemsFieldValidation:
 
 
 class TestBuildUpdateWorkItemsPayload:
-    """Tests for the private bulk-update payload builders."""
+    """Private bulk-update payload builders."""
 
     def test_minimal_resource_with_only_title(self) -> None:
         resource = _build_update_work_item_resource(
@@ -779,7 +779,7 @@ class TestBuildUpdateWorkItemsPayload:
             project_id="MyProj", spec=_spec(assignee_ids=["alice", "bob"])
         )
 
-        # Relationship-only change: no attributes block at all.
+        # Relationship-only change: no attributes block.
         assert "attributes" not in resource
         relationships = cast(dict[str, object], resource["relationships"])
         assert relationships["assignee"] == {
@@ -840,8 +840,8 @@ class TestBuildUpdateWorkItemsPayload:
         assert attributes == {"riskLevel": "low", "reviewerNote": rich}
 
     def test_none_valued_custom_entries_dropped(self) -> None:
-        # Polarion reads explicit None as "clear default"; the write contract
-        # skips them, and the spec validator has already ensured >=1 survives.
+        # Polarion read explicit None as "clear default" — write contract
+        # skip them; spec validator already ensure >=1 survive.
         resource = _build_update_work_item_resource(
             project_id="MyProj",
             spec=_spec(custom_fields={"cleared": None, "kept": "v"}),
@@ -859,7 +859,7 @@ class TestBuildUpdateWorkItemsPayload:
 
 
 class TestUpdateWorkItemsValidation:
-    """Batch-level validation before any Polarion round-trip."""
+    """Batch-level validation before Polarion round-trip."""
 
     async def test_duplicate_ids_rejected_before_any_request(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -875,8 +875,8 @@ class TestUpdateWorkItemsValidation:
     async def test_lucene_unsafe_id_rejected_before_any_request(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Project-qualified ids ('P/MCPT-1') are rejected too: '/' is outside
-        # the charset embedded into the id:(...) existence query.
+        # Project-qualified ids ('P/MCPT-1') rejected too: '/' outside
+        # charset embedded in id:(...) existence query.
         with pytest.raises(ValueError, match="outside"):
             await _call_update(
                 mock_ctx, items=[_spec(work_item_id="MyProj/MCPT-1", title="t")]
@@ -903,7 +903,7 @@ class TestUpdateWorkItemsValidation:
     async def test_missing_ids_checked_on_dry_run_too(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Preview must raise the same errors as the real write.
+        # Preview must raise same errors as real write.
         mock_client.get.return_value = _existence_response()
 
         with pytest.raises(ValueError, match="MCPT-1"):
@@ -912,8 +912,8 @@ class TestUpdateWorkItemsValidation:
     async def test_collision_raises_before_any_request(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # A custom key matching a standard attribute would shadow it; the
-        # payload is built before any guard round-trip, so this fails fast.
+        # Custom key match standard attr = shadow; payload built before
+        # guard round-trip — fail fast.
         with pytest.raises(ValueError, match="custom_fields keys collide"):
             await _call_update(
                 mock_ctx,
@@ -924,7 +924,7 @@ class TestUpdateWorkItemsValidation:
 
 
 class TestUpdateWorkItemsHyperlinkRoleGuard:
-    """``update_work_items`` validates hyperlink roles before the PATCH."""
+    """``update_work_items`` validate hyperlink roles before PATCH."""
 
     async def test_unknown_hyperlink_role_raises_without_patch(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -949,8 +949,8 @@ class TestUpdateWorkItemsHyperlinkRoleGuard:
     async def test_bad_role_names_offending_item_via_cache(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Item 0's role passes; item 1 reuses the cached options (no second
-        # enum GET) and is rejected with its batch position and id.
+        # Item 0 role pass; item 1 reuse cached options (no second enum
+        # GET), rejected with batch position and id.
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task"), ("MCPT-2", "task")),
             _project_enum_get_response("hyperlink-role", ["ref_int", "ref_ext"]),
@@ -974,7 +974,7 @@ class TestUpdateWorkItemsHyperlinkRoleGuard:
 
 
 class TestUpdateWorkItemsDryRun:
-    """Tests for ``update_work_items`` with ``dry_run=True``."""
+    """``update_work_items`` with ``dry_run=True``."""
 
     async def test_dry_run_skips_patch_but_validates_existence(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1033,7 +1033,7 @@ class TestUpdateWorkItemsDryRun:
 
 
 class TestUpdateWorkItemsHappyPath:
-    """Tests for a successful ``update_work_items`` call."""
+    """Successful ``update_work_items`` call."""
 
     async def test_returns_ids_in_input_order(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1080,8 +1080,8 @@ class TestUpdateWorkItemsHappyPath:
     async def test_no_followup_get_after_patch(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # ids-only result: the old per-item re-GET is gone (50 items would
-        # cost 50 extra requests at the 3 req/s cap).
+        # ids-only result: per-item re-GET gone (50 items = 50 extra
+        # requests at 3 req/s cap).
         mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
         mock_client.patch.return_value = {}
 
@@ -1131,8 +1131,8 @@ class TestUpdateWorkItemsHappyPath:
     async def test_custom_fields_inlined_into_patch_body(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Customs ride top-level in attributes; the key is pre-cached and the
-        # enum-value probe 404s (not an enum field, defers to Polarion).
+        # Customs ride top-level in attributes; key pre-cached, enum-value
+        # probe 404 (not enum field, defer to Polarion).
         _cache_mod.store_work_item_custom_keys(
             "MyProj", "task", frozenset({"riskLevel"})
         )
@@ -1161,7 +1161,7 @@ class TestUpdateWorkItemsHappyPath:
 
 
 class TestUpdateWorkItemsErrorMapping:
-    """Tests that domain exceptions are mapped at the tool layer."""
+    """Domain exceptions mapped at tool layer."""
 
     async def test_patch_401_raises_permission_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1175,7 +1175,7 @@ class TestUpdateWorkItemsErrorMapping:
     async def test_patch_404_raises_value_error(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Race fallback: existence passed above, then the batch changed.
+        # Race fallback: existence passed above, then batch changed.
         mock_client.get.return_value = _existence_response(("MCPT-1", "task"))
         mock_client.patch.side_effect = PolarionNotFoundError(
             "not found", status_code=404
@@ -1195,7 +1195,7 @@ class TestUpdateWorkItemsErrorMapping:
 
 
 class TestUpdateWorkItemsFieldValidation:
-    """Verify Field constraints attached to the tool parameters."""
+    """Field constraints on tool parameters."""
 
     @staticmethod
     def _adapter_for(param_name: str) -> TypeAdapter[object]:
@@ -1231,9 +1231,8 @@ class TestUpdateWorkItemsFieldValidation:
         assert len(cast(list[object], validated)) == MAX_BULK_ITEMS
 
     def test_typo_key_in_one_item_rejects_batch_naming_index(self) -> None:
-        # extra='forbid' smoke: without it, 'descrition' would sail through
-        # to Polarion and persist verbatim as a ghost custom field. The whole
-        # batch must be rejected at parse time, naming the offending index.
+        # extra='forbid' smoke: without it 'descrition' persist verbatim in
+        # Polarion as ghost custom field; batch rejected at parse, naming index.
         items: list[dict[str, object]] = [
             {"work_item_id": f"MCPT-{i}", "title": "t"} for i in range(1, 6)
         ]
@@ -1246,7 +1245,7 @@ class TestUpdateWorkItemsFieldValidation:
 
 
 class TestUpdateWorkItemsDocstringGuidance:
-    """Lock the read-before-update and REPLACE steers into the tool docs."""
+    """Lock read-before-update + REPLACE steers into tool docs."""
 
     def test_docstring_directs_get_before_update(self) -> None:
         document = update_work_items.__doc__ or ""
@@ -1259,8 +1258,8 @@ class TestUpdateWorkItemsDocstringGuidance:
         )
 
     def test_replace_steer_leads_docstring_and_items_field(self) -> None:
-        # Per-item fields nest one level deeper than the old flat tool, so
-        # the REPLACE steer must stay in the highest-salience spots.
+        # Per-item fields nest one deeper than old flat tool — REPLACE
+        # steer must stay in highest-salience spots.
         document = update_work_items.__doc__ or ""
         first_paragraph = document.split("\n\n")[0]
         assert "REPLACE" in first_paragraph
@@ -1269,7 +1268,7 @@ class TestUpdateWorkItemsDocstringGuidance:
 
 
 class TestEnumGuardCreateWorkItem:
-    """Integration: ``create_work_items`` rejects ghost enum ids before POST."""
+    """Integration: ``create_work_items`` reject ghost enum ids before POST."""
 
     async def test_unlisted_severity_raises_before_post(
         self,
@@ -1277,7 +1276,7 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # task passes the type-axis check; severity then trips.
+        # task pass type-axis check; severity then trip.
         mock_client.get.return_value = _enum_get_response(
             ["task", "must_have", "should_have"]
         )
@@ -1292,7 +1291,7 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Per-item guard runs before any POST, so a bad later item aborts the batch.
+        # Per-item guard run before POST — bad later item abort batch.
         mock_client.get.return_value = _enum_get_response(
             ["task", "must_have", "should_have"]
         )
@@ -1315,7 +1314,7 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # One response shape serves every guard probe plus the create.
+        # One response shape serve every guard probe plus create.
         mock_client.get.return_value = _enum_get_response(
             ["task", "must_have", "open", "50.0"]
         )
@@ -1343,8 +1342,8 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: type options, the MIN-per-key type sample, then the enum-value
-        # probe for the key (404 = not an enum field, defers).
+        # GETs: type options, MIN-per-key type sample, enum-value probe
+        # (404 = not enum field, defer).
         mock_client.get.side_effect = [
             _enum_get_response(["task"]),
             _wi_sample_response({"risk_score": 1}),
@@ -1363,8 +1362,8 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: type options, type sample (knows asil), then the enum-value
-        # probe -- '9' is not among the field's options.
+        # GETs: type options, type sample (know asil), enum-value probe —
+        # '9' not among field options.
         mock_client.get.side_effect = [
             _enum_get_response(["task"]),
             _wi_sample_response({"asil": "1"}),
@@ -1381,7 +1380,7 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Sample knows only risk_score; the ghost key is rejected after a retry.
+        # Sample know only risk_score; ghost key rejected after retry.
         mock_client.get.side_effect = [
             _enum_get_response(["task"]),
             _wi_sample_response({"risk_score": 1}),
@@ -1398,7 +1397,7 @@ class TestEnumGuardCreateWorkItem:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # No item of this type populates any custom field -> can't infer schema.
+        # No item of this type populate custom fields -> can't infer schema.
         mock_client.get.side_effect = [
             _enum_get_response(["task"]),
             {"data": []},
@@ -1411,7 +1410,7 @@ class TestEnumGuardCreateWorkItem:
 
 
 class TestEnumGuardUpdateWorkItems:
-    """Integration: ``update_work_items`` resolves types then guards per item."""
+    """Integration: ``update_work_items`` resolve types then guard per item."""
 
     async def test_unlisted_priority_raises_after_type_resolution(
         self,
@@ -1434,7 +1433,7 @@ class TestEnumGuardUpdateWorkItems:
             for c in mock_client.get.call_args_list
             if "fields/priority/actions/getAvailableOptions" in c.args[0]
         ]
-        # Enum options are scoped to the type resolved by the batched query.
+        # Enum options scoped to type resolved by batched query.
         assert probes[0].kwargs["params"]["type"] == "task"
 
     async def test_guard_error_names_offending_item(
@@ -1443,8 +1442,8 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Item 1 passes; item 2 reuses the cached options and is rejected
-        # with its batch position and id.
+        # Item 1 pass; item 2 reuse cached options — rejected with batch
+        # position and id.
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task"), ("MCPT-2", "task")),
             _enum_get_response(["50.0"]),
@@ -1467,7 +1466,7 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: existence, then the type sample (+ bypass-retry sample).
+        # GETs: existence, then type sample (+ bypass-retry sample).
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task")),
             _wi_sample_response({"risk_score": 5}),
@@ -1488,8 +1487,8 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Regression: a custom key valid for the type but unset on THIS item
-        # must pass — the type sample knows it even when the item does not.
+        # Regression: custom key valid for type but unset on THIS item must
+        # pass — type sample know it even when item does not.
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task")),
             _wi_sample_response({"release_train_id": "RT-1"}),
@@ -1511,8 +1510,7 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # GETs: existence, type sample (knows asil), enum probe — '9' is not
-        # among the field's options.
+        # GETs: existence, type sample (know asil), enum probe — '9' not in options.
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task")),
             _wi_sample_response({"asil": "1"}),
@@ -1530,10 +1528,10 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # change_type_to retypes the items in the same PATCH, so custom_fields
-        # are validated against the NEW type's schema, not the current one.
+        # change_type_to retype items in same PATCH — custom_fields validated
+        # against NEW type schema, not current.
         # GETs: existence, type options (change_type_to axis), custom sample,
-        # then the enum-value probe for the key (404 = not enum).
+        # enum-value probe (404 = not enum).
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task")),
             _enum_get_response(["requirement"]),
@@ -1582,7 +1580,7 @@ class TestEnumGuardUpdateWorkItems:
         reset_enum_guard_caches: None,
     ) -> None:
         # GETs: existence, type options (change_type_to axis), status options
-        # scoped to the target type.
+        # scoped to target type.
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task")),
             _enum_get_response(["requirement"]),
@@ -1611,8 +1609,8 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Two items of different types: status options are probed once per
-        # resolved type (the option cache is keyed by type).
+        # Two items, different types: status options probed once per
+        # resolved type (option cache keyed by type).
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task"), ("MCPT-2", "requirement")),
             _enum_get_response(["draft", "open"]),
@@ -1659,7 +1657,7 @@ class TestEnumGuardUpdateWorkItems:
 
 
 class TestListWorkItems:
-    """Tests for the ``list_work_items`` tool."""
+    """``list_work_items`` tool."""
 
     async def test_returns_work_items(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1893,7 +1891,7 @@ class TestListWorkItems:
     async def test_total_count_floor_when_api_returns_zero(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """When Polarion omits totalCount (returns 0), use item count as minimum."""
+        """Polarion omit totalCount (return 0) → item count as floor."""
         mock_client.get.return_value = {
             "data": [
                 {
@@ -1924,12 +1922,12 @@ class TestListWorkItems:
             page_number=1,
         )
 
-        # total_count should be at least 2 (the number of returned items)
+        # Floor = returned item count.
         assert result.total_count >= 2
 
 
 class TestGetWorkItem:
-    """Tests for the ``get_work_item`` tool."""
+    """``get_work_item`` tool."""
 
     async def test_returns_work_item_detail(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1994,7 +1992,7 @@ class TestGetWorkItem:
         assert result.document_name == "SRS"
         assert result.assignee_ids == ["alice"]
         assert result.author_id == "bob"
-        # Entry without uri is skipped.
+        # Entry without uri skipped.
         assert len(result.hyperlinks) == 1
         assert result.hyperlinks[0].role == "ref_ext"
         assert result.hyperlinks[0].uri == "https://example.com/spec"
@@ -2008,8 +2006,8 @@ class TestGetWorkItem:
     async def test_include_description_html_false_blanks_field(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """include_description_html=False blanks the field — body still travels
-        (``@all`` for customs); passed explicitly since direct calls bypass defaults.
+        """include_description_html=False blank field — body still travel
+        (``@all`` for customs); passed explicit, direct calls bypass defaults.
         """
         mock_client.get.return_value = {
             "data": {
@@ -2040,7 +2038,7 @@ class TestGetWorkItem:
     async def test_polarion_specific_markup_round_trips(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Polarion spans / data-* attributes survive on read.
+        """Polarion spans / data-* attrs survive read.
 
         Round-trip guarantee for update_work_items description_html.
         """
@@ -2115,7 +2113,7 @@ class TestGetWorkItem:
         )
 
         assert result.description_html == ""
-        # Default values for new detail-only fields.
+        # Defaults for detail-only fields.
         assert result.author_id == ""
         assert result.created == ""
         assert result.severity == ""
@@ -2165,7 +2163,7 @@ class TestGetWorkItem:
     async def test_custom_fields_populated_from_response(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Inline non-standard attributes flow through as ``custom_fields``."""
+        """Inline non-standard attrs flow through as ``custom_fields``."""
         rich_value = {"type": "text/html", "value": "<p>note</p>"}
         mock_client.get.return_value = {
             "data": {
@@ -2225,7 +2223,7 @@ class TestGetWorkItem:
     async def test_sparse_fieldset_uses_all_token(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """``fields[workitems]=@all`` is the only token that surfaces customs."""
+        """``fields[workitems]=@all`` = only token that surface customs."""
         mock_client.get.return_value = {
             "data": {
                 "id": "proj1/MCPT-1",
@@ -2244,10 +2242,10 @@ class TestGetWorkItem:
 
 
 class TestReadWorkItem:
-    """Tests for the ``read_work_item`` tool.
+    """``read_work_item`` tool.
 
-    Delegates the fetch + error mapping to ``get_work_item`` and converts
-    the raw HTML body to Markdown via ``html_to_markdown()``.
+    Delegate fetch + error mapping to ``get_work_item``; convert raw HTML
+    body to Markdown via ``html_to_markdown()``.
     """
 
     async def test_html_body_converted_to_markdown(
@@ -2322,8 +2320,8 @@ class TestReadWorkItem:
     async def test_polarion_specific_markup_collapses_to_text(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """Read-only contract: WorkItemRead.description is NOT round-trip shape —
-        feeding it back loses the polarion-rte-link span.
+        """Read-only contract: WorkItemRead.description NOT round-trip shape —
+        feed it back lose polarion-rte-link span.
         """
         raw = (
             '<p>Refs <span class="polarion-rte-link" '
@@ -2433,7 +2431,7 @@ class TestReadWorkItem:
         assert result.resolution == "fixed"
         assert len(result.hyperlinks) == 1
         assert result.hyperlinks[0].uri == "https://example.com/spec"
-        # Customs stay raw so the dict round-trips through update_work_items.
+        # Customs stay raw — dict round-trip through update_work_items.
         assert result.custom_fields == {
             "riskLevel": "high",
             "reviewerNote": rich_value,
@@ -2442,7 +2440,7 @@ class TestReadWorkItem:
     async def test_no_description_html_field_on_model(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """WorkItemRead does not expose description_html — read-only contract."""
+        """WorkItemRead expose no description_html — read-only contract."""
         mock_client.get.return_value = {
             "data": {
                 "id": "proj1/MCPT-1",

--- a/tests/mcp_server_polarion/utils/test_html.py
+++ b/tests/mcp_server_polarion/utils/test_html.py
@@ -1,4 +1,4 @@
-"""Tests for ``utils/html.py`` — HTML ↔ Markdown conversion edge cases."""
+"""``utils/html.py`` — HTML ↔ Markdown conversion edge cases."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ from mcp_server_polarion.utils.html import (
 
 
 class TestHtmlToMarkdown:
-    """Verify HTML → Markdown conversion."""
+    """HTML → Markdown conversion."""
 
     def test_simple_paragraph(self) -> None:
         result = html_to_markdown("<p>Hello world</p>")
@@ -55,7 +55,7 @@ class TestHtmlToMarkdown:
         result = html_to_markdown(html)
         assert "Item 1" in result
         assert "Item 2" in result
-        # Should use list markers (*, -, or +)
+        # List markers (*, -, or +).
         lines = [line.strip() for line in result.splitlines() if line.strip()]
         assert any(line.startswith(("* ", "- ", "+ ")) for line in lines)
 
@@ -108,8 +108,8 @@ class TestHtmlToMarkdown:
         assert "&" in result
 
     def test_empty_alt_filled_from_title(self) -> None:
-        """``<img title="X">`` (no alt) → ``![X](src)``; ``title`` dropped so the label
-        appears once.
+        """``<img title="X">`` (no alt) → ``![X](src)``; ``title`` dropped so
+        label appear once.
         """
         html = '<img src="attachment:1-shot.png" title="shot.png"/>'
         result = html_to_markdown(html)
@@ -117,8 +117,8 @@ class TestHtmlToMarkdown:
         assert '"shot.png"' not in result
 
     def test_empty_alt_filled_from_src_filename(self) -> None:
-        """No alt, no title → alt from the post-``:`` src segment (clipboard-pasted
-        attachments carry no title; the filename is the only readable label).
+        """No alt, no title → alt from post-``:`` src segment (clipboard-pasted
+        attachments carry no title; filename = only readable label).
         """
         html = (
             '<img src="attachment:1-screenshot-20260512-142738-1.png" '
@@ -131,7 +131,7 @@ class TestHtmlToMarkdown:
         )
 
     def test_existing_alt_preserved(self) -> None:
-        """An img that already carries a non-empty alt is left alone."""
+        """Img already carrying non-empty alt left alone."""
         html = '<img alt="My picture" src="workitemimg:1-foo.png" title="foo.png"/>'
         result = html_to_markdown(html)
         assert "![My picture](workitemimg:1-foo.png" in result
@@ -142,7 +142,7 @@ class TestHtmlToMarkdown:
         result = html_to_markdown(html)
         assert "Before" in result
         assert "After" in result
-        # No alt/title to promote, so src stays in a bare ![](src).
+        # No alt/title to promote — src stay in bare ![](src).
         assert "![](https://example.com/pic.jpg)" in result
 
     def test_nested_formatting(self) -> None:
@@ -244,7 +244,7 @@ class TestHtmlToMarkdownMergedCells:
         assert rows == [["X", "Y"]], result
 
     def test_table_rowspan_overflow_silently_clipped(self) -> None:
-        # rowspan claims 5 rows but only 2 exist — extra reservations dropped.
+        # rowspan claim 5 rows but only 2 exist — extra reservations dropped.
         html = (
             "<table><thead><tr><th>A</th><th>B</th></tr></thead>"
             '<tbody><tr><td rowspan="5">Tall</td><td>X</td></tr>'
@@ -257,9 +257,8 @@ class TestHtmlToMarkdownMergedCells:
         assert rows[2] == ["Tall", "Y"]
 
     def test_table_colspan_skips_rowspan_reservation(self) -> None:
-        """A colspan cell pushed past a previous row's rowspan must not
-        overwrite the reservation — it should land at non-contiguous columns
-        (matching browser rendering).
+        """Colspan cell pushed past previous row's rowspan must not overwrite
+        the reservation — land at non-contiguous columns (match browser).
         """
         # Row 0: A | B(rowspan=2) | C
         # Row 1: D(colspan=2) — should occupy cols 0 and 2 (col 1 reserved)
@@ -289,7 +288,7 @@ class TestHtmlToMarkdownMergedCells:
             "</tbody></table>"
         )
         result = html_to_markdown(html)
-        # Markdownify renders <strong> as **bold**; both duplicates carry it.
+        # Markdownify render <strong> as **bold**; both duplicates carry it.
         assert result.count("**bold**") == 2, result
 
     def test_nested_table_each_rectangularized(self) -> None:
@@ -311,8 +310,8 @@ class TestHtmlToMarkdownMergedCells:
         assert result.count("OUTER") >= 2, result
 
     def test_table_pathological_span_product_bounded(self) -> None:
-        """colspan*rowspan is clamped to keep worst-case allocation bounded."""
-        # Without the product clamp, 1000*1000 spans would materialise 1M clones.
+        """colspan*rowspan clamped — keep worst-case allocation bounded."""
+        # Without product clamp, 1000*1000 spans materialise 1M clones.
         html = (
             '<table><tbody><tr><td colspan="1000" rowspan="1000">M</td>'
             "<td>Z</td></tr></tbody></table>"
@@ -374,7 +373,7 @@ class TestHtmlToMarkdownPolarionRteLinks:
         assert "polarion:Design/%EC%84%A4%EA%B3%84%20%EB%AC%B8%EC%84%9C" in result
 
     def test_span_without_target_metadata_does_not_crash(self) -> None:
-        # Span carries no usable target metadata — surrounding text must still render.
+        # Span carry no usable target metadata — surrounding text must still render.
         html = '<p>Prefix <span class="polarion-rte-link">visible</span> suffix.</p>'
         result = html_to_markdown(html)
         assert "Prefix" in result
@@ -386,7 +385,7 @@ class TestHtmlToMarkdownPolarionRteLinks:
         assert "[x](https://example.com)" in result
 
     def test_work_item_link_with_scope_uses_project_segment(self) -> None:
-        """``data-scope`` becomes a ``project/<scope>/`` URI segment."""
+        """``data-scope`` become ``project/<scope>/`` URI segment."""
         html = (
             '<p><span class="polarion-rte-link" '
             'data-item-id="MCPT-7" data-scope="OtherProj"></span></p>'
@@ -395,14 +394,14 @@ class TestHtmlToMarkdownPolarionRteLinks:
         assert "[MCPT-7](polarion:project/OtherProj/workitem/MCPT-7)" in result
 
     def test_work_item_link_without_scope_keeps_bare_uri(self) -> None:
-        """No ``data-scope`` keeps the bare ``polarion:workitem/<id>`` URI."""
+        """No ``data-scope`` keep bare ``polarion:workitem/<id>`` URI."""
         html = '<p><span class="polarion-rte-link" data-item-id="MCPT-7"></span></p>'
         result = html_to_markdown(html)
         assert "[MCPT-7](polarion:workitem/MCPT-7)" in result
         assert "project/" not in result
 
     def test_label_brackets_are_md_escaped(self) -> None:
-        """``[`` / ``]`` inside the label must not collapse the link syntax."""
+        """``[`` / ``]`` inside label must not collapse link syntax."""
         html = (
             '<p><span class="polarion-rte-link" data-item-id="MCPT-1">'
             "see [draft]</span></p>"
@@ -411,7 +410,7 @@ class TestHtmlToMarkdownPolarionRteLinks:
         assert "[see \\[draft\\]](polarion:workitem/MCPT-1)" in result
 
     def test_label_backslash_is_md_escaped(self) -> None:
-        """A trailing ``\\`` in the label must be doubled to stay literal."""
+        """Trailing ``\\`` in label must double to stay literal."""
         html = (
             '<p><span class="polarion-rte-link" data-item-id="MCPT-1">a\\b</span></p>'
         )
@@ -430,7 +429,7 @@ class TestHtmlToMarkdownPolarionRteLinks:
 
 
 class TestMarkdownToHtml:
-    """Verify Markdown → HTML conversion."""
+    """Markdown → HTML conversion."""
 
     def test_single_paragraph(self) -> None:
         result = markdown_to_html("Hello world")
@@ -475,7 +474,7 @@ class TestMarkdownToHtml:
         """Critical test: LLMs produce 2-space indented nested lists."""
         text = "- Parent\n  - Child 1\n  - Child 2"
         result = markdown_to_html(text)
-        # Must produce nested <ul>, not a flat list
+        # Nested <ul>, not flat list.
         assert result.count("<ul>") == 2
 
     def test_table(self) -> None:
@@ -514,31 +513,31 @@ class TestMarkdownToHtml:
         assert markdown_to_html("\n\n\n") == ""
 
     def test_html_block_not_passed_through(self) -> None:
-        """Raw HTML blocks in Markdown must be escaped, not injected as live HTML."""
+        """Raw HTML blocks in Markdown escaped, not injected live."""
         text = "<script>alert('xss')</script>\n\nSafe"
         result = markdown_to_html(text)
-        # html_block rule is disabled → the tag is HTML-escaped, never a live element
+        # html_block rule disabled → tag HTML-escaped, never live element.
         assert "<script>" not in result  # no executable script tag
         assert "&lt;script&gt;" in result  # tag is safely encoded as text
 
     def test_html_inline_not_passed_through(self) -> None:
-        """Inline raw HTML in Markdown must be escaped, not injected as live HTML."""
+        """Inline raw HTML in Markdown escaped, not injected live."""
         text = 'Click <a onclick="evil()">here</a>'
         result = markdown_to_html(text)
-        # html_inline rule is disabled → inline HTML is HTML-escaped, not live
+        # html_inline rule disabled → inline HTML escaped, not live.
         assert "<a onclick=" not in result  # no executable attribute
         assert "&lt;a" in result  # tag is safely encoded as text
 
 
 class TestSanitizeHtml:
-    """Verify disallowed tag removal while preserving content."""
+    """Disallowed tag removal while preserving content."""
 
     def test_allowed_tags_preserved(self) -> None:
         html = "<p>Hello <strong>world</strong></p>"
         assert sanitize_html(html) == html
 
     def test_script_tag_and_content_removed(self) -> None:
-        """script content (JS code) must be fully discarded, not leaked as text."""
+        """script content (JS) fully discarded, not leaked as text."""
         html = "<p><script>alert('xss')</script>Safe text</p>"
         result = sanitize_html(html)
         assert "<script>" not in result
@@ -546,7 +545,7 @@ class TestSanitizeHtml:
         assert "Safe text" in result
 
     def test_style_tag_and_content_removed(self) -> None:
-        """style content (CSS) must be fully discarded, not leaked as text."""
+        """style content (CSS) fully discarded, not leaked as text."""
         html = "<style>.red{color:red}</style><p>Visible</p>"
         result = sanitize_html(html)
         assert "<style>" not in result
@@ -561,11 +560,11 @@ class TestSanitizeHtml:
         assert "<p>Content</p>" in result
 
     def test_decompose_with_nested_disallowed_child_no_error(self) -> None:
-        """decompose() removes a script subtree; the loop must not crash when it
-        subsequently encounters the already-detached child tag (font inside script).
+        """decompose() remove script subtree; loop must not crash when it later
+        hit the already-detached child tag (font inside script).
         """
         html = "<p><script><font>nested</font></script>After</p>"
-        # Should not raise ValueError; script + its child are silently dropped
+        # No ValueError; script + child silently dropped.
         result = sanitize_html(html)
         assert "<script>" not in result
         assert "nested" not in result
@@ -578,7 +577,7 @@ class TestSanitizeHtml:
         assert sanitize_html("   \n\t  ") == ""
 
     def test_all_allowed_tags_accepted(self) -> None:
-        # Self-closing tags like <br> are rendered as <br/> by BS4
+        # BS4 render self-closing tags like <br> as <br/>.
         self_closing = {"br"}
         for tag in ALLOWED_TAGS:
             if tag in self_closing:
@@ -617,7 +616,7 @@ class TestSanitizeHtml:
         assert "onclick" not in result  # event handler removed
 
     def test_disallowed_attr_stripped_from_allowed_tag(self) -> None:
-        """Arbitrary non-allowlisted attributes are removed from allowed tags."""
+        """Arbitrary non-allowlisted attrs removed from allowed tags."""
         html = '<p class="red" style="color:red">Text</p>'
         result = sanitize_html(html)
         assert "class" not in result
@@ -629,13 +628,13 @@ class TestSanitizeHtml:
         assert "href" in ALLOWED_ATTRS.get("a", frozenset())
 
     def test_table_cell_span_attributes_preserved(self) -> None:
-        """colspan/rowspan on td/th must be preserved as they control table layout."""
+        """colspan/rowspan on td/th preserved — control table layout."""
         html = '<table><tr><td colspan="2">Cell</td></tr></table>'
         result = sanitize_html(html)
         assert 'colspan="2"' in result
 
     def test_javascript_href_stripped(self) -> None:
-        """javascript: URIs in href must be removed to prevent stored XSS."""
+        """javascript: URIs in href removed — prevent stored XSS."""
         html = "<a href=\"javascript:alert('xss')\">Click</a>"
         result = sanitize_html(html)
         assert "javascript:" not in result
@@ -681,7 +680,7 @@ class TestSanitizeHtml:
 
 
 class TestRoundTrip:
-    """Verify that Markdown → HTML → Markdown round-trips preserve content."""
+    """Markdown → HTML → Markdown round-trips preserve content."""
 
     @pytest.mark.parametrize(
         "text",
@@ -695,7 +694,7 @@ class TestRoundTrip:
     def test_roundtrip_preserves_content(self, text: str) -> None:
         html = markdown_to_html(text)
         recovered = html_to_markdown(html)
-        # All original words must appear in the round-tripped text
+        # All original words must appear in round-tripped text.
         for word in text.split():
             word_clean = word.strip("#-*")
             if word_clean:
@@ -703,8 +702,8 @@ class TestRoundTrip:
 
 
 class TestStampBlockIds:
-    """Verify ``stamp_block_ids`` covers exactly the blocks Polarion's
-    ``/parts`` derivation requires and leaves headings alone.
+    """``stamp_block_ids`` cover exactly the blocks Polarion ``/parts``
+    derivation require; headings left alone.
     """
 
     def test_each_block_tag_gets_unique_sequential_id(self) -> None:
@@ -727,13 +726,13 @@ class TestStampBlockIds:
         html = '<p id="existing">a</p><p>b</p>'
         result = stamp_block_ids(html)
         assert '<p id="existing">a</p>' in result
-        # Counter starts at 0 even when the prior block had a caller-provided id.
+        # Counter start at 0 even when prior block had caller-provided id.
         assert '<p id="polarion_mcp_0">b</p>' in result
 
     def test_existing_polarion_mcp_id_avoids_collision(self) -> None:
-        """A pre-existing ``polarion_mcp_N`` anchor (e.g. raw HTML embedded
-        in Markdown) must not be duplicated by the counter, otherwise
-        Polarion rejects the PATCH with HTTP 400.
+        """Pre-existing ``polarion_mcp_N`` anchor (e.g. raw HTML embedded in
+        Markdown) must not be duplicated by counter — Polarion reject the
+        PATCH with HTTP 400.
         """
         html = (
             '<p id="polarion_mcp_0">manual0</p>'
@@ -760,9 +759,9 @@ class TestStampBlockIds:
         assert '<p id="anchor_1">y</p>' in result
 
     def test_clean_input_returned_verbatim(self) -> None:
-        """When every target block already carries a non-blank id, the input
-        is returned byte-for-byte — no BeautifulSoup reserialization, so
-        ``&nbsp;``/``&copy;`` and quote style survive an anchored round-trip.
+        """Every target block already carrying non-blank id → input returned
+        byte-for-byte — no BeautifulSoup reserialization, so ``&nbsp;``/
+        ``&copy;`` and quote style survive anchored round-trip.
         """
         html = '<p id="a">x&nbsp;y</p><table id="t"><tr><td>&copy;</td></tr></table>'
         assert stamp_block_ids(html) == html
@@ -773,8 +772,8 @@ class TestStampBlockIds:
         assert stamp_block_ids(html) == html
 
     def test_whitespace_only_id_is_stamped(self) -> None:
-        # A blank id does not anchor the block (mirrors first_anchorless_block);
-        # it gets restamped rather than skipped.
+        # Blank id not anchor block (mirror first_anchorless_block) —
+        # restamped, not skipped.
         result = stamp_block_ids('<p id="   ">x</p>')
         assert '<p id="polarion_mcp_0">x</p>' in result
 
@@ -784,8 +783,8 @@ class TestStampBlockIds:
 
 
 class TestFirstAnchorlessBlock:
-    """``first_anchorless_block`` is the write-side reject predicate; every
-    block in ``_BLOCK_TAGS_NEEDING_IDS`` must carry a non-empty id.
+    """``first_anchorless_block`` = write-side reject predicate; every
+    block in ``_BLOCK_TAGS_NEEDING_IDS`` must carry non-empty id.
     """
 
     @pytest.mark.parametrize("value", ["", "   ", "\n\t"])
@@ -810,7 +809,7 @@ class TestFirstAnchorlessBlock:
         assert first_anchorless_block(html) is None
 
     def test_returns_first_offender_in_document_order(self) -> None:
-        # The <p> is anchored; the <ul> is not, so the <ul> is reported.
+        # <p> anchored; <ul> not — <ul> reported.
         html = '<p id="a">x</p><ul><li>y</li></ul>'
         assert first_anchorless_block(html) == "ul"
 
@@ -818,11 +817,11 @@ class TestFirstAnchorlessBlock:
         assert first_anchorless_block('<p id="">x</p>') == "p"
 
     def test_whitespace_only_id_is_anchorless(self) -> None:
-        # Stricter than stamp_block_ids: a blank id does not anchor the block.
+        # Stricter than stamp_block_ids: blank id not anchor block.
         assert first_anchorless_block('<p id="   ">x</p>') == "p"
 
     def test_nested_anchorless_block_is_caught(self) -> None:
-        # An anchored outer block does not excuse an anchorless inner block.
+        # Anchored outer block not excuse anchorless inner block.
         html = '<div id="outer"><p>inner</p></div>'
         assert first_anchorless_block(html) == "p"
 
@@ -831,13 +830,13 @@ class TestFirstAnchorlessBlock:
         assert first_anchorless_block(html) == "table"
 
     def test_inline_elements_do_not_count(self) -> None:
-        # <span>/<strong> are not in the block set, so an anchored <p>
-        # wrapping them passes even though the inline tags lack ids.
+        # <span>/<strong> not in block set — anchored <p> wrapping them
+        # pass even though inline tags lack ids.
         assert first_anchorless_block('<p id="a">x <span>y</span></p>') is None
 
 
 class TestPolarionifyTables:
-    """Verify bare-table styling injection."""
+    """Bare-table styling injection."""
 
     def test_bare_table_gets_polarion_class(self) -> None:
         result = polarionify_html("<table><tr><td>x</td></tr></table>")
@@ -890,7 +889,7 @@ class TestPolarionifyTables:
 
 
 class TestPolarionifyCaptions:
-    """Verify Table:/Figure: paragraph → native caption widget."""
+    """Table:/Figure: paragraph → native caption widget."""
 
     def test_table_caption_converted(self) -> None:
         html = "<table><tr><td>x</td></tr></table><p>Table: 병합 테스트</p>"
@@ -904,7 +903,7 @@ class TestPolarionifyCaptions:
     def test_caption_paragraph_shape(self) -> None:
         html = "<table><tr><td>x</td></tr></table><p>Table: cap</p>"
         result = polarionify_html(html)
-        # BS4 serializes class before data-*; Polarion accepts either order.
+        # BS4 serialize class before data-*; Polarion accept either order.
         assert (
             '<p class="polarion-rte-caption-paragraph" style="text-align: left;">'
             'Table <span class="polarion-rte-caption" data-sequence="Table">#</span>'
@@ -956,7 +955,7 @@ class TestPolarionifyPipeline:
         assert "테스트 표" in result
 
     def test_markdown_image_stripped_so_figure_caption_stays_prose(self) -> None:
-        # sanitize_html drops <img>, so the Figure: paragraph loses its anchor.
+        # sanitize_html drop <img> — Figure: paragraph lose anchor.
         markdown = "![alt](https://example.com/x.png)\n\nFigure: 그림 캡션\n"
         result = polarionify_html(sanitize_html(markdown_to_html(markdown)))
         assert "polarion-rte-caption" not in result


### PR DESCRIPTION
## Summary

Compress every comment and dev docstring under tests/ to dense caveman style: drop articles and filler, compress verbs, keep the why, delete comments derivable from code. No executable line changed -- every file passes the compress-code-comments comment-only AST gate against main. Functional pseudo-comments (noqa, type: ignore, pragma), assert-message strings, and fixture literals untouched; one now-redundant noqa: E501 removed together with the shortened line it suppressed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Verbose test comments/docstrings re-sync on every edit and drag reading
- Caveman-compress all tests/ comments and dev docstrings; comment-only AST diff, all gates green

## Testing

- assert_comment_only.py passes for all 57 changed files (comment/docstring-only AST diff vs main)
- ruff check, ruff format --check, mypy src/, pytest (1597 passed) all green; diff-cover: no coverage-relevant lines in diff

## Notes for Reviewers

Comment content only -- 57 files, +681/-695 lines, net -14. Heaviest files: tools/test_work_items.py, tools/test_documents.py, utils/test_html.py. Already-dense module docstrings (eval-case invariants, SQL-escape pin) kept as-is on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)