### PR TITLE
feat(test-runs): surface group_id + template_id

### DIFF
--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -21,6 +21,9 @@ class TestRunSummary(BaseModel):
     updated: str = ""
     author_name: str = ""
     is_template: bool = False
+    group_id: str = ""
+    # short id, round-trips into create_test_runs(template_id=...)
+    template_id: str = ""
 
 
 class TestRunCreateSpec(BaseModel):

--- a/src/mcp_server_polarion/tools/_shared/fields.py
+++ b/src/mcp_server_polarion/tools/_shared/fields.py
@@ -11,10 +11,10 @@ MAX_BULK_ITEMS: Final[int] = 50
 WORK_ITEM_LIST_FIELDS: Final[str] = "title,type,status,priority,updated,module,author"
 WORK_ITEM_DETAIL_FIELDS: Final[str] = "@all"
 WORK_ITEM_PART_FIELDS: Final[str] = "title,type,status,description,outlineNumber"
-# camelCase finishedOn/isTemplate = Polarion attr names; author keep
-# relationship block alive under sparse fieldset.
+# camelCase finishedOn/isTemplate/groupId = Polarion attr names; author +
+# template keep relationship blocks alive under sparse fieldset.
 TEST_RUN_LIST_FIELDS: Final[str] = (
-    "title,type,status,finishedOn,updated,author,isTemplate"
+    "title,type,status,finishedOn,updated,author,isTemplate,groupId,template"
 )
 DOCUMENT_DETAIL_FIELDS: Final[str] = "@all"
 # Sparse fieldset filters relationships too — name them explicitly.

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -288,6 +288,8 @@ class TestRunSummaryKwargs(TypedDict):
     updated: str
     author_name: str
     is_template: bool
+    group_id: str
+    template_id: str
 
 
 def parse_test_run_summary_kwargs(
@@ -314,6 +316,10 @@ def parse_test_run_summary_kwargs(
         "updated": safe_str(attributes.get("updated", "")),
         "author_name": user_names.get(author_id, ""),
         "is_template": bool(attributes.get("isTemplate", False)),
+        "group_id": safe_str(attributes.get("groupId", "")),
+        "template_id": extract_short_id(
+            extract_relationship_id(relationships, "template")
+        ),
     }
 
 

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -192,7 +192,7 @@ async def list_test_runs(  # noqa: PLR0913
     query: str | None = Field(
         default=None,
         description=(
-            "Optional Lucene filter (e.g. 'status:open', "
+            "Optional Lucene filter (e.g. 'status:open', 'groupId:Release-2.5', "
             "'author.name:\"Jane Doe\"', 'HAS_VALUE:<field>' to match runs "
             "with that field populated)."
         ),

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -331,6 +331,8 @@ class TestParseTestRunSummaries:
         assert kwargs["id"] == "TR-1"
         assert kwargs["title"] == ""
         assert kwargs["author_name"] == ""
+        assert kwargs["group_id"] == ""
+        assert kwargs["template_id"] == ""
 
     def test_author_name_resolved(self) -> None:
         kwargs = parse_test_run_summary_kwargs(
@@ -342,6 +344,20 @@ class TestParseTestRunSummaries:
             user_names={"proj/jdoe": "J Doe"},
         )
         assert kwargs["author_name"] == "J Doe"
+
+    def test_group_id_and_template_id_populate(self) -> None:
+        kwargs = parse_test_run_summary_kwargs(
+            {
+                "id": "proj/TR-1",
+                "attributes": {"groupId": "Release-2.5"},
+                "relationships": {
+                    "template": {"data": {"id": "proj/TR-tmpl"}},
+                },
+            },
+            user_names={},
+        )
+        assert kwargs["group_id"] == "Release-2.5"
+        assert kwargs["template_id"] == "TR-tmpl"
 
     def test_non_list_data_is_empty(self) -> None:
         assert parse_test_run_summaries({"data": None}) == []

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -53,9 +53,13 @@ class TestListTestRuns:
                         "finishedOn": "2026-05-02T11:00:00Z",
                         "updated": "2026-05-01T09:00:00Z",
                         "isTemplate": False,
+                        "groupId": "Release-2.5",
                     },
                     "relationships": {
-                        "author": {"data": {"type": "users", "id": "proj1/devemberx"}}
+                        "author": {"data": {"type": "users", "id": "proj1/devemberx"}},
+                        "template": {
+                            "data": {"type": "testruns", "id": "proj1/TR-tmpl"}
+                        },
                     },
                 },
                 {
@@ -102,6 +106,8 @@ class TestListTestRuns:
         assert first.updated == "2026-05-01T09:00:00Z"
         assert first.author_name == "Devember X"
         assert first.is_template is False
+        assert first.group_id == "Release-2.5"
+        assert first.template_id == "TR-tmpl"
 
         second = result.items[1]
         assert second.id == "TR-002"
@@ -109,6 +115,9 @@ class TestListTestRuns:
         assert second.updated == ""
         assert second.author_name == ""
         assert second.is_template is True
+        # No groupId attr / template relationship -> blanks.
+        assert second.group_id == ""
+        assert second.template_id == ""
 
     async def test_missing_author_yields_empty_name(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
@@ -159,6 +168,9 @@ class TestListTestRuns:
         _, kwargs = mock_client.get.call_args
         params = kwargs["params"]
         assert "fields[testruns]" in params
+        # groupId attr + template relationship kept under sparse fieldset.
+        assert "groupId" in params["fields[testruns]"]
+        assert "template" in params["fields[testruns]"]
         assert params["include"] == "author"
         assert params["fields[users]"] == "name"
 


### PR DESCRIPTION
## Summary

`list_test_runs` is currently the only read path for test runs (no `get_test_run` detail tool yet), so any field it drops is invisible to the LLM. This surfaces two useful ones on `TestRunSummary`:

- **`group_id`** - Polarion's free-text grouping label. Its value is list-scan discovery: without it in the list output, the LLM can't learn the group strings to build a `groupId:<x>` Lucene filter. Empty when unused (near-zero cost).
- **`template_id`** - short id of the template a run was created from; feeds straight back into `create_test_runs(template_id=...)` for the "clone this run" flow. Empty for non-template runs.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- `list_test_runs` sole read path; `group_id` enables filter-discovery, `template_id` bridges into `create_test_runs`
- add to `TestRunSummary` + sparse fieldset (`groupId` attr, `template` rel) + parser; tests cover populate + empty

## Testing

- `ruff check` / `ruff format --check` / `mypy src/` - clean
- `uv run pytest` - 1562 passed, 11 skipped
- `diff-cover` vs `origin/main` - changed lines 100%
- End-to-end: tool tests drive `list_test_runs` against a mocked client and assert `group_id` / `template_id` on the returned `TestRunSummary` (fields, parse, model path)

## Notes for Reviewers

- `template_id` is a short id in a list output. #153 ("trim ids from list outputs") moved `author_id`/`assignee_ids` off list summaries, but that targeted id/name duplication - `template_id` has no `template_name` twin and is the sole pointer to the template, so it doesn't hit that concern. When `get_test_run` lands, revisit whether `template_id` belongs there instead.
- Deferred to the future `get_test_run`: `selectTestCasesBy` (always-populated enum, per-row cost without list-scan value) and other inspection-only fields.
