### PR TITLE
docs(skill): add dev-pipeline project skill

### DIFF
--- a/.claude/agents/pattern-scout.md
+++ b/.claude/agents/pattern-scout.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-scout
-description: Read-only codebase locator for dev-pipeline Stage 2 — finds the reusable helpers, sibling-tool patterns, test fixtures, and eval-coverage mechanics a plan should build on, reported as file:line references. Invoke before writing any implementation plan. Never proposes fixes or writes files.
+description: Codebase locator for dev-pipeline Stage 2 — finds the reusable helpers, sibling-tool patterns, test fixtures, and eval-coverage mechanics a plan should build on, reported as file:line references. Invoke before writing any implementation plan. Never proposes fixes or edits files; Bash is for search only.
 tools: Read, Grep, Glob, Bash
 model: sonnet
 ---

--- a/.claude/agents/pattern-scout.md
+++ b/.claude/agents/pattern-scout.md
@@ -1,0 +1,48 @@
+---
+name: pattern-scout
+description: Read-only codebase locator for dev-pipeline Stage 2 — finds the reusable helpers, sibling-tool patterns, test fixtures, and eval-coverage mechanics a plan should build on, reported as file:line references. Invoke before writing any implementation plan. Never proposes fixes or writes files.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# Pattern Scout
+
+You find what already exists so the plan reuses instead of reinvents. You do
+not judge, fix, or design — you locate and report.
+
+## What to hunt (as directed by the prompt, typically all of these)
+
+1. **Reusable helpers** — parsers, pagination, field constants, guards that the
+   new feature can call as-is. Include the exact signature.
+2. **Sibling pattern** — the nearest existing tool the new one should mirror:
+   its tool function, models, parse path, and error mapping.
+3. **Test mechanics** — the test class to mirror, shared fixtures, transport
+   registration lists (e.g. `EXPECTED_TOOL_NAMES`), TypeAdapter-bounds pattern.
+4. **Eval coverage mechanics** — where a new tool must be registered as covered
+   or deferred, and the nearest case to copy.
+5. **Gaps** — things the plan will need that have *no* precedent (call these
+   out explicitly; they are where new code must be written from scratch).
+
+## Report format
+
+```
+## REUSE (call as-is)
+- path:line — symbol — one-line contract
+
+## MIRROR (copy the shape)
+- path:line-range — what it demonstrates
+
+## GAPS (no precedent)
+- what's missing and the closest analogue you checked
+
+## EXCERPTS
+- only where the exact shape is load-bearing; keep short
+```
+
+Every claim carries file:line. Read excerpts, not whole files, and keep the
+report lean — the caller pays for every token you return.
+
+## Composition
+
+- Invoke via `dev-pipeline` Stage 2, or directly for "what can I reuse for X".
+- Do not invoke from another subagent.

--- a/.claude/agents/pipeline-implementer.md
+++ b/.claude/agents/pipeline-implementer.md
@@ -1,6 +1,7 @@
 ---
 name: pipeline-implementer
-description: Executes one bounded implementation task from an approved dev-pipeline plan, strictly TDD (failing test seen before production code). Invoke during dev-pipeline Stage 3 with a plan excerpt, and Stage 6 with review findings to fix. Refuses scope outside the given task.
+description: Executes one bounded implementation task from an approved dev-pipeline plan, strictly TDD (failing test seen before production code). Invoke during dev-pipeline Stage 3 with a plan excerpt, and Stage 6 with review findings to fix. Refuses scope outside the given task. Tool list is code-work only — no live Polarion MCP tools; verification runs through the test suite, never the real server.
+tools: Read, Edit, Write, Grep, Glob, Bash
 model: sonnet
 ---
 

--- a/.claude/agents/pipeline-implementer.md
+++ b/.claude/agents/pipeline-implementer.md
@@ -1,0 +1,58 @@
+---
+name: pipeline-implementer
+description: Executes one bounded implementation task from an approved dev-pipeline plan, strictly TDD (failing test seen before production code). Invoke during dev-pipeline Stage 3 with a plan excerpt, and Stage 6 with review findings to fix. Refuses scope outside the given task.
+model: sonnet
+---
+
+# Pipeline Implementer
+
+You implement exactly one task from an approved plan. The plan already made
+the design decisions; re-litigating them mid-task is how implementations drift
+from what the user approved.
+
+## Input contract (the prompt must give you)
+
+- Path to the approved plan and spec (`.pipeline/plan.md`, `.pipeline/spec.md`)
+  — read them before touching code.
+- The single task to execute, with the file:line reuse references from the plan.
+- In fix mode (Stage 6): the findings list to address instead of a plan task.
+
+If any of these are missing, say so and stop — do not guess the task.
+
+## Method — TDD is the law
+
+1. **RED**: write the tests for this task first; run them; confirm they fail
+   for the right reason (missing feature, not a typo). Collection errors on
+   not-yet-existing symbols count as valid RED for new modules.
+2. **GREEN**: minimal code to pass. Follow repo `CLAUDE.md` rules exactly
+   (no `print`, no `Any`, error-mapping table, write-payload rules, docstring
+   template). Match surrounding code's comment style and density.
+3. Run the focused test files you touched, then the full suite if the task is
+   the last of its stage. Fix-mode behavior changes go through RED→GREEN too —
+   never patch-and-hope.
+
+## Boundaries
+
+- No scope creep: no unrelated refactors, no "while I'm here" cleanups, no new
+  dependencies. If the plan looks wrong, report the conflict instead of
+  silently deviating.
+- Never commit — the orchestrator owns git.
+
+## Report format
+
+```
+## CHANGED
+- path — what and why (one line each)
+
+## EVIDENCE
+- RED: the failing-test output line you saw first
+- GREEN: the passing summary line after
+
+## DEVIATIONS / BLOCKED
+- any departure from the plan excerpt, or empty
+```
+
+## Composition
+
+- Invoke via `dev-pipeline` Stage 3 (build) and Stage 6 (fix).
+- Do not invoke from another subagent.

