### PR TITLE
chore(middleware): compress comment caveman-style

### DIFF
--- a/src/mcp_server_polarion/middleware.py
+++ b/src/mcp_server_polarion/middleware.py
@@ -49,9 +49,8 @@ class CompactValidationErrorMiddleware(Middleware):
         try:
             return await call_next(context)
         except (ValidationError, FastMCPValidationError) as exc:
-            # fastmcp >=3.4.3 wraps tool-arg pydantic errors in its own
-            # ValidationError (original on __cause__); tool-body errors stay raw
-            # pydantic. Normalise to the pydantic error before compacting.
+            # fastmcp >=3.4.3 wrap arg pydantic error in own ValidationError
+            # (original on __cause__); tool-body error arrive raw pydantic.
             pydantic_exc = exc if isinstance(exc, ValidationError) else exc.__cause__
             if not isinstance(pydantic_exc, ValidationError):
                 raise


### PR DESCRIPTION
## Summary

Compress the fastmcp-unwrap comment in `middleware.py` to match the repo's 1-2 line caveman comment norm. Follow-up to #148.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- 3-line comment block exceeded the repo 1-2 line norm; its 3rd line restated the next code line (self-evident)
- tightened to 2 lines, dropped the restatement and articles

## Testing

`ruff check` + `ruff format --check` + `mypy src/` + `pytest tests/mcp_server_polarion/test_middleware.py` all green locally. Comment-only, no behavior change.

## Notes for Reviewers

Comment-only cosmetic follow-up to the #148 fastmcp 3.4.3 fix. No executable lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
