### PR TITLE
chore(hooks): validate PR title, warn unlabeled

### DIFF
--- a/.claude/hooks/validate_pr.py
+++ b/.claude/hooks/validate_pr.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PreToolUse hook: block PR/issue body Bash invocations that violate repo conventions.
+"""PreToolUse hook: block PR/issue Bash invocations that violate repo conventions.
 
 Triggered on: gh pr (create|edit|comment), gh issue (create|edit|comment),
 gh api .../pulls/... or .../issues/...
@@ -98,7 +98,7 @@ def main() -> int:
             errors.extend(changes_format_errors(body))
 
     if errors:
-        sys.stderr.write("BLOCKED by .claude/hooks/validate-pr.py:\n\n")
+        sys.stderr.write("BLOCKED by .claude/hooks/validate_pr.py:\n\n")
         for e in errors:
             sys.stderr.write(f"* {e}\n\n")
         return 2

--- a/.claude/hooks/validate_pr.py
+++ b/.claude/hooks/validate_pr.py
@@ -11,6 +11,9 @@ Rules:
      must appear (PR create/edit only).
   3. ## Changes section — required, with exactly two non-empty bullets, each
      <= 120 chars (PR create/edit only).
+  4. Title — conventional-commit subject "type(scope)!: summary", type from the
+     8 label-pr.yml keys, <= 50 chars (PR create/edit only). Valid title = must
+     get labeled; keeps hook + label-pr.yml in lockstep.
 
 Exit 0 = allow, exit 2 = block.
 """
@@ -43,6 +46,10 @@ NEXT_SECTION_RE = re.compile(r"^##\s", re.MULTILINE)
 TEMPLATE_PATH = Path(".github/PULL_REQUEST_TEMPLATE.md")
 BULLET_LIMIT = 120
 REQUIRED_BULLETS = 2
+# Type set = label-pr.yml map keys exact, so valid title always labels.
+TITLE_TYPES = ("feat", "fix", "docs", "refactor", "perf", "test", "ci", "chore")
+TITLE_RE = re.compile(rf"^(?:{'|'.join(TITLE_TYPES)})(?:\([a-z0-9-]+\))?!?: .+")
+TITLE_LIMIT = 50
 
 PR_CREATE_EDIT_RE = re.compile(r"\bgh\s+pr\s+(create|edit)\b")
 PR_COMMENT_RE = re.compile(r"\bgh\s+pr\s+comment\b")
@@ -65,29 +72,33 @@ def main() -> int:
     if kind is None:
         return 0
 
+    # Body optional: title-only `gh pr edit` still needs title checked.
     body = extract_body(cmd)
-    if body is None:
-        return 0
 
     errors: list[str] = []
-    if has_disallowed_non_ascii(body):
+    if body is not None and has_disallowed_non_ascii(body):
         errors.append(
-            "Body contains non-ASCII characters (other than emoji). Per repo "
-            "convention PR/issue/commit artifacts must be in English."
+            "Body contains non-ASCII characters (other than emoji and "
+            "typographic punctuation). Per repo convention PR/issue/commit "
+            "artifacts must be in English."
         )
 
     if kind == "pr":
-        missing = missing_template_boxes(body)
-        if missing:
-            errors.append(
-                "Body is missing template checkboxes. "
-                "Do NOT delete unchecked options."
-                + "\n".join(f"    - [ ] {m}" for m in missing)
-            )
-        errors.extend(changes_format_errors(body))
+        title = extract_title(cmd)
+        if title is not None:
+            errors.extend(title_errors(title))
+        if body is not None:
+            missing = missing_template_boxes(body)
+            if missing:
+                errors.append(
+                    "Body is missing template checkboxes. "
+                    "Do NOT delete unchecked options."
+                    + "\n".join(f"    - [ ] {m}" for m in missing)
+                )
+            errors.extend(changes_format_errors(body))
 
     if errors:
-        sys.stderr.write("BLOCKED by .claude/hooks/validate-pr-body.py:\n\n")
+        sys.stderr.write("BLOCKED by .claude/hooks/validate-pr.py:\n\n")
         for e in errors:
             sys.stderr.write(f"* {e}\n\n")
         return 2
@@ -154,6 +165,40 @@ def _read_file(path: str) -> str | None:
         return Path(path).read_text()
     except OSError:
         return None