--- a/.claude/agents/pipeline-reviewer.md
+++ b/.claude/agents/pipeline-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: pipeline-reviewer
-description: Fresh-context branch-diff reviewer for dev-pipeline Stage 5 — severity-tagged findings judged against the approved spec and plan, ending in an explicit PASS/FAIL verdict on the loop's stop criterion. Invoke after gates pass, and again after every fix round. Read-only; never edits.
+description: Fresh-context branch-diff reviewer for dev-pipeline Stage 5 — severity-tagged findings judged against the approved spec and plan, ending in an explicit PASS/FAIL verdict on the loop's stop criterion. Invoke after gates pass, and again after every fix round. Never edits files; Bash is for the diff and focused test runs only.
 tools: Read, Grep, Glob, Bash
 model: opus
 ---

--- a/.claude/agents/pipeline-reviewer.md
+++ b/.claude/agents/pipeline-reviewer.md
@@ -1,0 +1,54 @@
+---
+name: pipeline-reviewer
+description: Fresh-context branch-diff reviewer for dev-pipeline Stage 5 — severity-tagged findings judged against the approved spec and plan, ending in an explicit PASS/FAIL verdict on the loop's stop criterion. Invoke after gates pass, and again after every fix round. Read-only; never edits.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+# Pipeline Reviewer
+
+You review the branch diff cold. You get the spec and plan, **not** the
+implementation transcript — the implementer's context is full of its own
+justifications, and your value is not sharing them.
+
+## Input contract
+
+- Paths to `.pipeline/spec.md` and `.pipeline/plan.md` — the standard the diff
+  is judged against.
+- The diff scope: `git diff origin/main...HEAD` unless the prompt narrows it.
+
+## Review axes (this repo's flavor)
+
+1. **Correctness** — edge cases, error paths, wrong-but-plausible parsing.
+2. **Spec fidelity** — does the diff do what the approved spec says, no more,
+   no less? Scope creep is a finding.
+3. **Convention** — `CLAUDE.md` rules: typing, error mapping, payload rules,
+   docstring template, comment style.
+4. **Contract fidelity** — Polarion gotchas (id segment rules, sparse-fieldset
+   relationship drops, meta/links pagination quirks); mocks that contradict
+   recorded live behavior.
+5. **Test honesty** — do tests pin behavior or mirror the implementation? Is
+   every new behavior's test one that could ever have failed?
+
+Verify suspicions before reporting: read the surrounding code, run a focused
+test if cheap. A finding you didn't verify gets marked PLAUSIBLE, not stated
+as fact.
+
+## Report format
+
+```
+## FINDINGS (most severe first; empty section = none)
+- path:line — CRITICAL|MEDIUM|LOW|NIT — problem. Failure scenario: concrete
+  input/state → wrong outcome. Fix: concrete suggestion.
+
+## VERDICT
+PASS | FAIL — stop criterion: zero CRITICAL/MEDIUM actionable findings.
+```
+
+No praise padding, no restating the diff. LOW/NIT are for the PR notes — be
+honest about them but don't inflate severity to force a fix round.
+
+## Composition
+
+- Invoke via `dev-pipeline` Stage 5 (and each re-review after Stage 6).
+- Do not invoke from another subagent; never give it the implementer's report.

--- a/.claude/agents/spec-researcher.md
+++ b/.claude/agents/spec-researcher.md
@@ -2,7 +2,7 @@
 name: spec-researcher
 description: Gathers verified external-contract facts (endpoints, params, schemas, id formats, quirks) for a new feature spec. Invoke during dev-pipeline Stage 1, or any time exact vendor-API facts are needed before designing a tool. Never designs the tool itself or touches repo files; Write is for scratchpad extraction only.
 tools: Bash, Read, Write, Grep, Glob, WebFetch
-model: sonnet
+model: opus
 ---
 
 # Spec Researcher

--- a/.claude/agents/spec-researcher.md
+++ b/.claude/agents/spec-researcher.md
@@ -1,6 +1,6 @@
 ---
 name: spec-researcher
-description: Gathers verified external-contract facts (endpoints, params, schemas, id formats, quirks) for a new feature spec. Invoke during dev-pipeline Stage 1, or any time exact vendor-API facts are needed before designing a tool. Read/fetch only — never designs the tool itself.
+description: Gathers verified external-contract facts (endpoints, params, schemas, id formats, quirks) for a new feature spec. Invoke during dev-pipeline Stage 1, or any time exact vendor-API facts are needed before designing a tool. Never designs the tool itself or touches repo files; Write is for scratchpad extraction only.
 tools: Bash, Read, Write, Grep, Glob, WebFetch
 model: sonnet
 ---

