### PR TITLE
chore(git): pre-push branch-name guard

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Enforce the branch-naming rule from .github/CONTRIBUTING.md:
+#   <type>/<short-kebab-summary>, type in feat|fix|refactor|test|docs|chore|ci
+# Refuses direct pushes to main and worktree-* / other non-conforming refs.
+# Activate locally with: git config core.hooksPath .githooks
+
+set -euo pipefail
+
+allowed='^(feat|fix|refactor|test|docs|chore|ci)/[a-z0-9][a-z0-9._-]*$'
+bypass='^(dependabot|renovate)/'  # bot branches skip the local convention
+
+fail=0
+while read -r local_ref local_sha _remote_ref _remote_sha; do
+    # Branch deletion (all-zero sha) has no name to check.
+    case "$local_sha" in *[!0]*) ;; *) continue ;; esac
+    case "$local_ref" in refs/heads/*) ;; *) continue ;; esac
+    branch="${local_ref#refs/heads/}"
+
+    if [ "$branch" = "main" ]; then
+        printf 'pre-push: direct push to main not allowed; open a PR from a branch.\n' >&2
+        fail=1
+        continue
+    fi
+    printf '%s' "$branch" | grep -qE "$bypass" && continue
+    if ! printf '%s' "$branch" | grep -qE "$allowed"; then
+        printf "pre-push: branch '%s' violates <type>/<short-kebab-summary>.\n" "$branch" >&2
+        printf '  allowed types: feat fix refactor test docs chore ci\n' >&2
+        printf '  e.g. feat/read-fidelity, fix/utils-html-attachments\n' >&2
+        fail=1
+    fi
+done
+
+exit "$fail"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,7 +61,7 @@ git config core.hooksPath .githooks
 
    | Prefix      | For                                          | Example                       |
    | ----------- | -------------------------------------------- | ----------------------------- |
-   | `feature/`  | new tool or user-visible behavior            | `feature/read-fidelity`       |
+   | `feat/`     | new tool or user-visible behavior            | `feat/read-fidelity`          |
    | `fix/`      | bug fix on existing behavior                 | `fix/utils-html-attachments`  |
    | `refactor/` | internal restructuring, no behavior change   | `refactor/tools`              |
    | `test/`     | tests, eval cases, fixtures only             | `test/efficiency-eval-cases`  |


### PR DESCRIPTION
## Summary

Nothing gates branch names before a push, so non-conforming branches slip through - e.g. the `EnterWorktree`-generated `worktree-*` names, and `feat/` vs `feature/`. This adds a `pre-push` hook that enforces the `<type>/<short-kebab-summary>` rule, and corrects the docs that had drifted from actual practice.

Two parts:

- **`.githooks/pre-push`** - rejects direct pushes to `main` and any branch not matching `^(feat|fix|refactor|test|docs|chore|ci)/<kebab>$`. Bot branches (`dependabot/`, `renovate/`) bypass. Catches every creation path (git, IDE, worktree) at the push gate, since git has no branch-create hook.
- **`.github/CONTRIBUTING.md`** - the branch table listed `feature/`, but every branch in history uses `feat/` (`feat/list-test-runs`, `feat/create-test-runs`, ...) and the commit-type vocabulary is `feat`. Corrected `feature/` to `feat/` so branch and commit types are one vocabulary.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- no gate caught non-conforming branch names before push; worktree-* and feat/ vs feature/ slipped through
- add `.githooks/pre-push` validating `<type>/<kebab>`; correct CONTRIBUTING branch table feature/ to feat/

## Testing

- Ran `.githooks/pre-push` against sample refs on stdin: `feat/`, `chore/`, `fix/`, `dependabot/*` pass (exit 0); `worktree-feat+...`, `main`, `Feature/Foo`, bare `randomname` fail (exit 1) with a message; all-zero-sha (branch deletion) skipped.
- Hook activates repo-wide once merged (`core.hooksPath` is already `.githooks`).

## Notes for Reviewers

- git has no branch-create hook, and `EnterWorktree` always emits `worktree-*`, so the push gate is the only place that catches all paths; the workflow is create-then-rename-before-push, which this hook now enforces.
- Contributors who never set `core.hooksPath .githooks` locally get neither this nor the existing `commit-msg` hook - same pre-existing activation caveat, unchanged here.
