### PR TITLE
docs(skill): add CI watch and fetch-first steps

### DIFF
--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -163,6 +163,8 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 - CI: after opening the PR, `gh pr checks <PR#> --watch --fail-fast` until
   every check is green — merge is blocked on red anyway, but an unwatched red
   PR rots until a human notices; catch it while the session context is hot.
+  Right after `gh pr create` it can exit "no checks reported" before check
+  runs register — wait a few seconds and rerun, don't skip the watch.
   A red check is a Stage 4 gate failure, not a review finding: fix, re-run
   gates, and if code changed re-enter Stage 5. Protection is strict-mode, so
   if main moved, update the branch and let checks re-run.
@@ -203,4 +205,5 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 - [ ] Live test done for contract-boundary changes, findings folded into mocks
 - [ ] Final `pipeline-reviewer` verdict is PASS (zero CRITICAL/MEDIUM)
 - [ ] PR open with template filled, LOW/NIT + live evidence recorded
-- [ ] PR CI checks all green (`gh pr checks`), branch up to date with main
+- [ ] PR CI checks all green (`gh pr checks <PR#> --watch --fail-fast`),
+      branch up to date with main

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -156,6 +156,12 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
   change), bullets ≤120 chars — hook enforces. `.pipeline/` stays uncommitted.
 - PR: flip template checkboxes `[ ]`→`[x]`, keep unchecked options, record
   live-test evidence and unfixed LOW/NIT findings in Notes. Squash merge only.
+- CI: after opening the PR, `gh pr checks <PR#> --watch --fail-fast` until
+  every check is green — merge is blocked on red anyway, but an unwatched red
+  PR rots until a human notices; catch it while the session context is hot.
+  A red check is a Stage 4 gate failure, not a review finding: fix, re-run
+  gates, and if code changed re-enter Stage 5. Protection is strict-mode, so
+  if main moved, update the branch and let checks re-run.
 
 ## Common Rationalizations
 
@@ -193,3 +199,4 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 - [ ] Live test done for contract-boundary changes, findings folded into mocks
 - [ ] Final `pipeline-reviewer` verdict is PASS (zero CRITICAL/MEDIUM)
 - [ ] PR open with template filled, LOW/NIT + live evidence recorded
+- [ ] PR CI checks all green (`gh pr checks`), branch up to date with main

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -62,15 +62,19 @@ sequentially, in one Agent call each.
 
 ## Stage 0 — Worktree (main thread)
 
-1. `EnterWorktree` (never bare `git worktree add` — native tool tracks cleanup).
-2. Rename the generated branch to `<type>/<kebab-summary>` — pre-push hook
+1. `git fetch origin` first — EnterWorktree branches from `origin/main`
+   (default `worktree.baseRef: fresh`), a remote-tracking ref that moves only
+   on fetch; skip this and parallel sessions branch from a stale base, hitting
+   conflicts and strict-mode update-branch churn at merge time.
+2. `EnterWorktree` (never bare `git worktree add` — native tool tracks cleanup).
+3. Rename the generated branch to `<type>/<kebab-summary>` — pre-push hook
    accepts only `feat|fix|refactor|test|docs|chore|ci` prefixes (`feat/`, not
    `feature/`).
-3. Symlink untracked configs from the main checkout: `.env`, `.mcp.json`,
+4. Symlink untracked configs from the main checkout: `.env`, `.mcp.json`,
    `.claude/settings.local.json`, `.vscode/settings.json`.
-4. `uv sync --dev --group evals`, then baseline `uv run pytest` — must be green
+5. `uv sync --dev --group evals`, then baseline `uv run pytest` — must be green
    before any change, else you can't tell new breakage from old.
-5. `mkdir -p .pipeline` for the handoff files.
+6. `mkdir -p .pipeline` for the handoff files.
 
 ## Stage 1 — Spec
 


### PR DESCRIPTION
## Summary

Two gap fixes in the dev-pipeline skill. Stage 7 previously ended at PR creation without consuming CI results — a red check would only surface as a blocked merge, left for a human to notice outside the session. Stage 0 created worktrees from `origin/main` without fetching first — a remote-tracking ref that moves only on fetch, so parallel sessions branched from a stale base.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Pipeline ended at PR open with CI unconsumed, and worktrees branched from stale origin/main in parallel sessions.
- Add gh pr checks --watch to Stage 7 and exit checklist; add git fetch origin as Stage 0 step 1.

## Testing

Docs-only change (skill markdown). Verified against this repo's branch protection: required checks are `check`, `security-scan / scan`, `security-scan / audit`, `CodeQL` with strict mode, so `gh pr checks --watch --fail-fast` covers all of them. Confirmed EnterWorktree's default `worktree.baseRef: fresh` branches from `origin/main` and no settings file overrides it.

## Notes for Reviewers

A red check is deliberately routed to the Stage 4 gate-failure path (fix → gates → re-review if code changed), not treated as a review finding — keeps the reviewer's input contract (spec + plan + diff) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)