### PR TITLE
feat(test-runs): add get_test_run detail tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
 - `/backlinkedworkitems` unsupported — back direction via `query=linkedWorkItems:{wi}`, so back results have `role=None`.
 - Polarion validate neither custom-field ids (unknown keys persist; wrong-type 400), nor enum values, nor link targets/roles — `guard/` validate pre-write. `getAvailableOptions` = only key→enum-options API (non-enum/unknown → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (`data` = dict, not list).
 - Custom fields inline under `attributes` (no `customFields` container; `@all` tokens dropped). `GET /projects/{p}/documents` absent on some builds.
-- Testruns: POST require explicit `id` (400 without; UI-only autofill); enums resolve only under `testing` context (`~` 404); no `getAvailableOptions` → custom-field enum values unguardable (keys only); `isTemplate` served only on templates.
+- Testruns: POST require explicit `id` (400 without; UI-only autofill); enums resolve only under `testing` context (`~` 404); no `getAvailableOptions` → custom-field enum values unguardable (keys only); `isTemplate` served only on templates; `homePageContent` served only on runs owning report — absent under `useReportFromTemplate` (even when requested explicit).
 
 ## Testing
 

--- a/evals/cases/triggers.py
+++ b/evals/cases/triggers.py
@@ -17,6 +17,7 @@ from evals.harness.fixtures import (
     PARENT_REQ_ID,
     PROJECT,
     SPACE,
+    TEST_RUN_ID,
 )
 
 MIN_PASS_RATE = 1.0
@@ -182,6 +183,16 @@ CASES: list[Case] = [
         covers=["list_test_runs"],
         expect="list_test_runs",
         reject=["list_work_items"],
+    ),
+    _case(
+        "TRIG-GET-TEST-RUN",
+        f"Show the full details of test run '{TEST_RUN_ID}' in project '{PROJECT}'.",
+        "triggers_tool",
+        intent="Fetching one known run's details must call get_test_run, not "
+        "page through list_test_runs.",
+        covers=["get_test_run"],
+        expect="get_test_run",
+        reject=["list_test_runs"],
     ),
     _case(
         "TRIG-CREATE-TEST-RUN",

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -391,25 +391,21 @@ class FakePolarion:
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
             )
 
-        # Single test run (template-guard pre-read); isTemplate served only on
-        # templates, mirror live Polarion omitting it on instances.
+        # Single test run (template guard + get_test_run); isTemplate served
+        # only on templates, mirror live Polarion omitting it on instances.
         single_tr = re.search(r"/testruns/([^/]+)$", path)
         if single_tr:
             tr = self.seeds.test_runs.get(single_tr.group(1))
             if tr is None:
                 return httpx.Response(404, json={"errors": [{"status": "404"}]})
-            attributes: dict[str, Any] = {"id": tr.short_id}
-            if tr.is_template:
-                attributes["isTemplate"] = True
+            resource = self._test_run_resource(tr)
+            attributes = resource["attributes"]
+            attributes["id"] = tr.short_id
+            if not tr.is_template:
+                del attributes["isTemplate"]
             return httpx.Response(
                 200,
-                json={
-                    "data": {
-                        "type": "testruns",
-                        "id": f"{PROJECT}/{tr.short_id}",
-                        "attributes": attributes,
-                    }
-                },
+                json={"data": resource, "included": self._author_included()},
             )
 
         # Test runs: templates=true return blueprints, else actual instances;

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -42,6 +42,7 @@ from mcp_server_polarion.models.recipes import (
 )
 from mcp_server_polarion.models.test_runs import (
     TestRunCreateSpec,
+    TestRunDetail,
     TestRunsCreateResult,
     TestRunSummary,
 )
@@ -77,6 +78,7 @@ __all__: list[str] = [
     "ProjectSummary",
     "SqlRecipeGallery",
     "TestRunCreateSpec",
+    "TestRunDetail",
     "TestRunSummary",
     "TestRunsCreateResult",
     "WorkItemCommentSpec",

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -26,6 +26,23 @@ class TestRunSummary(BaseModel):
     template_id: str = ""
 
 
+class TestRunDetail(TestRunSummary):
+    """Full test-run detail from ``get_test_run``."""
+
+    __test__ = False
+
+    project_id: str
+    author_id: str = ""
+    created: str = ""
+    # LiveDoc selection source; empty for non-LiveDoc runs.
+    space_id: str = ""
+    document_name: str = ""
+    query: str = ""
+    select_test_cases_by: str = ""
+    home_page_html: str = ""
+    custom_fields: dict[str, object] = Field(default_factory=dict)
+
+
 class TestRunCreateSpec(BaseModel):
     """One test run to create via ``create_test_runs``."""
 

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -39,7 +39,9 @@ class TestRunDetail(TestRunSummary):
     document_name: str = ""
     query: str = ""
     select_test_cases_by: str = ""
-    home_page_html: str = ""
+    # True = report inherit from template; Polarion omit homePageContent then.
+    use_report_from_template: bool = False
+    content_html: str = ""
     custom_fields: dict[str, object] = Field(default_factory=dict)
 
 

--- a/src/mcp_server_polarion/tools/_shared/fields.py
+++ b/src/mcp_server_polarion/tools/_shared/fields.py
@@ -16,6 +16,7 @@ WORK_ITEM_PART_FIELDS: Final[str] = "title,type,status,description,outlineNumber
 TEST_RUN_LIST_FIELDS: Final[str] = (
     "title,type,status,finishedOn,updated,author,isTemplate,groupId,template"
 )
+TEST_RUN_DETAIL_FIELDS: Final[str] = "@all"
 DOCUMENT_DETAIL_FIELDS: Final[str] = "@all"
 # Sparse fieldset filters relationships too — name them explicitly.
 DOCUMENT_COMMENT_LIST_FIELDS: Final[str] = (
@@ -30,6 +31,7 @@ __all__: list[str] = [
     "DOCUMENT_COMMENT_LIST_FIELDS",
     "DOCUMENT_DETAIL_FIELDS",
     "MAX_BULK_ITEMS",
+    "TEST_RUN_DETAIL_FIELDS",
     "TEST_RUN_LIST_FIELDS",
     "WORK_ITEM_COMMENT_LIST_FIELDS",
     "WORK_ITEM_DETAIL_FIELDS",

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -385,7 +385,8 @@ def parse_test_run_detail(
         document_name=document_name,
         query=safe_str(attributes.get("query", "")),
         select_test_cases_by=safe_str(attributes.get("selectTestCasesBy", "")),
-        home_page_html=body_html,
+        use_report_from_template=bool(attributes.get("useReportFromTemplate", False)),
+        content_html=body_html,
         custom_fields=extract_custom_fields(attributes, STANDARD_TEST_RUN_ATTRIBUTES),
     )
 

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -13,12 +13,14 @@ from mcp_server_polarion.models import (
     EnumOption,
     Hyperlink,
     PaginatedResult,
+    TestRunDetail,
     TestRunSummary,
     WorkItemDetail,
     WorkItemLink,
     WorkItemSummary,
 )
 from mcp_server_polarion.tools._shared.custom_fields import (
+    STANDARD_TEST_RUN_ATTRIBUTES,
     STANDARD_WORK_ITEM_ATTRIBUTES,
     extract_custom_fields,
 )
@@ -340,6 +342,52 @@ def parse_test_run_summaries(response: dict[str, object]) -> list[TestRunSummary
             continue
         items.append(TestRunSummary(**parse_test_run_summary_kwargs(item, user_names)))
     return items
+
+
+def parse_test_run_detail(
+    item: dict[str, object],
+    *,
+    project_id: str,
+    fallback_id: str = "",
+    user_names: Mapping[str, str] | None = None,
+) -> TestRunDetail:
+    """JSON:API testrun resource → ``TestRunDetail``. Expect
+    ``TEST_RUN_DETAIL_FIELDS`` + ``include=author``; homePageContent pass
+    through as raw HTML, round-trip unchanged. ``user_names`` map full
+    user id → display name (from included ``users``).
+    """
+    attributes = item.get("attributes", {})
+    if not isinstance(attributes, dict):
+        attributes = {}
+    relationships = item.get("relationships", {})
+    if not isinstance(relationships, dict):
+        relationships = {}
+
+    body_obj = attributes.get("homePageContent", {})
+    body_html = ""
+    if isinstance(body_obj, dict):
+        body_html = safe_str(body_obj.get("value", ""))
+
+    summary_kwargs = parse_test_run_summary_kwargs(item, dict(user_names or {}))
+    if not summary_kwargs["id"]:
+        summary_kwargs["id"] = fallback_id
+
+    author_full = extract_relationship_id(relationships, "author")
+    space_id, document_name = split_module_id(
+        extract_relationship_id(relationships, "document")
+    )
+    return TestRunDetail(
+        **summary_kwargs,
+        project_id=project_id,
+        author_id=extract_short_id(author_full),
+        created=safe_str(attributes.get("created", "")),
+        space_id=space_id,
+        document_name=document_name,
+        query=safe_str(attributes.get("query", "")),
+        select_test_cases_by=safe_str(attributes.get("selectTestCasesBy", "")),
+        home_page_html=body_html,
+        custom_fields=extract_custom_fields(attributes, STANDARD_TEST_RUN_ATTRIBUTES),
+    )
 
 
 def _parse_comment(item: dict[str, object], user_names: Mapping[str, str]) -> Comment:

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -259,9 +259,9 @@ async def get_test_run(
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
     test_run_id: str = Field(description="Test run ID (e.g. 'TR-2026-01')."),
-    include_home_page_html: bool = Field(
+    include_homepage_content_html: bool = Field(
         default=False,
-        description="Fill ``home_page_html`` with the run's raw HTML report body.",
+        description="Fill ``content_html`` with the run's raw HTML report body.",
     ),
 ) -> TestRunDetail:
     """Get full details of one test run by ID.
@@ -270,9 +270,10 @@ async def get_test_run(
     read-only context: how test cases are selected (select_test_cases_by with
     its query or source document space_id/document_name), template provenance
     (is_template, template_id), author, and timestamps.
-    include_home_page_html=True fills home_page_html with the raw HTML report
-    body (empty when the run inherits its report from a template); keep it
-    verbatim — never feed back a blanked (flag=False) body.
+    include_homepage_content_html=True fills content_html with the raw HTML
+    report body; it stays empty when use_report_from_template is true (the run
+    inherits its report from its template). Keep it verbatim — never feed back
+    a blanked (flag=False) body.
     """
     client = get_client(ctx)
     path = (
@@ -312,7 +313,7 @@ async def get_test_run(
         fallback_id=test_run_id,
         user_names=parse_included_user_name_map(response),
     )
-    if not include_home_page_html:
+    if not include_homepage_content_html:
         # Body always travel over wire; blank per flag=False contract.
-        detail = detail.model_copy(update={"home_page_html": ""})
+        detail = detail.model_copy(update={"content_html": ""})
     return detail

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -1,4 +1,4 @@
-"""Test run tools — list, search, and create test runs in a project."""
+"""Test run tools — list, search, get, and create test runs in a project."""
 
 from __future__ import annotations
 
@@ -16,6 +16,7 @@ from mcp_server_polarion.models import (
     JsonValue,
     PaginatedResult,
     TestRunCreateSpec,
+    TestRunDetail,
     TestRunsCreateResult,
     TestRunSummary,
 )
@@ -26,6 +27,7 @@ from mcp_server_polarion.tools._shared.custom_fields import (
 )
 from mcp_server_polarion.tools._shared.fields import (
     MAX_BULK_ITEMS,
+    TEST_RUN_DETAIL_FIELDS,
     TEST_RUN_LIST_FIELDS,
 )
 from mcp_server_polarion.tools._shared.guard import (
@@ -44,6 +46,8 @@ from mcp_server_polarion.tools._shared.pagination import (
 )
 from mcp_server_polarion.tools._shared.parse import (
     extract_created_short_ids,
+    parse_included_user_name_map,
+    parse_test_run_detail,
     parse_test_run_summaries,
 )
 
@@ -244,3 +248,71 @@ async def list_test_runs(  # noqa: PLR0913
     items = parse_test_run_summaries(response)
 
     return make_page(items, response, page_number, page_size)
+
+
+@mcp.tool(
+    tags={"read"},
+    timeout=60.0,
+    annotations={"readOnlyHint": True},
+)
+async def get_test_run(
+    ctx: Context,
+    project_id: str = Field(description="Polarion project ID."),
+    test_run_id: str = Field(description="Test run ID (e.g. 'TR-2026-01')."),
+    include_home_page_html: bool = Field(
+        default=False,
+        description="Fill ``home_page_html`` with the run's raw HTML report body.",
+    ),
+) -> TestRunDetail:
+    """Get full details of one test run by ID.
+
+    Returns writable fields (title, status, group_id, custom_fields) plus
+    read-only context: how test cases are selected (select_test_cases_by with
+    its query or source document space_id/document_name), template provenance
+    (is_template, template_id), author, and timestamps.
+    include_home_page_html=True fills home_page_html with the raw HTML report
+    body (empty when the run inherits its report from a template); keep it
+    verbatim — never feed back a blanked (flag=False) body.
+    """
+    client = get_client(ctx)
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/testruns/{encode_path_segment(test_run_id)}"
+    )
+    try:
+        response = await client.get(
+            path,
+            params={
+                "fields[testruns]": TEST_RUN_DETAIL_FIELDS,
+                "include": "author",
+                "fields[users]": "name",
+            },
+        )
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Test run '{test_run_id}' not found in project '{project_id}'. "
+            "Use `list_test_runs` to discover valid IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot access test run -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(
+            f"Failed to get test run '{test_run_id}': {exc.message}"
+        ) from exc
+
+    data = response.get("data", {})
+    if not isinstance(data, dict):
+        data = {}
+
+    detail = parse_test_run_detail(
+        data,
+        project_id=project_id,
+        fallback_id=test_run_id,
+        user_names=parse_included_user_name_map(response),
+    )
+    if not include_home_page_html:
+        # Body always travel over wire; blank per flag=False contract.
+        detail = detail.model_copy(update={"home_page_html": ""})
+    return detail

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -216,6 +216,17 @@ class TestTestRunRouting:
         response = _get(FakePolarion(), f"/projects/{PROJECT}/testruns/Nope")
         assert response.status_code == 404
 
+    def test_single_instance_serves_detail_attributes(self) -> None:
+        # get_test_run consume same endpoint as template guard; serve full
+        # resource so detail fields populate.
+        response = _get(FakePolarion(), f"/projects/{PROJECT}/testruns/{TEST_RUN_ID}")
+        payload = _json(response)
+        attributes = payload["data"]["attributes"]
+        assert attributes["title"] == "Fake Regression Run"
+        assert attributes["status"] == "open"
+        included = payload["included"]
+        assert included and included[0]["type"] == "users"
+
     def test_testing_context_enum_resolves(self) -> None:
         response = _get(
             FakePolarion(),

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -32,6 +32,7 @@ _READ_TOOL_NAMES: frozenset[str] = frozenset(
         "read_document",
         "list_work_items",
         "list_test_runs",
+        "get_test_run",
         "get_sql_query_recipes",
         "get_html_recipes",
         "get_work_item",

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -17,6 +17,7 @@ from mcp_server_polarion.tools._shared.parse import (
     parse_hyperlinks,
     parse_included_user_name_map,
     parse_included_work_item_map,
+    parse_test_run_detail,
     parse_test_run_summaries,
     parse_test_run_summary_kwargs,
     parse_work_item_detail,
@@ -389,6 +390,91 @@ class TestParseTestRunSummaries:
             ]
         }
         assert [s.id for s in parse_test_run_summaries(response)] == ["TR-2"]
+
+
+class TestParseTestRunDetail:
+    """Tests for `parse_test_run_detail`."""
+
+    def test_passes_home_page_html_verbatim_and_extracts_customs(self) -> None:
+        item: dict[str, object] = {
+            "id": "proj/TR-1",
+            "attributes": {
+                "title": "T",
+                "type": "manual",
+                "status": "open",
+                "created": "2026-06-01T08:00:00Z",
+                "query": "type:testcase",
+                "selectTestCasesBy": "staticQueryResult",
+                "homePageContent": {"type": "text/html", "value": "<p>raw</p>"},
+                "myCustomField": "x",
+            },
+            "relationships": {"author": {"data": {"id": "proj/jdoe"}}},
+        }
+        detail = parse_test_run_detail(item, project_id="proj")
+        assert detail.home_page_html == "<p>raw</p>"
+        assert detail.created == "2026-06-01T08:00:00Z"
+        assert detail.query == "type:testcase"
+        assert detail.select_test_cases_by == "staticQueryResult"
+        assert detail.project_id == "proj"
+        assert detail.author_id == "jdoe"
+        assert detail.author_name == ""
+        assert detail.custom_fields == {"myCustomField": "x"}
+
+    def test_user_names_resolve_author_name(self) -> None:
+        item: dict[str, object] = {
+            "id": "proj/TR-1",
+            "attributes": {"title": "T"},
+            "relationships": {"author": {"data": {"id": "proj/jdoe"}}},
+        }
+        detail = parse_test_run_detail(
+            item, project_id="proj", user_names={"proj/jdoe": "J Doe"}
+        )
+        assert detail.author_id == "jdoe"
+        assert detail.author_name == "J Doe"
+
+    def test_document_relationship_splits_space_and_name(self) -> None:
+        # Doc names may contain '/' — split_module_id keep tail intact.
+        item: dict[str, object] = {
+            "id": "proj/TR-1",
+            "attributes": {"title": "T"},
+            "relationships": {
+                "document": {"data": {"id": "proj/Testing/Auth/Plan"}},
+            },
+        }
+        detail = parse_test_run_detail(item, project_id="proj")
+        assert detail.space_id == "Testing"
+        assert detail.document_name == "Auth/Plan"
+
+    def test_no_document_relationship_defaults_empty(self) -> None:
+        item: dict[str, object] = {"id": "proj/TR-1", "attributes": {"title": "T"}}
+        detail = parse_test_run_detail(item, project_id="proj")
+        assert detail.space_id == ""
+        assert detail.document_name == ""
+
+    def test_non_dict_home_page_content_defaults_empty(self) -> None:
+        item: dict[str, object] = {
+            "id": "proj/TR-1",
+            "attributes": {"title": "T", "homePageContent": "nope"},
+        }
+        detail = parse_test_run_detail(item, project_id="proj")
+        assert detail.home_page_html == ""
+
+    def test_fallback_id_used_when_id_missing(self) -> None:
+        item: dict[str, object] = {"attributes": {"title": "T"}}
+        detail = parse_test_run_detail(item, project_id="proj", fallback_id="TR-9")
+        assert detail.id == "TR-9"
+
+    def test_non_dict_attributes_and_relationships_default_empty(self) -> None:
+        item: dict[str, object] = {
+            "id": "proj/TR-1",
+            "attributes": [],
+            "relationships": "nope",
+        }
+        detail = parse_test_run_detail(item, project_id="proj")
+        assert detail.id == "TR-1"
+        assert detail.home_page_html == ""
+        assert detail.author_id == ""
+        assert detail.custom_fields == {}
 
 
 class TestParseComment:

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -395,7 +395,7 @@ class TestParseTestRunSummaries:
 class TestParseTestRunDetail:
     """Tests for `parse_test_run_detail`."""
 
-    def test_passes_home_page_html_verbatim_and_extracts_customs(self) -> None:
+    def test_passes_content_html_verbatim_and_extracts_customs(self) -> None:
         item: dict[str, object] = {
             "id": "proj/TR-1",
             "attributes": {
@@ -411,14 +411,25 @@ class TestParseTestRunDetail:
             "relationships": {"author": {"data": {"id": "proj/jdoe"}}},
         }
         detail = parse_test_run_detail(item, project_id="proj")
-        assert detail.home_page_html == "<p>raw</p>"
+        assert detail.content_html == "<p>raw</p>"
         assert detail.created == "2026-06-01T08:00:00Z"
         assert detail.query == "type:testcase"
         assert detail.select_test_cases_by == "staticQueryResult"
+        assert detail.use_report_from_template is False
         assert detail.project_id == "proj"
         assert detail.author_id == "jdoe"
         assert detail.author_name == ""
         assert detail.custom_fields == {"myCustomField": "x"}
+
+    def test_use_report_from_template_true_with_absent_body(self) -> None:
+        # Polarion omit homePageContent when report inherit from template.
+        item: dict[str, object] = {
+            "id": "proj/TR-1",
+            "attributes": {"title": "T", "useReportFromTemplate": True},
+        }
+        detail = parse_test_run_detail(item, project_id="proj")
+        assert detail.use_report_from_template is True
+        assert detail.content_html == ""
 
     def test_user_names_resolve_author_name(self) -> None:
         item: dict[str, object] = {
@@ -457,7 +468,7 @@ class TestParseTestRunDetail:
             "attributes": {"title": "T", "homePageContent": "nope"},
         }
         detail = parse_test_run_detail(item, project_id="proj")
-        assert detail.home_page_html == ""
+        assert detail.content_html == ""
 
     def test_fallback_id_used_when_id_missing(self) -> None:
         item: dict[str, object] = {"attributes": {"title": "T"}}
@@ -472,7 +483,7 @@ class TestParseTestRunDetail:
         }
         detail = parse_test_run_detail(item, project_id="proj")
         assert detail.id == "TR-1"
-        assert detail.home_page_html == ""
+        assert detail.content_html == ""
         assert detail.author_id == ""
         assert detail.custom_fields == {}
 

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -16,10 +16,15 @@ from mcp_server_polarion.core.exceptions import (
     PolarionError,
     PolarionNotFoundError,
 )
-from mcp_server_polarion.models import PaginatedResult, TestRunCreateSpec
+from mcp_server_polarion.models import (
+    PaginatedResult,
+    TestRunCreateSpec,
+    TestRunDetail,
+)
 from mcp_server_polarion.tools.test_runs import (
     _build_create_test_runs_payload,
     create_test_runs,
+    get_test_run,
     list_test_runs,
 )
 
@@ -679,3 +684,170 @@ class TestListTestRunsFieldValidation:
     def test_page_number_below_min_rejected(self) -> None:
         with pytest.raises(ValidationError):
             self._adapter("page_number").validate_python(0)
+
+
+def _detail_response() -> dict[str, object]:
+    """Full single-testrun GET body covering every detail field."""
+    return {
+        "data": {
+            "type": "testruns",
+            "id": "proj1/TR-100",
+            "attributes": {
+                "title": "Regression 2.5",
+                "type": "manual",
+                "status": "open",
+                "created": "2026-06-01T08:00:00Z",
+                "updated": "2026-06-20T10:00:00Z",
+                "finishedOn": "2026-06-19T17:30:00Z",
+                "groupId": "Release-2.5",
+                "isTemplate": False,
+                "query": "type:testcase AND component:auth",
+                "selectTestCasesBy": "dynamicQueryResult",
+                "homePageContent": {
+                    "type": "text/html",
+                    "value": '<p id="polarion_1">Run <strong>notes</strong></p>',
+                },
+                "myCustomField": "custom-value",
+            },
+            "relationships": {
+                "author": {"data": {"type": "users", "id": "proj1/bob"}},
+                "document": {
+                    "data": {"type": "documents", "id": "proj1/Testing/Auth Plan"}
+                },
+                "template": {"data": {"type": "testruns", "id": "proj1/TPL-1"}},
+            },
+        },
+        "included": [
+            {"type": "users", "id": "proj1/bob", "attributes": {"name": "Bob B"}},
+        ],
+    }
+
+
+class TestGetTestRun:
+    """``get_test_run`` tool."""
+
+    async def test_returns_test_run_detail(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = _detail_response()
+
+        result = await get_test_run(
+            mock_ctx,
+            project_id="proj1",
+            test_run_id="TR-100",
+            include_home_page_html=True,
+        )
+
+        assert isinstance(result, TestRunDetail)
+        assert result.id == "TR-100"
+        assert result.title == "Regression 2.5"
+        assert result.type == "manual"
+        assert result.status == "open"
+        assert result.created == "2026-06-01T08:00:00Z"
+        assert result.updated == "2026-06-20T10:00:00Z"
+        assert result.finished_on == "2026-06-19T17:30:00Z"
+        assert result.group_id == "Release-2.5"
+        assert result.is_template is False
+        assert result.query == "type:testcase AND component:auth"
+        assert result.select_test_cases_by == "dynamicQueryResult"
+        assert result.project_id == "proj1"
+        assert result.author_id == "bob"
+        assert result.author_name == "Bob B"
+        assert result.space_id == "Testing"
+        assert result.document_name == "Auth Plan"
+        assert result.template_id == "TPL-1"
+        # Raw HTML passthrough — anchor ids survive verbatim.
+        assert result.home_page_html == (
+            '<p id="polarion_1">Run <strong>notes</strong></p>'
+        )
+        assert result.custom_fields == {"myCustomField": "custom-value"}
+
+    async def test_request_params(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = _detail_response()
+
+        await get_test_run(
+            mock_ctx,
+            project_id="proj1",
+            test_run_id="TR-100",
+            include_home_page_html=False,
+        )
+
+        args, kwargs = mock_client.get.call_args
+        assert args[0] == "/projects/proj1/testruns/TR-100"
+        assert kwargs["params"]["fields[testruns]"] == "@all"
+        assert kwargs["params"]["include"] == "author"
+        assert kwargs["params"]["fields[users]"] == "name"
+
+    async def test_include_home_page_html_false_blanks_field(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """Flag off blank body — body still travel (``@all`` for customs)."""
+        mock_client.get.return_value = _detail_response()
+
+        result = await get_test_run(
+            mock_ctx,
+            project_id="proj1",
+            test_run_id="TR-100",
+            include_home_page_html=False,
+        )
+
+        assert result.home_page_html == ""
+        # Other metadata still populated.
+        assert result.title == "Regression 2.5"
+
+    async def test_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="list_test_runs"):
+            await get_test_run(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="TR-404",
+                include_home_page_html=False,
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await get_test_run(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="TR-100",
+                include_home_page_html=False,
+            )
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError("boom", status_code=500)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await get_test_run(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="TR-100",
+                include_home_page_html=False,
+            )
+
+    async def test_non_dict_data_falls_back_to_arg_id(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": []}
+
+        result = await get_test_run(
+            mock_ctx,
+            project_id="proj1",
+            test_run_id="TR-100",
+            include_home_page_html=False,
+        )
+
+        assert result.id == "TR-100"

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -703,6 +703,7 @@ def _detail_response() -> dict[str, object]:
                 "isTemplate": False,
                 "query": "type:testcase AND component:auth",
                 "selectTestCasesBy": "dynamicQueryResult",
+                "useReportFromTemplate": False,
                 "homePageContent": {
                     "type": "text/html",
                     "value": '<p id="polarion_1">Run <strong>notes</strong></p>',
@@ -735,7 +736,7 @@ class TestGetTestRun:
             mock_ctx,
             project_id="proj1",
             test_run_id="TR-100",
-            include_home_page_html=True,
+            include_homepage_content_html=True,
         )
 
         assert isinstance(result, TestRunDetail)
@@ -750,6 +751,7 @@ class TestGetTestRun:
         assert result.is_template is False
         assert result.query == "type:testcase AND component:auth"
         assert result.select_test_cases_by == "dynamicQueryResult"
+        assert result.use_report_from_template is False
         assert result.project_id == "proj1"
         assert result.author_id == "bob"
         assert result.author_name == "Bob B"
@@ -757,7 +759,7 @@ class TestGetTestRun:
         assert result.document_name == "Auth Plan"
         assert result.template_id == "TPL-1"
         # Raw HTML passthrough — anchor ids survive verbatim.
-        assert result.home_page_html == (
+        assert result.content_html == (
             '<p id="polarion_1">Run <strong>notes</strong></p>'
         )
         assert result.custom_fields == {"myCustomField": "custom-value"}
@@ -771,7 +773,7 @@ class TestGetTestRun:
             mock_ctx,
             project_id="proj1",
             test_run_id="TR-100",
-            include_home_page_html=False,
+            include_homepage_content_html=False,
         )
 
         args, kwargs = mock_client.get.call_args
@@ -780,7 +782,7 @@ class TestGetTestRun:
         assert kwargs["params"]["include"] == "author"
         assert kwargs["params"]["fields[users]"] == "name"
 
-    async def test_include_home_page_html_false_blanks_field(
+    async def test_include_homepage_content_html_false_blanks_field(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         """Flag off blank body — body still travel (``@all`` for customs)."""
@@ -790,10 +792,10 @@ class TestGetTestRun:
             mock_ctx,
             project_id="proj1",
             test_run_id="TR-100",
-            include_home_page_html=False,
+            include_homepage_content_html=False,
         )
 
-        assert result.home_page_html == ""
+        assert result.content_html == ""
         # Other metadata still populated.
         assert result.title == "Regression 2.5"
 
@@ -809,7 +811,7 @@ class TestGetTestRun:
                 mock_ctx,
                 project_id="proj1",
                 test_run_id="TR-404",
-                include_home_page_html=False,
+                include_homepage_content_html=False,
             )
 
     async def test_auth_error_raises_permission_error(
@@ -822,7 +824,7 @@ class TestGetTestRun:
                 mock_ctx,
                 project_id="proj1",
                 test_run_id="TR-100",
-                include_home_page_html=False,
+                include_homepage_content_html=False,
             )
 
     async def test_other_error_raises_runtime_error(
@@ -835,7 +837,7 @@ class TestGetTestRun:
                 mock_ctx,
                 project_id="proj1",
                 test_run_id="TR-100",
-                include_home_page_html=False,
+                include_homepage_content_html=False,
             )
 
     async def test_non_dict_data_falls_back_to_arg_id(
@@ -847,7 +849,7 @@ class TestGetTestRun:
             mock_ctx,
             project_id="proj1",
             test_run_id="TR-100",
-            include_home_page_html=False,
+            include_homepage_content_html=False,
         )
 
         assert result.id == "TR-100"


### PR DESCRIPTION
- list_test_runs summaries expose no body, selection config, or customs
- add TestRunDetail model, @all detail parse, tool + eval trigger case

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>