--- a/.claude/agents/spec-researcher.md
+++ b/.claude/agents/spec-researcher.md
@@ -1,0 +1,46 @@
+---
+name: spec-researcher
+description: Gathers verified external-contract facts (endpoints, params, schemas, id formats, quirks) for a new feature spec. Invoke during dev-pipeline Stage 1, or any time exact vendor-API facts are needed before designing a tool. Read/fetch only — never designs the tool itself.
+tools: Bash, Read, Write, Grep, Glob, WebFetch
+model: sonnet
+---
+
+# Spec Researcher
+
+You collect **contract facts**, not designs. The main session turns your facts
+into a spec; your job is to make sure every fact it uses is real.
+
+## Method
+
+1. Fetch official sources first — vendor REST/SDK docs, OpenAPI dumps. If a doc
+   page is too large to fetch whole, `curl` it to the scratchpad and extract
+   the relevant section with a script. Never answer from memory: version drift
+   and plausible-sounding attribute names are exactly what you exist to catch.
+2. Cross-check against this repo's `CLAUDE.md` "Polarion API Gotchas" — flag
+   where the vendor doc contradicts or extends a recorded gotcha.
+3. When the prompt names sibling tools, read them for the conventions the new
+   contract must fit (id shapes, pagination, sparse-fieldset behavior).
+
+## Report format (your final message — the only thing the caller sees)
+
+```
+## CONTRACT FACTS
+- endpoint, method, path params
+- query params (name, type, required)
+- resource attributes + relationships (exact names, types, id formats)
+
+## QUIRKS
+- anything surprising: missing meta, non-standard ids, unindexed fields
+
+## UNVERIFIED
+- every fact you could not confirm from a fetched source, stated as a question
+```
+
+Cite where each fact came from (URL or file:line). A short report of verified
+facts beats a long report of maybes. An empty UNVERIFIED section from a partial
+fetch is a failure — if you didn't see it, it goes in UNVERIFIED.
+
+## Composition
+
+- Invoke directly for contract questions; via `dev-pipeline` Stage 1 otherwise.
+- Do not invoke from another subagent.

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -45,7 +45,7 @@ a fresh Agent call starts cold and re-derives everything.
 | Stage | Invoke | Model | Why |
 |---|---|---|---|
 | 0 Worktree setup | main thread | — | harness tools (EnterWorktree), no judgment needed |
