### PR TITLE
fix(work-items): recipe-source table edits

### DIFF
--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -107,7 +107,10 @@ class WorkItemUpdateSpec(BaseModel):
         default=None,
         max_length=MAX_BODY_HTML_LEN,
         description=(
-            "Raw HTML from get_work_item(include_description_html=True); verbatim."
+            "Raw Polarion HTML from get_work_item("
+            "include_description_html=True), sent verbatim. Adding a table, "
+            "caption, or widget requires get_html_recipes first — build this "
+            "field from its template; hand-written table markup is rejected."
         ),
     )
     status: str | None = Field(

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -362,9 +362,10 @@ async def update_work_items(  # noqa: PLR0913
 
     description_html is raw Polarion HTML, sent verbatim — source from
     get_work_item(include_description_html=True); greenfield bodies use
-    create_work_items Markdown, formats never mix. New table, caption, link,
-    or widget HTML must be adapted from get_html_recipes templates, never
-    hand-written. custom_fields is partial,
+    create_work_items Markdown, formats never mix. To add a table, caption,
+    link, or widget, call get_html_recipes first and adapt its template
+    before writing description_html; hand-written table markup is rejected.
+    custom_fields is partial,
     keys outside the type schema rejected, values NOT validated — resolve via
     list_work_item_enum_options first.
 


### PR DESCRIPTION
## Summary

The `EFF-TABLE-RECIPE-SOURCED` efficiency eval (added in #141) blocked the v1.6.0
release: `gpt-4o-mini` hand-wrote table markup in `update_work_items` instead of
sourcing it from `get_html_recipes`, failing the gate 0/10. This firms the
LLM-facing steering on the `update_work_items` raw-HTML path so the recipe step
is taken reliably.

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- gpt-4o-mini hand-wrote table HTML without get_html_recipes -- EFF-TABLE-RECIPE-SOURCED gate 0/10 blocked v1.6.0.
- Firm update_work_items docstring + field: require get_html_recipes before table markup; create path unchanged.

## Testing

- `EVAL_MODEL=openai/gpt-4o-mini python -m evals.run --case EFF-TABLE-RECIPE-SOURCED --runs 10` → **10/10 PASS** (was 0/10).
- Full `efficiency` category 10 runs → all PASS (no regression on `EFF-BULK-UPDATE`).
- `SAFE-UPDATE-NEEDS-GET`, `SAFE-HYPERLINK-PRESERVE`, `ORCH-CONDITIONAL-UPDATE` → 10/10 each.
- `ruff check` + `ruff format --check` clean; `mypy src/` clean; `pytest` 1657 passed; `diff-cover` gate clean.

## Notes for Reviewers

- Wording is deliberately mid-strength (imperative + "before writing" + "rejected"), not shouty. Empirically both surfaces — the tool docstring **and** the `description_html` field — must carry it; softening either drops gpt-4o-mini back to 0/10 (conjunction).
- `create_work_items` / `create_document` intentionally untouched: greenfield create takes Markdown (`markdown_to_html`), so tables come from conversion + native styling, never hand-written HTML — no recipe step to steer.
- `update_document` left at its existing soft wording; that path has no registered eval case, so this PR does not change it. Flag if you want it firmed for consistency.
