### PR TITLE
refactor(tools): unify tool description template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,6 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
 
 Full rules in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md); enforced by `.githooks/commit-msg` + `.claude/hooks/`.
 
-- Branches off `main`: `<type>/<short-kebab-summary>`. Commits: `type(scope): summary` ≤50 chars + 2-bullet body (motivation, change).
+- Branches off `main`: `<type>/<short-kebab-summary>`; type = feat|fix|refactor|test|docs|chore|ci (pre-push enforce; `feature/` reject). Commits: `type(scope): summary` ≤50 chars + 2-bullet body (motivation, change).
 - PR checklist: flip `[ ]`→`[x]`; don't delete unchecked options.
 - Squash merge only; NEVER `--subject` to `gh pr merge`. Force-push feature branches only with explicit authorization; never `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,11 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
 - Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`.
 - Guards fail closed: validation GET error block write; only successful empty option set defer to Polarion.
 - Docstrings = LLM manual, Google-style; only prose above `Args:` ship — keep tight; return-field bullets sync with model. Field descriptions one line, skip when name + type say all.
+- Tool description template (order, skip empty):
+  - [1] verb-first what + hard limits; [2] sibling routing ("— use X instead"); [3] call strategy only if behavior-change (REPLACE / "Call X first" / Atomic).
+  - [4] round-trip format rules; [5] returns + follow-up; [6] errors as prevention-form ("resolve via list_*_enum_options first").
+  - Shipped text = docstring prose + `Field(description=...)` + input spec-model class docstrings (`$defs` ship them) — NEVER exception class names / raw HTTP codes / RST double-backticks; caps only NEVER/REPLACE/Atomic; `dry_run` = approved byte-exact variants.
+  - Budget: read ≤~50, write ≤~150 words. Gate `test_tool_description_style.py`; eval-FAIL-restored phrase = lock via docstring contract test.
 - No `WARNING:`/`NOTE:` prefixes, no dev-narrative, no banner dividers. CLAUDE.md dev-only — MCP-user info live in `@mcp.tool` docstring. Module docstrings = why module exists; constraints inline next to what they constrain.
 - Comments + dev docstrings caveman-style: drop articles/filler, compress verbs — `# Custom key match standard attr = silent shadow.` One line per point, why not what; never restate self-evident code; multi-line only when each line carry distinct fact. Technical terms/ids/API names/numbers exact; no invented abbreviations. Exempt (LLM-facing, eval-gated): `@mcp.tool` docstrings + `Field(description=...)` — normal prose per Docstrings rule above. `TODO` = `# TODO(#issue): concrete action`, never stray. No dead code; keep comments sync when code change.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **P
 
 - **33 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
 - **Read** — render documents as Markdown, search with Lucene or SQL, walk incoming/outgoing links, resolve enum options.
-- **Write** — create and update work items and documents, create test runs, manage links, reorganize document structure, post comments.
+- **Write** — create and update work items, documents, and test runs, manage links, reorganize document structure, post comments.
 - **Safe writes** — every write tool supports `dry_run`, and pre-write guards validate fields, enum values, and link targets before hitting Polarion.
 - **Plays nice with your server** — requests are paced to Polarion's rate limits, with automatic retries on 429/5xx responses.
 - **Built for LLMs** — strict async, fully typed, pagination on every list tool, docstrings written as the assistant's manual.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **P
 
 ## Features
 
-- **31 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
+- **33 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
 - **Read** — render documents as Markdown, search with Lucene or SQL, walk incoming/outgoing links, resolve enum options.
 - **Write** — create and update work items and documents, create test runs, manage links, reorganize document structure, post comments.
 - **Safe writes** — every write tool supports `dry_run`, and pre-write guards validate fields, enum values, and link targets before hitting Polarion.