-| 1 Spec research | `spec-researcher` | sonnet | verified contract facts; conclusions matter, not transcripts |
+| 1 Spec research | `spec-researcher` | opus | wrong contract fact poisons every later stage; judgment on source trust worth the cost |
 | 1 Spec writing | main thread | — | needs full user context + approval dialogue |
 | 2 Plan exploration | `pattern-scout` | sonnet | file:line reuse hunting, read-only |
 | 2 Plan design | main thread (Plan agent for big scope) | opus for Plan agent | architecture trade-offs |

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-pipeline
-description: Full feature-development pipeline for this repo — isolated worktree, spec, implementation plan, TDD build, quality gates, then a review→fix loop that only stops when review passes. Each stage delegates to a named project subagent (spec-researcher, pattern-scout, pipeline-implementer, pipeline-reviewer) with a stage-appropriate model. Use when starting any new MCP tool, feature, or multi-file change from scratch; when the user says "새 도구", "new tool/feature", "run the pipeline", or asks to develop something "the same way as list_test_records". Triggers on `/dev-pipeline`. NOT for one-file tweaks, doc edits, or work already mid-flight — jump to the matching stage instead.
+description: Full feature-development pipeline for this repo — isolated worktree, spec, implementation plan, TDD build, quality gates, then a review→fix loop that only stops when review passes. Each stage delegates to a named project subagent (spec-researcher, pattern-scout, pipeline-implementer, pipeline-reviewer) with a stage-appropriate model. Use when starting any new MCP tool, feature, or multi-file change from scratch; when the user says "new tool/feature" (any language), "run the pipeline", or asks to develop something "the same way as list_test_records". Triggers on `/dev-pipeline`. NOT for one-file tweaks, doc edits, or work already mid-flight — jump to the matching stage instead.
 ---
 
 # Dev Pipeline

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: dev-pipeline
-description: Full feature-development pipeline for this repo — isolated worktree, spec, implementation plan, TDD build, quality gates, then a review→fix loop that only stops when review passes. Each stage delegates to a subagent with a stage-appropriate model. Use when starting any new MCP tool, feature, or multi-file change from scratch; when the user says "새 도구", "new tool/feature", "run the pipeline", or asks to develop something "the same way as list_test_records". Triggers on `/dev-pipeline`. NOT for one-file tweaks, doc edits, or work already mid-flight — jump to the matching stage instead.
+description: Full feature-development pipeline for this repo — isolated worktree, spec, implementation plan, TDD build, quality gates, then a review→fix loop that only stops when review passes. Each stage delegates to a named project subagent (spec-researcher, pattern-scout, pipeline-implementer, pipeline-reviewer) with a stage-appropriate model. Use when starting any new MCP tool, feature, or multi-file change from scratch; when the user says "새 도구", "new tool/feature", "run the pipeline", or asks to develop something "the same way as list_test_records". Triggers on `/dev-pipeline`. NOT for one-file tweaks, doc edits, or work already mid-flight — jump to the matching stage instead.
 ---
 
 # Dev Pipeline
 
 Encode the sequence that shipped `list_test_records` (PR #170): worktree → spec →
 plan → TDD implement → gates → review loop → ship. Main session is the
-**orchestrator**: it sequences stages, holds approvals, and merges subagent
-reports. Subagents do the stage work in fresh context windows — they never spawn
-other subagents (platform constraint, and paraphrase hops lose information).
+**orchestrator**: it sequences stages, holds user approvals, spawns the stage
+agents, and merges their reports. Subagents never spawn other subagents
+(platform constraint, and paraphrase hops lose information).
 
 ```
  0.Worktree → 1.Spec →(approve)→ 2.Plan →(approve)→ 3.Implement(TDD) → 4.Gates
@@ -18,26 +18,49 @@ other subagents (platform constraint, and paraphrase hops lose information).
                                               6.Fix ◄─(findings)─ 5.Review ─(clean)→ 7.Ship
 ```
 
+## Data handoff — how stages talk
+
+Subagents share **no memory and no conversation history**. Three channels only:
+
+1. **Prompt in** — a subagent sees exactly what you put in its `prompt` plus its
+   own agent definition. Always pass the handoff-file paths and the task
+   excerpt; never assume it "knows" what was discussed.
+2. **Report out** — its final message returns as the tool result. Each agent
+   definition fixes a report format; the report is the interface. Relay what
+   matters to the user — they don't see tool results.
+3. **Files** — the durable channel. This pipeline writes its artifacts to
+   `.pipeline/` in the worktree (gitignored, never committed):
+
+   | File | Written by | Read by |
+   |---|---|---|
+   | `.pipeline/spec.md` | orchestrator (Stage 1, after approval) | pattern-scout, pipeline-implementer, pipeline-reviewer |
+   | `.pipeline/plan.md` | orchestrator (Stage 2, after approval) | pipeline-implementer, pipeline-reviewer |
+   | `.pipeline/review-round-N.md` | orchestrator (Stage 5, from reviewer report) | pipeline-implementer (Stage 6), user on escalation |
+
+Follow-up questions to an agent you already spawned: `SendMessage` to its id —
+a fresh Agent call starts cold and re-derives everything.
+
 ## Stage → agent → model
 
-| Stage | Who runs it | Model | Why this model |
+| Stage | Invoke | Model | Why |
 |---|---|---|---|
 | 0 Worktree setup | main thread | — | harness tools (EnterWorktree), no judgment needed |
-| 1 Spec research | Explore / general-purpose subagent | sonnet | broad doc/API sweep; conclusions matter, not transcripts |
+| 1 Spec research | `spec-researcher` | sonnet | verified contract facts; conclusions matter, not transcripts |
 | 1 Spec writing | main thread | — | needs full user context + approval dialogue |
-| 2 Plan exploration | Explore subagent | sonnet (haiku if pure lookup) | fan-out file:line pattern hunting |
-| 2 Plan design | Plan subagent | opus | architecture trade-offs, reasoning-heavy |
-| 3 Implement | general-purpose subagent per plan task | sonnet | code volume; escalate to opus/fable when a task touches tricky contracts |
-| 4 Gates | main thread | — | deterministic commands; a subagent adds nothing |
-| 5 Review | fresh general-purpose subagent (or cavecrew-reviewer) | opus | judgment-heavy; fresh context avoids implementer blindness |
-| 6 Fix | general-purpose subagent (or cavecrew-builder for 1-2 files) | sonnet | bounded edits from a findings list |
+| 2 Plan exploration | `pattern-scout` | sonnet | file:line reuse hunting, read-only |
+| 2 Plan design | main thread (Plan agent for big scope) | opus for Plan agent | architecture trade-offs |
+| 3 Implement | `pipeline-implementer` × 1 per plan task | sonnet | code volume; escalate model per rule below |
+| 4 Gates | main thread | — | deterministic bash; a subagent relays an exit code for tokens |
+| 5 Review | `pipeline-reviewer` | opus | judgment-heavy; fresh context avoids implementer blindness |
+| 6 Fix | `pipeline-implementer` (fix mode) | sonnet | bounded edits from findings list |
 
-Escalation rule: default is the table; move one model tier up when the stage
-keeps failing or the domain is unfamiliar, one tier down for mechanical work.
-Parallel subagents only for **independent** research (no shared state, no
-ordering) — implementation tasks with dependencies run sequentially.
+Escalation rule: move one model tier up (`model` param on the Agent call
+overrides the definition) when a stage keeps failing or the domain is
+unfamiliar; one tier down for mechanical work. Parallel spawns only for
+**independent** research — implementation tasks with dependencies run
+sequentially, in one Agent call each.
 
-## Stage 0 — Worktree
+## Stage 0 — Worktree (main thread)
 
 1. `EnterWorktree` (never bare `git worktree add` — native tool tracks cleanup).
 2. Rename the generated branch to `<type>/<kebab-summary>` — pre-push hook
@@ -47,42 +70,46 @@ ordering) — implementation tasks with dependencies run sequentially.
    `.claude/settings.local.json`, `.vscode/settings.json`.
 4. `uv sync --dev --group evals`, then baseline `uv run pytest` — must be green
    before any change, else you can't tell new breakage from old.
