### PR TITLE
chore(deps): bump click 8.3.1 to 8.4.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -439,14 +439,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`security-scan / audit` fails on every open PR: `click 8.3.1` carries PYSEC-2026-2132 (High, CVSS 7.2), fixed in 8.3.3. Lockfile-only bump to 8.4.2 unblocks the audit gate (currently blocking #173).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- click 8.3.1 flagged by PYSEC-2026-2132 (High); security-scan audit gate red on all PRs until fixed
- `uv lock --upgrade-package click` — lockfile bump to 8.4.2, no source changes

## Testing

- Full suite 1694 passed after `uv sync` on the new lock; ruff check and mypy clean
- CI audit job re-scans `runtime-requirements.txt` exported from this lock — expected green

## Notes for Reviewers

- Transitive pin only (click is not a direct dependency); rebase/re-run #173 after this merges to clear its audit failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)