### PR TITLE
chore(hooks): allow typographic marks in PRs

### DIFF
--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -5,7 +5,9 @@ Triggered on: gh pr (create|edit|comment), gh issue (create|edit|comment),
 gh api .../pulls/... or .../issues/...
 
 Rules:
-  1. English-only — no non-ASCII characters in the body.
+  1. English-only — no non-ASCII letters. Common typographic punctuation
+     (dashes, arrows, curly quotes, ellipsis, math signs) + emoji allowed;
+     foreign-script prose (Korean/CJK) + accented Latin still blocked.
   2. Template checkboxes preserved — every checkbox from PULL_REQUEST_TEMPLATE.md
      must appear (PR create/edit only).
   3. ## Changes section — required, with exactly two non-empty bullets, each
@@ -23,6 +25,12 @@ import sys
 from pathlib import Path
 
 NON_ASCII_RE = re.compile(r"[^\x00-\x7F]")
+# Typographic punctuation allowed: formatting not language.
+TYPOGRAPHIC_RE = re.compile(
+    "[\u2013\u2014\u2018\u2019\u201c\u201d\u2022\u2026"  # dashes quotes bullet ellipsis
+    "\u2190\u2192\u2194\u21d2\u2260\u2264\u2265"  # arrows ne le ge
+    "\u00b1\u00b7\u00d7\u00f7]"  # plus-minus middot times divide
+)
 EMOJI_RE = re.compile(
     "[\U0001f000-\U0001faff"  # pictographs, emoticons, transport, flags
     "\U00002600-\U000027bf"  # misc symbols + dingbats
@@ -89,7 +97,8 @@ def main() -> int:
 
 
 def has_disallowed_non_ascii(body: str) -> bool:
-    return bool(NON_ASCII_RE.search(EMOJI_RE.sub("", body)))
+    stripped = TYPOGRAPHIC_RE.sub("", EMOJI_RE.sub("", body))
+    return bool(NON_ASCII_RE.search(stripped))
 
 
 def classify(cmd: str) -> str | None:

--- a/tests/claude_hooks/test_validate_pr_body.py
+++ b/tests/claude_hooks/test_validate_pr_body.py
@@ -106,6 +106,9 @@ class TestNonAsciiDetection:
             "ship it 🚀",  # lone emoji
             "done ✅ and 🎉",  # symbol + emoji
             "flags 🇰🇷 and family 👨‍👩‍👧 sequences",  # regional indicators + ZWJ
+            "id → name resolve — see below",  # arrow + em-dash
+            "quotes “curly” and ‘single’ plus …",  # noqa: RUF001  curly quotes
+            "bounds ≤ 100, count ≠ 0, 3 × 4",  # noqa: RUF001  math signs
         ],
     )
     def test_allows_ascii_and_emoji(self, text: str) -> None:


### PR DESCRIPTION
## Summary

The PR-body hook blocked any non-ASCII char except emoji, so common typographic punctuation (arrows, em-dash, curly quotes, ellipsis, math signs like <=, !=, x) forced awkward ASCII rewrites -- hit twice while opening #156.

Rule intent is English-only prose, not banning Unicode punctuation. Now a tight allowlist of typographic marks is stripped before the non-ASCII check, alongside emoji. Foreign-script prose (Korean/CJK) and accented Latin stay blocked.

Note: this PR body itself is plain ASCII because the fix is not merged yet -- the active hook is still the old one. Once merged, future PR bodies may use the whitelisted marks.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- non-ASCII check blocked arrows/dashes/quotes, forcing ASCII rewrites in PR bodies
- whitelist typographic marks (dashes, arrows, quotes, ellipsis, math signs); foreign-script + accents still blocked

## Testing

`pytest tests/claude_hooks/` 103 passed; ruff + format clean. Added allow-cases (arrows/em-dash, curly quotes/ellipsis, math signs) to test_allows_ascii_and_emoji; existing block-cases (Korean + accented Latin) unchanged. End-to-end: fed the hook a mock `gh pr create` body containing typographic marks, no non-ASCII error raised.

## Notes for Reviewers

Allowlist is an explicit char set (dashes, curly quotes, bullet, ellipsis, arrows, ne/le/ge, plus-minus/middot/times/divide), written as escapes so the hook source stays ASCII. Extend the set if a mark is missing rather than widening to ranges.