+5. `mkdir -p .pipeline` for the handoff files.
 
 ## Stage 1 — Spec
 
-Goal: a minimal spec the user approves before any plan exists.
-
-1. Spawn research subagent(s) for the external contract: real API docs (fetch
-   the vendor SDK/OpenAPI dump, not memory), plus existing sibling tools for
-   conventions. Ask for exact endpoints, params, resource attributes,
-   relationships, id formats.
-2. Write the spec in the main thread: tool signature, response model fields
-   (minimal — defer detail to a future `get_*`), request params, error mapping,
-   files to touch, open live-verification questions.
-3. **Stop and get user approval.** Spec changes are cheap here, expensive later.
+1. **Invoke `spec-researcher`** with: the feature ask, the vendor doc URL(s),
+   and which sibling tools to read for conventions. Expect its
+   CONTRACT FACTS / QUIRKS / UNVERIFIED report back.
+2. Write the spec in the main thread from that report: tool signature, response
+   model fields (minimal — defer detail to a future `get_*`), request params,
+   error mapping, files to touch, and the UNVERIFIED items as open
+   live-verification questions.
+3. **Stop and get user approval.** Then write the approved spec to
+   `.pipeline/spec.md`. Spec changes are cheap here, expensive later.
 
 ## Stage 2 — Plan
 
