### PR TITLE
refactor(tools): trim ids from list outputs

### DIFF
--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -17,7 +17,6 @@ class Comment(BaseModel):
     title: str = ""
     text: str = ""
     text_format: Literal["text/html", "text/plain"] = "text/html"
-    author_id: str | None = None
     author_name: str = ""
     parent_comment_id: str | None = None
     child_comment_ids: list[str] = Field(default_factory=list)

--- a/src/mcp_server_polarion/models/documents.py
+++ b/src/mcp_server_polarion/models/documents.py
@@ -16,9 +16,7 @@ class DocumentSummary(BaseModel):
     type: str = ""
     status: str = ""
     updated: str = ""
-    author_id: str = ""
     author_name: str = ""
-    last_updated_by_id: str = ""
     last_updated_by_name: str = ""
 
 

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -19,7 +19,6 @@ class TestRunSummary(BaseModel):
     status: str
     finished_on: str = ""
     updated: str = ""
-    author_id: str = ""
     author_name: str = ""
     is_template: bool = False
 

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -20,7 +20,7 @@ class WorkItemSummary(BaseModel):
     updated: str = ""
     space_id: str = ""
     document_name: str = ""
-    assignee_ids: list[str] = Field(default_factory=list)
+    author_name: str = ""
 
 
 class Hyperlink(BaseModel):
@@ -40,7 +40,7 @@ class WorkItemDetail(WorkItemSummary):
     description_html: str = ""
     project_id: str
     author_id: str = ""
-    author_name: str = ""
+    assignee_ids: list[str] = Field(default_factory=list)
     created: str = ""
     resolution: str = ""
     severity: str = ""
@@ -55,7 +55,7 @@ class WorkItemRead(WorkItemSummary):
     description: str = ""
     project_id: str
     author_id: str = ""
-    author_name: str = ""
+    assignee_ids: list[str] = Field(default_factory=list)
     created: str = ""
     resolution: str = ""
     severity: str = ""

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -60,9 +60,7 @@ class DiscoveredDocument(NamedTuple):
     type: str = ""
     status: str = ""
     updated: str = ""
-    author_id: str = ""
     author_name: str = ""
-    updated_by_id: str = ""
     updated_by_name: str = ""
 
 

--- a/src/mcp_server_polarion/tools/_shared/fields.py
+++ b/src/mcp_server_polarion/tools/_shared/fields.py
@@ -8,7 +8,7 @@ from typing import Final
 MAX_BULK_ITEMS: Final[int] = 50
 
 # Detail fetches need ``@all`` — explicit field lists drop inline customs.
-WORK_ITEM_LIST_FIELDS: Final[str] = "title,type,status,priority,updated,module,assignee"
+WORK_ITEM_LIST_FIELDS: Final[str] = "title,type,status,priority,updated,module,author"
 WORK_ITEM_DETAIL_FIELDS: Final[str] = "@all"
 WORK_ITEM_PART_FIELDS: Final[str] = "title,type,status,description,outlineNumber"
 # camelCase finishedOn/isTemplate = Polarion attr names; author keep

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -37,7 +37,7 @@ class WorkItemSummaryKwargs(TypedDict):
     updated: str
     space_id: str
     document_name: str
