### PR TITLE
chore(hooks): note typographic marks in body error

### DIFF
--- a/.claude/hooks/validate_pr_body.py
+++ b/.claude/hooks/validate_pr_body.py
@@ -72,8 +72,9 @@ def main() -> int:
     errors: list[str] = []
     if has_disallowed_non_ascii(body):
         errors.append(
-            "Body contains non-ASCII characters (other than emoji). Per repo "
-            "convention PR/issue/commit artifacts must be in English."
+            "Body contains non-ASCII characters (other than emoji and "
+            "typographic punctuation). Per repo convention PR/issue/commit "
+            "artifacts must be in English."
         )
 
     if kind == "pr":

--- a/tests/claude_hooks/test_validate_pr_body.py
+++ b/tests/claude_hooks/test_validate_pr_body.py
@@ -102,6 +102,16 @@ class TestNonAsciiDetection:
     @pytest.mark.parametrize(
         "text",
         [
+            "maps ↦ here",  # arrow outside allowlist
+            "dagger † not allowlisted",  # punctuation outside allowlist
+        ],
+    )
+    def test_blocks_non_allowlisted_punctuation(self, text: str) -> None:
+        assert body.has_disallowed_non_ascii(text)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
             "plain english only - [x] done!",
             "ship it 🚀",  # lone emoji
             "done ✅ and 🎉",  # symbol + emoji


### PR DESCRIPTION
## Summary

Follow-up to #158. That change allowlisted emoji + typographic punctuation in the PR/issue body ASCII check, but the error message shown on rejection still only mentioned emoji. This syncs the message wording and adds a regression test for punctuation still outside the allowlist.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- error text omitted the emoji+punctuation allowlist added in #158, misleading contributors
- reword message and add test that non-allowlisted punctuation stays blocked

## Testing

uv run pytest tests/claude_hooks/test_validate_pr_body.py -- 42 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)