### PR TITLE
fix(comments): drop author_id write param

### DIFF
--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -31,7 +31,6 @@ class CommentSpec(BaseModel):
     text: str = Field(min_length=1)
     text_format: Literal["text/html", "text/plain"] = "text/plain"
     resolved: bool | None = None
-    author_id: str | None = None
     parent_comment_id: str | None = None
 
 

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -64,9 +64,9 @@ def _build_comment_create_payload(
         if spec.resolved is not None:
             attributes["resolved"] = spec.resolved
 
+        # No author relationship: comment author = token user always. Client
+        # cannot attribute to another user (Polarion no-validate = forgery).
         relationships: dict[str, JsonValue] = {}
-        if spec.author_id is not None:
-            relationships["author"] = {"data": {"id": spec.author_id, "type": "users"}}
         if spec.parent_comment_id is not None:
             relationships["parentComment"] = {
                 "data": {
@@ -321,8 +321,8 @@ async def create_document_comments(  # noqa: PLR0913
     """Create one or more comments on a document in a single request.
 
     Reply: set parent_comment_id to a short ID from list_document_comments
-    (None = top-level). 'text/html' text is sent unsanitized; omit author_id
-    for the token's user. NOT idempotent — a retry duplicates.
+    (None = top-level). 'text/html' text is sent unsanitized. Comment is always
+    authored by the token's user. NOT idempotent — a retry duplicates.
     """
     payload = _build_document_comments_payload(
         specs=comments,
@@ -409,8 +409,8 @@ async def create_work_item_comments(
 
     Reply: set parent_comment_id to a short ID from list_work_item_comments
     (None = top-level). Optional title sets the comment heading. 'text/html'
-    text is sent unsanitized; omit author_id for the token's user. NOT
-    idempotent — a retry duplicates.
+    text is sent unsanitized. Comment is always authored by the token's user.
+    NOT idempotent — a retry duplicates.
     """
     payload = _build_work_item_comments_payload(
         specs=comments,

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -715,18 +715,22 @@ class TestBuildDocumentCommentsPayload:
         attrs = payload["data"][0]["attributes"]  # type: ignore[index]
         assert "resolved" not in attrs  # type: ignore[operator]
 
-    def test_author_relationship(self) -> None:
+    def test_author_id_rejected(self) -> None:
+        """author_id dropped: impersonation blocked; extra=forbid rejects key."""
+        with pytest.raises(ValidationError):
+            CommentSpec(text="t", author_id="alice")  # type: ignore[call-arg]
+
+    def test_no_author_relationship_emitted(self) -> None:
+        """Payload never carry author: comment author = token user always."""
         payload = _build_document_comments_payload(
-            specs=[CommentSpec(text="t", author_id="alice")],
+            specs=[CommentSpec(text="t")],
             project_id="P",
             space_id="S",
             document_name="D",
         )
         item = payload["data"][0]  # type: ignore[index]
         assert isinstance(item, dict)
-        assert item["relationships"]["author"] == {  # type: ignore[index]
-            "data": {"id": "alice", "type": "users"}
-        }
+        assert "author" not in item.get("relationships", {})  # type: ignore[operator]
 
     def test_parent_comment_full_path_composed(self) -> None:
         """Short parent_comment_id expanded to full 4-segment path."""
@@ -740,19 +744,6 @@ class TestBuildDocumentCommentsPayload:
         assert isinstance(item, dict)
         rel = item["relationships"]["parentComment"]  # type: ignore[index]
         assert rel == {"data": {"id": "Proj/Space/Doc/c1", "type": "document_comments"}}
-
-    def test_both_relationships_present(self) -> None:
-        payload = _build_document_comments_payload(
-            specs=[CommentSpec(text="t", author_id="bob", parent_comment_id="c5")],
-            project_id="P",
-            space_id="S",
-            document_name="D",
-        )
-        item = payload["data"][0]  # type: ignore[index]
-        assert isinstance(item, dict)
-        rels = item["relationships"]
-        assert "author" in rels  # type: ignore[operator]
-        assert "parentComment" in rels  # type: ignore[operator]
 
     def test_html_format_preserved(self) -> None:
         payload = _build_document_comments_payload(
@@ -833,16 +824,14 @@ class TestCreateDocumentCommentsDryRun:
             project_id="P",
             space_id="S",
             document_name="D",
-            comments=[
-                CommentSpec(text="reply", author_id="bob", parent_comment_id="c5")
-            ],
+            comments=[CommentSpec(text="reply", parent_comment_id="c5")],
             dry_run=True,
         )
         assert result.payload_preview is not None
         item = result.payload_preview["data"][0]  # type: ignore[index]
         assert isinstance(item, dict)
-        assert "author" in item["relationships"]  # type: ignore[index]
         assert "parentComment" in item["relationships"]  # type: ignore[index]
+        assert "author" not in item["relationships"]  # type: ignore[index]
 
 
 class TestCreateDocumentCommentsHappyPath:
@@ -1123,17 +1112,10 @@ class TestBuildWorkItemCommentsPayload:
         attrs = payload["data"][0]["attributes"]  # type: ignore[index]
         assert "resolved" not in attrs  # type: ignore[operator]
 
-    def test_author_relationship(self) -> None:
-        payload = _build_work_item_comments_payload(
-            specs=[WorkItemCommentSpec(text="t", author_id="alice")],
-            project_id="P",
-            work_item_id="MCPT-1",
-        )
-        item = payload["data"][0]  # type: ignore[index]
-        assert isinstance(item, dict)
-        assert item["relationships"]["author"] == {  # type: ignore[index]
-            "data": {"id": "alice", "type": "users"}
-        }
+    def test_author_id_rejected(self) -> None:
+        """Inherited from CommentSpec: author_id key rejected, no impersonation."""
+        with pytest.raises(ValidationError):
+            WorkItemCommentSpec(text="t", author_id="alice")  # type: ignore[call-arg]
 
     def test_parent_comment_full_path_composed(self) -> None:
         """Short parent_comment_id expanded to full 3-segment path."""


### PR DESCRIPTION
## Summary

Comment create tools accepted an `author_id` write input, letting the caller attribute a comment to any user - a forgery vector on an LLM-facing tool. Live-tested against `MCP_Test_Project`: a comment posted with `author_id=admin` persisted authored-as `admin` (not the token user), and `author_id=ghost-user-nonexistent-xyz` (a non-existent id) also persisted verbatim. Polarion does not validate the comment author relationship. This removes the write-side `author_id`; comments are now always authored by the token's user.

Read-side `Comment.author_id` (list output) is unaffected - this only removes the ability to set author on create.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- remove `CommentSpec.author_id`; payload omits the author relationship, so comment author = token user always
- reject the key via `extra=forbid`; swap author-rel tests for impersonation-blocked ones; refresh 2 tool docstrings

## Testing

`ruff check` + `ruff format --check` + `mypy src/` clean; full `pytest` 1599 passed; `diff-cover` has no changed executable lines to gate. Removal empirically justified by the live `admin` + non-existent-id writes above (both persisted).

## Notes for Reviewers

- Breaking: `CommentSpec`/`WorkItemCommentSpec` no longer accept `author_id`; callers that set it now get a `ValidationError`. Scope is comment create; read output and `update_*_comment` (resolved-only) unchanged.
- No other write tool sets an author relationship, so the same forgery shape does not exist elsewhere - no further removals needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)