### PR TITLE
feat(work-items): surface assignee names

### DIFF
--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -41,6 +41,7 @@ class WorkItemDetail(WorkItemSummary):
     project_id: str
     author_id: str = ""
     assignee_ids: list[str] = Field(default_factory=list)
+    assignee_names: list[str] = Field(default_factory=list)
     created: str = ""
     resolution: str = ""
     severity: str = ""
@@ -56,6 +57,7 @@ class WorkItemRead(WorkItemSummary):
     project_id: str
     author_id: str = ""
     assignee_ids: list[str] = Field(default_factory=list)
+    assignee_names: list[str] = Field(default_factory=list)
     created: str = ""
     resolution: str = ""
     severity: str = ""

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -222,16 +222,17 @@ def parse_work_item_detail(
         summary_kwargs["id"] = fallback_id
 
     author_full = extract_relationship_id(relationships, "author")
-    assignee_ids = [
-        extract_short_id(uid)
-        for uid in extract_relationship_ids(relationships, "assignee")
-    ]
+    # user_names keyed full id; resolve name before extract_short_id.
+    assignee_full = extract_relationship_ids(relationships, "assignee")
+    assignee_ids = [extract_short_id(uid) for uid in assignee_full]
+    assignee_names = [(user_names or {}).get(uid, "") for uid in assignee_full]
     return WorkItemDetail(
         **summary_kwargs,
         description_html=desc_html,
         project_id=project_id,
         author_id=extract_short_id(author_full),
         assignee_ids=assignee_ids,
+        assignee_names=assignee_names,
         created=safe_str(attributes.get("created", "")),
         resolution=safe_str(attributes.get("resolution", "")),
         severity=safe_str(attributes.get("severity", "")),

--- a/tests/mcp_server_polarion/models/test_work_items.py
+++ b/tests/mcp_server_polarion/models/test_work_items.py
@@ -226,6 +226,8 @@ class TestWorkItemDetail:
             project_id="proj1",
         )
         assert detail.author_id == ""
+        assert detail.assignee_ids == []
+        assert detail.assignee_names == []
         assert detail.created == ""
         assert detail.resolution == ""
         assert detail.severity == ""

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -248,6 +248,7 @@ class TestParseWorkItemDetail:
         assert detail.author_id == "jdoe"
         assert detail.author_name == ""
         assert detail.assignee_ids == ["alice", "bob"]
+        assert detail.assignee_names == ["", ""]
         assert detail.custom_fields == {"riskLevel": "high"}
 
     def test_user_names_resolve_author_name(self) -> None:
@@ -261,6 +262,21 @@ class TestParseWorkItemDetail:
         )
         assert detail.author_id == "jdoe"
         assert detail.author_name == "J Doe"
+
+    def test_user_names_resolve_assignee_names_index_paired(self) -> None:
+        # bob unresolved -> "" at same index; keeps pairing with assignee_ids.
+        item: dict[str, object] = {
+            "id": "proj/MCPT-1",
+            "attributes": {"title": "T", "type": "task", "status": "open"},
+            "relationships": {
+                "assignee": {"data": [{"id": "proj/alice"}, {"id": "proj/bob"}]},
+            },
+        }
+        detail = parse_work_item_detail(
+            item, project_id="proj", user_names={"proj/alice": "Alice A"}
+        )
+        assert detail.assignee_ids == ["alice", "bob"]
+        assert detail.assignee_names == ["Alice A", ""]
 
     def test_fallback_id_used_when_id_missing(self) -> None:
         item: dict[str, object] = {

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -1974,7 +1974,12 @@ class TestGetWorkItem:
                 },
             },
             "included": [
-                {"type": "users", "id": "proj1/bob", "attributes": {"name": "Bob B"}}
+                {"type": "users", "id": "proj1/bob", "attributes": {"name": "Bob B"}},
+                {
+                    "type": "users",
+                    "id": "proj1/alice",
+                    "attributes": {"name": "Alice A"},
+                },
             ],
         }
 
@@ -1997,6 +2002,7 @@ class TestGetWorkItem:
         assert result.space_id == "Design"
         assert result.document_name == "SRS"
         assert result.assignee_ids == ["alice"]
+        assert result.assignee_names == ["Alice A"]
         assert result.author_id == "bob"
         assert result.author_name == "Bob B"
         # Entry without uri skipped.


### PR DESCRIPTION
## Summary

`get_work_item` / `read_work_item` returned `assignee_ids` (short ids like `alice`) with no display name -- an LLM sees an opaque id it cannot render. Author already pairs `author_id` + `author_name` (#150); assignee never got the twin field.

The name data is already on the wire: `get_work_item` sends `include=assignee,author` + `fields[users]=name` and builds a full-id-to-name map. The parser just discarded assignee names. Pure read-output surfacing -- no new fetch, no API/fields change, no guard change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- get/read only exposed assignee_ids; opaque without display name
- add assignee_names paired list (index-aligned, unresolved -> ""), mirror author_id/author_name convention

## Testing

CI-covered: ruff + format + mypy clean; full suite 1562 passed / 11 skipped; diff-cover 100% (gate 90). New assertions: parse index-pairing + unresolved-id "" case, get_work_item fixture, model default empty list. Write specs unchanged (create/update stay id-only; Polarion validates users relationship server-side).

## Notes for Reviewers

Not live-checked against real Polarion -- relies on author's proven `fields[users]=name` path. List output intentionally left lean (no assignee), per #153 trim trend.