-    assignee_ids: list[str]
+    author_name: str
 
 
 def extract_relationship_id(
@@ -142,9 +142,11 @@ def parse_included_user_name_map(response: dict[str, object]) -> dict[str, str]:
 
 def parse_work_item_summary_kwargs(
     item: dict[str, object],
+    user_names: Mapping[str, str] | None = None,
 ) -> WorkItemSummaryKwargs:
-    """``WorkItemSummary`` kwargs from JSON:API resource; shared so
-    ``WorkItemDetail`` stay strict superset of ``WorkItemSummary``.
+    """``WorkItemSummary`` kwargs from JSON:API resource; shared base so
+    ``WorkItemDetail`` stay superset (author_id/assignee_ids add on detail).
+    ``user_names`` map full author id → display name (from included ``users``).
     """
     attributes = item.get("attributes", {})
     if not isinstance(attributes, dict):
@@ -155,10 +157,7 @@ def parse_work_item_summary_kwargs(
 
     module_id = extract_relationship_id(relationships, "module")
     space_id, document_name = split_module_id(module_id)
-    assignee_ids = [
-        extract_short_id(uid)
-        for uid in extract_relationship_ids(relationships, "assignee")
-    ]
+    author_full = extract_relationship_id(relationships, "author")
 
     return {
         "id": extract_short_id(safe_str(item.get("id", ""))),
@@ -169,7 +168,7 @@ def parse_work_item_summary_kwargs(
         "updated": safe_str(attributes.get("updated", "")),
         "space_id": space_id,
         "document_name": document_name,
-        "assignee_ids": assignee_ids,
+        "author_name": (user_names or {}).get(author_full, ""),
     }
 
 
@@ -218,17 +217,21 @@ def parse_work_item_detail(
     if isinstance(desc_obj, dict):
         desc_html = safe_str(desc_obj.get("value", ""))
 
-    summary_kwargs = parse_work_item_summary_kwargs(item)
+    summary_kwargs = parse_work_item_summary_kwargs(item, user_names)
     if not summary_kwargs["id"]:
         summary_kwargs["id"] = fallback_id
 
     author_full = extract_relationship_id(relationships, "author")
+    assignee_ids = [
+        extract_short_id(uid)
+        for uid in extract_relationship_ids(relationships, "assignee")
+    ]
     return WorkItemDetail(
         **summary_kwargs,
         description_html=desc_html,
         project_id=project_id,
         author_id=extract_short_id(author_full),
-        author_name=(user_names or {}).get(author_full, ""),
+        assignee_ids=assignee_ids,
         created=safe_str(attributes.get("created", "")),
         resolution=safe_str(attributes.get("resolution", "")),
         severity=safe_str(attributes.get("severity", "")),
@@ -257,8 +260,11 @@ def summary_to_back_link(summary: WorkItemSummary) -> WorkItemLink:
 
 def parse_work_item_summaries(
     data: object,
+    user_names: Mapping[str, str] | None = None,
 ) -> list[WorkItemSummary]:
-    """JSON:API ``data`` array → ``WorkItemSummary`` models."""
+    """JSON:API ``data`` array → ``WorkItemSummary`` models. ``user_names``
+    map full author id → display name (from included ``users``).
+    """
     items: list[WorkItemSummary] = []
     if not isinstance(data, list):
         return items
@@ -266,7 +272,8 @@ def parse_work_item_summaries(
     for item in data:
         if not isinstance(item, dict):
             continue
-        items.append(WorkItemSummary(**parse_work_item_summary_kwargs(item)))
+        kwargs = parse_work_item_summary_kwargs(item, user_names)
+        items.append(WorkItemSummary(**kwargs))
     return items
 
 
@@ -279,7 +286,6 @@ class TestRunSummaryKwargs(TypedDict):
     status: str
     finished_on: str
     updated: str
-    author_id: str
     author_name: str
     is_template: bool
 
@@ -306,7 +312,6 @@ def parse_test_run_summary_kwargs(
         "status": safe_str(attributes.get("status", "")),
         "finished_on": safe_str(attributes.get("finishedOn", "")),
         "updated": safe_str(attributes.get("updated", "")),
-        "author_id": extract_short_id(author_id),
         "author_name": user_names.get(author_id, ""),
         "is_template": bool(attributes.get("isTemplate", False)),
     }
@@ -362,7 +367,6 @@ def _parse_comment(item: dict[str, object], user_names: Mapping[str, str]) -> Co
         title=safe_str(attributes.get("title", "")),
         text=text_value,
         text_format=text_format,
-        author_id=extract_short_id(author_full) or None,
         author_name=user_names.get(author_full, ""),
         parent_comment_id=extract_short_id(parent_full) or None,
         child_comment_ids=[extract_short_id(c) for c in child_full],

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -392,9 +392,7 @@ async def _discover_documents(
             type=meta.type,
             status=meta.status,
             updated=meta.updated,
-            author_id=extract_short_id(meta.author_id),
             author_name=user_names.get(meta.author_id, ""),
-            updated_by_id=extract_short_id(meta.updated_by_id),
             updated_by_name=user_names.get(meta.updated_by_id, ""),
         )
         for (space, name), meta in documents.items()
@@ -521,9 +519,9 @@ async def list_documents(
     """List a project's documents.
 
     Returns space_id + document_name (inputs to the other document tools) plus
-    type, status, updated timestamp, and id + display name of the creator
-    (author_id/author_name) and last editor (last_updated_by_id/_name).
-    Discovery scan cached 60s.
+    type, status, updated timestamp, and display names of the creator
+    (author_name) and last editor (last_updated_by_name). Use get_document for
+    author/editor IDs. Discovery scan cached 60s.
     """
     client = get_client(ctx)
 
@@ -556,9 +554,7 @@ async def list_documents(
             type=doc.type,
             status=doc.status,
             updated=doc.updated,
-            author_id=doc.author_id,
             author_name=doc.author_name,
-            last_updated_by_id=doc.updated_by_id,
             last_updated_by_name=doc.updated_by_name,
         )
         for doc in page_slice

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -208,8 +208,9 @@ async def list_test_runs(  # noqa: PLR0913
 
     Returns actual run instances by default; set templates=True for the reusable
     template blueprints instead. Filter with a Lucene query (status:open,
-    type:manual, HAS_VALUE:<field>) or omit for all. To filter by person, match
-    the full author_name exactly and quoted: author.name:"Jane Doe".
+    type:manual, HAS_VALUE:<field>) or omit for all. Filter by person with
+    author.name (exact, quoted) -- author.id does not match on test runs;
+    discover the full name from an unfiltered page first.
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -192,8 +192,9 @@ async def list_test_runs(  # noqa: PLR0913
     query: str | None = Field(
         default=None,
         description=(
-            "Optional Lucene filter (e.g. 'status:open', 'author.id:devemberx', "
-            "'HAS_VALUE:<field>' to match runs with that field populated)."
+            "Optional Lucene filter (e.g. 'status:open', "
+            "'author.name:\"Jane Doe\"', 'HAS_VALUE:<field>' to match runs "
+            "with that field populated)."
         ),
     ),
     templates: bool = Field(
@@ -207,10 +208,8 @@ async def list_test_runs(  # noqa: PLR0913
 
     Returns actual run instances by default; set templates=True for the reusable
     template blueprints instead. Filter with a Lucene query (status:open,
-    type:manual, author.id:<userid>, HAS_VALUE:<field>) or omit for all.
-
-    Results carry author_id + author_name — to find runs by a person, match
-    their name in an unfiltered page, then requery author.id:<author_id>.
+    type:manual, HAS_VALUE:<field>) or omit for all. To filter by person, match
+    the full author_name exactly and quoted: author.name:"Jane Doe".
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -495,7 +495,7 @@ async def list_work_items(
     client = get_client(ctx)
     params: dict[str, str | int] = {
         "fields[workitems]": WORK_ITEM_LIST_FIELDS,
-        # author single-include resolve display name; users sparse to name only.
+        # include author resolve display name; fields[users]=name trim payload.
         "include": "author",
         "fields[users]": "name",
         "page[size]": page_size,

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -495,8 +495,9 @@ async def list_work_items(
     client = get_client(ctx)
     params: dict[str, str | int] = {
         "fields[workitems]": WORK_ITEM_LIST_FIELDS,
-        # To-many ``assignee.data`` inlined only when explicitly included.
-        "include": "assignee",
+        # author single-include resolve display name; users sparse to name only.
+        "include": "author",
+        "fields[users]": "name",
         "page[size]": page_size,
         "page[number]": page_number,
     }
@@ -520,7 +521,7 @@ async def list_work_items(
         raise RuntimeError(f"Failed to list work items: {exc.message}") from exc
 
     data = response.get("data", [])
-    items = parse_work_item_summaries(data)
+    items = parse_work_item_summaries(data, parse_included_user_name_map(response))
 
     return make_page(items, response, page_number, page_size)
 

--- a/tests/mcp_server_polarion/models/test_documents.py
+++ b/tests/mcp_server_polarion/models/test_documents.py
@@ -29,9 +29,7 @@ class TestDocumentSummary:
         d = DocumentSummary(space_id="_default", document_name="SRS")
         assert d.status == ""
         assert d.updated == ""
-        assert d.author_id == ""
         assert d.author_name == ""
-        assert d.last_updated_by_id == ""
         assert d.last_updated_by_name == ""
 
 

--- a/tests/mcp_server_polarion/models/test_work_items.py
+++ b/tests/mcp_server_polarion/models/test_work_items.py
@@ -120,7 +120,7 @@ class TestWorkItemSummary:
         assert work_item.updated == ""
         assert work_item.space_id == ""
         assert work_item.document_name == ""
-        assert work_item.assignee_ids == []
+        assert work_item.author_name == ""
 
     def test_full_metadata(self):
         work_item = WorkItemSummary(
@@ -132,13 +132,13 @@ class TestWorkItemSummary:
             updated="2026-04-29T10:23:00Z",
             space_id="Design",
             document_name="Software Requirement Specification",
-            assignee_ids=["alice", "bob"],
+            author_name="Alice A",
         )
         assert work_item.priority == "90.0"
         assert work_item.updated == "2026-04-29T10:23:00Z"
         assert work_item.space_id == "Design"
         assert work_item.document_name == "Software Requirement Specification"
-        assert work_item.assignee_ids == ["alice", "bob"]
+        assert work_item.author_name == "Alice A"
 
     def test_various_types(self):
         for work_item_type in ("requirement", "task", "testCase", "defect"):

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -169,20 +169,20 @@ class TestParseIncludedUserNameMap:
 class TestParseWorkItemSummaryKwargs:
     """Tests for `parse_work_item_summary_kwargs`."""
 
-    def test_splits_module_and_shortens_assignees(self) -> None:
+    def test_splits_module_and_resolves_author(self) -> None:
         item: dict[str, object] = {
             "id": "proj/MCPT-1",
             "attributes": {"title": "T", "type": "task", "status": "open"},
             "relationships": {
                 "module": {"data": {"id": "proj/Design/Spec"}},
-                "assignee": {"data": [{"id": "proj/jdoe"}]},
+                "author": {"data": {"id": "proj/jdoe"}},
             },
         }
-        kwargs = parse_work_item_summary_kwargs(item)
+        kwargs = parse_work_item_summary_kwargs(item, {"proj/jdoe": "J Doe"})
         assert kwargs["id"] == "MCPT-1"
         assert kwargs["space_id"] == "Design"
         assert kwargs["document_name"] == "Spec"
-        assert kwargs["assignee_ids"] == ["jdoe"]
+        assert kwargs["author_name"] == "J Doe"
 
     def test_non_dict_attributes_and_relationships_default_blank(self) -> None:
         kwargs = parse_work_item_summary_kwargs(
@@ -191,7 +191,7 @@ class TestParseWorkItemSummaryKwargs:
         assert kwargs["id"] == "MCPT-2"
         assert kwargs["title"] == ""
         assert kwargs["space_id"] == ""
-        assert kwargs["assignee_ids"] == []
+        assert kwargs["author_name"] == ""
 
 
 class TestParseHyperlinks:
@@ -228,12 +228,16 @@ class TestParseWorkItemDetail:
                 "description": {"type": "text/html", "value": "<p>raw</p>"},
                 "riskLevel": "high",
             },
-            "relationships": {"author": {"data": {"id": "proj/jdoe"}}},
+            "relationships": {
+                "author": {"data": {"id": "proj/jdoe"}},
+                "assignee": {"data": [{"id": "proj/alice"}, {"id": "proj/bob"}]},
+            },
         }
         detail = parse_work_item_detail(item, project_id="proj")
         assert detail.description_html == "<p>raw</p>"
         assert detail.author_id == "jdoe"
         assert detail.author_name == ""
+        assert detail.assignee_ids == ["alice", "bob"]
         assert detail.custom_fields == {"riskLevel": "high"}
 
     def test_user_names_resolve_author_name(self) -> None:
@@ -316,10 +320,9 @@ class TestParseTestRunSummaries:
         )
         assert kwargs["id"] == "TR-1"
         assert kwargs["title"] == ""
-        assert kwargs["author_id"] == ""
         assert kwargs["author_name"] == ""
 
-    def test_author_id_and_name_pair(self) -> None:
+    def test_author_name_resolved(self) -> None:
         kwargs = parse_test_run_summary_kwargs(
             {
                 "id": "proj/TR-1",
@@ -328,7 +331,6 @@ class TestParseTestRunSummaries:
             },
             user_names={"proj/jdoe": "J Doe"},
         )
-        assert kwargs["author_id"] == "jdoe"
         assert kwargs["author_name"] == "J Doe"
 
     def test_non_list_data_is_empty(self) -> None:
@@ -369,7 +371,6 @@ class TestParseComment:
         assert comment.text == "<p>hi</p>"
         assert comment.text_format == "text/html"
         assert comment.resolved is True
-        assert comment.author_id == "jdoe"
         assert comment.author_name == "J Doe"
         assert comment.child_comment_ids == ["cmt-2"]
 
@@ -380,7 +381,6 @@ class TestParseComment:
             "relationships": {"author": {"data": {"id": "proj/jdoe"}}},
         }
         comment = _parse_comment(item, {})
-        assert comment.author_id == "jdoe"
         assert comment.author_name == ""
 
     def test_plain_format_honored(self) -> None:
@@ -403,12 +403,12 @@ class TestParseComment:
         }
         assert _parse_comment(item, {}).text_format == "text/html"
 
-    def test_absent_author_is_none(self) -> None:
+    def test_absent_author_name_empty(self) -> None:
         item: dict[str, object] = {
             "id": "proj/WI-1/cmt-1",
             "attributes": {"created": "x"},
         }
-        assert _parse_comment(item, {}).author_id is None
+        assert _parse_comment(item, {}).author_name == ""
 
 
 class TestParseCommentsPage:

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -184,6 +184,16 @@ class TestParseWorkItemSummaryKwargs:
         assert kwargs["document_name"] == "Spec"
         assert kwargs["author_name"] == "J Doe"
 
+    def test_author_present_but_unresolved_yields_blank_name(self) -> None:
+        # Author relationship present but id absent from user_names map -> "".
+        item: dict[str, object] = {
+            "id": "proj/MCPT-3",
+            "attributes": {"title": "T", "type": "task", "status": "open"},
+            "relationships": {"author": {"data": {"id": "proj/ghost"}}},
+        }
+        kwargs = parse_work_item_summary_kwargs(item, {"proj/jdoe": "J Doe"})
+        assert kwargs["author_name"] == ""
+
     def test_non_dict_attributes_and_relationships_default_blank(self) -> None:
         kwargs = parse_work_item_summary_kwargs(
             {"id": "proj/MCPT-2", "attributes": None, "relationships": None}

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -88,7 +88,6 @@ class TestListDocumentComments:
         assert comment.resolved is False
         assert comment.text == "<p>Review me</p>"
         assert comment.text_format == "text/html"
-        assert comment.author_id == "alice"
         assert comment.author_name == "Alice A"
         assert comment.parent_comment_id is None
         assert comment.child_comment_ids == []
@@ -211,7 +210,6 @@ class TestListDocumentComments:
         )
 
         comment = result.items[0]
-        assert comment.author_id is None
         assert comment.parent_comment_id is None
         assert comment.child_comment_ids == []
         assert comment.text == ""
@@ -407,7 +405,6 @@ class TestListWorkItemComments:
         assert comment.title == "Needs review"
         assert comment.text == "<p>Review me</p>"
         assert comment.text_format == "text/html"
-        assert comment.author_id == "alice"
         assert comment.author_name == "Alice A"
         assert comment.parent_comment_id is None
         assert comment.child_comment_ids == []
@@ -527,7 +524,6 @@ class TestListWorkItemComments:
         )
 
         comment = result.items[0]
-        assert comment.author_id is None
         assert comment.parent_comment_id is None
         assert comment.child_comment_ids == []
         assert comment.title == ""

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -263,9 +263,7 @@ class TestListDocuments:
         doc = result.items[0]
         assert doc.status == "draft"
         assert doc.updated == "2026-02-22T14:53:03.244Z"
-        assert doc.author_id == "admin"
         assert doc.author_name == "System Administrator"
-        assert doc.last_updated_by_id == "72c2462f"
         assert doc.last_updated_by_name == "Dev Member"
 
     async def test_unresolved_user_yields_empty_name(
@@ -286,8 +284,7 @@ class TestListDocuments:
             page_number=1,
         )
 
-        # Unresolvable name still expose the id — the machine key survives.
-        assert result.items[0].author_id == "ghost"
+        # Unresolvable author id → name stay blank.
         assert result.items[0].author_name == ""
 
     async def test_id_less_included_user_never_matches(
@@ -330,9 +327,7 @@ class TestListDocuments:
         doc = result.items[0]
         assert doc.status == ""
         assert doc.updated == ""
-        assert doc.author_id == ""
         assert doc.author_name == ""
-        assert doc.last_updated_by_id == ""
         assert doc.last_updated_by_name == ""
 
     async def test_deduplicates_documents(

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -100,7 +100,6 @@ class TestListTestRuns:
         assert first.status == "open"
         assert first.finished_on == "2026-05-02T11:00:00Z"
         assert first.updated == "2026-05-01T09:00:00Z"
-        assert first.author_id == "devemberx"
         assert first.author_name == "Devember X"
         assert first.is_template is False
 
@@ -108,7 +107,6 @@ class TestListTestRuns:
         assert second.id == "TR-002"
         assert second.finished_on == ""
         assert second.updated == ""
-        assert second.author_id == ""
         assert second.author_name == ""
         assert second.is_template is True
 
@@ -141,8 +139,7 @@ class TestListTestRuns:
             page_number=1,
         )
 
-        # Unresolvable name still expose the id — the machine key survives.
-        assert result.items[0].author_id == "ghost"
+        # Unresolvable author id → name stay blank.
         assert result.items[0].author_name == ""
 
     async def test_sparse_fieldset_and_includes_requested(
@@ -201,14 +198,14 @@ class TestListTestRuns:
         await list_test_runs(
             mock_ctx,
             project_id="proj1",
-            query="author.id:devemberx",
+            query='author.name:"Jane Doe"',
             templates=False,
             page_size=100,
             page_number=1,
         )
 
         _, kwargs = mock_client.get.call_args
-        assert kwargs["params"]["query"] == "author.id:devemberx"
+        assert kwargs["params"]["query"] == 'author.name:"Jane Doe"'
 
     async def test_query_none_omits_param(
         self, mock_ctx: MagicMock, mock_client: AsyncMock

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -1681,12 +1681,7 @@ class TestListWorkItems:
                                 "id": "proj1/Design/Software Requirement Specification",
                             }
                         },
-                        "assignee": {
-                            "data": [
-                                {"type": "users", "id": "proj1/alice"},
-                                {"type": "users", "id": "proj1/bob"},
-                            ]
-                        },
+                        "author": {"data": {"type": "users", "id": "proj1/alice"}},
                     },
                 },
                 {
@@ -1699,9 +1694,15 @@ class TestListWorkItems:
                     },
                     "relationships": {
                         "module": {"data": None},
-                        "assignee": {"data": []},
                     },
                 },
+            ],
+            "included": [
+                {
+                    "type": "users",
+                    "id": "proj1/alice",
+                    "attributes": {"name": "Alice A"},
+                }
             ],
             "meta": {"totalCount": 2},
         }
@@ -1725,7 +1726,7 @@ class TestListWorkItems:
         assert first.updated == "2026-04-29T10:23:00Z"
         assert first.space_id == "Design"
         assert first.document_name == "Software Requirement Specification"
-        assert first.assignee_ids == ["alice", "bob"]
+        assert first.author_name == "Alice A"
 
         second = result.items[1]
         assert second.id == "MCPT-002"
@@ -1733,7 +1734,7 @@ class TestListWorkItems:
         assert second.updated == ""
         assert second.space_id == ""
         assert second.document_name == ""
-        assert second.assignee_ids == []
+        assert second.author_name == ""
 
     async def test_sparse_fieldset_requested(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -1753,6 +1754,8 @@ class TestListWorkItems:
 
         _, kwargs = mock_client.get.call_args
         assert "fields[workitems]" in kwargs["params"]
+        assert kwargs["params"]["include"] == "author"
+        assert kwargs["params"]["fields[users]"] == "name"
 
     async def test_project_not_found(
         self, mock_ctx: MagicMock, mock_client: AsyncMock


### PR DESCRIPTION
## Summary

`list_*` tools returned per-row identity fields (`author_id`, `last_updated_by_id`, `assignee_ids`) that cost LLM output tokens without earning their keep — the display name covers list-scanning, and IDs are still available on `get_*`/`read_*`. This trims list summaries to names only.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- `list_*` leaked per-row author_id/assignee_ids, wasting LLM output tokens; ids belong on get_*/read_*
- list summaries now carry names only (author_name); detail models keep author_id + assignee_ids

## Testing

- `ruff check` + `ruff format --check` + `mypy src/` clean
- `pytest` 1529 passed / 11 skipped; `diff-cover` 100% on changed lines
- Verified against live Polarion (`MCP_Test_Project`): filter-by-person for test runs uses `author.name:"<full name>"` (exact, quoted) — `author.id:<username>` does not match — docstring/example updated accordingly

## Notes for Reviewers

- Output-shape change: `WorkItemSummary` swaps `assignee_ids` → `author_name`; `DocumentSummary`/`TestRunSummary`/`Comment` drop `author_id` (+ `last_updated_by_id` on docs). Detail views unchanged.
- `assignee_names` (name resolution for assignees on detail views) intentionally deferred — out of scope.
