### PR TITLE
feat(test-runs): add list_test_records tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **P
 
 ## Features
 
-- **33 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
+- **34 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
 - **Read** — render documents as Markdown, search with Lucene or SQL, walk incoming/outgoing links, resolve enum options.
 - **Write** — create and update work items, documents, and test runs, manage links, reorganize document structure, post comments.
 - **Safe writes** — every write tool supports `dry_run`, and pre-write guards validate fields, enum values, and link targets before hitting Polarion.
@@ -55,6 +55,7 @@ Other clients (VS Code, Claude Desktop, Cursor) — see [Client Configuration](#
 | `list_work_items` | List work items in a project (Lucene/SQL query) |
 | `list_test_runs` | List test runs in a project (Lucene query, templates filter) |
 | `get_test_run` | Get test run details, optionally with the raw HTML report body |
+| `list_test_records` | List a test run's execution records, one per test case iteration |
 | `get_sql_query_recipes` | Fetch copy-paste SQL recipes for advanced queries |
 | `get_html_recipes` | Fetch copy-paste Polarion HTML templates for raw-HTML body edits |
 | `get_document` | Get document metadata, optionally with the raw body HTML |

--- a/evals/cases/triggers.py
+++ b/evals/cases/triggers.py
@@ -203,7 +203,7 @@ CASES: list[Case] = [
         "list_test_runs.",
         covers=["list_test_records"],
         expect="list_test_records",
-        reject=["list_test_runs"],
+        reject=["list_test_runs", "get_test_run"],
     ),
     _case(
         "TRIG-GET-TEST-RUN",

--- a/evals/cases/triggers.py
+++ b/evals/cases/triggers.py
@@ -195,6 +195,17 @@ CASES: list[Case] = [
         reject=["list_work_items"],
     ),
     _case(
+        "TRIG-LIST-TEST-RECORDS",
+        f"Which test cases failed in test run '{TEST_RUN_ID}' of project '{PROJECT}'?",
+        "triggers_tool",
+        intent="Reading per-test-case execution results of a run must call "
+        "list_test_records, not fetch run metadata via get_test_run or "
+        "list_test_runs.",
+        covers=["list_test_records"],
+        expect="list_test_records",
+        reject=["list_test_runs"],
+    ),
+    _case(
         "TRIG-GET-TEST-RUN",
         f"Show the full details of test run '{TEST_RUN_ID}' in project '{PROJECT}'.",
         "triggers_tool",

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -24,6 +24,7 @@ from .fixtures import (
     PROJECT,
     SEEDS,
     SPACE,
+    TESTCASE_ID,
     TS,
     Comment,
     Seeds,
@@ -82,6 +83,26 @@ class FakePolarion:
             },
             "relationships": {
                 "author": {"data": {"type": "users", "id": f"{PROJECT}/{AUTHOR}"}},
+            },
+        }
+
+    def _test_record_resource(self, tr: TestRun) -> dict[str, Any]:
+        # One failed TESTCASE_ID execution per run -- enough for trigger +
+        # result-filter behavior.
+        return {
+            "type": "testrecords",
+            "id": f"{PROJECT}/{tr.short_id}/{PROJECT}/{TESTCASE_ID}/0",
+            "attributes": {
+                "executed": TS,
+                "duration": 1.5,
+                "result": "failed",
+                "iteration": 0,
+            },
+            "relationships": {
+                "testCase": {
+                    "data": {"type": "workitems", "id": f"{PROJECT}/{TESTCASE_ID}"}
+                },
+                "executedBy": {"data": {"type": "users", "id": f"{PROJECT}/{AUTHOR}"}},
             },
         }
 
@@ -389,6 +410,25 @@ class FakePolarion:
             data = [self._work_item_resource(w) for w in items]
             return httpx.Response(
                 200, json={"data": data, "meta": {"totalCount": len(data)}}
+            )
+
+        # Test records of one run; testResultId filter server-side. No meta
+        # block -- live endpoint omit totalCount (verified 2026-07-12).
+        records = re.search(r"/testruns/([^/]+)/testrecords$", path)
+        if records:
+            tr = self.seeds.test_runs.get(records.group(1))
+            if tr is None:
+                return httpx.Response(404, json={"errors": [{"status": "404"}]})
+            data = [self._test_record_resource(tr)]
+            wanted = params.get("testResultId", "")
+            if wanted:
+                data = [r for r in data if r["attributes"]["result"] == wanted]
+            return httpx.Response(
+                200,
+                json={
+                    "data": data,
+                    "included": self._author_included() if data else [],
+                },
             )
 
         # Single test run (template guard + get_test_run); isTemplate served

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -419,7 +419,8 @@ class FakePolarion:
             tr = self.seeds.test_runs.get(records.group(1))
             if tr is None:
                 return httpx.Response(404, json={"errors": [{"status": "404"}]})
-            data = [self._test_record_resource(tr)]
+            # Blueprints never executed -- empty page for templates.
+            data = [] if tr.is_template else [self._test_record_resource(tr)]
             wanted = params.get("testResultId", "")
             if wanted:
                 data = [r for r in data if r["attributes"]["result"] == wanted]

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -42,6 +42,7 @@ from mcp_server_polarion.models.recipes import (
     SqlRecipeGallery,
 )
 from mcp_server_polarion.models.test_runs import (
+    TestRecordSummary,
     TestRunCreateSpec,
     TestRunDetail,
     TestRunsCreateResult,
@@ -81,6 +82,7 @@ __all__: list[str] = [
     "PaginatedResult",
     "ProjectSummary",
     "SqlRecipeGallery",
+    "TestRecordSummary",
     "TestRunCreateSpec",
     "TestRunDetail",
     "TestRunSummary",

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -7,6 +7,23 @@ from collections.abc import Mapping
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
+class TestRecordSummary(BaseModel):
+    """Compact test-record representation for list results."""
+
+    # pytest collect Test*-named classes on import; opt out.
+    __test__ = False
+
+    # Full "project/WI-id" from relationships.testCase; record 5-segment id
+    # never parsed. test_case_id + iteration = record identity within run.
+    test_case_id: str
+    iteration: int = 0
+    result: str = ""
+    executed: str = ""
+    duration: float = 0.0
+    executed_by_name: str = ""
+    defect_id: str = ""
+
+
 class TestRunSummary(BaseModel):
     """Compact test-run representation for list results."""
 

--- a/src/mcp_server_polarion/tools/_shared/fields.py
+++ b/src/mcp_server_polarion/tools/_shared/fields.py
@@ -17,6 +17,11 @@ TEST_RUN_LIST_FIELDS: Final[str] = (
     "title,type,status,finishedOn,updated,author,isTemplate,groupId,template"
 )
 TEST_RUN_DETAIL_FIELDS: Final[str] = "@all"
+# testCase/executedBy/defect keep relationship blocks alive under sparse
+# fieldset.
+TEST_RECORD_LIST_FIELDS: Final[str] = (
+    "executed,duration,result,iteration,testCase,executedBy,defect"
+)
 DOCUMENT_DETAIL_FIELDS: Final[str] = "@all"
 # Sparse fieldset filters relationships too — name them explicitly.
 DOCUMENT_COMMENT_LIST_FIELDS: Final[str] = (
@@ -31,6 +36,7 @@ __all__: list[str] = [
     "DOCUMENT_COMMENT_LIST_FIELDS",
     "DOCUMENT_DETAIL_FIELDS",
     "MAX_BULK_ITEMS",
+    "TEST_RECORD_LIST_FIELDS",
     "TEST_RUN_DETAIL_FIELDS",
     "TEST_RUN_LIST_FIELDS",
     "WORK_ITEM_COMMENT_LIST_FIELDS",

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -54,6 +54,15 @@ def safe_str(value: object) -> str:
     return str(value)
 
 
+def safe_float(value: object) -> float:
+    """``float(value)`` for numbers; ``0.0`` otherwise. bool excluded —
+    int subclass, would read as 1.0.
+    """
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    return 0.0
+
+
 def encode_path_segment(segment: str) -> str:
     """URL-encode single path segment (e.g. document name with spaces)."""
     return quote(segment, safe="")
@@ -108,6 +117,7 @@ __all__: list[str] = [
     "format_option_list",
     "get_client",
     "reraise_with_item_context",
+    "safe_float",
     "safe_str",
     "validate_work_item_id_for_lucene",
 ]

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -13,6 +13,7 @@ from mcp_server_polarion.models import (
     EnumOption,
     Hyperlink,
     PaginatedResult,
+    TestRecordSummary,
     TestRunDetail,
     TestRunSummary,
     WorkItemDetail,
@@ -24,7 +25,7 @@ from mcp_server_polarion.tools._shared.custom_fields import (
     STANDARD_WORK_ITEM_ATTRIBUTES,
     extract_custom_fields,
 )
-from mcp_server_polarion.tools._shared.helpers import safe_str
+from mcp_server_polarion.tools._shared.helpers import safe_float, safe_str
 from mcp_server_polarion.tools._shared.pagination import make_page
 
 
@@ -277,6 +278,71 @@ def parse_work_item_summaries(
             continue
         kwargs = parse_work_item_summary_kwargs(item, user_names)
         items.append(WorkItemSummary(**kwargs))
+    return items
+
+
+class TestRecordSummaryKwargs(TypedDict):
+    """Kwargs shape from ``parse_test_record_summary_kwargs``."""
+
+    test_case_id: str
+    iteration: int
+    result: str
+    executed: str
+    duration: float
+    executed_by_name: str
+    defect_id: str
+
+
+def parse_test_record_summary_kwargs(
+    item: dict[str, object],
+    user_names: dict[str, str],
+) -> TestRecordSummaryKwargs:
+    """``TestRecordSummary`` kwargs from JSON:API resource; ``user_names``
+    map full user id → display name (from included ``users``). Work-item
+    targets keep full ids — record 5-segment id never parsed.
+    """
+    attributes = item.get("attributes", {})
+    if not isinstance(attributes, dict):
+        attributes = {}
+    relationships = item.get("relationships", {})
+    if not isinstance(relationships, dict):
+        relationships = {}
+
+    iteration = attributes.get("iteration", 0)
+    executed_by_id = extract_relationship_id(relationships, "executedBy")
+    return {
+        "test_case_id": extract_relationship_id(relationships, "testCase"),
+        # bool is int subclass -- reject as iteration.
+        "iteration": iteration
+        if isinstance(iteration, int) and not isinstance(iteration, bool)
+        else 0,
+        "result": safe_str(attributes.get("result", "")),
+        "executed": safe_str(attributes.get("executed", "")),
+        "duration": safe_float(attributes.get("duration", 0.0)),
+        "executed_by_name": user_names.get(executed_by_id, ""),
+        "defect_id": extract_relationship_id(relationships, "defect"),
+    }
+
+
+def parse_test_record_summaries(
+    response: dict[str, object],
+) -> list[TestRecordSummary]:
+    """Test-records list response → ``TestRecordSummary`` models. Take whole
+    response (not just ``data``) to resolve executedBy names from included
+    ``users``.
+    """
+    user_names = parse_included_user_name_map(response)
+    data = response.get("data", [])
+    items: list[TestRecordSummary] = []
+    if not isinstance(data, list):
+        return items
+
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        items.append(
+            TestRecordSummary(**parse_test_record_summary_kwargs(item, user_names))
+        )
     return items
 
 

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -15,6 +15,7 @@ from mcp_server_polarion.core.exceptions import (
 from mcp_server_polarion.models import (
     JsonValue,
     PaginatedResult,
+    TestRecordSummary,
     TestRunCreateSpec,
     TestRunDetail,
     TestRunsCreateResult,
@@ -29,6 +30,7 @@ from mcp_server_polarion.tools._shared.custom_fields import (
 )
 from mcp_server_polarion.tools._shared.fields import (
     MAX_BULK_ITEMS,
+    TEST_RECORD_LIST_FIELDS,
     TEST_RUN_DETAIL_FIELDS,
     TEST_RUN_LIST_FIELDS,
 )
@@ -50,6 +52,7 @@ from mcp_server_polarion.tools._shared.pagination import (
 from mcp_server_polarion.tools._shared.parse import (
     extract_created_short_ids,
     parse_included_user_name_map,
+    parse_test_record_summaries,
     parse_test_run_detail,
     parse_test_run_summaries,
 )
@@ -370,6 +373,63 @@ async def list_test_runs(  # noqa: PLR0913
         raise RuntimeError(f"Failed to list test runs: {exc.message}") from exc
 
     items = parse_test_run_summaries(response)
+
+    return make_page(items, response, page_number, page_size)
+
+
+@mcp.tool(
+    tags={"read"},
+    timeout=60.0,
+    annotations={"readOnlyHint": True},
+)
+async def list_test_records(  # noqa: PLR0913
+    ctx: Context,
+    project_id: str = Field(description="Polarion project ID."),
+    test_run_id: str = Field(description="Test run ID (e.g. 'TR-2026-01')."),
+    result: str | None = Field(
+        default=None,
+        description="Filter by result enum ID (e.g. 'passed', 'failed', 'blocked').",
+    ),
+    page_size: int = Field(default=DEFAULT_PAGE_SIZE, ge=1, le=100),
+    page_number: int = Field(default=1, ge=1),
+) -> PaginatedResult[TestRecordSummary]:
+    """List execution records of one test run — one row per test case
+    iteration.
+
+    Filter by result (e.g. 'failed') or omit for all; not-yet-executed
+    records have empty result. Lucene query is NOT supported here. Returns
+    summaries — test_case_id + iteration identify a record; defect_id links
+    the failure work item.
+    """
+    client = get_client(ctx)
+    params: dict[str, str | int] = {
+        "fields[testrecords]": TEST_RECORD_LIST_FIELDS,
+        "include": "executedBy",
+        "fields[users]": "name",
+        "page[size]": page_size,
+        "page[number]": page_number,
+    }
+    if result is not None:
+        params["testResultId"] = result
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/testruns/{encode_path_segment(test_run_id)}/testrecords"
+    )
+    try:
+        response = await client.get(path, params=params)
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Test run '{test_run_id}' not found in project '{project_id}'. "
+            "Use `list_test_runs` to discover valid IDs."
+        ) from exc
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot list test records -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(f"Failed to list test records: {exc.message}") from exc
+
+    items = parse_test_record_summaries(response)
 
     return make_page(items, response, page_number, page_size)
 

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -394,7 +394,7 @@ async def list_test_records(  # noqa: PLR0913
     page_number: int = Field(default=1, ge=1),
 ) -> PaginatedResult[TestRecordSummary]:
     """List execution records of one test run — one row per test case
-    iteration.
+    iteration. For run metadata use get_test_run.
 
     Filter by result (e.g. 'failed') or omit for all; not-yet-executed
     records have empty result. Lucene query is NOT supported here. Returns

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -245,6 +245,47 @@ class TestTestRunRouting:
         assert response.status_code == 404
 
 
+class TestTestRecordRouting:
+    def test_records_carry_test_case_and_executed_by(self) -> None:
+        response = _get(
+            FakePolarion(), f"/projects/{PROJECT}/testruns/{TEST_RUN_ID}/testrecords"
+        )
+        assert response.status_code == 200
+        payload = _json(response)
+        record = payload["data"][0]
+        assert record["type"] == "testrecords"
+        assert record["attributes"]["result"] == "failed"
+        rel = record["relationships"]
+        assert rel["testCase"]["data"]["id"] == f"{PROJECT}/{TESTCASE_ID}"
+        assert rel["executedBy"]["data"]["type"] == "users"
+        assert payload["included"][0]["attributes"]["name"] == "Fake Author"
+        # Live endpoint omit meta.totalCount; mirror it so pagination
+        # fallback path exercised.
+        assert "meta" not in payload
+
+    def test_records_of_missing_run_is_404(self) -> None:
+        response = _get(
+            FakePolarion(), f"/projects/{PROJECT}/testruns/Nope/testrecords"
+        )
+        assert response.status_code == 404
+
+    def test_result_filter_matches(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/testruns/{TEST_RUN_ID}/testrecords",
+            testResultId="failed",
+        )
+        assert len(_json(response)["data"]) == 1
+
+    def test_result_filter_excludes(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/testruns/{TEST_RUN_ID}/testrecords",
+            testResultId="passed",
+        )
+        assert _json(response)["data"] == []
+
+
 class TestWorkItemResource:
     def test_module_relationship_only_for_module_items(self) -> None:
         fake = FakePolarion()

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -285,6 +285,15 @@ class TestTestRecordRouting:
         )
         assert _json(response)["data"] == []
 
+    def test_template_run_has_no_records(self) -> None:
+        # Blueprints never executed -- mirror live empty page.
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/testruns/{TEST_RUN_TEMPLATE_ID}/testrecords",
+        )
+        assert response.status_code == 200
+        assert _json(response)["data"] == []
+
 
 class TestWorkItemResource:
     def test_module_relationship_only_for_module_items(self) -> None:

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -32,6 +32,7 @@ _READ_TOOL_NAMES: frozenset[str] = frozenset(
         "read_document",
         "list_work_items",
         "list_test_runs",
+        "list_test_records",
         "get_test_run",
         "get_sql_query_recipes",
         "get_html_recipes",
@@ -265,6 +266,55 @@ class TestEndToEndInvocation:
         assert body["has_more"] is False
         assert body["items"][0]["id"] == "TR-1"
         assert body["items"][0]["author_name"] == "Devember X"
+
+    async def test_list_test_records_round_trip(self, mcp_client: _MCPClient) -> None:
+        with respx.mock(base_url=_BASE, assert_all_called=False) as mock:
+            mock.get("/projects/P1/testruns/TR-1/testrecords").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "data": [
+                            {
+                                "type": "testrecords",
+                                "id": "P1/TR-1/P1/TC-9/0",
+                                "attributes": {
+                                    "result": "passed",
+                                    "duration": 3.5,
+                                    "iteration": 0,
+                                },
+                                "relationships": {
+                                    "testCase": {
+                                        "data": {"type": "workitems", "id": "P1/TC-9"}
+                                    },
+                                    "executedBy": {
+                                        "data": {"type": "users", "id": "P1/devemberx"}
+                                    },
+                                },
+                            }
+                        ],
+                        "included": [
+                            {
+                                "type": "users",
+                                "id": "P1/devemberx",
+                                "attributes": {"name": "Devember X"},
+                            }
+                        ],
+                        # Live endpoint omit meta.totalCount.
+                    },
+                )
+            )
+            result = await mcp_client.call_tool(
+                "list_test_records",
+                {"project_id": "P1", "test_run_id": "TR-1"},
+            )
+
+        body = result.structured_content
+        assert body is not None
+        assert body["total_count"] == 1
+        assert body["has_more"] is False
+        assert body["items"][0]["test_case_id"] == "P1/TC-9"
+        assert body["items"][0]["result"] == "passed"
+        assert body["items"][0]["executed_by_name"] == "Devember X"
 
     async def test_polarion_not_found_surfaces_as_tool_error(
         self, mcp_client: _MCPClient

--- a/tests/mcp_server_polarion/tools/_shared/test_helpers.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_helpers.py
@@ -1,6 +1,7 @@
 """Core helpers worth pinning beyond transitive per-tool coverage —
-`format_option_list` rendering, `safe_str` coercion, slash-encoding contract
-of `encode_path_segment`, Lucene-id guard, `get_client` lookup.
+`format_option_list` rendering, `safe_str`/`safe_float` coercion,
+slash-encoding contract of `encode_path_segment`, Lucene-id guard,
+`get_client` lookup.
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ from mcp_server_polarion.tools._shared.helpers import (
     format_option_list,
     get_client,
     reraise_with_item_context,
+    safe_float,
     safe_str,
     validate_work_item_id_for_lucene,
 )
@@ -78,6 +80,24 @@ class TestSafeStr:
         assert safe_str(42) == "42"
         assert safe_str(1.5) == "1.5"
         assert safe_str(False) == "False"
+
+
+class TestSafeFloat:
+    """Tests for `safe_float`."""
+
+    def test_float_passes_through(self) -> None:
+        assert safe_float(12.5) == 12.5
+
+    def test_int_coerced(self) -> None:
+        assert safe_float(7) == 7.0
+
+    def test_bool_rejected(self) -> None:
+        # bool is int subclass -- must not read as 1.0.
+        assert safe_float(True) == 0.0
+
+    def test_none_and_str_default_zero(self) -> None:
+        assert safe_float(None) == 0.0
+        assert safe_float("fast") == 0.0
 
 
 class TestEncodePathSegment:

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -17,6 +17,8 @@ from mcp_server_polarion.tools._shared.parse import (
     parse_hyperlinks,
     parse_included_user_name_map,
     parse_included_work_item_map,
+    parse_test_record_summaries,
+    parse_test_record_summary_kwargs,
     parse_test_run_detail,
     parse_test_run_summaries,
     parse_test_run_summary_kwargs,
@@ -390,6 +392,85 @@ class TestParseTestRunSummaries:
             ]
         }
         assert [s.id for s in parse_test_run_summaries(response)] == ["TR-2"]
+
+
+class TestParseTestRecordSummaries:
+    """Tests for `parse_test_record_summaries` and its kwargs helper."""
+
+    def test_full_record_resolves_relationships(self) -> None:
+        kwargs = parse_test_record_summary_kwargs(
+            {
+                "id": "proj/TR-1/proj/TC-42/0",
+                "attributes": {
+                    "executed": "2026-06-01T10:00:00Z",
+                    "duration": 12.5,
+                    "result": "failed",
+                    "iteration": 3,
+                },
+                "relationships": {
+                    "testCase": {"data": {"id": "proj/TC-42"}},
+                    "executedBy": {"data": {"id": "proj/jdoe"}},
+                    "defect": {"data": {"id": "proj/DEF-7"}},
+                },
+            },
+            user_names={"proj/jdoe": "J Doe"},
+        )
+        # Full ids kept -- no extract_short_id on work-item targets.
+        assert kwargs["test_case_id"] == "proj/TC-42"
+        assert kwargs["defect_id"] == "proj/DEF-7"
+        assert kwargs["executed_by_name"] == "J Doe"
+        assert kwargs["iteration"] == 3
+        assert kwargs["duration"] == 12.5
+        assert kwargs["result"] == "failed"
+        assert kwargs["executed"] == "2026-06-01T10:00:00Z"
+
+    def test_non_dict_attributes_and_relationships_default_empty(self) -> None:
+        kwargs = parse_test_record_summary_kwargs(
+            {"id": "proj/TR-1/proj/TC-1/0", "attributes": [], "relationships": "nope"},
+            user_names={},
+        )
+        assert kwargs["test_case_id"] == ""
+        assert kwargs["result"] == ""
+        assert kwargs["executed"] == ""
+        assert kwargs["duration"] == 0.0
+        assert kwargs["iteration"] == 0
+        assert kwargs["executed_by_name"] == ""
+        assert kwargs["defect_id"] == ""
+
+    def test_non_numeric_duration_and_iteration_default_zero(self) -> None:
+        kwargs = parse_test_record_summary_kwargs(
+            {
+                "id": "proj/TR-1/proj/TC-1/0",
+                "attributes": {"duration": "fast", "iteration": True},
+            },
+            user_names={},
+        )
+        # bool is int subclass -- reject as iteration.
+        assert kwargs["duration"] == 0.0
+        assert kwargs["iteration"] == 0
+
+    def test_int_duration_coerced_to_float(self) -> None:
+        kwargs = parse_test_record_summary_kwargs(
+            {"id": "proj/TR-1/proj/TC-1/0", "attributes": {"duration": 7}},
+            user_names={},
+        )
+        assert kwargs["duration"] == 7.0
+
+    def test_non_list_data_is_empty(self) -> None:
+        assert parse_test_record_summaries({"data": None}) == []
+
+    def test_skips_non_dict_entries(self) -> None:
+        response = {
+            "data": [
+                "nope",
+                {
+                    "id": "proj/TR-1/proj/TC-2/0",
+                    "relationships": {"testCase": {"data": {"id": "proj/TC-2"}}},
+                },
+            ]
+        }
+        parsed = parse_test_record_summaries(response)
+        assert [r.test_case_id for r in parsed] == ["proj/TC-2"]
 
 
 class TestParseTestRunDetail:

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -27,6 +27,7 @@ from mcp_server_polarion.tools.test_runs import (
     _build_update_test_runs_payload,
     create_test_runs,
     get_test_run,
+    list_test_records,
     list_test_runs,
     update_test_runs,
 )
@@ -362,6 +363,220 @@ class TestListTestRunsQueryDocumentation:
         assert "SQL" not in (list_test_runs.__doc__ or ""), (
             "list_test_runs docstring must not mention SQL"
         )
+
+
+class TestListTestRecords:
+    """``list_test_records`` tool."""
+
+    async def test_returns_test_records(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {
+            "data": [
+                {
+                    "type": "testrecords",
+                    "id": "proj1/TR-001/proj1/TC-42/0",
+                    "attributes": {
+                        "executed": "2026-06-01T10:00:00Z",
+                        "duration": 12.5,
+                        "result": "failed",
+                        "iteration": 0,
+                    },
+                    "relationships": {
+                        "testCase": {
+                            "data": {"type": "workitems", "id": "proj1/TC-42"}
+                        },
+                        "executedBy": {
+                            "data": {"type": "users", "id": "proj1/devemberx"}
+                        },
+                        "defect": {"data": {"type": "workitems", "id": "proj1/DEF-7"}},
+                    },
+                },
+                {
+                    "type": "testrecords",
+                    "id": "proj1/TR-001/proj1/TC-43/1",
+                    "attributes": {"iteration": 1},
+                    "relationships": {
+                        "testCase": {
+                            "data": {"type": "workitems", "id": "proj1/TC-43"}
+                        },
+                    },
+                },
+            ],
+            "included": [
+                {
+                    "type": "users",
+                    "id": "proj1/devemberx",
+                    "attributes": {"name": "Devember X"},
+                }
+            ],
+            # Live endpoint omit meta.totalCount -- total falls back to
+            # offset estimate.
+        }
+
+        result = await list_test_records(
+            mock_ctx,
+            project_id="proj1",
+            test_run_id="TR-001",
+            result=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        assert isinstance(result, PaginatedResult)
+        assert len(result.items) == 2
+        assert result.total_count == 2
+
+        first = result.items[0]
+        # Full work-item ids preserved -- never derived from 5-segment record id.
+        assert first.test_case_id == "proj1/TC-42"
+        assert first.iteration == 0
+        assert first.result == "failed"
+        assert first.executed == "2026-06-01T10:00:00Z"
+        assert first.duration == 12.5
+        assert first.executed_by_name == "Devember X"
+        assert first.defect_id == "proj1/DEF-7"
+
+        second = result.items[1]
+        # Not-yet-executed record -> blanks and zeros.
+        assert second.test_case_id == "proj1/TC-43"
+        assert second.iteration == 1
+        assert second.result == ""
+        assert second.executed == ""
+        assert second.duration == 0.0
+        assert second.executed_by_name == ""
+        assert second.defect_id == ""
+
+    async def test_sparse_fieldset_and_includes_requested(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": []}
+
+        await list_test_records(
+            mock_ctx,
+            project_id="proj1",
+            test_run_id="TR-001",
+            result=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        args, kwargs = mock_client.get.call_args
+        assert args[0] == "/projects/proj1/testruns/TR-001/testrecords"
+        params = kwargs["params"]
+        # Sparse fieldset drop relationships -- all three named explicit.
+        assert "testCase" in params["fields[testrecords]"]
+        assert "executedBy" in params["fields[testrecords]"]
+        assert "defect" in params["fields[testrecords]"]
+        assert params["include"] == "executedBy"
+        assert params["fields[users]"] == "name"
+
+    async def test_result_filter_forwarded(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": []}
+
+        await list_test_records(
+            mock_ctx,
+            project_id="proj1",
+            test_run_id="TR-001",
+            result="failed",
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"]["testResultId"] == "failed"
+
+    async def test_result_none_omits_param(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": []}
+
+        await list_test_records(
+            mock_ctx,
+            project_id="proj1",
+            test_run_id="TR-001",
+            result=None,
+            page_size=100,
+            page_number=1,
+        )
+
+        _, kwargs = mock_client.get.call_args
+        assert "testResultId" not in kwargs["params"]
+
+    async def test_run_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await list_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="missing",
+                result=None,
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await list_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="TR-001",
+                result=None,
+                page_size=100,
+                page_number=1,
+            )
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError("boom", status_code=500)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await list_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="TR-001",
+                result=None,
+                page_size=100,
+                page_number=1,
+            )
+
+
+class TestListTestRecordsFieldValidation:
+    """``page_size`` bounds — direct calls bypass JSON Schema; proven via
+    ``TypeAdapter`` rebuild from signature.
+    """
+
+    @staticmethod
+    def _adapter(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(list_test_records)
+        sig = inspect.signature(list_test_records)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_page_size_boundaries_accepted(self) -> None:
+        adapter = self._adapter("page_size")
+        assert adapter.validate_python(1) == 1
+        assert adapter.validate_python(100) == 100
+
+    def test_page_size_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("page_size").validate_python(101)
+
+    def test_page_number_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("page_number").validate_python(0)
 
 
 class TestBuildCreateTestRunsPayload:


### PR DESCRIPTION
## Summary

Adds `list_test_records` — read-only MCP tool over `GET /projects/{p}/testruns/{r}/testrecords`, one row per test case iteration of a run. Minimal summary fields by design; a future `get_test_record` will carry detail (comment, testCaseRevision, custom fields).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- No tool read per-test-case execution results inside a run; get_test_run only serve run metadata
- Add read-only list tool over GET /testruns/{id}/testrecords with testResultId filter and executedBy name resolution

## Testing

- TDD: parse/helpers/tool/transport tests written first (RED), then implementation (GREEN); 1758 passed, diff-cover 100% on changed lines.
- Live-verified against testdrive (`MCP_Test_Project/test2`): sparse fieldset keeps `testCase`/`executedBy`/`defect` relationship blocks; `testResultId` filter works server-side; `executedBy` id is a bare user GUID matching `included` users (name resolves); endpoint omits `meta.totalCount` — fake harness and mocks mirror that so the pagination fallback path is exercised.
- Eval: `TRIG-LIST-TEST-RECORDS` trigger case + fake-Polarion testrecords route; coverage gate green.

## Notes for Reviewers

- This endpoint has no Lucene `query` support — the only server-side filter is `testResultId` (exposed as `result`).
- Record ids are 5-segment; the parser never splits them — `test_case_id` comes from `relationships.testCase.data.id`.
- Not-yet-executed record shape (attrs absent vs null) could not be live-verified (no unexecuted record available); parser defaults cover both, unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)