+
+
+def extract_title(cmd: str) -> str | None:
+    try:
+        argv = shlex.split(cmd)
+    except ValueError:
+        return None
+
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        nxt = argv[i + 1] if i + 1 < len(argv) else None
+        if a in {"--title", "-t"} and nxt is not None:
+            return nxt
+        if a.startswith("--title="):
+            return a[len("--title=") :]
+        i += 1
+    return None
+
+
+def title_errors(title: str) -> list[str]:
+    errors: list[str] = []
+    if not TITLE_RE.match(title):
+        errors.append(
+            "Title must be a conventional-commit subject 'type(scope): summary'. "
+            f"type one of: {', '.join(TITLE_TYPES)} (append '!' for breaking). "
+            "Anything else is left unlabeled by label-pr.yml."
+        )
+    if len(title) > TITLE_LIMIT:
+        errors.append(
+            f"Title is {len(title)} chars (limit: {TITLE_LIMIT}); it becomes the "
+            "squash commit subject."
+        )
+    return errors
 
 
 def missing_template_boxes(body: str) -> list[str]:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate_pr_body.py"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate_pr.py"
           },
           {
             "type": "command",

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -28,7 +28,7 @@ jobs:
           scope="$(printf '%s' "$PR_TITLE" | sed -nE 's/^[a-z]+\(([^)]*)\)!?:.*/\1/p')"
           bang="$(printf '%s' "$PR_TITLE" | sed -nE 's/^[a-z]+(\([^)]*\))?(!):.*/\2/p')"
 
-          # 2. Map commit type → release-note label.
+          # 2. Resolve release-note labels from type / scope / bang.
           declare -A map=(
             [feat]=feature
             [fix]=bug
@@ -39,7 +39,6 @@ jobs:
             [ci]=ci
             [chore]=chore
           )
-
           labels=()
           case "$scope" in
             deps|deps-dev) labels+=("dependencies") ;;  # dependabot → Dependencies group
@@ -47,22 +46,25 @@ jobs:
           esac
           [ -n "$bang" ] && labels+=("breaking")
 
-          # Prior unlabeled-warning comment id, empty if none. Drives dedup + cleanup.
+          # 3. Find any prior unlabeled-warning comment (drives dedup + cleanup).
           marker='<!-- label-pr:unlabeled -->'
           prior="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
             --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -n1)"
 