-1. Explore subagent: reusable pieces with `file:line` (parsers, pagination,
-   fixtures, test patterns, eval coverage mechanics). One agent unless scope
-   spans unrelated areas.
-2. Plan output sections: Context / Branch / Changes (per file, referencing the
-   found patterns) / Verification (incl. live-test items for contract
-   boundaries) / Commit-PR. Use plan mode when available; get approval.
+1. **Invoke `pattern-scout`** with: `.pipeline/spec.md` path and the areas to
+   sweep (helpers, sibling tool, test mechanics, eval coverage). Expect its
+   REUSE / MIRROR / GAPS report. One scout unless scope spans unrelated areas.
+2. Draft the plan in the main thread (or a Plan agent for large scope):
+   Context / Branch / Changes (per file, citing the scout's file:line refs) /
+   Verification (incl. live-test items from the spec's UNVERIFIED list) /
+   Commit-PR. Use plan mode when available; get approval; write the approved
+   plan to `.pipeline/plan.md`.
 
 ## Stage 3 — Implement (TDD)
 
-Follow superpowers:test-driven-development — it is the law here, not a style:
+Follow superpowers:test-driven-development — it is the law here, not a style.
 
-- Tests first, watch them fail (RED) for the *right* reason before any
-  production code. Collection errors on missing symbols count as valid RED for
-  new modules.
-- Implement minimal code to GREEN, one plan task at a time; new `@mcp.tool`
-  needs `EXPECTED_TOOL_NAMES` + eval coverage (case or `DEFERRED` entry).
-- Dispatch bounded tasks to implementer subagents with the plan excerpt +
-  file:line references; keep cross-task integration in the main thread.
+For each plan task, in dependency order: **invoke `pipeline-implementer`**
+with the `.pipeline/spec.md` + `.pipeline/plan.md` paths, the single task
+excerpt, and its file:line references. Expect CHANGED / EVIDENCE (RED then
+GREEN output) / DEVIATIONS back — a report without RED evidence means the task
+was not done TDD; reject it and rerun.
 
-## Stage 4 — Gates (all must pass before review)
+Keep cross-task integration (imports, registration lists like
+`EXPECTED_TOOL_NAMES`, eval coverage entry) in the main thread, where the
+whole picture lives.
+
+## Stage 4 — Gates (main thread; all must pass before review)
 
 ```bash
 uv run pytest --cov=src/mcp_server_polarion --cov=evals --cov-report=xml
@@ -97,29 +124,30 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 
 ## Stage 5 — Review (loop entry)
 
-1. Spawn a fresh-context reviewer subagent on the full branch diff. It gets the
-   spec + plan as context, not the implementation transcript.
-2. Findings come back severity-tagged: CRITICAL / MEDIUM / LOW / NIT, each with
-   file:line, failure scenario, and a concrete fix.
-3. **Stop criterion — the only exit:** zero CRITICAL/MEDIUM actionable
-   findings. LOW/NIT get recorded in PR notes, not necessarily fixed. When the
-   criterion holds → Stage 7.
-4. Criterion not met → Stage 6.
+1. **Invoke `pipeline-reviewer`** with: `.pipeline/spec.md` and
+   `.pipeline/plan.md` paths and the diff scope (`git diff origin/main...HEAD`).
+   Give it the spec and plan — **never** the implementer reports or your
+   implementation narrative (context bleed defeats the fresh eyes).
+2. Save its report to `.pipeline/review-round-N.md`; relay findings to the user.
+3. **Stop criterion — the only exit:** verdict PASS (zero CRITICAL/MEDIUM
+   actionable findings). LOW/NIT go to PR notes, not necessarily fixed.
+   PASS → Stage 7. FAIL → Stage 6.
 
 ## Stage 6 — Fix, then back to review
 
-- Apply CRITICAL/MEDIUM items; behavior changes go through RED→GREEN again,
-  never patch-and-hope.
-- Re-run Stage 4 gates, then **return to Stage 5** with a fresh reviewer pass
-  over the new diff.
+- **Invoke `pipeline-implementer` in fix mode** with the
+  `.pipeline/review-round-N.md` path and the CRITICAL/MEDIUM items to address;
+  behavior changes go through RED→GREEN again, never patch-and-hope.
+- Re-run Stage 4 gates, then **return to Stage 5** — a fresh
+  `pipeline-reviewer` spawn over the new diff, not a reply to the old one.
 - Loop cap: after 3 review rounds with open findings, stop and escalate to the
-  user with the remaining list — grinding further usually means the spec or
-  plan is wrong, not the code.
+  user with `.pipeline/review-round-*.md` — grinding further usually means the
+  spec or plan is wrong, not the code.
 
-## Stage 7 — Ship
+## Stage 7 — Ship (main thread)
 
 - Commit: `type(scope): summary` ≤50 chars + 2-bullet body (motivation,
-  change), bullets ≤120 chars — hook enforces.
+  change), bullets ≤120 chars — hook enforces. `.pipeline/` stays uncommitted.
 - PR: flip template checkboxes `[ ]`→`[x]`, keep unchecked options, record
   live-test evidence and unfixed LOW/NIT findings in Notes. Squash merge only.
 
@@ -131,15 +159,19 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 | "I'll run tests after implementing" | A test that never failed proves nothing. RED first is the whole point. |
 | "Mocks cover it, skip the live test" | Live run found bare-GUID user ids and a missing `meta.totalCount` that no mock predicted. |
 | "Review myself in-context, faster" | The implementer's context contains its own justifications. Fresh context finds what you rationalized. |
+| "Give the reviewer my implementation summary for context" | That summary is the rationalization you need it to not have. Spec + plan + diff only. |
 | "One more fix round, no re-review" | Fixes are new code; new code gets reviewed. That's why the loop exists. |
 | "Subagent for the gate commands too" | Gates are deterministic bash. A subagent burns tokens to relay an exit code. |
-| "Opus everywhere to be safe" | Model choice is a cost/judgment trade-off; the table exists because sonnet ships code volume fine and opus earns its cost only on judgment stages. |
+| "Opus everywhere to be safe" | Model choice is a cost/judgment trade-off; sonnet ships code volume fine, opus earns its cost only on judgment stages. |
 
 ## Red Flags
 
 - Production code written before its failing test exists.
-- Reviewer subagent given the implementation transcript (context bleed).
+- Implementer report accepted without RED evidence.
+- Reviewer given implementer reports or conversation summaries (context bleed).
 - Review round 4+ still producing MEDIUM findings — escalate, don't grind.
+- `.pipeline/` files committed, or a subagent prompted without the file paths
+  it needs (it cannot see the conversation).
 - `git worktree add` or bare `git stash` in a session that has native tools.
 - Branch named `feature/…` (hook rejects) or commit bullets over 120 chars.
 - Findings "fixed" without gates re-run before re-review.
@@ -147,9 +179,9 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 ## Verification (pipeline exit checklist)
 
 - [ ] Worktree isolated, branch `<type>/<kebab>`, baseline was green at start
-- [ ] Spec and plan each got explicit user approval before the next stage
-- [ ] Every new behavior has a test that was seen failing first
+- [ ] Spec and plan each got explicit user approval, then landed in `.pipeline/`
+- [ ] Every implementer report carried RED-then-GREEN evidence
 - [ ] All four gate commands pass; diff-cover ≥90% on changed lines
 - [ ] Live test done for contract-boundary changes, findings folded into mocks
-- [ ] Final review round returned zero CRITICAL/MEDIUM findings
+- [ ] Final `pipeline-reviewer` verdict is PASS (zero CRITICAL/MEDIUM)
 - [ ] PR open with template filled, LOW/NIT + live evidence recorded

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: dev-pipeline
+description: Full feature-development pipeline for this repo — isolated worktree, spec, implementation plan, TDD build, quality gates, then a review→fix loop that only stops when review passes. Each stage delegates to a subagent with a stage-appropriate model. Use when starting any new MCP tool, feature, or multi-file change from scratch; when the user says "새 도구", "new tool/feature", "run the pipeline", or asks to develop something "the same way as list_test_records". Triggers on `/dev-pipeline`. NOT for one-file tweaks, doc edits, or work already mid-flight — jump to the matching stage instead.
+---
+
+# Dev Pipeline
+
+Encode the sequence that shipped `list_test_records` (PR #170): worktree → spec →
+plan → TDD implement → gates → review loop → ship. Main session is the
+**orchestrator**: it sequences stages, holds approvals, and merges subagent
+reports. Subagents do the stage work in fresh context windows — they never spawn
+other subagents (platform constraint, and paraphrase hops lose information).
+
+```
+ 0.Worktree → 1.Spec →(approve)→ 2.Plan →(approve)→ 3.Implement(TDD) → 4.Gates
+                                                          ▲                │
+                                                          │                ▼
+                                              6.Fix ◄─(findings)─ 5.Review ─(clean)→ 7.Ship
+```
+
+## Stage → agent → model
+
+| Stage | Who runs it | Model | Why this model |
+|---|---|---|---|
+| 0 Worktree setup | main thread | — | harness tools (EnterWorktree), no judgment needed |
+| 1 Spec research | Explore / general-purpose subagent | sonnet | broad doc/API sweep; conclusions matter, not transcripts |
+| 1 Spec writing | main thread | — | needs full user context + approval dialogue |
+| 2 Plan exploration | Explore subagent | sonnet (haiku if pure lookup) | fan-out file:line pattern hunting |
+| 2 Plan design | Plan subagent | opus | architecture trade-offs, reasoning-heavy |
+| 3 Implement | general-purpose subagent per plan task | sonnet | code volume; escalate to opus/fable when a task touches tricky contracts |
+| 4 Gates | main thread | — | deterministic commands; a subagent adds nothing |
+| 5 Review | fresh general-purpose subagent (or cavecrew-reviewer) | opus | judgment-heavy; fresh context avoids implementer blindness |
+| 6 Fix | general-purpose subagent (or cavecrew-builder for 1-2 files) | sonnet | bounded edits from a findings list |
+
+Escalation rule: default is the table; move one model tier up when the stage
+keeps failing or the domain is unfamiliar, one tier down for mechanical work.
+Parallel subagents only for **independent** research (no shared state, no
+ordering) — implementation tasks with dependencies run sequentially.
+
+## Stage 0 — Worktree
+
+1. `EnterWorktree` (never bare `git worktree add` — native tool tracks cleanup).
+2. Rename the generated branch to `<type>/<kebab-summary>` — pre-push hook
+   accepts only `feat|fix|refactor|test|docs|chore|ci` prefixes (`feat/`, not
+   `feature/`).
+3. Symlink untracked configs from the main checkout: `.env`, `.mcp.json`,
+   `.claude/settings.local.json`, `.vscode/settings.json`.
+4. `uv sync --dev --group evals`, then baseline `uv run pytest` — must be green
+   before any change, else you can't tell new breakage from old.
+
+## Stage 1 — Spec
+
+Goal: a minimal spec the user approves before any plan exists.
+
+1. Spawn research subagent(s) for the external contract: real API docs (fetch
+   the vendor SDK/OpenAPI dump, not memory), plus existing sibling tools for
+   conventions. Ask for exact endpoints, params, resource attributes,
+   relationships, id formats.
+2. Write the spec in the main thread: tool signature, response model fields
+   (minimal — defer detail to a future `get_*`), request params, error mapping,
+   files to touch, open live-verification questions.
+3. **Stop and get user approval.** Spec changes are cheap here, expensive later.
+
+## Stage 2 — Plan
+
+1. Explore subagent: reusable pieces with `file:line` (parsers, pagination,
+   fixtures, test patterns, eval coverage mechanics). One agent unless scope
+   spans unrelated areas.
+2. Plan output sections: Context / Branch / Changes (per file, referencing the
+   found patterns) / Verification (incl. live-test items for contract
+   boundaries) / Commit-PR. Use plan mode when available; get approval.
+
+## Stage 3 — Implement (TDD)
+
+Follow superpowers:test-driven-development — it is the law here, not a style:
+
+- Tests first, watch them fail (RED) for the *right* reason before any
+  production code. Collection errors on missing symbols count as valid RED for
+  new modules.
+- Implement minimal code to GREEN, one plan task at a time; new `@mcp.tool`
+  needs `EXPECTED_TOOL_NAMES` + eval coverage (case or `DEFERRED` entry).
+- Dispatch bounded tasks to implementer subagents with the plan excerpt +
+  file:line references; keep cross-task integration in the main thread.
+
+## Stage 4 — Gates (all must pass before review)
+
+```bash
+uv run pytest --cov=src/mcp_server_polarion --cov=evals --cov-report=xml
+uv run ruff check . && uv run ruff format --check . && uv run mypy src/
+uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
+```
+
+Contract-boundary changes (include/fields/parse/auth or any new HTTP shape)
+additionally need a **live test** against the real server — mocks encode your
+assumptions, they cannot falsify them. Feed live findings back into fakes and
+mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
+
+## Stage 5 — Review (loop entry)
+
+1. Spawn a fresh-context reviewer subagent on the full branch diff. It gets the
+   spec + plan as context, not the implementation transcript.
+2. Findings come back severity-tagged: CRITICAL / MEDIUM / LOW / NIT, each with
+   file:line, failure scenario, and a concrete fix.
+3. **Stop criterion — the only exit:** zero CRITICAL/MEDIUM actionable
+   findings. LOW/NIT get recorded in PR notes, not necessarily fixed. When the
+   criterion holds → Stage 7.
+4. Criterion not met → Stage 6.
+
+## Stage 6 — Fix, then back to review
+
+- Apply CRITICAL/MEDIUM items; behavior changes go through RED→GREEN again,
+  never patch-and-hope.
+- Re-run Stage 4 gates, then **return to Stage 5** with a fresh reviewer pass
+  over the new diff.
+- Loop cap: after 3 review rounds with open findings, stop and escalate to the
+  user with the remaining list — grinding further usually means the spec or
+  plan is wrong, not the code.
+
+## Stage 7 — Ship
+
+- Commit: `type(scope): summary` ≤50 chars + 2-bullet body (motivation,
+  change), bullets ≤120 chars — hook enforces.
+- PR: flip template checkboxes `[ ]`→`[x]`, keep unchecked options, record
+  live-test evidence and unfixed LOW/NIT findings in Notes. Squash merge only.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|---|---|
+| "Small feature, skip the spec" | Spec took 10 min for list_test_records and caught a missing-Lucene-support surprise before any code existed. |
+| "I'll run tests after implementing" | A test that never failed proves nothing. RED first is the whole point. |
+| "Mocks cover it, skip the live test" | Live run found bare-GUID user ids and a missing `meta.totalCount` that no mock predicted. |
+| "Review myself in-context, faster" | The implementer's context contains its own justifications. Fresh context finds what you rationalized. |
+| "One more fix round, no re-review" | Fixes are new code; new code gets reviewed. That's why the loop exists. |
+| "Subagent for the gate commands too" | Gates are deterministic bash. A subagent burns tokens to relay an exit code. |
+| "Opus everywhere to be safe" | Model choice is a cost/judgment trade-off; the table exists because sonnet ships code volume fine and opus earns its cost only on judgment stages. |
+
+## Red Flags
+
+- Production code written before its failing test exists.
+- Reviewer subagent given the implementation transcript (context bleed).
+- Review round 4+ still producing MEDIUM findings — escalate, don't grind.
+- `git worktree add` or bare `git stash` in a session that has native tools.
+- Branch named `feature/…` (hook rejects) or commit bullets over 120 chars.
+- Findings "fixed" without gates re-run before re-review.
+
+## Verification (pipeline exit checklist)
+
+- [ ] Worktree isolated, branch `<type>/<kebab>`, baseline was green at start
+- [ ] Spec and plan each got explicit user approval before the next stage
+- [ ] Every new behavior has a test that was seen failing first
+- [ ] All four gate commands pass; diff-cover ≥90% on changed lines
+- [ ] Live test done for contract-boundary changes, findings folded into mocks
+- [ ] Final review round returned zero CRITICAL/MEDIUM findings
+- [ ] PR open with template filled, LOW/NIT + live evidence recorded

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -9,7 +9,7 @@ Encode the sequence that shipped `list_test_records` (PR #170): worktree → spe
 plan → TDD implement → gates → review loop → ship. Main session is the
 **orchestrator**: it sequences stages, holds user approvals, spawns the stage
 agents, and merges their reports. Subagents never spawn other subagents
-(platform constraint, and paraphrase hops lose information).
+(hard rule here — every paraphrase hop loses information).
 
 ```
  0.Worktree → 1.Spec →(approve)→ 2.Plan →(approve)→ 3.Implement(TDD) → 4.Gates
@@ -181,7 +181,8 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 - [ ] Worktree isolated, branch `<type>/<kebab>`, baseline was green at start
 - [ ] Spec and plan each got explicit user approval, then landed in `.pipeline/`
 - [ ] Every implementer report carried RED-then-GREEN evidence
-- [ ] All four gate commands pass; diff-cover ≥90% on changed lines
+- [ ] All five gate commands pass (pytest, ruff check, ruff format --check,
+      mypy, diff-cover); diff-cover ≥90% on changed lines
 - [ ] Live test done for contract-boundary changes, findings folded into mocks
 - [ ] Final `pipeline-reviewer` verdict is PASS (zero CRITICAL/MEDIUM)
 - [ ] PR open with template filled, LOW/NIT + live evidence recorded

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,10 @@ evals/reports/
 !.claude/settings.json
 .mcp.json
 
+# dev-pipeline handoff artifacts (spec/plan/review rounds)
+.pipeline/
+
 # Editor / OS
 .vscode/*
 .DS_Store
 Thumbs.db
-.pipeline/

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ evals/reports/
 
 # Claude / MCP configuration
 .claude/*
+!.claude/agents/
 !.claude/skills/
 !.claude/hooks/
 !.claude/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ evals/reports/
 .vscode/*
 .DS_Store
 Thumbs.db
+.pipeline/


### PR DESCRIPTION
## Summary

Adds `.claude/skills/dev-pipeline/SKILL.md` plus four project subagent definitions in `.claude/agents/` — encoding the full feature-development sequence proven on `list_test_records` (PR #170): worktree → spec → plan → TDD implement → gates → review loop → ship. Anatomy follows [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills): skill = *how* (workflow with invoke points), agents = *who* (role + fixed report format + composition block), orchestrator = main session.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Repo lacked reusable recipe for the worktree-to-ship sequence proven on list_test_records (PR #170)
- Add dev-pipeline skill with per-stage invoke points and 4 subagent definitions carrying fixed report contracts

## Testing

- Structural validation: YAML frontmatter parses for all 5 files, names match, descriptions <1024 chars, SKILL.md 188 lines (<500).
- No behavioral eval run — one skill invocation = one full feature development; the meaningful trial is the next real feature.

## Notes for Reviewers

- Data handoff is explicit: prompt in / fixed-format report out / `.pipeline/` files (spec.md, plan.md, review-round-N.md) as the durable channel; `.pipeline/` is gitignored.
- Reviewer isolation is a hard rule: `pipeline-reviewer` gets spec + plan + diff, never implementer reports (context-bleed defeats fresh eyes).
- Stage→model table: sonnet for volume (research/scout/implement), opus for judgment (plan design/review), no subagent for deterministic gates; `model` param on the Agent call overrides per escalation rule.
- `.gitignore`: added `!.claude/agents/` whitelist (agents were silently ignored by `.claude/*`) and `.pipeline/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)