@@ -54,6 +54,7 @@ Other clients (VS Code, Claude Desktop, Cursor) — see [Client Configuration](#
 | `list_documents` | List documents in a project |
 | `list_work_items` | List work items in a project (Lucene/SQL query) |
 | `list_test_runs` | List test runs in a project (Lucene query, templates filter) |
+| `get_test_run` | Get test run details, optionally with the raw HTML report body |
 | `get_sql_query_recipes` | Fetch copy-paste SQL recipes for advanced queries |
 | `get_html_recipes` | Fetch copy-paste Polarion HTML templates for raw-HTML body edits |
 | `get_document` | Get document metadata, optionally with the raw body HTML |
@@ -79,6 +80,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | `update_document` | Update document metadata, body, or workflow status |
 | `copy_document` | Copy a document to a new name, space, or project |
 | `create_test_runs` | Create one or more test runs, optionally from a template |
+| `update_test_runs` | Update title, status, group, or custom fields on one or more test runs |
 | `create_work_item_links` | Create one or more outgoing links from a source work item |
 | `update_work_item_link` | Update `suspect` / `revision` on one outgoing link |
 | `delete_work_item_links` | Delete one or more outgoing links from a source work item |

--- a/src/mcp_server_polarion/models/comments.py
+++ b/src/mcp_server_polarion/models/comments.py
@@ -35,7 +35,7 @@ class CommentSpec(BaseModel):
 
 
 class WorkItemCommentSpec(CommentSpec):
-    """Work item comment to create; adds ``title`` (document comments have none)."""
+    """Work item comment to create; adds title (document comments have none)."""
 
     title: str | None = Field(default=None, description="Comment heading.")
 

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -46,7 +46,7 @@ class TestRunDetail(TestRunSummary):
 
 
 class TestRunCreateSpec(BaseModel):
-    """One test run to create via ``create_test_runs``."""
+    """One test run to create via create_test_runs."""
 
     __test__ = False
 
@@ -76,8 +76,7 @@ class TestRunsCreateResult(BaseModel):
 
 
 class TestRunUpdateSpec(BaseModel):
-    """One test run's changes in an ``update_test_runs`` batch; unset
-    fields stay unchanged."""
+    """One update_test_runs batch entry; unset fields stay unchanged."""
 
     __test__ = False
 

--- a/src/mcp_server_polarion/models/work_items.py
+++ b/src/mcp_server_polarion/models/work_items.py
@@ -67,7 +67,7 @@ class WorkItemRead(WorkItemSummary):
 
 
 class WorkItemCreateSpec(BaseModel):
-    """One work item to create via ``create_work_items``."""
+    """One work item to create via create_work_items."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -94,8 +94,7 @@ class WorkItemsCreateResult(BaseModel):
 
 
 class WorkItemUpdateSpec(BaseModel):
-    """One work item's changes in an ``update_work_items`` batch; unset
-    fields stay unchanged."""
+    """One update_work_items batch entry; unset fields stay unchanged."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -309,7 +309,7 @@ async def create_document_comments(  # noqa: PLR0913
     ),
     document_name: str = Field(
         min_length=1,
-        description="Document name within ``space_id``.",
+        description="Document name within space_id.",
     ),
     comments: list[CommentSpec] = Field(  # noqa: B008
         min_length=1,
@@ -322,9 +322,9 @@ async def create_document_comments(  # noqa: PLR0913
 ) -> CommentsCreateResult:
     """Create one or more comments on a document in a single request.
 
-    Reply: set parent_comment_id to a short ID from list_document_comments
-    (None = top-level). 'text/html' text is sent unsanitized. Comment is always
-    authored by the token's user. NOT idempotent — a retry duplicates.
+    Reply: set parent_comment_id to a short id from list_document_comments
+    (None = top-level). 'text/html' text is sent unsanitized. Comments are
+    always authored by the token's user. NOT idempotent — a retry duplicates.
     """
     payload = _build_document_comments_payload(
         specs=comments,
@@ -409,10 +409,10 @@ async def create_work_item_comments(
 ) -> CommentsCreateResult:
     """Create one or more comments on a work item in a single request.
 
-    Reply: set parent_comment_id to a short ID from list_work_item_comments
+    Reply: set parent_comment_id to a short id from list_work_item_comments
     (None = top-level). Optional title sets the comment heading. 'text/html'
-    text is sent unsanitized. Comment is always authored by the token's user.
-    NOT idempotent — a retry duplicates.
+    text is sent unsanitized. Comments are always authored by the token's
+    user. NOT idempotent — a retry duplicates.
     """
     payload = _build_work_item_comments_payload(
         specs=comments,
@@ -484,7 +484,7 @@ async def update_document_comment(  # noqa: PLR0913
     ),
     document_name: str = Field(
         min_length=1,
-        description="Document name within ``space_id``.",
+        description="Document name within space_id.",
     ),
     comment_id: str = Field(
         min_length=1,
@@ -498,9 +498,9 @@ async def update_document_comment(  # noqa: PLR0913
 ) -> CommentUpdateResult:
     """Resolve or re-open one document comment thread.
 
-    Root comments only (a reply 400s) — pick a root id (parent_comment_id=None)
-    from list_document_comments; resolving the root resolves the whole thread.
-    Idempotent.
+    Root comments only — replies cannot be updated; pick a root id
+    (parent_comment_id=None) from list_document_comments. Resolving the root
+    resolves the whole thread. Idempotent.
     """
     payload = _build_document_comment_update_payload(
         project_id=project_id,
@@ -579,9 +579,9 @@ async def update_work_item_comment(  # noqa: PLR0913
 ) -> CommentUpdateResult:
     """Resolve or re-open one work item comment.
 
-    Root comments only (a reply 400s) — pick a root id (parent_comment_id=None)
-    from list_work_item_comments; resolving a root flips only that comment.
-    Idempotent.
+    Root comments only — replies cannot be updated; pick a root id
+    (parent_comment_id=None) from list_work_item_comments. Resolving a root
+    flips only that comment. Idempotent.
     """
     payload = _build_work_item_comment_update_payload(
         project_id=project_id,

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -190,7 +190,7 @@ async def list_document_comments(  # noqa: PLR0913
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
     space_id: str = Field(description="Space ID ('_default' = default space)."),
-    document_name: str = Field(description="Document name within ``space_id``."),
+    document_name: str = Field(description="Document name within space_id."),
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[Comment]:

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -323,8 +323,8 @@ async def create_document_comments(  # noqa: PLR0913
     """Create one or more comments on a document in a single request.
 
     Reply: set parent_comment_id to a short id from list_document_comments
-    (None = top-level). 'text/html' text is sent unsanitized. Comments are
-    always authored by the token's user. NOT idempotent — a retry duplicates.
+    (None = top-level). 'text/html' text is sent unsanitized. Always
+    authored by the token's user. NOT idempotent — a retry duplicates.
     """
     payload = _build_document_comments_payload(
         specs=comments,
@@ -411,8 +411,8 @@ async def create_work_item_comments(
 
     Reply: set parent_comment_id to a short id from list_work_item_comments
     (None = top-level). Optional title sets the comment heading. 'text/html'
-    text is sent unsanitized. Comments are always authored by the token's
-    user. NOT idempotent — a retry duplicates.
+    text is sent unsanitized. Always authored by the token's user. NOT
+    idempotent — a retry duplicates.
     """
     payload = _build_work_item_comments_payload(
         specs=comments,

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -320,7 +320,7 @@ async def create_document_comments(  # noqa: PLR0913
         description="Preview payload without calling Polarion.",
     ),
 ) -> CommentsCreateResult:
-    """Create one or more comments on a document in a single request.
+    """Create one or more comments on a document in one request.
 
     Reply: set parent_comment_id to a short id from list_document_comments
     (None = top-level). 'text/html' text is sent unsanitized. Always
@@ -407,7 +407,7 @@ async def create_work_item_comments(
         description="Preview payload without calling Polarion.",
     ),
 ) -> CommentsCreateResult:
-    """Create one or more comments on a work item in a single request.
+    """Create one or more comments on a work item in one request.
 
     Reply: set parent_comment_id to a short id from list_work_item_comments
     (None = top-level). Optional title sets the comment heading. 'text/html'

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -1105,9 +1105,9 @@ async def create_document(  # noqa: PLR0913
 ) -> DocumentCreateResult:
     """Create a new Polarion document in a space.
 
-    module_name must be unique in the space — check list_documents first.
-    type/status and custom_fields keys are validated on write — resolve ids
-    via list_document_enum_options first.
+    module_name must be unique in the space — a duplicate name conflicts;
+    check list_documents first. type/status and custom_fields keys are
+    validated on write — resolve ids via list_document_enum_options first.
 
     home_page_content is Markdown (greenfield only), converted to sanitized
     HTML. Markdown tables get native Polarion styling; a paragraph starting

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -913,8 +913,7 @@ async def update_document(  # noqa: PLR0913
     via get_document BEFORE updating. home_page_content_html is raw Polarion
     HTML, sent verbatim — source from
     get_document(include_homepage_content_html=True). An empty string is
-    rejected (wipes the body, orphans headings) — pass '<p></p>' for
-    near-empty.
+    rejected — pass '<p></p>' for near-empty.
 
     Body rules:
 
@@ -1110,9 +1109,8 @@ async def create_document(  # noqa: PLR0913
     validated on write — resolve ids via list_document_enum_options first.
 
     home_page_content is Markdown (greenfield only), converted to sanitized
-    HTML. Markdown tables get native Polarion styling; a paragraph starting
-    'Table:' directly after a table becomes a numbered caption widget.
-    Post-create edits round-trip raw HTML via
+    HTML. A paragraph starting 'Table:' directly after a Markdown table
+    becomes its numbered caption. Post-create edits round-trip raw HTML via
     get_document(include_homepage_content_html=True) and update_document;
     add work items via move_work_item_to_document.
     """

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -553,10 +553,9 @@ async def list_documents(
 ) -> PaginatedResult[DocumentSummary]:
     """List a project's documents.
 
-    Returns space_id + document_name (inputs to the other document tools) plus
-    type, status, updated timestamp, and display names of the creator
-    (author_name) and last editor (last_updated_by_name). Use get_document for
-    author/editor IDs. Discovery scan cached 60s.
+    Returns space_id + document_name — the inputs to every other document
+    tool — plus type, status, updated, and creator/editor display names.
+    Use get_document for author/editor ids. Discovery scan cached 60s.
     """
     client = get_client(ctx)
 
@@ -625,16 +624,11 @@ async def get_document(
 ) -> DocumentDetail:
     """Get a document's metadata: title/type/status/editors/custom fields.
 
-    Also returns outline numbering + autoSuspect (round-trip via update_document).
-    author_id/author_name (creator) and last_updated_by_id/last_updated_by_name
-    (last editor) pair the machine id with the display name; updated is the
-    last-modified timestamp.
-
     include_homepage_content_html=True fills content_html with raw
     homePageContent HTML — the required source for
-    update_document(home_page_content_html=...). That body is inline prose only
-    (headings / embedded work items live elsewhere; read_document renders all).
-    Never feed back a blanked (flag=False) body.
+    update_document(home_page_content_html=...). That body is inline prose
+    only; headings and embedded work items live elsewhere — read_document
+    renders all. Never feed back a blanked (flag=False) body.
     """
     client = get_client(ctx)
     path = (
@@ -721,9 +715,9 @@ async def read_document_parts(  # noqa: PLR0913
 ) -> PaginatedResult[DocumentPart]:
     """List a document's structural parts in order.
 
-    Use for structure: part IDs (positions for move_work_item_to_document),
-    heading levels, per-part Markdown. Plain reading → read_document; a
-    document's work items → list_work_items.
+    Use for structure: part ids (move_work_item_to_document anchors),
+    heading levels, per-part Markdown. For plain reading use read_document;
+    for a document's work items use list_work_items.
     """
     client = get_client(ctx)
     path = (
@@ -787,10 +781,10 @@ async def read_document(  # noqa: PLR0913
 ) -> DocumentReadResult:
     """Render a document end-to-end as flowing Markdown — THE way to read a body.
 
-    Interleaves headings, work-item descriptions, and prose. Synthesis output:
-    NEVER feed to update_document (anchors collapse, headings orphan) —
-    round-trip via get_document(include_homepage_content_html=True). For
-    metadata-only extraction prefer list_work_items SQL.
+    Interleaves headings, work-item descriptions, and prose. Synthesis
+    output: NEVER feed it to update_document — round-trip via
+    get_document(include_homepage_content_html=True). For metadata-only
+    extraction use list_work_items with SQL.
     """
     # read_document_parts handle fetch + error mapping (@mcp.tool return
     # original function).
@@ -873,7 +867,7 @@ async def update_document(  # noqa: PLR0913
         min_length=1,
         description="Document name within space_id.",
     ),
-    title: str | None = None,
+    title: str | None = Field(default=None, description="New document title."),
     status: str | None = Field(
         default=None,
         description="New status; prefer workflow_action for real transitions.",
@@ -913,14 +907,14 @@ async def update_document(  # noqa: PLR0913
         description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> DocumentUpdateResult:
-    """Update a Polarion document's metadata or body.
+    """Update a document's metadata or body.
 
-    PATCHes only supplied attributes (omitted preserved); no follow-up GET.
-    Fetch via get_document BEFORE updating. home_page_content_html is never
-    sanitized or converted — source from
-    get_document(include_homepage_content_html=True); blocks lacking an id= get
-    one auto-stamped, a fully anchored body is sent byte-for-byte. Empty string
-    rejected (orphans headings) — pass '<p></p>' for near-empty.
+    PATCHes only supplied attributes — omitted fields stay unchanged. Fetch
+    via get_document BEFORE updating. home_page_content_html is raw Polarion
+    HTML, sent verbatim — source from
+    get_document(include_homepage_content_html=True). An empty string is
+    rejected (wipes the body, orphans headings) — pass '<p></p>' for
+    near-empty.
 
     Body rules:
 
@@ -933,10 +927,10 @@ async def update_document(  # noqa: PLR0913
       page breaks) must be adapted from get_html_recipes templates, never
       hand-written.
 
-    workflow_action must pair with ≥1 attribute (else 400). Unknown status/type
-    raise ValueError; custom_fields keys outside the document type's schema are
-    rejected, values NOT validated — resolve via list_document_enum_options
-    first.
+    workflow_action must pair with at least one attribute. Unknown
+    status/type ids are rejected; custom_fields keys outside the document
+    type's schema are rejected, values are not validated — resolve via
+    list_document_enum_options first.
     """
     if home_page_content_html is not None and not home_page_content_html.strip():
         raise ValueError(
@@ -1111,16 +1105,16 @@ async def create_document(  # noqa: PLR0913
 ) -> DocumentCreateResult:
     """Create a new Polarion document in a space.
 
-    module_name must be unique in the space (duplicate → HTTP 409) — check
-    list_documents first. type/status validated — unknown ids raise ValueError
-    with options; custom_fields keys validated against the document type schema.
+    module_name must be unique in the space — check list_documents first.
+    type/status and custom_fields keys are validated on write — resolve ids
+    via list_document_enum_options first.
 
-    home_page_content is Markdown → sanitized HTML, blocks auto-stamped with
-    unique ids. Markdown tables get native Polarion styling; a paragraph
-    starting 'Table:' directly after a table becomes a numbered caption
-    widget. Post-create edits round-trip raw HTML via
-    get_document(include_homepage_content_html=True) ↔ update_document; add work
-    items via move_work_item_to_document.
+    home_page_content is Markdown (greenfield only), converted to sanitized
+    HTML. Markdown tables get native Polarion styling; a paragraph starting
+    'Table:' directly after a table becomes a numbered caption widget.
+    Post-create edits round-trip raw HTML via
+    get_document(include_homepage_content_html=True) and update_document;
+    add work items via move_work_item_to_document.
     """
     client = get_client(ctx)
     await guard_document_enums(
@@ -1221,10 +1215,7 @@ async def copy_document(  # noqa: PLR0913
     document_name: str = Field(min_length=1, description="Source document name."),
     target_document_name: str = Field(
         min_length=1,
-        description=(
-            "New document name; must not already exist at the destination "
-            "(duplicate → HTTP 409)."
-        ),
+        description="New document name; must not already exist at the destination.",
     ),
     target_project_id: str | None = Field(
         default=None,
@@ -1256,13 +1247,14 @@ async def copy_document(  # noqa: PLR0913
 ) -> DocumentCopyResult:
     """Copy a document, duplicating its structure, body, and contained work items.
 
-    target_document_name must be free at the destination (duplicate → HTTP 409)
-    — check list_documents first. The copy lands in target_project_id /
-    target_space_id, both defaulting to the source.
+    Use this to duplicate an existing document — rebuilding it via
+    create_document/update_document loses the contained items.
+    target_document_name must be free at the destination — check
+    list_documents first. Destination defaults to the source project/space.
 
     link_original_items_with_role is validated against the TARGET project's
-    workitem-link-role enum; an unknown id is rejected. remove_outgoing_links
-    strips links carried over from the source.
+    workitem-link-role enum; remove_outgoing_links strips links carried over
+    from the source.
     """
     client = get_client(ctx)
     if link_original_items_with_role is not None:

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -627,8 +627,8 @@ async def get_document(
     include_homepage_content_html=True fills content_html with raw
     homePageContent HTML — the required source for
     update_document(home_page_content_html=...). That body is inline prose
-    only; headings and embedded work items live elsewhere — read_document
-    renders all. Never feed back a blanked (flag=False) body.
+    only — headings and embedded work items render via read_document.
+    Never feed back a blanked (flag=False) body.
     """
     client = get_client(ctx)
     path = (
@@ -928,8 +928,8 @@ async def update_document(  # noqa: PLR0913
       hand-written.
 
     workflow_action must pair with at least one attribute. Unknown
-    status/type ids are rejected; custom_fields keys outside the document
-    type's schema are rejected, values are not validated — resolve via
+    status/type ids and custom_fields keys outside the type schema are
+    rejected, values are not validated — resolve via
     list_document_enum_options first.
     """
     if home_page_content_html is not None and not home_page_content_html.strip():
@@ -1103,7 +1103,7 @@ async def create_document(  # noqa: PLR0913
         description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> DocumentCreateResult:
-    """Create a new Polarion document in a space.
+    """Create a document in a space.
 
     module_name must be unique in the space — a duplicate name conflicts;
     check list_documents first. type/status and custom_fields keys are
@@ -1247,9 +1247,8 @@ async def copy_document(  # noqa: PLR0913
 ) -> DocumentCopyResult:
     """Copy a document, duplicating its structure, body, and contained work items.
 
-    Use this to duplicate an existing document — rebuilding it via
-    create_document/update_document loses the contained items.
-    target_document_name must be free at the destination — check
+    Rebuilding via create_document/update_document loses the contained
+    items. target_document_name must be free at the destination — check
     list_documents first. Destination defaults to the source project/space.
 
     link_original_items_with_role is validated against the TARGET project's

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -1109,8 +1109,9 @@ async def create_document(  # noqa: PLR0913
     validated on write — resolve ids via list_document_enum_options first.
 
     home_page_content is Markdown (greenfield only), converted to sanitized
-    HTML. A paragraph starting 'Table:' directly after a Markdown table
-    becomes its numbered caption. Post-create edits round-trip raw HTML via
+    HTML. Markdown tables get native Polarion styling; a paragraph starting
+    'Table:' directly after a table becomes a numbered caption widget.
+    Post-create edits round-trip raw HTML via
     get_document(include_homepage_content_html=True) and update_document;
     add work items via move_work_item_to_document.
     """

--- a/src/mcp_server_polarion/tools/enum.py
+++ b/src/mcp_server_polarion/tools/enum.py
@@ -99,9 +99,9 @@ async def list_work_item_enum_options(  # noqa: PLR0913
 ) -> PaginatedResult[EnumOption]:
     """List valid enum option ids for a work item field of a given type.
 
-    Resolve enum ids here before create_work_items / update_work_items — enums
-    are validated on write, invalid ids raise with this set. An unknown
-    work_item_type silently falls back to ~, so verify the type id first.
+    Call this before create_work_items / update_work_items — invalid enum ids
+    are rejected on write. An unknown work_item_type silently falls back to
+    '~', so verify the type id first.
     """
     return await _list_enum_options(
         ctx,
@@ -134,9 +134,9 @@ async def list_document_enum_options(  # noqa: PLR0913
 ) -> PaginatedResult[EnumOption]:
     """List valid enum option ids for a document field of a given type.
 
-    Resolve enum ids here before create_document / update_document — enums are
-    validated on write, invalid ids raise with this set. An unknown
-    document_type silently falls back to ~, so verify the type id first.
+    Call this before create_document / update_document — invalid enum ids are
+    rejected on write. An unknown document_type silently falls back to '~',
+    so verify the type id first.
     """
     return await _list_enum_options(
         ctx,

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -396,15 +396,16 @@ async def create_work_item_links(
 ) -> WorkItemLinksCreateResult:
     """Create 1-50 outgoing links from one source work item, atomically.
 
-    Role and target existence validated before POST — invalid ones raise
-    ValueError. Per spec: target_project_id defaults to source, revision pins
-    (else HEAD), suspect flags re-review. A 4xx (e.g. duplicate role+target →
-    409) rolls back the whole batch — re-query list_work_item_links before
-    retrying. link_ids are the delete-path ids, input order.
+    Role and target existence are validated before writing. Per spec:
+    target_project_id defaults to the source, revision pins (else HEAD),
+    suspect flags re-review. A duplicate role+target rolls back the whole
+    batch — re-query list_work_item_links before retrying. link_ids are the
+    delete-path ids, input order.
 
     Phantom success: when the source sits in a document,
     move_work_item_to_document already auto-created one heading link; a NEW
-    same-role link 201s but is NOT persisted — verify with list_work_item_links.
+    same-role link reports created but is NOT persisted — verify with
+    list_work_item_links.
     """
     payload = _build_create_links_payload(
         source_project_id=project_id,
@@ -490,9 +491,9 @@ async def delete_work_item_links(
 ) -> WorkItemLinksDeleteResult:
     """Delete 1-50 outgoing links from one source work item.
 
-    Outgoing only — delete a back link from its source item. Refs from
-    list_work_item_links(direction="forward") or a prior create. Stale refs
-    never raise: a pre-read splits results into deleted_link_ids /
+    Outgoing only — delete a back link from its source item instead. Refs
+    from list_work_item_links(direction="forward") or a prior create. Stale
+    refs never fail: results split into deleted_link_ids /
     not_found_link_ids.
     """
     link_ids, payload = _build_delete_links_payload(
@@ -588,9 +589,10 @@ async def update_work_item_link(  # noqa: PLR0913
 ) -> WorkItemLinkUpdateResult:
     """Set suspect and/or revision on one existing outgoing link.
 
-    Identify the link via list_work_item_links(direction="forward") (role +
-    target address one link). None = unchanged; at least one of suspect /
-    revision required. One link per call. A role typo 404s.
+    Identify the link via list_work_item_links(direction="forward") — role +
+    target address one link; copy the role exactly as listed. None =
+    unchanged; at least one of suspect / revision required. One link per
+    call.
     """
     if suspect is None and revision is None:
         raise ValueError(

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -402,10 +402,9 @@ async def create_work_item_links(
     batch — re-query list_work_item_links before retrying. link_ids are the
     delete-path ids, input order.
 
-    Phantom success: when the source sits in a document,
-    move_work_item_to_document already auto-created one heading link; a NEW
-    same-role link reports created but is NOT persisted — verify with
-    list_work_item_links.
+    Phantom success: a document-attached source already has an auto-created
+    heading link; a NEW same-role link reports created but is NOT
+    persisted — verify with list_work_item_links.
     """
     payload = _build_create_links_payload(
         source_project_id=project_id,

--- a/src/mcp_server_polarion/tools/moves.py
+++ b/src/mcp_server_polarion/tools/moves.py
@@ -79,7 +79,7 @@ async def move_work_item_to_document(  # noqa: PLR0913
     ),
     target_document_name: str = Field(
         min_length=1,
-        description="Target document name within ``target_space_id``.",
+        description="Target document name within target_space_id.",
     ),
     previous_part_id: str | None = Field(
         default=None,
@@ -96,15 +96,15 @@ async def move_work_item_to_document(  # noqa: PLR0913
 ) -> WorkItemMoveResult:
     """Move an existing work item into a document at a given position.
 
-    THE attach path: atomically sets module and inserts a part. Headings
-    rejected (HTTP 400) — add headings via update_document <hN>. An item
-    already in a document is moved, not copied.
+    THE attach path: atomically sets module and inserts a part. Headings are
+    rejected — add headings via update_document <hN>. An item already in a
+    document is moved, not copied.
 
-    At most one of previous_part_id (AFTER) / next_part_id (BEFORE); omit both
-    to append. Part IDs from read_document_parts.
+    At most one of previous_part_id (AFTER) / next_part_id (BEFORE); omit
+    both to append. Part ids from read_document_parts.
 
     Auto-creates one link to the enclosing heading; a later same-role
-    create_work_item_links returns 201 but is NOT persisted.
+    create_work_item_links reports created but is NOT persisted.
     """
     if previous_part_id is not None and next_part_id is not None:
         raise ValueError(
@@ -185,10 +185,10 @@ async def move_work_item_from_document(
 ) -> WorkItemMoveResult:
     """Detach a work item from its document — the ONLY detach path.
 
-    NOT idempotent: an already free-floating item returns HTTP 400 — first
-    confirm it is in a document (get_work_item: non-empty space_id) and skip
-    the call when already detached. Item preserved, re-attachable via
-    move_work_item_to_document. Headings detachable too.
+    NOT idempotent: an already free-floating item fails — first confirm it
+    is in a document (get_work_item: non-empty space_id) and skip the call
+    when already detached. The item is preserved and re-attachable via
+    move_work_item_to_document. Headings are detachable too.
     """
     if dry_run:
         return WorkItemMoveResult(

--- a/src/mcp_server_polarion/tools/moves.py
+++ b/src/mcp_server_polarion/tools/moves.py
@@ -185,10 +185,10 @@ async def move_work_item_from_document(
 ) -> WorkItemMoveResult:
     """Detach a work item from its document — the ONLY detach path.
 
-    NOT idempotent: an already free-floating item fails — first confirm it
-    is in a document (get_work_item: non-empty space_id) and skip the call
-    when already detached. The item is preserved and re-attachable via
-    move_work_item_to_document. Headings are detachable too.
+    NOT idempotent: an already free-floating item fails — confirm attachment
+    first (get_work_item: non-empty space_id). The item is preserved and
+    re-attachable via move_work_item_to_document. Headings are detachable
+    too.
     """
     if dry_run:
         return WorkItemMoveResult(

--- a/src/mcp_server_polarion/tools/projects.py
+++ b/src/mcp_server_polarion/tools/projects.py
@@ -44,9 +44,10 @@ async def list_projects(
     page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[ProjectSummary]:
-    """List accessible Polarion projects — the source of project IDs.
+    """List accessible Polarion projects — the source of project ids.
 
-    Lucene query allows trailing wildcards (name:ILCU*); leading ones 400.
+    Lucene query allows trailing wildcards (name:ILCU*); leading ones are
+    rejected.
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {

--- a/src/mcp_server_polarion/tools/recipes.py
+++ b/src/mcp_server_polarion/tools/recipes.py
@@ -45,9 +45,9 @@ async def get_html_recipes() -> HtmlRecipeGallery:
     """Fetch the required HTML templates for tables, captions, links, and
     widgets written via update_work_items / update_document.
 
-    Any new <table>, numbered caption, link, or TOC / Table-of-Figures
-    widget must be adapted from these templates — hand-written markup
-    renders unstyled and breaks numbering. Also covers macro-id and
-    metadata-scope caveats.
+    Any new <table>, numbered caption, work-item / cross-reference / wiki-page
+    link, or TOC / Table-of-Figures widget must be adapted from these
+    templates — plain hand-written markup renders unstyled and breaks
+    numbering. Also covers macro-id and metadata-scope caveats.
     """
     return HtmlRecipeGallery(recipes=_HTML_RECIPES)

--- a/src/mcp_server_polarion/tools/recipes.py
+++ b/src/mcp_server_polarion/tools/recipes.py
@@ -45,9 +45,9 @@ async def get_html_recipes() -> HtmlRecipeGallery:
     """Fetch the required HTML templates for tables, captions, links, and
     widgets written via update_work_items / update_document.
 
-    Any new <table>, numbered caption, work-item / cross-reference / wiki-page
-    link, or TOC / Table-of-Figures widget must be adapted from these
-    templates — plain hand-written markup renders unstyled and breaks
-    numbering. Also covers macro-id and metadata-scope caveats.
+    Any new <table>, numbered caption, link, or TOC / Table-of-Figures
+    widget must be adapted from these templates — hand-written markup
+    renders unstyled and breaks numbering. Also covers macro-id and
+    metadata-scope caveats.
     """
     return HtmlRecipeGallery(recipes=_HTML_RECIPES)

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -391,8 +391,7 @@ async def get_test_run(
     read-only context: test-case selection, template provenance, author, and
     timestamps. include_homepage_content_html=True fills content_html with
     the raw HTML report body; it stays empty when use_report_from_template
-    is true (the run inherits its template's report). Never feed back a
-    blanked (flag=False) body.
+    is true. Never feed back a blanked (flag=False) body.
     """
     client = get_client(ctx)
     path = (

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -126,13 +126,12 @@ async def create_test_runs(
 ) -> TestRunsCreateResult:
     """Create 1-50 test runs in one project in a single bulk request.
 
-    id is required per item (Polarion REST does not auto-generate one).
+    id is required per item — Polarion REST does not auto-generate one.
     type/status are validated against the project's testing enumerations and
-    template_id against existing templates (list_test_runs(templates=True)) —
-    unknown ids raise ValueError. custom_fields keys are validated against a
-    sample of existing runs; enum-typed custom values are not (test runs have
-    no options API). Atomic: one bad item rejects the whole batch; an id-count
-    mismatch raises — re-query list_test_runs before retrying.
+    template_id against existing templates (list_test_runs(templates=True)).
+    custom_fields keys are validated against a sample of existing runs;
+    enum-typed custom values are not (test runs have no options API).
+    Atomic: one bad item rejects the whole batch.
     """
     client = get_client(ctx)
     ensure_unique_ids((spec.id for spec in items), label="id")
@@ -253,14 +252,13 @@ async def update_test_runs(
     ),
 ) -> TestRunsUpdateResult:
     """Update fields on 1-50 existing test runs in one bulk PATCH; unset
-    fields stay unchanged.
+    fields stay unchanged. Atomic: one bad item rejects the whole batch.
 
     Writable: title, status, group_id, custom_fields. status is validated
-    against the project's testing enumerations — unknown ids raise ValueError.
-    custom_fields is partial; keys are validated against a sample of existing
-    runs, values are NOT (test runs have no options API). finishedOn is
-    server-managed and not settable. Atomic: one bad item rejects the whole
-    batch. Returns ids only — re-read via list_test_runs if needed.
+    against the project's testing enumerations. custom_fields is partial;
+    keys are validated against a sample of existing runs, values are not
+    (test runs have no options API). finishedOn is server-managed — not
+    settable. Returns ids only — re-read via list_test_runs if needed.
     """
     client = get_client(ctx)
     ensure_unique_ids((spec.test_run_id for spec in items), label="test_run_id")
@@ -334,11 +332,10 @@ async def list_test_runs(  # noqa: PLR0913
 ) -> PaginatedResult[TestRunSummary]:
     """List / search test runs in a project.
 
-    Returns actual run instances by default; set templates=True for the reusable
-    template blueprints instead. Filter with a Lucene query (status:open,
-    type:manual, HAS_VALUE:<field>) or omit for all. Filter by person with
-    author.name (exact, quoted) -- author.id does not match on test runs;
-    discover the full name from an unfiltered page first.
+    Returns actual run instances by default; set templates=True for the
+    reusable template blueprints. Filter by person with author.name (exact,
+    quoted) — author.id does not match on test runs; discover the full name
+    from an unfiltered page first.
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {
@@ -385,19 +382,17 @@ async def get_test_run(
     test_run_id: str = Field(description="Test run ID (e.g. 'TR-2026-01')."),
     include_homepage_content_html: bool = Field(
         default=False,
-        description="Fill ``content_html`` with the run's raw HTML report body.",
+        description="Fill content_html with the run's raw HTML report body.",
     ),
 ) -> TestRunDetail:
     """Get full details of one test run by ID.
 
     Returns writable fields (title, status, group_id, custom_fields) plus
-    read-only context: how test cases are selected (select_test_cases_by with
-    its query or source document space_id/document_name), template provenance
-    (is_template, template_id), author, and timestamps.
-    include_homepage_content_html=True fills content_html with the raw HTML
-    report body; it stays empty when use_report_from_template is true (the run
-    inherits its report from its template). Keep it verbatim — never feed back
-    a blanked (flag=False) body.
+    read-only context: test-case selection, template provenance, author, and
+    timestamps. include_homepage_content_html=True fills content_html with
+    the raw HTML report body; it stays empty when use_report_from_template
+    is true (the run inherits its template's report). Never feed back a
+    blanked (flag=False) body.
     """
     client = get_client(ctx)
     path = (

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -332,7 +332,7 @@ async def list_test_runs(  # noqa: PLR0913
 ) -> PaginatedResult[TestRunSummary]:
     """List / search test runs in a project.
 
-    Returns actual run instances by default; set templates=True for the
+    Returns run instances by default; set templates=True for the
     reusable template blueprints. Filter by person with author.name (exact,
     quoted) — author.id does not match on test runs; discover the full name
     from an unfiltered page first.

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -124,9 +124,9 @@ async def create_test_runs(
         description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> TestRunsCreateResult:
-    """Create 1-50 test runs in one project in a single bulk request.
+    """Create 1-50 test runs in one project in one bulk request.
 
-    id is required per item — Polarion REST does not auto-generate one.
+    id is required per item — never auto-generated.
     type/status are validated against the project's testing enumerations and
     template_id against existing templates (list_test_runs(templates=True)).
     custom_fields keys are validated against a sample of existing runs;
@@ -258,7 +258,7 @@ async def update_test_runs(
     against the project's testing enumerations. custom_fields is partial;
     keys are validated against a sample of existing runs, values are not
     (test runs have no options API). finishedOn is server-managed — not
-    settable. Returns ids only — re-read via list_test_runs if needed.
+    settable. Returns ids only — re-read via list_test_runs.
     """
     client = get_client(ctx)
     ensure_unique_ids((spec.test_run_id for spec in items), label="test_run_id")

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -232,11 +232,11 @@ async def create_work_items(
         description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> WorkItemsCreateResult:
-    """Create 1-50 work items in one project in a single bulk request.
+    """Create 1-50 work items in one project in one bulk request.
 
     Items are created free-floating — place into a document with
-    move_work_item_to_document (this tool cannot). Atomic: one bad item
-    rejects the whole batch.
+    move_work_item_to_document. Atomic: one bad item rejects the whole
+    batch.
 
     description is Markdown (greenfield only); later edits are raw-HTML
     round-trip via get_work_item(include_description_html=True) and
@@ -356,10 +356,9 @@ async def update_work_items(  # noqa: PLR0913
 ) -> WorkItemsUpdateResult:
     """Update fields on 1-50 existing work items in one bulk PATCH; unset
     fields stay unchanged. hyperlinks/assignee_ids REPLACE the stored
-    lists: even to add ONE entry, call get_work_item on the target BEFORE
-    updating and resubmit every existing entry plus the new one — anything
-    omitted is silently deleted. Atomic: one bad item rejects the whole
-    batch.
+    lists: even to add ONE entry, call get_work_item BEFORE updating and
+    resubmit every existing entry plus the new one — anything omitted is
+    silently deleted. Atomic: one bad item rejects the whole batch.
 
     description_html is raw Polarion HTML, sent verbatim — source from
     get_work_item(include_description_html=True); greenfield bodies use
@@ -368,12 +367,12 @@ async def update_work_items(  # noqa: PLR0913
     before writing description_html — hand-written table markup is
     rejected.
 
-    custom_fields is partial; keys outside the type schema are rejected,
-    values are not validated — resolve via list_work_item_enum_options
-    first. module is not settable here — use move_work_item_to_document /
+    custom_fields is partial; unknown keys are rejected, values are not
+    validated — resolve via list_work_item_enum_options first. module is
+    not settable here — use move_work_item_to_document /
     move_work_item_from_document. workflow_action/change_type_to apply to
     EVERY item; change_type_to rescopes enums to the target type and
-    resets status. Returns ids only — re-read via get_work_item if needed.
+    resets status. Returns ids only — re-read via get_work_item.
     """
     client = get_client(ctx)
 

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -234,17 +234,17 @@ async def create_work_items(
 ) -> WorkItemsCreateResult:
     """Create 1-50 work items in one project in a single bulk request.
 
-    Standard enums (type/status/severity/priority) are validated — unknown ids
-    raise ValueError with valid options. custom_fields keys are validated
-    against the type's schema. Atomic: one bad item rejects the whole batch; an
-    id-count mismatch raises — re-query list_work_items before retrying.
+    Items are created free-floating — place into a document with
+    move_work_item_to_document (this tool cannot). Atomic: one bad item
+    rejects the whole batch.
 
-    Items are created free-floating; place into a document with
-    move_work_item_to_document (this tool cannot). description is Markdown →
-    sanitized HTML; later edits are raw-HTML round-trip via
-    get_work_item(include_description_html=True) ↔ update_work_items.
-    Markdown tables get native Polarion styling; a paragraph starting
-    'Table:' directly after a table becomes a numbered caption widget.
+    description is Markdown (greenfield only); later edits are raw-HTML
+    round-trip via get_work_item(include_description_html=True) and
+    update_work_items — formats never mix. Markdown tables get native
+    Polarion styling; a paragraph starting 'Table:' directly after a table
+    becomes a numbered caption widget. Enum values and custom_fields keys
+    are validated on write — resolve ids via list_work_item_enum_options
+    first. Returns the new work item ids.
     """
     client = get_client(ctx)
     for spec in items:
@@ -355,27 +355,26 @@ async def update_work_items(  # noqa: PLR0913
     ),
 ) -> WorkItemsUpdateResult:
     """Update fields on 1-50 existing work items in one bulk PATCH; unset
-    fields stay unchanged. Per-item hyperlinks/assignee_ids REPLACE the
-    stored lists: even to add ONE entry, call get_work_item on the target
-    BEFORE updating and resubmit every existing entry plus the new one —
-    anything omitted is silently deleted.
+    fields stay unchanged. Atomic: one bad item rejects the whole batch.
+
+    hyperlinks/assignee_ids REPLACE the stored lists: even to add ONE
+    entry, call get_work_item on the target BEFORE updating and resubmit
+    every existing entry plus the new one — anything omitted is silently
+    deleted.
 
     description_html is raw Polarion HTML, sent verbatim — source from
     get_work_item(include_description_html=True); greenfield bodies use
     create_work_items Markdown, formats never mix. To add a table, caption,
     link, or widget, call get_html_recipes first and adapt its template
-    before writing description_html; hand-written table markup is rejected.
-    custom_fields is partial,
-    keys outside the type schema rejected, values NOT validated — resolve via
-    list_work_item_enum_options first.
+    before writing description_html — hand-written table markup is
+    rejected.
 
-    module not settable here — use move_work_item_to_document /
+    custom_fields is partial; keys outside the type schema are rejected,
+    values are not validated — resolve via list_work_item_enum_options
+    first. module is not settable here — use move_work_item_to_document /
     move_work_item_from_document. workflow_action/change_type_to apply to
-    EVERY item; each item needs ≥1 body field (else 400); change_type_to
-    scopes status/severity/resolution to the target type and resets status.
-    Unknown enum ids and missing/duplicate work_item_ids raise ValueError.
-    Atomic: one bad item rejects the whole batch. Returns ids only — re-read
-    via get_work_item if needed.
+    EVERY item; change_type_to rescopes enums to the target type and
+    resets status. Returns ids only — re-read via get_work_item if needed.
     """
     client = get_client(ctx)
 
@@ -484,14 +483,11 @@ async def list_work_items(
 ) -> PaginatedResult[WorkItemSummary]:
     """List / search work items in a project.
 
-    Lucene query (type:requirement, title:SRS*; leading wildcards 400) or omit
-    for all. module and body text are NOT Lucene-indexed — scope by document
-    via SQL:(...) or read_document_parts, never a Lucene module term.
-
-    SQL:(...) runs native SQL: call get_sql_query_recipes first and adapt a
-    recipe (document scope, custom-field, traceability), do not hand-write.
-    Escape ' as ''; keep LIKE top-level via INNER JOIN (rejected inside EXISTS;
-    C_DESCRIPTION LIKE never matches).
+    Leading Lucene wildcards are rejected; module and body text are NOT
+    Lucene-indexed — scope by document via SQL:(...) or
+    read_document_parts, never a Lucene module term. For SQL:(...), call
+    get_sql_query_recipes first and adapt a recipe — never hand-write SQL.
+    For one known id, use get_work_item instead of scanning.
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {
@@ -538,7 +534,7 @@ async def get_work_item(
     work_item_id: str = Field(description="Work item ID (e.g. 'MCPT-001')."),
     include_description_html: bool = Field(
         default=False,
-        description="Fill ``description_html`` with raw HTML for round-trip editing.",
+        description="Fill description_html with raw HTML for round-trip editing.",
     ),
 ) -> WorkItemDetail:
     """Get full details of one work item by ID.
@@ -604,9 +600,9 @@ async def read_work_item(
 ) -> WorkItemRead:
     """Read one work item with its body rendered as Markdown.
 
-    get_work_item plus description as Markdown. Synthesis output (collapses
-    Polarion anchors) — NEVER feed to update_work_items; round-trip via the HTML
-    pair instead.
+    Synthesis output — collapses Polarion anchors; NEVER feed it to
+    update_work_items. Edits round-trip via
+    get_work_item(include_description_html=True) instead.
     """
     # Pull raw HTML from get_work_item — conversion need no second round trip.
     detail = await get_work_item(

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -240,9 +240,9 @@ async def create_work_items(
 
     description is Markdown (greenfield only); later edits are raw-HTML
     round-trip via get_work_item(include_description_html=True) and
-    update_work_items — formats never mix. Markdown tables get native
-    Polarion styling; a paragraph starting 'Table:' directly after a table
-    becomes a numbered caption widget. Enum values and custom_fields keys
+    update_work_items — formats never mix. A paragraph starting 'Table:'
+    directly after a Markdown table becomes its numbered caption. Enum
+    values and custom_fields keys
     are validated on write — resolve ids via list_work_item_enum_options
     first. Returns the new work item ids.
     """

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -232,11 +232,11 @@ async def create_work_items(
         description="Preview payload without writing; guards still query Polarion.",
     ),
 ) -> WorkItemsCreateResult:
-    """Create 1-50 work items in one project in one bulk request.
+    """Create 1-50 work items in one project in a single bulk request.
 
     Items are created free-floating — place into a document with
-    move_work_item_to_document. Atomic: one bad item rejects the whole
-    batch.
+    move_work_item_to_document (this tool cannot). Atomic: one bad item
+    rejects the whole batch.
 
     description is Markdown (greenfield only); later edits are raw-HTML
     round-trip via get_work_item(include_description_html=True) and
@@ -356,9 +356,10 @@ async def update_work_items(  # noqa: PLR0913
 ) -> WorkItemsUpdateResult:
     """Update fields on 1-50 existing work items in one bulk PATCH; unset
     fields stay unchanged. hyperlinks/assignee_ids REPLACE the stored
-    lists: even to add ONE entry, call get_work_item BEFORE updating and
-    resubmit every existing entry plus the new one — anything omitted is
-    silently deleted. Atomic: one bad item rejects the whole batch.
+    lists: even to add ONE entry, call get_work_item on the target BEFORE
+    updating and resubmit every existing entry plus the new one — anything
+    omitted is silently deleted. Atomic: one bad item rejects the whole
+    batch.
 
     description_html is raw Polarion HTML, sent verbatim — source from
     get_work_item(include_description_html=True); greenfield bodies use
@@ -367,12 +368,12 @@ async def update_work_items(  # noqa: PLR0913
     before writing description_html — hand-written table markup is
     rejected.
 
-    custom_fields is partial; unknown keys are rejected, values are not
-    validated — resolve via list_work_item_enum_options first. module is
-    not settable here — use move_work_item_to_document /
+    custom_fields is partial; keys outside the type schema are rejected,
+    values are not validated — resolve via list_work_item_enum_options
+    first. module is not settable here — use move_work_item_to_document /
     move_work_item_from_document. workflow_action/change_type_to apply to
     EVERY item; change_type_to rescopes enums to the target type and
-    resets status. Returns ids only — re-read via get_work_item.
+    resets status. Returns ids only — re-read via get_work_item if needed.
     """
     client = get_client(ctx)
 

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -240,9 +240,9 @@ async def create_work_items(
 
     description is Markdown (greenfield only); later edits are raw-HTML
     round-trip via get_work_item(include_description_html=True) and
-    update_work_items — formats never mix. A paragraph starting 'Table:'
-    directly after a Markdown table becomes its numbered caption. Enum
-    values and custom_fields keys
+    update_work_items — formats never mix. Markdown tables get native
+    Polarion styling; a paragraph starting 'Table:' directly after a table
+    becomes a numbered caption widget. Enum values and custom_fields keys
     are validated on write — resolve ids via list_work_item_enum_options
     first. Returns the new work item ids.
     """

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -355,12 +355,11 @@ async def update_work_items(  # noqa: PLR0913
     ),
 ) -> WorkItemsUpdateResult:
     """Update fields on 1-50 existing work items in one bulk PATCH; unset
-    fields stay unchanged. Atomic: one bad item rejects the whole batch.
-
-    hyperlinks/assignee_ids REPLACE the stored lists: even to add ONE
-    entry, call get_work_item on the target BEFORE updating and resubmit
-    every existing entry plus the new one — anything omitted is silently
-    deleted.
+    fields stay unchanged. hyperlinks/assignee_ids REPLACE the stored
+    lists: even to add ONE entry, call get_work_item on the target BEFORE
+    updating and resubmit every existing entry plus the new one — anything
+    omitted is silently deleted. Atomic: one bad item rejects the whole
+    batch.
 
     description_html is raw Polarion HTML, sent verbatim — source from
     get_work_item(include_description_html=True); greenfield bodies use

--- a/tests/mcp_server_polarion/test_tool_description_style.py
+++ b/tests/mcp_server_polarion/test_tool_description_style.py
@@ -1,0 +1,138 @@
+"""Mechanical style gate for LLM-facing tool text — walk every registered
+tool's description + full input schema (incl ``$defs`` spec models), enforce
+template bans + budgets so drift fail CI, not eval.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import pytest
+from fastmcp import Client
+from mcp.types import Tool
+
+from mcp_server_polarion.server import mcp
+
+# Caps = current max + headroom (desc 1110 / param 230). Bump = deliberate
+# decision in review, not silent drift.
+_MAX_TOOL_DESC_CHARS = 1300
+_MAX_PARAM_DESC_CHARS = 400
+
+# Prevention-form rule: no exception class names, no raw HTTP status codes.
+_EXCEPTION_NAME = re.compile(r"\b[A-Z]\w*Error\b")
+_HTTP_STATUS_CODE = re.compile(r"\b(20[0-9]|30[0-9]|4[0-9]{2}|5[0-9]{2})\b")
+
+# dry_run phrasing deliberate per write shape — byte-exact, no paraphrase.
+_DRY_RUN_VARIANTS: frozenset[str] = frozenset(
+    {
+        "Preview payload without calling Polarion.",
+        "Preview payload without writing; guards still query Polarion.",
+        "Preview payload without deleting; the pre-read still queries Polarion.",
+    }
+)
+
+
+@pytest.fixture
+async def all_tools(monkeypatch: pytest.MonkeyPatch) -> list[Tool]:
+    """Every registered tool as the MCP client see it."""
+    monkeypatch.setenv("POLARION_URL", "https://polarion.example.com")
+    monkeypatch.setenv("POLARION_TOKEN", "test-token-secret")
+    async with Client(mcp) as client:
+        return list(await client.list_tools())
+
+
+def _iter_descriptions(node: object, path: str) -> Iterator[tuple[str, str]]:
+    """Yield (schema path, text) for every description in input schema."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "description" and isinstance(value, str):
+                yield path, value
+            else:
+                yield from _iter_descriptions(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from _iter_descriptions(value, f"{path}[{index}]")
+
+
+def _all_texts(tools: list[Tool]) -> Iterator[tuple[str, str]]:
+    """Yield (location, text) over tool descriptions + schema descriptions."""
+    for tool in tools:
+        yield f"{tool.name}", tool.description or ""
+        yield from _iter_descriptions(tool.inputSchema, tool.name)
+
+
+class TestDescriptionStyleGate:
+    """Template bans hold across every tool + every shipped Field text."""
+
+    async def test_no_exception_type_names(self, all_tools: list[Tool]) -> None:
+        bad = [
+            (where, match.group())
+            for where, text in _all_texts(all_tools)
+            if (match := _EXCEPTION_NAME.search(text))
+        ]
+        assert not bad, (
+            f"Exception class names in shipped text (rephrase as prevention: "
+            f"what to call first / what is rejected): {bad}"
+        )
+
+    async def test_no_raw_http_status_codes(self, all_tools: list[Tool]) -> None:
+        bad = [
+            (where, match.group())
+            for where, text in _all_texts(all_tools)
+            if (match := _HTTP_STATUS_CODE.search(text))
+        ]
+        assert not bad, (
+            f"Raw HTTP status codes in shipped text (state the conflict/limit "
+            f"in words instead): {bad}"
+        )
+
+    async def test_no_rst_double_backticks(self, all_tools: list[Tool]) -> None:
+        bad = [where for where, text in _all_texts(all_tools) if "``" in text]
+        assert not bad, f"RST double-backticks ship as noise — plain identifiers: {bad}"
+
+    async def test_schema_descriptions_single_line(self, all_tools: list[Tool]) -> None:
+        bad = [
+            where
+            for tool in all_tools
+            for where, text in _iter_descriptions(tool.inputSchema, tool.name)
+            if "\n" in text
+        ]
+        assert not bad, (
+            f"Multi-line Field/spec-model descriptions (one line each; long "
+            f"guidance belongs in the tool docstring): {bad}"
+        )
+
+    async def test_tool_description_budget(self, all_tools: list[Tool]) -> None:
+        bad = [
+            (tool.name, len(tool.description or ""))
+            for tool in all_tools
+            if len(tool.description or "") > _MAX_TOOL_DESC_CHARS
+        ]
+        assert not bad, (
+            f"Tool descriptions over {_MAX_TOOL_DESC_CHARS} chars — trim or "
+            f"raise the cap deliberately: {bad}"
+        )
+
+    async def test_param_description_budget(self, all_tools: list[Tool]) -> None:
+        bad = [
+            (where, len(text))
+            for tool in all_tools
+            for where, text in _iter_descriptions(tool.inputSchema, tool.name)
+            if len(text) > _MAX_PARAM_DESC_CHARS
+        ]
+        assert not bad, (
+            f"Param descriptions over {_MAX_PARAM_DESC_CHARS} chars — move "
+            f"guidance into the tool docstring: {bad}"
+        )
+
+    async def test_dry_run_descriptions_byte_exact(self, all_tools: list[Tool]) -> None:
+        bad = [
+            (tool.name, props["dry_run"].get("description"))
+            for tool in all_tools
+            if "dry_run" in (props := tool.inputSchema.get("properties", {}))
+            and props["dry_run"].get("description") not in _DRY_RUN_VARIANTS
+        ]
+        assert not bad, (
+            f"dry_run description must be one approved variant (no paraphrase): {bad}"
+        )

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -1266,6 +1266,14 @@ class TestUpdateWorkItemsDocstringGuidance:
         items_field = inspect.signature(update_work_items).parameters["items"].default
         assert "REPLACE" in (items_field.description or "")
 
+    def test_table_steer_keeps_eval_proven_phrasing(self) -> None:
+        # EFF-TABLE-RECIPE-SOURCED: reword "To add a table" to "For a new
+        # table" drop get_html_recipes triggering 3/3 to 0/3 — task-verb
+        # phrasing load-bearing, keep byte-close.
+        document = " ".join((update_work_items.__doc__ or "").split())
+        assert "To add a table" in document
+        assert "call get_html_recipes first" in document
+
 
 class TestEnumGuardCreateWorkItem:
     """Integration: ``create_work_items`` reject ghost enum ids before POST."""


### PR DESCRIPTION
## Summary

Unify all 33 `@mcp.tool` docstrings and `Field(description=...)` strings under one template (purpose / routing / call-strategy semantics / data-format rules / returns / prevention-form errors). Removes three coexisting error registers (`raise ValueError`, raw HTTP codes, vague "raise"), ad-hoc routing phrasings, docstring-vs-Field duplication, and RST backticks. Total LLM-facing chars: 19,088 → 17,864 (-6.4%); several tools gained routing lines (e.g. copy_document) where triggers were weak.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Tool descriptions drifted across 9 modules: 3 error registers, ad-hoc routing vocab, Field duplication, token bloat
- Rewrite every docstring + param description to one template; errors prevention-form; triggers kept byte-close

## Testing

- Per-module eval loop: every covering case run 3x after each module rewrite (all GREEN before commit)
- One real regression caught and fixed mid-loop: EFF-TABLE-RECIPE-SOURCED went 0/3 after dropping "To add a table ... before writing description_html"; restoring the phrase returned 3/3
- Docstring contract tests (`TestUpdateWorkItemsDocstringGuidance`, `TestCreateDocumentDocstringGuidance`) caught two phrasing violations; fixed in the final commit
- Final gate: full eval 42 cases x 10 runs GREEN (4 cases failed only under parallel-run OpenAI TPM exhaustion; sequential re-runs 10/10, 10/10, 10/10, 9/10 all above thresholds) - `uv run pytest` 1731 passed - ruff/mypy clean - diff-cover: no coverable lines in diff

## Notes for Reviewers

recipes.py left untouched (already template-conformant). dry_run phrasing variants kept intentionally (guarded vs unguarded writes differ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)