+          # 4. No label: warn once (skip if already warned), then stop.
           if [ ${#labels[@]} -eq 0 ]; then
             echo "Title has no conventional-commit type; nothing to label."
-            # Warn once: skip when marker comment already present.
             if [ -z "$prior" ]; then
-              body=$'<!-- label-pr:unlabeled -->\nThis PR title does not start with a conventional-commit type, so it is not auto-labeled for release-note grouping.\n\nRename it to "type(scope): summary" using one of: feat, fix, docs, refactor, perf, test, ci, chore. Editing the title re-runs this check.'
+              body="$(printf '%s\n%s\n\n%s\n' \
+                "$marker" \
+                "This PR title does not start with a conventional-commit type, so it is not auto-labeled for release-note grouping." \
+                'Rename it to "type(scope): summary" using one of: feat, fix, docs, refactor, perf, test, ci, chore. Editing the title re-runs this check.')"
               gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$body" >/dev/null
             fi
             exit 0
           fi
 
-          # 3. Create missing labels, then apply to the PR.
+          # 5. Create missing labels, apply them, then drop any stale warning.
           for l in "${labels[@]}"; do
             gh label create "$l" --repo "$REPO" --color ededed >/dev/null 2>&1 || true
           done
@@ -71,7 +73,6 @@ jobs:
           for l in "${labels[@]}"; do args+=(-f "labels[]=$l"); done
           gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" "${args[@]}" >/dev/null
 
-          # Title fixed since warning: drop stale unlabeled comment.
           if [ -n "$prior" ]; then
             gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/comments/$prior" >/dev/null
           fi

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -47,8 +47,18 @@ jobs:
           esac
           [ -n "$bang" ] && labels+=("breaking")
 
+          # Prior unlabeled-warning comment id, empty if none. Drives dedup + cleanup.
+          marker='<!-- label-pr:unlabeled -->'
+          prior="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -n1)"
+
           if [ ${#labels[@]} -eq 0 ]; then
             echo "Title has no conventional-commit type; nothing to label."
+            # Warn once: skip when marker comment already present.
+            if [ -z "$prior" ]; then
+              body=$'<!-- label-pr:unlabeled -->\nThis PR title does not start with a conventional-commit type, so it is not auto-labeled for release-note grouping.\n\nRename it to "type(scope): summary" using one of: feat, fix, docs, refactor, perf, test, ci, chore. Editing the title re-runs this check.'
+              gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$body" >/dev/null
+            fi
             exit 0
           fi
 
@@ -60,3 +70,8 @@ jobs:
           args=()
           for l in "${labels[@]}"; do args+=(-f "labels[]=$l"); done
           gh api -X POST "repos/$REPO/issues/$PR_NUMBER/labels" "${args[@]}" >/dev/null
+
+          # Title fixed since warning: drop stale unlabeled comment.
+          if [ -n "$prior" ]; then
+            gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/comments/$prior" >/dev/null
+          fi

--- a/tests/claude_hooks/test_validate_pr.py
+++ b/tests/claude_hooks/test_validate_pr.py
@@ -1,4 +1,4 @@
-"""`validate_pr_body` hook tests, loaded by path via importlib (script live
+"""`validate_pr` hook tests, loaded by path via importlib (script live
 outside any package). Pure helpers only; `main()` left to e2e.
 """
 
@@ -12,7 +12,7 @@ from tests.conftest import load_module_from_path
 
 HOOKS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
 
-body = load_module_from_path(HOOKS_DIR / "validate_pr_body.py", "validate_pr_body")
+body = load_module_from_path(HOOKS_DIR / "validate_pr.py", "validate_pr")
 
 
 class TestBodyClassify:
@@ -84,6 +84,56 @@ class TestBodyExtractBody:
 
     def test_no_body(self) -> None:
         assert body.extract_body("gh pr edit --title only") is None
+
+
+class TestExtractTitle:
+    def test_long_flag(self) -> None:
+        assert body.extract_title("gh pr create --title 'fix: x'") == "fix: x"
+
+    def test_long_flag_equals(self) -> None:
+        assert body.extract_title("gh pr create --title=fix:x") == "fix:x"
+
+    def test_short_flag(self) -> None:
+        assert body.extract_title("gh pr create -t 'fix: x' --body y") == "fix: x"
+
+    def test_absent(self) -> None:
+        assert body.extract_title("gh pr edit 5 --body y") is None
+
+
+class TestTitleErrors:
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "feat: add a tool",
+            "fix(client): retry on 429",
+            "chore(deps): bump fastmcp",
+            "refactor!: drop legacy path",
+            "ci: cache uv deps",
+            "feat: " + "x" * 44,  # exactly 50 chars
+        ],
+    )
+    def test_valid(self, title: str) -> None:
+        # Fixture guard: boundary case on limit, not over.
+        assert len(title) <= body.TITLE_LIMIT
+        assert body.title_errors(title) == []
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "add a tool",  # no type prefix
+            "feature: add a tool",  # type outside 8 keys
+            "Fix: capitalized type",  # uppercase type
+            "feat add a tool",  # missing colon
+            "build: not a labeled type",  # conventional but unmapped
+        ],
+    )
+    def test_bad_prefix(self, title: str) -> None:
+        assert any("conventional-commit" in e for e in body.title_errors(title))
+
+    def test_over_limit(self) -> None:
+        title = "feat: " + "x" * 50
+        errs = body.title_errors(title)
+        assert any("limit: 50" in e for e in errs)
 
 
 class TestNonAsciiDetection:


### PR DESCRIPTION
## Summary

The PR hook validated the body but not the title, so a malformed title (wrong prefix, >50 chars, non-conventional type) passed the hook and then silently missed label-pr.yml labeling. This adds title validation to the hook, renames it to reflect the broader scope, and makes label-pr.yml post a dedup comment when a title yields no label.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- PR titles skipped hook validation, so malformed ones passed then went unlabeled by label-pr.yml
- Add title check to renamed validate_pr hook; label-pr.yml upserts a dedup comment when a title yields none

## Testing

`pytest` 1582 passed, 11 skipped; `ruff check .` + `ruff format --check` clean. Hook e2e via piped stdin JSON: title-only edit with a bad title blocks (exit 2), a valid title-only edit allows, wrong type and >50 chars block, issue titles are not validated. label-pr.yml run script passes `bash -n` plus YAML parse.

## Notes for Reviewers

Allowed title types are exactly label-pr.yml's 8 map keys, so a hook-accepted title is always labelable — a mismatch can only make the hook stricter, never looser. The label-pr comment uses a hidden marker `<!-- label-pr:unlabeled -->` for dedup and deletes it once a title is fixed. gh api PR-title JSON and issue titles are out of scope.
