### PR TITLE
chore(hooks): add comment-style tripwire

### DIFF
--- a/.claude/hooks/lint_comment_style.py
+++ b/.claude/hooks/lint_comment_style.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""PostToolUse tripwire: flag caveman-rule violations in ``#`` comments the
+model just wrote. Scope = ``#`` comments in ``.py`` files only. Docstrings
+skipped on purpose — ``@mcp.tool`` docstrings + ``Field(description=...)`` are
+LLM-facing prose (eval-gated), false-positive risk too high.
+
+Exit 2 with stderr feeds the finding back to the model so it self-corrects;
+never blocks the edit (tool already ran).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+# Functional pseudo-comments drive tooling — never lint prose after them.
+_FUNCTIONAL = re.compile(
+    r"#\s*(noqa|type:\s*ignore|pragma|fmt:|ruff:|isort:|coding:|!)"
+)
+
+# whole-word, case-insensitive where prose varies.
+_ARTICLE = re.compile(r"\b(the|an)\b", re.IGNORECASE)
+_FILLER = re.compile(
+    r"\b(just|really|basically|actually|simply|of course|please)\b",
+    re.IGNORECASE,
+)
+# caveman bans leading NOTE / WARNING prefixes + banner dividers.
+_PREFIX = re.compile(r"#\s*(WARNING|NOTE)\b", re.IGNORECASE)
+_BANNER = re.compile(r"#\s*[=\-*_]{4,}")
+# task-marker without ``(owner/#issue)`` = stray.
+_STRAY_TODO = re.compile(r"#.*\bTODO\b(?!\s*\()")
+
+
+def _comment_text(line: str) -> str | None:
+    """Return the ``#`` comment portion of a line, or None. Naive split: skip
+    lines where ``#`` sits inside a string literal (best-effort, tripwire only).
+    """
+    idx = line.find("#")
+    if idx == -1:
+        return None
+    before = line[:idx]
+    # crude string guard: unbalanced quote before # = likely inside.
+    if before.count('"') % 2 or before.count("'") % 2:
+        return None
+    return line[idx:]
+
+
+def _scan(text: str) -> list[str]:
+    findings: list[str] = []
+    for raw in text.splitlines():
+        comment = _comment_text(raw)
+        if comment is None or _FUNCTIONAL.search(comment):
+            continue
+        body = comment.lstrip("#").strip()
+        if not body:
+            continue
+        if _ARTICLE.search(body):
+            findings.append(f'article: "{body}"')
+        if _FILLER.search(body):
+            findings.append(f'filler: "{body}"')
+        if _PREFIX.search(comment):
+            findings.append(f'NOTE/WARNING prefix: "{body}"')
+        if _BANNER.search(comment):
+            findings.append(f'banner divider: "{body}"')
+        if _STRAY_TODO.search(comment):
+            findings.append(f'stray TODO (need owner/#issue): "{body}"')
+    return findings
+
+
+def _edited_text(tool_input: dict[str, object]) -> str:
+    """Concatenate new comment-bearing text from Edit/Write/MultiEdit input."""
+    parts: list[str] = []
+    for key in ("new_string", "content"):
+        val = tool_input.get(key)
+        if isinstance(val, str):
+            parts.append(val)
+    edits = tool_input.get("edits")
+    if isinstance(edits, list):
+        for e in edits:
+            if isinstance(e, dict) and isinstance(e.get("new_string"), str):
+                parts.append(e["new_string"])
+    return "\n".join(parts)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    tool_input = payload.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        return 0
+    path = tool_input.get("file_path", "")
+    if not (isinstance(path, str) and path.endswith(".py")):
+        return 0
+
+    findings = _scan(_edited_text(tool_input))
+    if not findings:
+        return 0
+
+    # dedup, keep order.
+    seen: dict[str, None] = {}
+    for f in findings:
+        seen.setdefault(f, None)
+    msg = "\n".join(f"  - {f}" for f in seen)
+    print(
+        "Comment-style tripwire (caveman rules) in "
+        f"{path}:\n{msg}\n"
+        "Drop articles/filler, no NOTE:/WARNING:/banner, TODO needs "
+        "(owner/#issue). Fix these comments. (Docstrings/Field prose exempt.)",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/lint_comment_style.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/tests/claude_hooks/test_lint_comment_style.py
+++ b/tests/claude_hooks/test_lint_comment_style.py
@@ -1,0 +1,119 @@
+"""`lint_comment_style` hook tests, loaded by path via importlib (script live
+outside any package). Helpers tested directly; ``main()`` driven via stdin.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import load_module_from_path
+
+HOOKS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
+
+lint = load_module_from_path(HOOKS_DIR / "lint_comment_style.py", "lint_comment_style")
+
+
+class TestScan:
+    @pytest.mark.parametrize(
+        ("text", "category"),
+        [
+            ("    x = 1  # increment the counter", "article"),
+            ("    # an off-by-one guard", "article"),
+            ("    # just a helper", "filler"),
+            ("    # really needed here", "filler"),
+            ("    # NOTE: watch out", "NOTE/WARNING"),
+            ("    # WARNING danger", "NOTE/WARNING"),
+            ("    # ====", "banner"),
+            ("    # ------------", "banner"),
+            ("    # TODO fix later", "stray TODO"),
+        ],
+    )
+    def test_flags(self, text: str, category: str) -> None:
+        findings = lint._scan(text)
+        assert any(category in f for f in findings)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "    # skip sentinel row",
+            "    # retry on 429 rate limit",
+            "    # TODO(#142): drop after 2410",
+            "    # TODO(devemberx): rework guard",
+            "    x = 1  # noqa: E501 the legacy path here",
+            "    y = f()  # type: ignore[arg-type] the shim",
+            "    code_only = 1",
+            "",
+        ],
+    )
+    def test_clean(self, text: str) -> None:
+        assert lint._scan(text) == []
+
+    def test_hash_inside_string_skipped(self) -> None:
+        # ``#`` sits inside an unbalanced quote → not a comment.
+        assert lint._scan('    sep = "the # char"') == []
+
+
+class TestCommentText:
+    def test_no_hash(self) -> None:
+        assert lint._comment_text("x = 1") is None
+
+    def test_plain_comment(self) -> None:
+        assert lint._comment_text("x = 1  # note") == "# note"
+
+    def test_inside_string_guard(self) -> None:
+        assert lint._comment_text('s = "a # b"') is None
+
+
+class TestEditedText:
+    def test_new_string(self) -> None:
+        assert "# a" in lint._edited_text({"new_string": "x  # a"})
+
+    def test_content(self) -> None:
+        assert "# b" in lint._edited_text({"content": "y  # b"})
+
+    def test_multiedit(self) -> None:
+        payload = {"edits": [{"new_string": "# c"}, {"new_string": "# d"}]}
+        text = lint._edited_text(payload)
+        assert "# c" in text and "# d" in text
+
+    def test_non_dict_edits_ignored(self) -> None:
+        assert lint._edited_text({"edits": ["nope", {}]}) == ""
+
+
+def _run(payload: dict[str, object], monkeypatch: pytest.MonkeyPatch) -> int:
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+    return lint.main()
+
+
+class TestMain:
+    def test_violation_exits_2(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        code = _run(
+            {"tool_input": {"file_path": "x.py", "new_string": "# just the thing"}},
+            monkeypatch,
+        )
+        assert code == 2
+        assert "tripwire" in capsys.readouterr().err
+
+    def test_clean_exits_0(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = {"tool_input": {"file_path": "x.py", "new_string": "# skip row"}}
+        assert _run(payload, monkeypatch) == 0
+
+    def test_non_py_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = {"tool_input": {"file_path": "x.md", "new_string": "# just this"}}
+        assert _run(payload, monkeypatch) == 0
+
+    def test_missing_file_path_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert _run({"tool_input": {"new_string": "# just this"}}, monkeypatch) == 0
+
+    def test_bad_json_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
+        assert lint.main() == 0
+
+    def test_non_dict_tool_input_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert _run({"tool_input": "nope"}, monkeypatch) == 0


### PR DESCRIPTION
## Summary

Caveman comment-style violations (articles, filler, `NOTE:`/`WARNING:` prefixes, banner dividers, stray `TODO`s) kept slipping through — `ruff`/`mypy` don't catch prose, and eyeball review missed them. This adds a PostToolUse tripwire that scans `#` comments in edited `.py` files and feeds any finding back to the model to self-correct.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- caveman comment violations slipped through unchecked; ruff/mypy do not catch prose, review missed them
- PostToolUse hook scans # comments in edited .py, exit 2 feeds finding to model; docstrings/Field prose exempt

## Testing

- `tests/claude_hooks/test_lint_comment_style.py` — 31 cases (each violation category, clean lines, functional-comment skip, string-literal guard, main() stdin paths)
- Dogfood: hook run on its own source is clean (exit 0); `ruff` + `ruff format --check` + `mypy src/` + full `pytest` (1560 passed) green

## Notes for Reviewers

- Scope is `#` comments only — `@mcp.tool` docstrings and `Field(description=...)` are LLM-facing prose (eval-gated), deliberately not linted to avoid false positives.
- Non-blocking: the edit already ran; exit 2 only surfaces the finding as feedback. String-literal detection is a best-effort heuristic (tripwire, not a parser).
