### PR TITLE
feat(documents): expose created in get_document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
   - Synthesis (READ-ONLY): `read_*` convert HTML→Markdown; feed output back to writes lose Polarion markup.
 - Write payloads skip `None`/empty (Polarion read empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
 - Every list tool: `page_size` (max 100) + `page_number` → `PaginatedResult[T]` with `has_more`.
-- Timestamps (where Polarion serve both): `list_*` summary = `updated` only; `get_*`/`read_*` detail add `created`. Domain without `get_*` tool: list expose what API serve (comments `created`-only). API without timestamps: omit.
+- Timestamps (where Polarion serve both): `list_*` summary = `updated` only; metadata-bearing `get_*`/`read_*` detail add `created` (read_document body-only synthesis — exempt). Domain without `get_*` tool: list expose what API serve (comments `created`-only). API without timestamps: omit.
 - Every write tool: `dry_run: bool = False` — return payload, no hit Polarion.
 - Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`.
 - Guards fail closed: validation GET error block write; only successful empty option set defer to Polarion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
   - Synthesis (READ-ONLY): `read_*` convert HTML→Markdown; feed output back to writes lose Polarion markup.
 - Write payloads skip `None`/empty (Polarion read empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
 - Every list tool: `page_size` (max 100) + `page_number` → `PaginatedResult[T]` with `has_more`.
+- Timestamps (where Polarion serve both): `list_*` summary = `updated` only; `get_*`/`read_*` detail add `created`. Domain without `get_*` tool: list expose what API serve (comments `created`-only). API without timestamps: omit.
 - Every write tool: `dry_run: bool = False` — return payload, no hit Polarion.
 - Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`.
 - Guards fail closed: validation GET error block write; only successful empty option set defer to Polarion.

--- a/src/mcp_server_polarion/models/documents.py
+++ b/src/mcp_server_polarion/models/documents.py
@@ -26,6 +26,7 @@ class DocumentDetail(BaseModel):
     title: str
     type: str = ""
     status: str = ""
+    created: str = ""
     updated: str = ""
     author_id: str = ""
     author_name: str = ""

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -622,7 +622,7 @@ async def get_document(
         description="Fill content_html with raw HTML for round-trip editing.",
     ),
 ) -> DocumentDetail:
-    """Get a document's metadata: title/type/status/editors/custom fields.
+    """Get a document's metadata: title/type/status/created/editors/custom fields.
 
     include_homepage_content_html=True fills content_html with raw
     homePageContent HTML — the required source for
@@ -687,6 +687,7 @@ async def get_document(
         title=safe_str(attributes.get("title", "")),
         type=safe_str(attributes.get("type", "")),
         status=safe_str(attributes.get("status", "")),
+        created=safe_str(attributes.get("created", "")),
         updated=safe_str(attributes.get("updated", "")),
         author_id=extract_short_id(author_full),
         author_name=user_names.get(author_full, ""),

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -622,7 +622,7 @@ async def get_document(
         description="Fill content_html with raw HTML for round-trip editing.",
     ),
 ) -> DocumentDetail:
-    """Get a document's metadata: title/type/status/created/editors/custom fields.
+    """Get a document's metadata: title/type/status/timestamps/editors/custom fields.
 
     include_homepage_content_html=True fills content_html with raw
     homePageContent HTML — the required source for

--- a/tests/mcp_server_polarion/models/test_documents.py
+++ b/tests/mcp_server_polarion/models/test_documents.py
@@ -44,6 +44,7 @@ class TestDocumentDetail:
 
     def test_editor_metadata_defaults_empty(self):
         d = DocumentDetail(title="Doc")
+        assert d.created == ""
         assert d.updated == ""
         assert d.author_id == ""
         assert d.author_name == ""

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -648,6 +648,7 @@ class TestGetDocument:
                     "title": "Software Requirement Spec",
                     "type": "req_specification",
                     "status": "approved",
+                    "created": "2025-11-30T09:00:00.000Z",
                     "updated": "2026-02-22T14:53:03.244Z",
                     "homePageContent": {
                         "type": "text/html",
@@ -677,6 +678,8 @@ class TestGetDocument:
         assert result.title == "Software Requirement Spec"
         assert result.type == "req_specification"
         assert result.status == "approved"
+        # get_* expose created; list_* summaries stay updated-only.
+        assert result.created == "2025-11-30T09:00:00.000Z"
         assert result.updated == "2026-02-22T14:53:03.244Z"
         # Editor id + name pair both surface for requery and intent matching.
         assert result.author_id == "admin"
@@ -706,6 +709,7 @@ class TestGetDocument:
             document_name="Doc",
         )
 
+        assert result.created == ""
         assert result.updated == ""
         assert result.author_id == ""
         assert result.author_name == ""


### PR DESCRIPTION
## Summary

`DocumentDetail` was the only `get_*` detail model missing `created` — work item and test run details already carry it while `list_*` summaries stay `updated`-only. This PR closes that gap and codifies the timestamp principle in CLAUDE.md so future tools follow it.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- get_*/list_* timestamp asymmetry held everywhere except get_document; DocumentDetail lacked created
- Add DocumentDetail.created parsed from attributes.created; document the conditional timestamp rule in CLAUDE.md

## Testing

- TDD: new assertions failed first (`'DocumentDetail' object has no attribute 'created'`), then went green
- Full suite 1694 passed; ruff check/format, mypy clean; diff-cover 100% on changed lines
- Live verification blocked: testdrive token now returns 403 on all REST calls. Contract risk is low — `created` is already listed in `STANDARD_DOCUMENT_ATTRIBUTES` (observed standard attribute) and `get_document` requests `fields[documents]=@all`, so no request change was needed

## Notes for Reviewers

- Comments/test-records/links/projects intentionally out of rule scope (no get_* tool or no timestamps in API) — covered by the CLAUDE.md wording
- get_document docstring metadata enumeration updated to include created (no docstring contract test locks this phrase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)