### PR TITLE
feat(test-runs): add update_test_runs tool

### DIFF
--- a/evals/cases/efficiency.py
+++ b/evals/cases/efficiency.py
@@ -13,6 +13,9 @@ from evals.harness.fixtures import (
     DOC,
     FLOATING_TASK_ID,
     SPACE,
+    TEST_RUN_ID,
+    TEST_RUN_ID_2,
+    TEST_RUN_ID_3,
     UNCOVERED_REQ_ID,
 )
 
@@ -59,6 +62,19 @@ CASES: list[Case] = [
         "zero commits fails.",
         covers=["update_work_items"],
         tool="update_work_items",
+        min_total_items=3,
+    ),
+    _case(
+        "EFF-BULK-UPDATE-RUNS",
+        f"Rename these test runs: {TEST_RUN_ID} to 'Fake Regression Run v2', "
+        f"{TEST_RUN_ID_2} to 'Fake Smoke Run v2', and "
+        f"{TEST_RUN_ID_3} to 'Fake Sanity Run v2'.",
+        "single_bulk_write",
+        intent="Metadata changes to several known test runs use ONE committed "
+        "update_test_runs call covering all of them; a per-item split or "
+        "zero commits fails.",
+        covers=["update_test_runs"],
+        tool="update_test_runs",
         min_total_items=3,
     ),
     _case(

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -15,6 +15,8 @@ CheckResult = tuple[bool, str]
 WRITE_TOOLS: frozenset[str] = frozenset(
     {
         "create_work_items",
+        "create_test_runs",
+        "update_test_runs",
         "update_work_items",
         "move_work_item_to_document",
         "move_work_item_from_document",

--- a/evals/harness/fixtures.py
+++ b/evals/harness/fixtures.py
@@ -53,6 +53,10 @@ SECTION_A_PART_ID = f"heading_{DOC_HEADING_ID}"
 # Test run instance served by list_test_runs (TRIG-LIST-TEST-RUNS).
 TEST_RUN_ID = "Fake-TR-001"
 
+# Extra run instances so 3-item bulk update prompt possible (EFF-BULK-UPDATE-RUNS).
+TEST_RUN_ID_2 = "Fake-TR-002"
+TEST_RUN_ID_3 = "Fake-TR-003"
+
 # Template blueprint; create_test_runs resolve it via template guard.
 TEST_RUN_TEMPLATE_ID = "Fake-TR-Template"
 
@@ -211,6 +215,7 @@ SEEDS = Seeds(
         ),
     },
     test_runs={
+        # TEST_RUN_ID stay data[0] — test_fake_polarion assert on it.
         TEST_RUN_ID: TestRun(
             TEST_RUN_ID,
             "Fake Regression Run",
@@ -218,6 +223,8 @@ SEEDS = Seeds(
             status="open",
             finished_on=TS,
         ),
+        TEST_RUN_ID_2: TestRun(TEST_RUN_ID_2, "Fake Smoke Run"),
+        TEST_RUN_ID_3: TestRun(TEST_RUN_ID_3, "Fake Sanity Run"),
         TEST_RUN_TEMPLATE_ID: TestRun(
             TEST_RUN_TEMPLATE_ID,
             "Fake Run Template",

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -46,6 +46,8 @@ from mcp_server_polarion.models.test_runs import (
     TestRunDetail,
     TestRunsCreateResult,
     TestRunSummary,
+    TestRunsUpdateResult,
+    TestRunUpdateSpec,
 )
 from mcp_server_polarion.models.work_items import (
     Hyperlink,
@@ -82,7 +84,9 @@ __all__: list[str] = [
     "TestRunCreateSpec",
     "TestRunDetail",
     "TestRunSummary",
+    "TestRunUpdateSpec",
     "TestRunsCreateResult",
+    "TestRunsUpdateResult",
     "WorkItemCommentSpec",
     "WorkItemCreateSpec",
     "WorkItemDetail",

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -1,10 +1,10 @@
-"""Test run models — summaries, create specs, write results."""
+"""Test run models — summaries, create/update specs, write results."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class TestRunSummary(BaseModel):
@@ -70,6 +70,60 @@ class TestRunsCreateResult(BaseModel):
     __test__ = False
 
     created: bool
+    dry_run: bool
+    test_run_ids: list[str] = Field(default_factory=list)
+    payload_preview: Mapping[str, object] | None = None
+
+
+class TestRunUpdateSpec(BaseModel):
+    """One test run's changes in an ``update_test_runs`` batch; unset
+    fields stay unchanged."""
+
+    __test__ = False
+
+    # LLM input model: reject typo keys, not silent-drop.
+    model_config = ConfigDict(extra="forbid")
+
+    test_run_id: str = Field(
+        min_length=1, description="Test run ID (e.g. 'TR-2024-01')."
+    )
+    title: str | None = None
+    status: str | None = None
+    group_id: str | None = Field(
+        default=None, description="Free-form grouping label (e.g. 'Release-2.5')."
+    )
+    custom_fields: dict[str, object] | None = Field(
+        default=None,
+        description="Partial; rich-text values as {'type':'text/html','value':...}.",
+    )
+
+    @model_validator(mode="after")
+    def _require_effective_change(self) -> TestRunUpdateSpec:
+        # None custom entries drop at payload build; attribute-less item 400 batch.
+        effective = (
+            self.title
+            or self.status
+            or self.group_id
+            or (
+                self.custom_fields
+                and any(value is not None for value in self.custom_fields.values())
+            )
+        )
+        if not effective:
+            msg = (
+                f"test run '{self.test_run_id}': no effective change -- set "
+                "at least one field (custom_fields values of None are dropped)."
+            )
+            raise ValueError(msg)
+        return self
+
+
+class TestRunsUpdateResult(BaseModel):
+    """``update_test_runs`` result."""
+
+    __test__ = False
+
+    updated: bool
     dry_run: bool
     test_run_ids: list[str] = Field(default_factory=list)
     payload_preview: Mapping[str, object] | None = None

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -1,4 +1,4 @@
-"""Test run tools — list, search, get, and create test runs in a project."""
+"""Test run tools — list, search, get, create, and update test runs in a project."""
 
 from __future__ import annotations
 
@@ -19,6 +19,8 @@ from mcp_server_polarion.models import (
     TestRunDetail,
     TestRunsCreateResult,
     TestRunSummary,
+    TestRunsUpdateResult,
+    TestRunUpdateSpec,
 )
 from mcp_server_polarion.server import mcp
 from mcp_server_polarion.tools._shared.custom_fields import (
@@ -39,6 +41,7 @@ from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     ensure_unique_ids,
     get_client,
+    reraise_with_item_context,
 )
 from mcp_server_polarion.tools._shared.pagination import (
     DEFAULT_PAGE_SIZE,
@@ -133,6 +136,11 @@ async def create_test_runs(
     """
     client = get_client(ctx)
     ensure_unique_ids((spec.id for spec in items), label="id")
+
+    # Build pre-guards -- standard-attr shadow collision raise locally,
+    # clearer than network key-guard message.
+    payload = _build_create_test_runs_payload(project_id=project_id, specs=items)
+
     for spec in items:
         await guard_test_run_enums(
             client, project_id, type=spec.type, status=spec.status
@@ -143,8 +151,6 @@ async def create_test_runs(
     for spec in items:
         if spec.custom_fields:
             await guard_test_run_custom_fields(client, project_id, spec.custom_fields)
-
-    payload = _build_create_test_runs_payload(project_id=project_id, specs=items)
 
     if dry_run:
         return TestRunsCreateResult(
@@ -181,6 +187,124 @@ async def create_test_runs(
         created=True,
         dry_run=False,
         test_run_ids=new_ids,
+        payload_preview=None,
+    )
+
+
+def _build_update_test_run_resource(
+    *,
+    project_id: str,
+    spec: TestRunUpdateSpec,
+) -> dict[str, JsonValue]:
+    """One ``testruns`` resource for bulk PATCH; skip unset so update
+    never blank existing attribute. Spec validator guarantee at least one
+    attribute survive; all writables live under ``attributes``.
+    """
+    attributes: dict[str, JsonValue] = {}
+    if spec.title:
+        attributes["title"] = spec.title
+    if spec.status:
+        attributes["status"] = spec.status
+    if spec.group_id:
+        attributes["groupId"] = spec.group_id
+    merge_custom_fields(attributes, spec.custom_fields, STANDARD_TEST_RUN_ATTRIBUTES)
+
+    return {
+        "type": "testruns",
+        "id": f"{project_id}/{spec.test_run_id}",
+        "attributes": attributes,
+    }
+
+
+def _build_update_test_runs_payload(
+    *,
+    project_id: str,
+    specs: list[TestRunUpdateSpec],
+) -> dict[str, JsonValue]:
+    """JSON:API body for bulk ``PATCH /projects/{p}/testruns``."""
+    data: list[JsonValue] = [
+        _build_update_test_run_resource(project_id=project_id, spec=spec)
+        for spec in specs
+    ]
+    return {"data": data}
+
+
+@mcp.tool(
+    tags={"write"},
+    timeout=60.0,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+async def update_test_runs(
+    ctx: Context,
+    project_id: str = Field(min_length=1, description="Polarion project ID."),
+    items: list[TestRunUpdateSpec] = Field(  # noqa: B008
+        min_length=1,
+        max_length=MAX_BULK_ITEMS,
+        description="Per-run changes (1-50); unset fields stay unchanged.",
+    ),
+    dry_run: bool = Field(
+        default=False,
+        description="Preview payload without writing; guards still query Polarion.",
+    ),
+) -> TestRunsUpdateResult:
+    """Update fields on 1-50 existing test runs in one bulk PATCH; unset
+    fields stay unchanged.
+
+    Writable: title, status, group_id, custom_fields. status is validated
+    against the project's testing enumerations — unknown ids raise ValueError.
+    custom_fields is partial; keys are validated against a sample of existing
+    runs, values are NOT (test runs have no options API). finishedOn is
+    server-managed and not settable. Atomic: one bad item rejects the whole
+    batch. Returns ids only — re-read via list_test_runs if needed.
+    """
+    client = get_client(ctx)
+    ensure_unique_ids((spec.test_run_id for spec in items), label="test_run_id")
+
+    # Build pre-guards -- standard-attr shadow collision raise locally,
+    # clearer than network key-guard message.
+    payload = _build_update_test_runs_payload(project_id=project_id, specs=items)
+
+    for index, spec in enumerate(items):
+        with reraise_with_item_context(index, spec.test_run_id):
+            if spec.status:
+                await guard_test_run_enums(client, project_id, status=spec.status)
+            if spec.custom_fields:
+                await guard_test_run_custom_fields(
+                    client, project_id, spec.custom_fields
+                )
+
+    if dry_run:
+        return TestRunsUpdateResult(
+            updated=False,
+            dry_run=True,
+            test_run_ids=[],
+            payload_preview=payload,
+        )
+
+    path = f"/projects/{encode_path_segment(project_id)}/testruns"
+    try:
+        await client.patch(path, json=cast(dict[str, object], payload))
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot update test runs -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"A test run in the batch was not found in project '{project_id}': "
+            f"{exc.message} Use `list_test_runs` to discover valid IDs."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(f"Failed to update test runs: {exc.message}") from exc
+
+    return TestRunsUpdateResult(
+        updated=True,
+        dry_run=False,
+        test_run_ids=[spec.test_run_id for spec in items],
         payload_preview=None,
     )
 

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -46,6 +46,7 @@ _WRITE_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "create_work_items",
         "create_test_runs",
+        "update_test_runs",
         "update_work_items",
         "move_work_item_to_document",
         "move_work_item_from_document",

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -20,12 +20,15 @@ from mcp_server_polarion.models import (
     PaginatedResult,
     TestRunCreateSpec,
     TestRunDetail,
+    TestRunUpdateSpec,
 )
 from mcp_server_polarion.tools.test_runs import (
     _build_create_test_runs_payload,
+    _build_update_test_runs_payload,
     create_test_runs,
     get_test_run,
     list_test_runs,
+    update_test_runs,
 )
 
 
@@ -452,6 +455,22 @@ class TestCreateTestRuns:
         mock_client.get.assert_not_awaited()
         mock_client.post.assert_not_awaited()
 
+    async def test_shadowing_custom_key_raises_before_network(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # title via custom_fields collide standard attr -- local build check
+        # raise clear param hint before guard round-trip.
+        with pytest.raises(ValueError, match="standard Polarion attributes"):
+            await create_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunCreateSpec(id="TR-1", custom_fields={"title": "shadow"})],
+                dry_run=False,
+            )
+
+        mock_client.get.assert_not_awaited()
+        mock_client.post.assert_not_awaited()
+
     async def test_minimal_create_posts_and_returns_ids(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
@@ -620,6 +639,340 @@ class TestCreateTestRuns:
                 items=[TestRunCreateSpec(id="TR-9")],
                 dry_run=False,
             )
+
+
+class TestBuildUpdateTestRunsPayload:
+    """``_build_update_test_runs_payload`` unit seam."""
+
+    def test_full_spec_builds_attributes(self) -> None:
+        spec = TestRunUpdateSpec(
+            test_run_id="TR-100",
+            title="New Title",
+            status="finished",
+            group_id="Release-2.5",
+            custom_fields={"goal": "regression"},
+        )
+
+        payload = _build_update_test_runs_payload(project_id="proj1", specs=[spec])
+
+        data = payload["data"]
+        assert isinstance(data, list)
+        resource = data[0]
+        assert isinstance(resource, dict)
+        assert resource["type"] == "testruns"
+        assert resource["id"] == "proj1/TR-100"
+        assert resource["attributes"] == {
+            "title": "New Title",
+            "status": "finished",
+            "groupId": "Release-2.5",
+            "goal": "regression",
+        }
+        assert "relationships" not in resource
+
+    def test_partial_spec_skips_unset(self) -> None:
+        spec = TestRunUpdateSpec(test_run_id="TR-101", title="Only Title")
+
+        payload = _build_update_test_runs_payload(project_id="proj1", specs=[spec])
+
+        data = payload["data"]
+        assert isinstance(data, list)
+        resource = data[0]
+        assert isinstance(resource, dict)
+        assert resource["attributes"] == {"title": "Only Title"}
+
+    def test_multiple_specs_keep_order(self) -> None:
+        specs = [
+            TestRunUpdateSpec(test_run_id="TR-1", title="A"),
+            TestRunUpdateSpec(test_run_id="TR-2", title="B"),
+        ]
+
+        payload = _build_update_test_runs_payload(project_id="proj1", specs=specs)
+
+        data = payload["data"]
+        assert isinstance(data, list)
+        ids = [entry["id"] for entry in data if isinstance(entry, dict)]
+        assert ids == ["proj1/TR-1", "proj1/TR-2"]
+
+    def test_custom_field_shadowing_standard_attribute_raises(self) -> None:
+        spec = TestRunUpdateSpec(
+            test_run_id="TR-102", custom_fields={"title": "shadow"}
+        )
+
+        with pytest.raises(ValueError, match="standard Polarion attributes"):
+            _build_update_test_runs_payload(project_id="proj1", specs=[spec])
+
+
+class TestUpdateTestRuns:
+    """``update_test_runs`` tool."""
+
+    async def test_duplicate_ids_rejected_before_any_request(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        items = [
+            TestRunUpdateSpec(test_run_id="TR-1", title="A"),
+            TestRunUpdateSpec(test_run_id="TR-1", title="B"),
+        ]
+
+        with pytest.raises(ValueError, match=r"Duplicate test_run_id\(s\)"):
+            await update_test_runs(
+                mock_ctx, project_id="proj1", items=items, dry_run=False
+            )
+
+        mock_client.get.assert_not_awaited()
+        mock_client.patch.assert_not_awaited()
+
+    async def test_minimal_update_patches_and_returns_ids(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.return_value = None
+
+        result = await update_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            items=[TestRunUpdateSpec(test_run_id="TR-1", title="Renamed")],
+            dry_run=False,
+        )
+
+        assert result.updated is True
+        assert result.dry_run is False
+        assert result.test_run_ids == ["TR-1"]
+        assert result.payload_preview is None
+        # Title-only update need zero guard traffic.
+        mock_client.get.assert_not_awaited()
+        args, kwargs = mock_client.patch.await_args
+        assert args[0] == "/projects/proj1/testruns"
+        data = kwargs["json"]["data"]
+        assert data[0]["id"] == "proj1/TR-1"
+
+    async def test_dry_run_returns_payload_without_patching(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        result = await update_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            items=[TestRunUpdateSpec(test_run_id="TR-2", title="Preview")],
+            dry_run=True,
+        )
+
+        assert result.updated is False
+        assert result.dry_run is True
+        assert result.test_run_ids == []
+        assert result.payload_preview is not None
+        data = result.payload_preview["data"]
+        assert isinstance(data, list)
+        mock_client.patch.assert_not_awaited()
+
+    async def test_unknown_status_blocks_before_patch(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "type": "enumerations",
+                "id": "testrun-status",
+                "attributes": {"options": [{"id": "open"}, {"id": "finished"}]},
+            }
+        }
+
+        with pytest.raises(ValueError, match=r"items\[0\].*test run status"):
+            await update_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunUpdateSpec(test_run_id="TR-3", status="ghost")],
+                dry_run=False,
+            )
+
+        mock_client.patch.assert_not_awaited()
+
+    async def test_dry_run_still_runs_guards(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": {
+                "type": "enumerations",
+                "id": "testrun-status",
+                "attributes": {"options": [{"id": "open"}]},
+            }
+        }
+
+        with pytest.raises(ValueError, match="test run status"):
+            await update_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunUpdateSpec(test_run_id="TR-4", status="ghost")],
+                dry_run=True,
+            )
+
+        mock_client.patch.assert_not_awaited()
+
+    async def test_custom_fields_guarded_against_sample(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = [
+            {
+                "data": [
+                    {
+                        "type": "testruns",
+                        "id": "proj1/R1",
+                        "attributes": {"id": "R1", "goal": "g"},
+                    }
+                ]
+            },
+            {"data": []},
+        ]
+        mock_client.patch.return_value = None
+
+        result = await update_test_runs(
+            mock_ctx,
+            project_id="proj1",
+            items=[TestRunUpdateSpec(test_run_id="TR-5", custom_fields={"goal": "x"})],
+            dry_run=False,
+        )
+
+        assert result.test_run_ids == ["TR-5"]
+        # Sampled instances then templates before PATCH.
+        assert mock_client.get.await_count == 2
+
+    async def test_shadowing_custom_key_raises_before_network(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # title via custom_fields collide standard attr -- local build check
+        # raise clear param hint before guard round-trip.
+        with pytest.raises(ValueError, match="standard Polarion attributes"):
+            await update_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[
+                    TestRunUpdateSpec(
+                        test_run_id="TR-9", custom_fields={"title": "shadow"}
+                    )
+                ],
+                dry_run=False,
+            )
+
+        mock_client.get.assert_not_awaited()
+        mock_client.patch.assert_not_awaited()
+
+    async def test_custom_field_guard_error_names_offending_item(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # First item title-only (no guard); second's unknown custom key trips
+        # guard -- error must carry its batch position, not items[0].
+        mock_client.get.side_effect = [
+            {
+                "data": [
+                    {
+                        "type": "testruns",
+                        "id": "proj1/R1",
+                        "attributes": {"id": "R1", "goal": "g"},
+                    }
+                ]
+            },
+            {"data": []},
+        ]
+
+        with pytest.raises(ValueError, match=r"items\[1\].*bogus"):
+            await update_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[
+                    TestRunUpdateSpec(test_run_id="TR-A", title="ok"),
+                    TestRunUpdateSpec(test_run_id="TR-B", custom_fields={"bogus": "x"}),
+                ],
+                dry_run=False,
+            )
+
+        mock_client.patch.assert_not_awaited()
+
+    async def test_run_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="list_test_runs"):
+            await update_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunUpdateSpec(test_run_id="TR-6", title="X")],
+                dry_run=False,
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await update_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunUpdateSpec(test_run_id="TR-7", title="X")],
+                dry_run=False,
+            )
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.patch.side_effect = PolarionError("boom", status_code=500)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await update_test_runs(
+                mock_ctx,
+                project_id="proj1",
+                items=[TestRunUpdateSpec(test_run_id="TR-8", title="X")],
+                dry_run=False,
+            )
+
+
+class TestUpdateTestRunsFieldValidation:
+    """Bulk bounds + spec constraints via ``TypeAdapter`` rebuild."""
+
+    @staticmethod
+    def _adapter(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(update_test_runs)
+        sig = inspect.signature(update_test_runs)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_empty_items_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("items").validate_python([])
+
+    def test_items_above_max_rejected(self) -> None:
+        specs = [{"test_run_id": f"TR-{i}", "title": "t"} for i in range(51)]
+        with pytest.raises(ValidationError):
+            self._adapter("items").validate_python(specs)
+
+    def test_items_at_max_accepted(self) -> None:
+        specs = [{"test_run_id": f"TR-{i}", "title": "t"} for i in range(50)]
+        validated = self._adapter("items").validate_python(specs)
+        assert isinstance(validated, list)
+        assert len(validated) == 50
+
+    def test_empty_project_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("project_id").validate_python("")
+
+    def test_spec_requires_non_empty_id(self) -> None:
+        with pytest.raises(ValidationError):
+            TestRunUpdateSpec(test_run_id="", title="t")
+
+    def test_spec_without_change_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="no effective change"):
+            TestRunUpdateSpec(test_run_id="TR-1")
+
+    def test_none_custom_values_not_effective(self) -> None:
+        with pytest.raises(ValidationError, match="no effective change"):
+            TestRunUpdateSpec(test_run_id="TR-1", custom_fields={"goal": None})
+
+    def test_group_id_alone_is_effective(self) -> None:
+        spec = TestRunUpdateSpec(test_run_id="TR-1", group_id="Release-1")
+        assert spec.group_id == "Release-1"
+
+    def test_unknown_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TestRunUpdateSpec(test_run_id="TR-1", bogus="x")  # type: ignore[call-arg]
 
 
 class TestCreateTestRunsFieldValidation:


### PR DESCRIPTION
## Summary

Adds `update_test_runs` — bulk PATCH for existing test runs (title, status, group_id, custom_fields). Completes the template-driven workflow: create runs from templates, then adjust metadata as runs progress. Writable set deliberately narrow: `finishedOn` is server-managed, `type`/`query`/`selectTestCasesBy` are template-determined at creation.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Test runs lacked update path; template workflow needs metadata edits after creation
- Bulk PATCH /testruns with title/status/groupId/custom_fields; reuses enum + custom-key guards; adds eval case

## Testing

- Unit: 24 new tests (payload builders, guards, dry_run, error mapping, TypeAdapter field bounds); 1608 passed, diff-cover 100%
- Live E2E vs testdrive.polarion.com `MCP_Test_Project`: create → dry_run preview → real PATCH → re-read verified (title/status/groupId/rich-text custom field); status guard and custom-key guard both blocked bad input with real option lists
- Eval: `EFF-BULK-UPDATE-RUNS` 10/10 PASS (gate ≥ 80%)

## Notes for Reviewers

- `WRITE_TOOLS` in evals/evaluators/checks.py also gains `create_test_runs` (pre-existing omission)
- Fixture seeds add Fake-TR-002/003 after Fake-TR-001 — `data[0]` assert in test_fake_polarion depends on order

🤖 Generated with [Claude Code](https://claude.com/claude-code)