### PR TITLE
test(readme): sync tool tables with registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
 
 - `tests/` mirror source one-to-one; shared fixtures in `tests/` `conftest.py`; `mock_client`/`mock_ctx` + autouse guard-cache reset in `tools/conftest.py`.
 - `pytest-asyncio` `mode=auto`. Tool tests call functions directly (`@mcp.tool` return original); client tests use `respx`. Pydantic `Field` constraints bypass JSON Schema on direct call — verify via `TypeAdapter` reconstruction.
-- New `@mcp.tool` needs update `EXPECTED_TOOL_NAMES` in `test_mcp_transport.py`.
+- New `@mcp.tool` needs update `EXPECTED_TOOL_NAMES` in `test_mcp_transport.py` + README tool-table row (marker-anchored sync test, same file).
 - `tests/evals/` open with `pytest.importorskip` (`evals` group; CI sync `--group evals`).
 
 ## Evals — deploy gate

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Other clients (VS Code, Claude Desktop, Cursor) — see [Client Configuration](#
 
 ### Read
 
+<!-- tool-table:read:start -->
 | Tool | Description |
 |---|---|
 | `list_projects` | List accessible projects |
@@ -68,11 +69,13 @@ Other clients (VS Code, Claude Desktop, Cursor) — see [Client Configuration](#
 | `list_work_item_comments` | List a work item's comments with thread relationships |
 | `list_document_enum_options` | Resolve valid enum ids for a document field |
 | `list_work_item_enum_options` | Resolve valid enum ids for a work item field |
+<!-- tool-table:read:end -->
 
 All list tools support pagination via `page_size` (1–100) and `page_number` parameters.
 
 ### Write
 
+<!-- tool-table:write:start -->
 | Tool | Description |
 |---|---|
 | `create_work_items` | Create one or more work items in a single request |
@@ -91,6 +94,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | `create_work_item_comments` | Add one or more comments or replies to a work item |
 | `update_document_comment` | Resolve or re-open a document comment |
 | `update_work_item_comment` | Resolve or re-open a work item comment |
+<!-- tool-table:write:end -->
 
 ## Example Prompts
 

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -402,7 +402,8 @@ class TestEndToEndInvocation:
 
 _README_PATH = Path(__file__).parents[2] / "README.md"
 # First-column backtick name only — description prose may cite tool names.
-_TOOL_ROW_RE = re.compile(r"^\| `([a-z_]+)` \|", re.MULTILINE)
+# \s* tolerate column-align padding; digits allowed in future tool names.
+_TOOL_ROW_RE = re.compile(r"^\|\s*`([a-z0-9_]+)`\s*\|", re.MULTILINE)
 
 
 def _readme_table_names(section: str) -> set[str]:
@@ -414,7 +415,11 @@ def _readme_table_names(section: str) -> set[str]:
     assert readme.count(start) == 1, f"README marker {start!r} missing or duplicated"
     assert readme.count(end) == 1, f"README marker {end!r} missing or duplicated"
     block = readme.split(start, 1)[1].split(end, 1)[0]
-    return set(_TOOL_ROW_RE.findall(block))
+    names = _TOOL_ROW_RE.findall(block)
+    # Set-equality alone hide duplicated row — catch before dedup.
+    dupes = sorted({n for n in names if names.count(n) > 1})
+    assert not dupes, f"README {section} tool table duplicate rows: {dupes}"
+    return set(names)
 
 
 class TestReadmeToolTable:

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -5,7 +5,9 @@ direct-call tool tests bypass.
 
 from __future__ import annotations
 
+import re
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 import httpx
 import pytest
@@ -396,3 +398,42 @@ class TestEndToEndInvocation:
         assert result.data.dry_run is True
         assert result.data.work_item_ids == []
         assert result.data.payload_preview is not None
+
+
+_README_PATH = Path(__file__).parents[2] / "README.md"
+# First-column backtick name only — description prose may cite tool names.
+_TOOL_ROW_RE = re.compile(r"^\| `([a-z_]+)` \|", re.MULTILINE)
+
+
+def _readme_table_names(section: str) -> set[str]:
+    """Tool names inside README marker-fenced table block."""
+    readme = _README_PATH.read_text(encoding="utf-8")
+    start = f"<!-- tool-table:{section}:start -->"
+    end = f"<!-- tool-table:{section}:end -->"
+    # Marker anchor, not heading — README prose free to restructure.
+    assert readme.count(start) == 1, f"README marker {start!r} missing or duplicated"
+    assert readme.count(end) == 1, f"README marker {end!r} missing or duplicated"
+    block = readme.split(start, 1)[1].split(end, 1)[0]
+    return set(_TOOL_ROW_RE.findall(block))
+
+
+class TestReadmeToolTable:
+    """README tool tables sync with registration — set equality per table."""
+
+    @pytest.mark.parametrize(
+        ("section", "expected"),
+        [
+            pytest.param("read", _READ_TOOL_NAMES, id="read"),
+            pytest.param("write", _WRITE_TOOL_NAMES, id="write"),
+        ],
+    )
+    def test_table_matches_registration(
+        self, section: str, expected: frozenset[str]
+    ) -> None:
+        actual = _readme_table_names(section)
+        missing = sorted(expected - actual)
+        stale = sorted(actual - expected)
+        assert not missing and not stale, (
+            f"README {section} tool table out of sync — "
+            f"add rows for {missing}; drop stale rows {stale}"
+        )


### PR DESCRIPTION
## Summary

README tool tables drifted silently when tools were added or removed — no gate caught missing or stale rows. This PR fences both README tables with HTML comment markers and adds a marker-anchored sync test asserting set equality against the registered tool names in `test_mcp_transport.py`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- README tool rows drift silent on tool add/remove; no gate caught missing or stale rows
- Marker-anchored set-equality test per read/write table; duplicate-row guard; CLAUDE.md note

## Testing

- `uv run pytest` — 1696 passed, 11 skipped
- `ruff check` / `ruff format --check` clean; diff-cover gate n/a (test/doc-only diff)
- Sync test verified both directions: fails loud on missing row, stale row, duplicate row, or missing/duplicated marker

## Notes for Reviewers

Row regex tolerates column-align padding and digits in tool names; description text is intentionally not asserted — only name presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)