### PR TITLE
feat(test-runs): add create_test_records tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ All list tools support pagination via `page_size` (1–100) and `page_number` pa
 | `update_document` | Update document metadata, body, or workflow status |
 | `copy_document` | Copy a document to a new name, space, or project |
 | `create_test_runs` | Create one or more test runs, optionally from a template |
+| `create_test_records` | Record test-case execution results on a test run |
 | `update_test_runs` | Update title, status, group, or custom fields on one or more test runs |
 | `create_work_item_links` | Create one or more outgoing links from a source work item |
 | `update_work_item_link` | Update `suspect` / `revision` on one outgoing link |

--- a/evals/cases/triggers.py
+++ b/evals/cases/triggers.py
@@ -18,6 +18,7 @@ from evals.harness.fixtures import (
     PROJECT,
     SPACE,
     TEST_RUN_ID,
+    TESTCASE_ID,
 )
 
 MIN_PASS_RATE = 1.0
@@ -225,5 +226,17 @@ CASES: list[Case] = [
         covers=["create_test_runs"],
         expect="create_test_runs",
         reject=["create_work_items"],
+    ),
+    _case(
+        "TRIG-CREATE-TEST-RECORDS",
+        f"Record that test case '{TESTCASE_ID}' passed in test run "
+        f"'{TEST_RUN_ID}' of project '{PROJECT}'.",
+        "triggers_tool",
+        intent="Recording a test-case execution result must call "
+        "create_test_records, not update_test_runs (run metadata) or "
+        "create_work_items.",
+        covers=["create_test_records"],
+        expect="create_test_records",
+        reject=["update_test_runs", "create_work_items"],
     ),
 ]

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -24,6 +24,7 @@ from .fixtures import (
     PROJECT,
     SEEDS,
     SPACE,
+    TEST_RUN_ID,
     TESTCASE_ID,
     TS,
     Comment,
@@ -564,6 +565,53 @@ class FakePolarion:
                         "data": [
                             {"type": "workitems", "id": f"{PROJECT}/MCPT-{9001 + i}"}
                             for i in range(submitted)
+                        ]
+                    },
+                )
+            if path.endswith("/testrecords"):
+                # Live-verified: server compose 5-segment id run/testCase/iter;
+                # unknown testCase 400, no client-set record id. Iteration 0
+                # enough — tool reject batch duplicate testCase client-side.
+                run_match = re.search(r"/testruns/([^/]+)/testrecords$", path)
+                run_id = run_match.group(1) if run_match else TEST_RUN_ID
+                record_ids: list[str] = []
+                entries = (
+                    body["data"]
+                    if isinstance(body, dict) and isinstance(body.get("data"), list)
+                    else []
+                )
+                for entry in entries:
+                    rels = (
+                        entry.get("relationships") if isinstance(entry, dict) else None
+                    )
+                    tc_rel = rels.get("testCase") if isinstance(rels, dict) else None
+                    tc_data = tc_rel.get("data") if isinstance(tc_rel, dict) else None
+                    tc_id = (
+                        str(tc_data.get("id") or "")
+                        if isinstance(tc_data, dict)
+                        else ""
+                    )
+                    tc_short = tc_id.rsplit("/", 1)[-1]
+                    if tc_short not in self.seeds.work_items:
+                        return httpx.Response(
+                            400,
+                            json={
+                                "errors": [
+                                    {
+                                        "status": "400",
+                                        "title": "Bad Request",
+                                        "detail": "Test Case is missing, or the "
+                                        "one specified is invalid.",
+                                    }
+                                ]
+                            },
+                        )
+                    record_ids.append(f"{PROJECT}/{run_id}/{tc_id}/0")
+                return httpx.Response(
+                    201,
+                    json={
+                        "data": [
+                            {"type": "testrecords", "id": rid} for rid in record_ids
                         ]
                     },
                 )

--- a/evals/harness/fixtures.py
+++ b/evals/harness/fixtures.py
@@ -289,5 +289,6 @@ SEEDS = Seeds(
         "workitem-link-role": ["relates_to", "parent", "satisfies", "verifies"],
         "testing/testrun-type": ["manual", "automated"],
         "testing/testrun-status": ["open", "inProgress", "finished"],
+        "testing/test-result": ["passed", "failed", "blocked"],
     },
 )

--- a/src/mcp_server_polarion/models/__init__.py
+++ b/src/mcp_server_polarion/models/__init__.py
@@ -42,6 +42,8 @@ from mcp_server_polarion.models.recipes import (
     SqlRecipeGallery,
 )
 from mcp_server_polarion.models.test_runs import (
+    TestRecordCreateSpec,
+    TestRecordsCreateResult,
     TestRecordSummary,
     TestRunCreateSpec,
     TestRunDetail,
@@ -82,7 +84,9 @@ __all__: list[str] = [
     "PaginatedResult",
     "ProjectSummary",
     "SqlRecipeGallery",
+    "TestRecordCreateSpec",
     "TestRecordSummary",
+    "TestRecordsCreateResult",
     "TestRunCreateSpec",
     "TestRunDetail",
     "TestRunSummary",

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -22,6 +23,43 @@ class TestRecordSummary(BaseModel):
     duration: float = 0.0
     executed_by_name: str = ""
     defect_id: str = ""
+
+
+class TestRecordCreateSpec(BaseModel):
+    """One test record to create via create_test_records."""
+
+    __test__ = False
+
+    # LLM input model: reject typo keys, not silent-drop.
+    model_config = ConfigDict(extra="forbid")
+
+    test_case_id: str = Field(
+        min_length=1,
+        description=(
+            "'WorkItemId' or 'ProjectId/WorkItemId'; bare id qualified with "
+            "the tool's project_id."
+        ),
+    )
+    result: str | None = None
+    comment: str | None = None
+    comment_format: Literal["text/html", "text/plain"] = "text/plain"
+    defect_id: str | None = Field(
+        default=None,
+        description=(
+            "'WorkItemId' or 'ProjectId/WorkItemId', qualified like test_case_id."
+        ),
+    )
+
+
+class TestRecordsCreateResult(BaseModel):
+    """``create_test_records`` result."""
+
+    __test__ = False
+
+    created: bool
+    dry_run: bool
+    record_ids: list[str] = Field(default_factory=list)
+    payload_preview: Mapping[str, object] | None = None
 
 
 class TestRunSummary(BaseModel):

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -158,6 +158,29 @@ def store_cached_project_enum(
     _project_enum_cache.set((project_id, enum_name), option_ids)
 
 
+# (project, work_item_id) -> True once confirmed existing. Positives only --
+# a missing WI may be created later, so absence never cache as a negative.
+_confirmed_work_item_cache: TTLCache[tuple[str, str], bool] = TTLCache(
+    _GUARD_TTL_SECONDS
+)
+
+
+def get_cached_confirmed_work_item(project_id: str, work_item_id: str) -> bool | None:
+    """``True`` if ``(project, work_item)`` confirmed existing, else
+    ``None`` -- ``None`` also cover expired/never-checked, both treated
+    as a cache miss by callers.
+    """
+    return _confirmed_work_item_cache.get((project_id, work_item_id))
+
+
+def store_cached_confirmed_work_item(project_id: str, work_item_id: str) -> None:
+    """Mark ``(project, work_item)`` confirmed existing for
+    ``_GUARD_TTL_SECONDS`` -- partial batches merge naturally since each
+    id is its own entry.
+    """
+    _confirmed_work_item_cache.set((project_id, work_item_id), True)
+
+
 # (project, work_item_type) -> full custom-field key schema (MIN-per-key sample).
 _work_item_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
     _GUARD_TTL_SECONDS
@@ -243,6 +266,7 @@ __all__ = [
     "DiscoveredDocument",
     "Resource",
     "TTLCache",
+    "get_cached_confirmed_work_item",
     "get_cached_documents",
     "get_cached_enum_options",
     "get_cached_project_enum",
@@ -253,6 +277,7 @@ __all__ = [
     "invalidate_documents_cache",
     "invalidate_test_run_custom_keys",
     "invalidate_work_item_custom_keys",
+    "store_cached_confirmed_work_item",
     "store_cached_documents",
     "store_cached_enum_options",
     "store_cached_project_enum",

--- a/src/mcp_server_polarion/tools/_shared/guard/__init__.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/__init__.py
@@ -21,6 +21,10 @@ from mcp_server_polarion.tools._shared.guard.links import (
     guard_work_item_link_targets,
     partition_delete_links,
 )
+from mcp_server_polarion.tools._shared.guard.test_records import (
+    guard_test_record_defect_targets,
+    guard_test_record_results,
+)
 from mcp_server_polarion.tools._shared.guard.test_runs import (
     guard_test_run_custom_fields,
     guard_test_run_enums,
@@ -36,6 +40,8 @@ __all__ = [
     "guard_document_custom_fields",
     "guard_document_enums",
     "guard_hyperlink_roles",
+    "guard_test_record_defect_targets",
+    "guard_test_record_results",
     "guard_test_run_custom_fields",
     "guard_test_run_enums",
     "guard_test_run_templates",

--- a/src/mcp_server_polarion/tools/_shared/guard/_targets.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/_targets.py
@@ -1,0 +1,79 @@
+"""Work-item target existence shared by write guards (link targets,
+test-record defects): chunked ``id:(...)`` queries + confirmed-positive
+cache. Polarion never validate relationship targets -- nonexistent id
+store as silent dangling reference (HTTP 201).
+"""
+
+from __future__ import annotations
+
+from mcp_server_polarion.core.client import PolarionClient
+from mcp_server_polarion.core.exceptions import PolarionNotFoundError
+from mcp_server_polarion.tools._shared.cache import (
+    get_cached_confirmed_work_item,
+    store_cached_confirmed_work_item,
+)
+from mcp_server_polarion.tools._shared.guard._http import (
+    GUARD_PAGE_SIZE,
+    guarded_get,
+)
+from mcp_server_polarion.tools._shared.helpers import encode_path_segment, safe_str
+from mcp_server_polarion.tools._shared.parse import extract_short_id
+
+
+async def existing_target_ids(
+    client: PolarionClient,
+    project_id: str,
+    target_ids: frozenset[str],
+) -> frozenset[str]:
+    """Subset of *target_ids* existing in *project_id*, via chunked
+    ``id:(...)`` queries. 404 (project missing) propagate to caller;
+    auth/other failures translate fail-closed.
+    """
+    ordered = sorted(target_ids)
+    found: set[str] = set()
+    for start in range(0, len(ordered), GUARD_PAGE_SIZE):
+        chunk = ordered[start : start + GUARD_PAGE_SIZE]
+        params: dict[str, str | int] = {
+            "query": f"id:({' '.join(chunk)})",
+            "fields[workitems]": "id",
+            "page[size]": GUARD_PAGE_SIZE,
+            "page[number]": 1,
+        }
+        path = f"/projects/{encode_path_segment(project_id)}/workitems"
+        response = await guarded_get(
+            client, path, params, what="link targets", project_id=project_id
+        )
+        data = response.get("data", [])
+        if isinstance(data, list):
+            for entry in data:
+                if isinstance(entry, dict):
+                    found.add(extract_short_id(safe_str(entry.get("id", ""))))
+    return frozenset(found)
+
+
+async def missing_work_item_targets(
+    client: PolarionClient,
+    by_project: dict[str, set[str]],
+) -> list[str]:
+    """``"Proj/WI"`` ids from *by_project* not existing in Polarion.
+    Confirmed-existing ids cache across calls (server-load requirement) --
+    never negatives, a missing WI may be created later. Only cache misses
+    reach Polarion, grouped one ``id:(...)`` query per project.
+    Project-level 404 = whole group missing (fail closed).
+    """
+    missing: list[str] = []
+    for proj, requested in by_project.items():
+        to_query = {
+            wi for wi in requested if get_cached_confirmed_work_item(proj, wi) is None
+        }
+        if not to_query:
+            continue
+        try:
+            existing = await existing_target_ids(client, proj, frozenset(to_query))
+        except PolarionNotFoundError:
+            missing.extend(f"{proj}/{wi}" for wi in sorted(to_query))
+            continue
+        for wi in existing:
+            store_cached_confirmed_work_item(proj, wi)
+        missing.extend(f"{proj}/{wi}" for wi in sorted(to_query - existing))
+    return missing

--- a/src/mcp_server_polarion/tools/_shared/guard/links.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/links.py
@@ -12,18 +12,13 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import WorkItemLinkSpec
-from mcp_server_polarion.tools._shared.guard._http import (
-    GUARD_PAGE_SIZE,
-    guarded_get,
-    paged_responses,
-)
+from mcp_server_polarion.tools._shared.guard._http import paged_responses
+from mcp_server_polarion.tools._shared.guard._targets import missing_work_item_targets
 from mcp_server_polarion.tools._shared.guard.enums import check_project_enum_roles
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     format_option_list,
-    safe_str,
 )
-from mcp_server_polarion.tools._shared.parse import extract_short_id
 
 logger = logging.getLogger("mcp_server_polarion.tools._shared.guard.links")
 
@@ -69,37 +64,6 @@ async def guard_hyperlink_roles(
     )
 
 
-async def _existing_target_ids(
-    client: PolarionClient,
-    project_id: str,
-    target_ids: frozenset[str],
-) -> frozenset[str]:
-    """Subset of *target_ids* existing in *project_id*, via chunked
-    ``id:(...)`` queries. 404 (project missing) propagate to caller;
-    auth/other failures translate fail-closed.
-    """
-    ordered = sorted(target_ids)
-    found: set[str] = set()
-    for start in range(0, len(ordered), GUARD_PAGE_SIZE):
-        chunk = ordered[start : start + GUARD_PAGE_SIZE]
-        params: dict[str, str | int] = {
-            "query": f"id:({' '.join(chunk)})",
-            "fields[workitems]": "id",
-            "page[size]": GUARD_PAGE_SIZE,
-            "page[number]": 1,
-        }
-        path = f"/projects/{encode_path_segment(project_id)}/workitems"
-        response = await guarded_get(
-            client, path, params, what="link targets", project_id=project_id
-        )
-        data = response.get("data", [])
-        if isinstance(data, list):
-            for entry in data:
-                if isinstance(entry, dict):
-                    found.add(extract_short_id(safe_str(entry.get("id", ""))))
-    return frozenset(found)
-
-
 async def guard_work_item_link_targets(
     client: PolarionClient,
     source_project_id: str,
@@ -107,24 +71,15 @@ async def guard_work_item_link_targets(
 ) -> None:
     """Reject links whose target work item not exist — Polarion store
     nonexistent target as silent dangling link (HTTP 201, empty
-    title/type/status). One ``id:(...)`` query per target project.
+    title/type/status). Confirmed targets cache across calls; only cache
+    misses reach Polarion, one ``id:(...)`` query per target project.
     """
     by_project: dict[str, set[str]] = {}
     for spec in links:
         target_project = spec.target_project_id or source_project_id
         by_project.setdefault(target_project, set()).add(spec.target_work_item_id)
 
-    missing: list[str] = []
-    for project_id, requested in by_project.items():
-        try:
-            existing = await _existing_target_ids(
-                client, project_id, frozenset(requested)
-            )
-        except PolarionNotFoundError:
-            missing.extend(f"{project_id}/{wi}" for wi in sorted(requested))
-            continue
-        missing.extend(f"{project_id}/{wi}" for wi in sorted(requested - existing))
-
+    missing = await missing_work_item_targets(client, by_project)
     if missing:
         raise ValueError(
             f"Link target work item(s) {format_option_list(missing)} do not exist. "

--- a/src/mcp_server_polarion/tools/_shared/guard/test_records.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/test_records.py
@@ -1,0 +1,82 @@
+"""Test-record write guards: ``result`` enum, defect-target existence.
+Server 201s both silently when wrong (verbatim bogus result stored;
+dangling defect id stored, WI type unchecked) -- live-verified.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from mcp_server_polarion.core.client import PolarionClient
+from mcp_server_polarion.core.exceptions import PolarionNotFoundError
+from mcp_server_polarion.tools._shared.cache import (
+    get_cached_confirmed_work_item,
+    store_cached_confirmed_work_item,
+)
+from mcp_server_polarion.tools._shared.guard.enums import check_project_enum_roles
+from mcp_server_polarion.tools._shared.guard.links import _existing_target_ids
+from mcp_server_polarion.tools._shared.helpers import format_option_list
+
+
+async def guard_test_record_results(
+    client: PolarionClient,
+    project_id: str,
+    results: Iterable[str],
+) -> None:
+    """Validate ``result`` against ``testing``-context ``test-result``
+    enum -- unknown value stores verbatim (HTTP 201), ghosting silently
+    against Lucene/UI result filters.
+    """
+    await check_project_enum_roles(
+        client,
+        project_id,
+        "test-result",
+        results,
+        field_label="result",
+        discovery_hint="use list_test_records to see values in use.",
+        context="testing",
+    )
+
+
+async def guard_test_record_defect_targets(
+    client: PolarionClient,
+    project_id: str,
+    defect_ids: Iterable[str],
+) -> None:
+    """Reject defect targets that don't exist -- Polarion silently 201s a
+    dangling defect id (HTTP 201, target WI type unchecked too, live-verified).
+    *defect_ids* = full ``"Proj/WI"`` ids (bare id falls back to *project_id*).
+    Confirmed-existing ids cache across calls (server-load requirement) --
+    never negatives, a missing WI may be created later. Only cache misses
+    reach Polarion, grouped one ``id:(...)`` query per project.
+    """
+    by_project: dict[str, set[str]] = {}
+    for defect_id in defect_ids:
+        proj, sep, wi = defect_id.partition("/")
+        if not sep:
+            proj, wi = project_id, defect_id
+        by_project.setdefault(proj, set()).add(wi)
+
+    missing: list[str] = []
+    for proj, requested in by_project.items():
+        to_query = {
+            wi for wi in requested if get_cached_confirmed_work_item(proj, wi) is None
+        }
+        if not to_query:
+            continue
+        try:
+            existing = await _existing_target_ids(client, proj, frozenset(to_query))
+        except PolarionNotFoundError:
+            missing.extend(f"{proj}/{wi}" for wi in sorted(to_query))
+            continue
+        for wi in existing:
+            store_cached_confirmed_work_item(proj, wi)
+        missing.extend(f"{proj}/{wi}" for wi in sorted(to_query - existing))
+
+    if missing:
+        raise ValueError(
+            f"Defect target work item(s) {format_option_list(missing)} do not "
+            f"exist. A nonexistent target stores as a silent dangling defect "
+            f"link (HTTP 201, target type unchecked) -- use list_work_items to "
+            f"find valid target ids first."
+        )

--- a/src/mcp_server_polarion/tools/_shared/guard/test_records.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/test_records.py
@@ -8,13 +8,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from mcp_server_polarion.core.client import PolarionClient
-from mcp_server_polarion.core.exceptions import PolarionNotFoundError
-from mcp_server_polarion.tools._shared.cache import (
-    get_cached_confirmed_work_item,
-    store_cached_confirmed_work_item,
-)
+from mcp_server_polarion.tools._shared.guard._targets import missing_work_item_targets
 from mcp_server_polarion.tools._shared.guard.enums import check_project_enum_roles
-from mcp_server_polarion.tools._shared.guard.links import _existing_target_ids
 from mcp_server_polarion.tools._shared.helpers import format_option_list
 
 
@@ -46,9 +41,8 @@ async def guard_test_record_defect_targets(
     """Reject defect targets that don't exist -- Polarion silently 201s a
     dangling defect id (HTTP 201, target WI type unchecked too, live-verified).
     *defect_ids* = full ``"Proj/WI"`` ids (bare id falls back to *project_id*).
-    Confirmed-existing ids cache across calls (server-load requirement) --
-    never negatives, a missing WI may be created later. Only cache misses
-    reach Polarion, grouped one ``id:(...)`` query per project.
+    Existence + confirmed-positive caching shared via
+    :func:`missing_work_item_targets`.
     """
     by_project: dict[str, set[str]] = {}
     for defect_id in defect_ids:
@@ -57,22 +51,7 @@ async def guard_test_record_defect_targets(
             proj, wi = project_id, defect_id
         by_project.setdefault(proj, set()).add(wi)
 
-    missing: list[str] = []
-    for proj, requested in by_project.items():
-        to_query = {
-            wi for wi in requested if get_cached_confirmed_work_item(proj, wi) is None
-        }
-        if not to_query:
-            continue
-        try:
-            existing = await _existing_target_ids(client, proj, frozenset(to_query))
-        except PolarionNotFoundError:
-            missing.extend(f"{proj}/{wi}" for wi in sorted(to_query))
-            continue
-        for wi in existing:
-            store_cached_confirmed_work_item(proj, wi)
-        missing.extend(f"{proj}/{wi}" for wi in sorted(to_query - existing))
-
+    missing = await missing_work_item_targets(client, by_project)
     if missing:
         raise ValueError(
             f"Defect target work item(s) {format_option_list(missing)} do not "

--- a/src/mcp_server_polarion/tools/_shared/helpers.py
+++ b/src/mcp_server_polarion/tools/_shared/helpers.py
@@ -68,6 +68,15 @@ def encode_path_segment(segment: str) -> str:
     return quote(segment, safe="")
 
 
+def qualify_work_item_id(id_: str, project_id: str) -> str:
+    """Prefix bare work item id with *project_id*; id already carrying a
+    ``/`` (e.g. ``Proj/WI-1``) pass through verbatim.
+    """
+    if "/" in id_:
+        return id_
+    return f"{project_id}/{id_}"
+
+
 # Thin guard before Lucene substitution, not a format validator.
 _WORK_ITEM_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_-]+$")
 
@@ -116,6 +125,7 @@ __all__: list[str] = [
     "ensure_unique_ids",
     "format_option_list",
     "get_client",
+    "qualify_work_item_id",
     "reraise_with_item_context",
     "safe_float",
     "safe_str",

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -113,6 +113,24 @@ def extract_created_short_ids(response: dict[str, object]) -> list[str]:
     return ids
 
 
+def extract_created_full_ids(response: dict[str, object]) -> list[str]:
+    """Verbatim resource ids from bulk 201 response -- testrecord ids are
+    5 segments (project/testRun/testCaseProject/testCaseId/iteration);
+    ``extract_created_short_ids`` would rsplit to the bare iteration index,
+    losing test case + run context. Collect ``data[].id`` as-is, never split.
+    """
+    data = response.get("data")
+    if not isinstance(data, list):
+        return []
+    ids: list[str] = []
+    for item in data:
+        if isinstance(item, dict):
+            full_id = safe_str(item.get("id", ""))
+            if full_id:
+                ids.append(full_id)
+    return ids
+
+
 def parse_included_work_item_map(
     response: dict[str, object],
 ) -> dict[str, dict[str, object]]:
@@ -531,6 +549,7 @@ def parse_enum_option(entry: dict[str, object]) -> EnumOption:
 
 __all__: list[str] = [
     "WorkItemSummaryKwargs",
+    "extract_created_full_ids",
     "extract_created_short_ids",
     "extract_relationship_id",
     "extract_relationship_ids",

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -449,8 +449,8 @@ async def create_test_records(
         ) from exc
     except PolarionNotFoundError as exc:
         raise ValueError(
-            f"Test run '{test_run_id}' not found in project '{project_id}'. "
-            "Use `list_test_runs` to discover valid test run IDs."
+            f"Test run '{test_run_id}' or project '{project_id}' not found. "
+            "Use `list_test_runs` (or `list_projects`) to discover valid IDs."
         ) from exc
     except PolarionError as exc:
         raise RuntimeError(f"Failed to create test records: {exc.message}") from exc

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -15,6 +15,8 @@ from mcp_server_polarion.core.exceptions import (
 from mcp_server_polarion.models import (
     JsonValue,
     PaginatedResult,
+    TestRecordCreateSpec,
+    TestRecordsCreateResult,
     TestRecordSummary,
     TestRunCreateSpec,
     TestRunDetail,
@@ -35,6 +37,8 @@ from mcp_server_polarion.tools._shared.fields import (
     TEST_RUN_LIST_FIELDS,
 )
 from mcp_server_polarion.tools._shared.guard import (
+    guard_test_record_defect_targets,
+    guard_test_record_results,
     guard_test_run_custom_fields,
     guard_test_run_enums,
     guard_test_run_templates,
@@ -43,6 +47,7 @@ from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     ensure_unique_ids,
     get_client,
+    qualify_work_item_id,
     reraise_with_item_context,
 )
 from mcp_server_polarion.tools._shared.pagination import (
@@ -50,6 +55,7 @@ from mcp_server_polarion.tools._shared.pagination import (
     make_page,
 )
 from mcp_server_polarion.tools._shared.parse import (
+    extract_created_full_ids,
     extract_created_short_ids,
     parse_included_user_name_map,
     parse_test_record_summaries,
@@ -306,6 +312,161 @@ async def update_test_runs(
         updated=True,
         dry_run=False,
         test_run_ids=[spec.test_run_id for spec in items],
+        payload_preview=None,
+    )
+
+
+def _build_test_record_resource(
+    *,
+    project_id: str,
+    spec: TestRecordCreateSpec,
+) -> dict[str, JsonValue]:
+    """One ``testrecords`` resource for bulk create POST. No client-set
+    ``id`` -- server compose the 5-segment id (testCase + auto-incremented
+    iteration).
+    """
+    attributes: dict[str, JsonValue] = {}
+    if spec.result:
+        attributes["result"] = spec.result
+    if spec.comment:
+        # Verbatim passthrough, no Markdown conversion (comments pattern).
+        attributes["comment"] = {"type": spec.comment_format, "value": spec.comment}
+
+    relationships: dict[str, JsonValue] = {
+        "testCase": {
+            "data": {
+                "id": qualify_work_item_id(spec.test_case_id, project_id),
+                "type": "workitems",
+            }
+        }
+    }
+    if spec.defect_id:
+        relationships["defect"] = {
+            "data": {
+                "id": qualify_work_item_id(spec.defect_id, project_id),
+                "type": "workitems",
+            }
+        }
+
+    resource: dict[str, JsonValue] = {"type": "testrecords"}
+    if attributes:
+        resource["attributes"] = attributes
+    resource["relationships"] = relationships
+    return resource
+
+
+def _build_create_test_records_payload(
+    *,
+    project_id: str,
+    specs: list[TestRecordCreateSpec],
+) -> dict[str, JsonValue]:
+    """JSON:API body for bulk ``POST .../testruns/{tr}/testrecords``."""
+    data: list[JsonValue] = [
+        _build_test_record_resource(project_id=project_id, spec=spec) for spec in specs
+    ]
+    return {"data": data}
+
+
+@mcp.tool(
+    tags={"write"},
+    timeout=60.0,
+    annotations={
+        # Additive: non-destructive; repeat testCase starts a new iteration.
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+async def create_test_records(
+    ctx: Context,
+    project_id: str = Field(min_length=1, description="Polarion project ID."),
+    test_run_id: str = Field(min_length=1, description="Test run ID."),
+    items: list[TestRecordCreateSpec] = Field(  # noqa: B008
+        min_length=1,
+        max_length=MAX_BULK_ITEMS,
+        description="Test records to create in one request (1-50).",
+    ),
+    dry_run: bool = Field(
+        default=False,
+        description="Preview payload without writing; guards still query Polarion.",
+    ),
+) -> TestRecordsCreateResult:
+    """Create 1-50 test records on one test run, recording which test cases
+    were executed with what result.
+
+    Use list_test_records to read them back; create_test_runs creates the
+    run itself. Atomic: one bad item rejects the whole batch. Posting the
+    same test_case_id again starts a new iteration rather than replacing it
+    -- use separate calls, not duplicates in one batch. comment is sent
+    verbatim in comment_format, no Markdown conversion.
+
+    Returns record_ids as full 5-segment ids -- never shortened. result is
+    validated against the project's testing enumerations; defect must
+    reference an existing work item. An invalid test_case_id is rejected by
+    Polarion -- resolve via list_work_items first.
+    """
+    client = get_client(ctx)
+    qualified_test_case_ids = [
+        qualify_work_item_id(spec.test_case_id, project_id) for spec in items
+    ]
+    ensure_unique_ids(qualified_test_case_ids, label="test_case_id")
+
+    payload = _build_create_test_records_payload(project_id=project_id, specs=items)
+
+    await guard_test_record_results(
+        client,
+        project_id,
+        (spec.result for spec in items if spec.result is not None),
+    )
+    await guard_test_record_defect_targets(
+        client,
+        project_id,
+        (
+            qualify_work_item_id(spec.defect_id, project_id)
+            for spec in items
+            if spec.defect_id
+        ),
+    )
+
+    if dry_run:
+        return TestRecordsCreateResult(
+            created=False,
+            dry_run=True,
+            record_ids=[],
+            payload_preview=payload,
+        )
+
+    path = (
+        f"/projects/{encode_path_segment(project_id)}"
+        f"/testruns/{encode_path_segment(test_run_id)}/testrecords"
+    )
+    try:
+        response = await client.post(path, json=cast(dict[str, object], payload))
+    except PolarionAuthError as exc:
+        raise PermissionError(
+            "Cannot create test records -- check your POLARION_TOKEN permissions."
+        ) from exc
+    except PolarionNotFoundError as exc:
+        raise ValueError(
+            f"Test run '{test_run_id}' not found in project '{project_id}'. "
+            "Use `list_test_runs` to discover valid test run IDs."
+        ) from exc
+    except PolarionError as exc:
+        raise RuntimeError(f"Failed to create test records: {exc.message}") from exc
+
+    new_ids = extract_created_full_ids(response)
+    if len(new_ids) != len(items):
+        raise RuntimeError(
+            f"Polarion accepted the bulk create but returned {len(new_ids)} "
+            f"ids for {len(items)} requested records. The batch may be "
+            "partially created; verify with list_test_records before retrying."
+        )
+
+    return TestRecordsCreateResult(
+        created=True,
+        dry_run=False,
+        record_ids=new_ids,
         payload_preview=None,
     )
 

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -358,6 +358,80 @@ class TestMutations:
         assert response.status_code == 201
         assert len(_json(response)["data"]) == 1
 
+    def test_post_testrecords_composes_five_segment_ids(self) -> None:
+        fake = FakePolarion()
+        response = _mutate(
+            fake,
+            "POST",
+            f"/projects/{PROJECT}/testruns/{TEST_RUN_ID}/testrecords",
+            {
+                "data": [
+                    {
+                        "type": "testrecords",
+                        "relationships": {
+                            "testCase": {
+                                "data": {
+                                    "type": "workitems",
+                                    "id": f"{PROJECT}/{TESTCASE_ID}",
+                                }
+                            }
+                        },
+                    },
+                    {
+                        "type": "testrecords",
+                        "relationships": {
+                            "testCase": {
+                                "data": {
+                                    "type": "workitems",
+                                    "id": f"{PROJECT}/{CHILD_REQ_ID}",
+                                }
+                            }
+                        },
+                    },
+                ]
+            },
+        )
+        assert response.status_code == 201
+        ids = [entry["id"] for entry in _json(response)["data"]]
+        assert ids == [
+            f"{PROJECT}/{TEST_RUN_ID}/{PROJECT}/{TESTCASE_ID}/0",
+            f"{PROJECT}/{TEST_RUN_ID}/{PROJECT}/{CHILD_REQ_ID}/0",
+        ]
+
+    def test_post_testrecords_unknown_test_case_is_400(self) -> None:
+        # Live-verified server message; tool relies on it flowing through.
+        fake = FakePolarion()
+        response = _mutate(
+            fake,
+            "POST",
+            f"/projects/{PROJECT}/testruns/{TEST_RUN_ID}/testrecords",
+            {
+                "data": [
+                    {
+                        "type": "testrecords",
+                        "relationships": {
+                            "testCase": {
+                                "data": {"type": "workitems", "id": f"{PROJECT}/Nope"}
+                            }
+                        },
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 400
+        detail = _json(response)["errors"][0]["detail"]
+        assert detail == "Test Case is missing, or the one specified is invalid."
+
+    def test_post_testrecords_missing_test_case_relationship_is_400(self) -> None:
+        fake = FakePolarion()
+        response = _mutate(
+            fake,
+            "POST",
+            f"/projects/{PROJECT}/testruns/{TEST_RUN_ID}/testrecords",
+            {"data": [{"type": "testrecords"}]},
+        )
+        assert response.status_code == 400
+
     def test_post_documents_echoes_module_id(self) -> None:
         fake = FakePolarion()
         response = _mutate(

--- a/tests/mcp_server_polarion/models/test_test_runs.py
+++ b/tests/mcp_server_polarion/models/test_test_runs.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from mcp_server_polarion.models import TestRunCreateSpec
+from mcp_server_polarion.models import (
+    TestRecordCreateSpec,
+    TestRecordsCreateResult,
+    TestRunCreateSpec,
+)
 
 
 class TestTestRunCreateSpec:
@@ -19,3 +23,42 @@ class TestTestRunCreateSpec:
         # extra='forbid': a typo key must error, not silently drop the field.
         with pytest.raises(ValidationError, match="titel"):
             TestRunCreateSpec.model_validate({"id": "RUN-1", "titel": "oops"})
+
+
+class TestTestRecordCreateSpec:
+    def test_minimal_spec(self):
+        spec = TestRecordCreateSpec(test_case_id="WI-1")
+        assert spec.test_case_id == "WI-1"
+        assert spec.result is None
+        assert spec.comment is None
+        assert spec.comment_format == "text/plain"
+        assert spec.defect_id is None
+
+    def test_full_spec(self):
+        spec = TestRecordCreateSpec(
+            test_case_id="Proj/WI-1",
+            result="passed",
+            comment="looks fine",
+            comment_format="text/html",
+            defect_id="Proj/BUG-1",
+        )
+        assert spec.result == "passed"
+        assert spec.comment == "looks fine"
+        assert spec.comment_format == "text/html"
+        assert spec.defect_id == "Proj/BUG-1"
+
+    def test_typo_key_rejected(self):
+        # extra='forbid': typo key must error, not silently drop.
+        with pytest.raises(ValidationError, match="tets_case_id"):
+            TestRecordCreateSpec.model_validate({"tets_case_id": "WI-1"}, strict=False)
+
+    def test_empty_test_case_id_rejected(self):
+        with pytest.raises(ValidationError):
+            TestRecordCreateSpec(test_case_id="")
+
+
+class TestTestRecordsCreateResult:
+    def test_defaults(self):
+        result = TestRecordsCreateResult(created=True, dry_run=False)
+        assert result.record_ids == []
+        assert result.payload_preview is None

--- a/tests/mcp_server_polarion/models/test_test_runs.py
+++ b/tests/mcp_server_polarion/models/test_test_runs.py
@@ -50,7 +50,7 @@ class TestTestRecordCreateSpec:
     def test_typo_key_rejected(self):
         # extra='forbid': typo key must error, not silently drop.
         with pytest.raises(ValidationError, match="tets_case_id"):
-            TestRecordCreateSpec.model_validate({"tets_case_id": "WI-1"}, strict=False)
+            TestRecordCreateSpec.model_validate({"tets_case_id": "WI-1"})
 
     def test_empty_test_case_id_rejected(self):
         with pytest.raises(ValidationError):

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -49,6 +49,7 @@ _WRITE_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "create_work_items",
         "create_test_runs",
+        "create_test_records",
         "update_test_runs",
         "update_work_items",
         "move_work_item_to_document",

--- a/tests/mcp_server_polarion/tools/_shared/guard/test__targets.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test__targets.py
@@ -1,0 +1,138 @@
+"""Shared target-existence helper tests: chunked queries + positive cache."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_server_polarion.core.exceptions import (
+    PolarionAuthError,
+    PolarionError,
+    PolarionNotFoundError,
+)
+from mcp_server_polarion.tools._shared.guard._targets import (
+    existing_target_ids,
+    missing_work_item_targets,
+)
+from tests.mcp_server_polarion.tools._shared.guard._builders import workitems_response
+
+
+class TestExistingTargetIds:
+    """``existing_target_ids`` -- chunked ``id:(...)`` probe."""
+
+    async def test_queries_sorted_ids_and_returns_short_ids(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", ["A", "B"])
+
+        found = await existing_target_ids(mock_client, "P", frozenset({"B", "A"}))
+
+        assert found == frozenset({"A", "B"})
+        path, kwargs = (
+            mock_client.get.call_args.args[0],
+            mock_client.get.call_args.kwargs,
+        )
+        assert path == "/projects/P/workitems"
+        assert kwargs["params"]["query"] == "id:(A B)"
+        assert kwargs["params"]["fields[workitems]"] == "id"
+
+    async def test_chunks_above_page_size(self, mock_client: AsyncMock) -> None:
+        ids = frozenset(f"WI-{n}" for n in range(150))
+
+        async def fake_get(path: str, **kwargs: object) -> dict[str, object]:
+            query = str(kwargs["params"]["query"])  # type: ignore[index]
+            chunk = query.removeprefix("id:(").removesuffix(")").split()
+            return workitems_response("P", chunk)
+
+        mock_client.get.side_effect = fake_get
+
+        found = await existing_target_ids(mock_client, "P", ids)
+
+        assert found == ids
+        assert mock_client.get.await_count == 2
+
+    async def test_non_list_data_yields_empty(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = {"data": {"id": "P/A"}}
+
+        assert await existing_target_ids(mock_client, "P", frozenset({"A"})) == (
+            frozenset()
+        )
+
+
+class TestMissingWorkItemTargets:
+    """``missing_work_item_targets`` -- grouped probe + confirmed-positive cache."""
+
+    async def test_all_existing_returns_empty(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = workitems_response("P", ["A"])
+
+        assert await missing_work_item_targets(mock_client, {"P": {"A"}}) == []
+
+    async def test_missing_ids_returned_qualified_and_sorted(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", [])
+
+        missing = await missing_work_item_targets(mock_client, {"P": {"B", "A"}})
+
+        assert missing == ["P/A", "P/B"]
+
+    async def test_project_404_marks_whole_group_missing(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError("no such project")
+
+        missing = await missing_work_item_targets(mock_client, {"P": {"A"}})
+
+        assert missing == ["P/A"]
+
+    async def test_confirmed_ids_cached_across_calls(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", ["A"])
+        await missing_work_item_targets(mock_client, {"P": {"A"}})
+        mock_client.get.reset_mock()
+
+        await missing_work_item_targets(mock_client, {"P": {"A"}})
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_missing_ids_never_cached_as_negative(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", [])
+        assert await missing_work_item_targets(mock_client, {"P": {"A"}}) == ["P/A"]
+
+        # WI created since last call -- next probe must hit Polarion again.
+        mock_client.get.return_value = workitems_response("P", ["A"])
+        assert await missing_work_item_targets(mock_client, {"P": {"A"}}) == []
+        assert mock_client.get.await_count == 2
+
+    async def test_partial_cache_queries_only_misses(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", ["A"])
+        await missing_work_item_targets(mock_client, {"P": {"A"}})
+        mock_client.get.reset_mock()
+
+        mock_client.get.return_value = workitems_response("P", ["B"])
+        await missing_work_item_targets(mock_client, {"P": {"A", "B"}})
+
+        mock_client.get.assert_awaited_once()
+        assert mock_client.get.call_args.kwargs["params"]["query"] == "id:(B)"
+
+    async def test_unreachable_backend_fails_closed(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError("backend down")
+
+        with pytest.raises(RuntimeError, match="Refusing the write"):
+            await missing_work_item_targets(mock_client, {"P": {"A"}})
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("forbidden", status_code=403)
+
+        with pytest.raises(PermissionError, match="lacks permission"):
+            await missing_work_item_targets(mock_client, {"P": {"A"}})

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_links.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_links.py
@@ -31,7 +31,9 @@ def _link(target: str, *, project: str | None = None) -> WorkItemLinkSpec:
 
 
 class TestGuardWorkItemLinkTargets:
-    """Target-existence guard for ``create_work_item_links`` (uncached)."""
+    """Target-existence guard for ``create_work_item_links`` -- confirmed
+    targets cache across calls (shared ``_targets`` helper).
+    """
 
     async def test_all_targets_exist_one_get_per_project(
         self, mock_client: AsyncMock
@@ -111,6 +113,19 @@ class TestGuardWorkItemLinkTargets:
             for call in mock_client.get.await_args_list
         ]
         assert [q.count(" ") + 1 for q in queries] == [100, 50]
+
+    async def test_cache_hit_second_call_makes_zero_http_calls(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", ["A"])
+
+        await guard_work_item_link_targets(mock_client, "P", [_link("A")])
+        assert mock_client.get.await_count == 1
+
+        mock_client.get.reset_mock()
+        await guard_work_item_link_targets(mock_client, "P", [_link("A")])
+
+        mock_client.get.assert_not_awaited()
 
     async def test_unreachable_backend_blocks_write(
         self, mock_client: AsyncMock

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_test_records.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_test_records.py
@@ -1,0 +1,174 @@
+"""Test-record guard tests: result enum + cached defect existence."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_server_polarion.core.exceptions import (
+    PolarionAuthError,
+    PolarionError,
+    PolarionNotFoundError,
+)
+from mcp_server_polarion.tools._shared.guard import (
+    guard_test_record_defect_targets,
+    guard_test_record_results,
+)
+from tests.mcp_server_polarion.tools._shared.guard._builders import (
+    project_enum_response,
+    workitems_response,
+)
+
+
+class TestGuardTestRecordResults:
+    """``result`` validated via the ``testing``-context ``test-result`` enum."""
+
+    async def test_valid_result_passes(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = project_enum_response(
+            "test-result", ["passed", "failed", "blocked"]
+        )
+
+        await guard_test_record_results(mock_client, "P", ["passed"])
+
+        path = mock_client.get.await_args.args[0]
+        assert path == "/projects/P/enumerations/testing/test-result/~"
+
+    async def test_unknown_result_raises_with_options(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = project_enum_response(
+            "test-result", ["passed", "failed", "blocked"]
+        )
+
+        with pytest.raises(ValueError, match="ghost") as exc:
+            await guard_test_record_results(mock_client, "P", ["ghost"])
+
+        assert "passed" in str(exc.value)
+
+    async def test_empty_results_skip_check(self, mock_client: AsyncMock) -> None:
+        await guard_test_record_results(mock_client, "P", [])
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_enum_404_defers(self, mock_client: AsyncMock) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
+
+        await guard_test_record_results(mock_client, "P", ["anything"])
+
+    async def test_dedup_one_get_for_repeated_results(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = project_enum_response("test-result", ["passed"])
+
+        await guard_test_record_results(mock_client, "P", ["passed", "passed"])
+
+        mock_client.get.assert_awaited_once()
+
+
+class TestGuardTestRecordDefectTargets:
+    """Defect-target existence guard -- cached across calls."""
+
+    async def test_existing_target_passes(self, mock_client: AsyncMock) -> None:
+        mock_client.get.return_value = workitems_response("P", ["MCPT-1"])
+
+        await guard_test_record_defect_targets(mock_client, "P", ["P/MCPT-1"])
+
+        mock_client.get.assert_awaited_once()
+        path, kwargs = (
+            mock_client.get.call_args.args[0],
+            mock_client.get.call_args.kwargs,
+        )
+        assert path == "/projects/P/workitems"
+        assert kwargs["params"]["query"] == "id:(MCPT-1)"
+
+    async def test_missing_target_raises_value_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", [])
+
+        with pytest.raises(ValueError, match="P/MCPT-99999") as exc:
+            await guard_test_record_defect_targets(mock_client, "P", ["P/MCPT-99999"])
+
+        assert "dangling" in str(exc.value)
+
+    async def test_mixed_projects_grouped_one_get_per_project(
+        self, mock_client: AsyncMock
+    ) -> None:
+        responses = {
+            "P": workitems_response("P", ["A"]),
+            "Q": workitems_response("Q", ["X"]),
+        }
+
+        async def fake_get(path: str, **kwargs: object) -> dict[str, object]:
+            project = path.split("/")[2]
+            return responses[project]
+
+        mock_client.get.side_effect = fake_get
+
+        await guard_test_record_defect_targets(mock_client, "P", ["P/A", "Q/X"])
+
+        assert mock_client.get.await_count == 2
+
+    async def test_bare_id_defaults_to_passed_project(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", ["A"])
+
+        await guard_test_record_defect_targets(mock_client, "P", ["A"])
+
+        kwargs = mock_client.get.call_args.kwargs
+        assert kwargs["params"]["query"] == "id:(A)"
+
+    async def test_cache_hit_second_call_makes_zero_http_calls(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", ["MCPT-1"])
+
+        await guard_test_record_defect_targets(mock_client, "P", ["P/MCPT-1"])
+        assert mock_client.get.await_count == 1
+
+        mock_client.get.reset_mock()
+        await guard_test_record_defect_targets(mock_client, "P", ["P/MCPT-1"])
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_partial_cache_only_misses_queried(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("P", ["MCPT-1"])
+        await guard_test_record_defect_targets(mock_client, "P", ["P/MCPT-1"])
+        mock_client.get.reset_mock()
+
+        mock_client.get.return_value = workitems_response("P", ["MCPT-2"])
+        await guard_test_record_defect_targets(
+            mock_client, "P", ["P/MCPT-1", "P/MCPT-2"]
+        )
+
+        mock_client.get.assert_awaited_once()
+        kwargs = mock_client.get.call_args.kwargs
+        assert kwargs["params"]["query"] == "id:(MCPT-2)"
+
+    async def test_unreachable_backend_blocks_write(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionError("backend down")
+
+        with pytest.raises(RuntimeError, match="Refusing the write"):
+            await guard_test_record_defect_targets(mock_client, "P", ["P/A"])
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionAuthError("forbidden", status_code=403)
+
+        with pytest.raises(PermissionError, match="lacks permission"):
+            await guard_test_record_defect_targets(mock_client, "P", ["P/A"])
+
+    async def test_missing_target_project_raises_value_error(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError("no such project")
+
+        with pytest.raises(ValueError, match="P/A"):
+            await guard_test_record_defect_targets(mock_client, "P", ["P/A"])

--- a/tests/mcp_server_polarion/tools/_shared/test_helpers.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_helpers.py
@@ -16,6 +16,7 @@ from mcp_server_polarion.tools._shared.helpers import (
     ensure_unique_ids,
     format_option_list,
     get_client,
+    qualify_work_item_id,
     reraise_with_item_context,
     safe_float,
     safe_str,
@@ -172,6 +173,19 @@ class TestEnsureUniqueIds:
     def test_accepts_generator(self) -> None:
         with pytest.raises(ValueError, match=r"\['X'\]"):
             ensure_unique_ids((i for i in ["X", "X"]), label="id")
+
+
+class TestQualifyWorkItemId:
+    """Tests for `qualify_work_item_id`."""
+
+    def test_bare_id_gets_qualified(self) -> None:
+        assert qualify_work_item_id("WI-1", "Proj") == "Proj/WI-1"
+
+    def test_already_qualified_id_stays_verbatim(self) -> None:
+        assert qualify_work_item_id("Proj/WI-1", "Other") == "Proj/WI-1"
+
+    def test_id_with_slash_anywhere_stays_verbatim(self) -> None:
+        assert qualify_work_item_id("a/b", "Proj") == "a/b"
 
 
 class TestReraiseWithItemContext:

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from mcp_server_polarion.models import Comment, WorkItemSummary
 from mcp_server_polarion.tools._shared.parse import (
     _parse_comment,
+    extract_created_full_ids,
     extract_created_short_ids,
     extract_relationship_id,
     extract_relationship_ids,
@@ -124,6 +125,46 @@ class TestExtractCreatedShortIds:
             ]
         }
         assert extract_created_short_ids(response) == ["MCPT-1"]
+
+
+class TestExtractCreatedFullIds:
+    """Tests for `extract_created_full_ids` (testrecord 5-segment ids)."""
+
+    def test_extracts_full_ids_verbatim_in_order(self) -> None:
+        # 5-segment testrecord id: project/testRun/testCaseProject/testCaseId/
+        # iteration -- extract_created_short_ids would rsplit to bare "0".
+        response: dict[str, object] = {
+            "data": [
+                {
+                    "type": "testrecords",
+                    "id": "MCP_Test_Project/run1/MCP_Test_Project/MCPT-568/0",
+                },
+                {
+                    "type": "testrecords",
+                    "id": "MCP_Test_Project/run1/MCP_Test_Project/MCPT-569/1",
+                },
+            ]
+        }
+        assert extract_created_full_ids(response) == [
+            "MCP_Test_Project/run1/MCP_Test_Project/MCPT-568/0",
+            "MCP_Test_Project/run1/MCP_Test_Project/MCPT-569/1",
+        ]
+
+    def test_returns_empty_when_data_missing(self) -> None:
+        assert extract_created_full_ids({}) == []
+
+    def test_returns_empty_when_data_not_a_list(self) -> None:
+        assert extract_created_full_ids({"data": {"id": "p/r/p/WI-1/0"}}) == []
+
+    def test_skips_entries_missing_id_or_not_dict(self) -> None:
+        response: dict[str, object] = {
+            "data": [
+                {"type": "testrecords", "id": "p/r/p/WI-1/0"},
+                {"type": "testrecords"},
+                "not a dict",
+            ]
+        }
+        assert extract_created_full_ids(response) == ["p/r/p/WI-1/0"]
 
 
 class TestParseIncludedWorkItemMap:

--- a/tests/mcp_server_polarion/tools/conftest.py
+++ b/tests/mcp_server_polarion/tools/conftest.py
@@ -19,6 +19,7 @@ def _clear_guard_caches() -> None:
     _cache_mod._work_item_custom_key_cache.clear()
     _cache_mod._document_type_custom_key_cache.clear()
     _cache_mod._test_run_custom_key_cache.clear()
+    _cache_mod._confirmed_work_item_cache.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -18,18 +18,26 @@ from mcp_server_polarion.core.exceptions import (
 )
 from mcp_server_polarion.models import (
     PaginatedResult,
+    TestRecordCreateSpec,
     TestRunCreateSpec,
     TestRunDetail,
     TestRunUpdateSpec,
 )
 from mcp_server_polarion.tools.test_runs import (
+    _build_create_test_records_payload,
     _build_create_test_runs_payload,
+    _build_test_record_resource,
     _build_update_test_runs_payload,
+    create_test_records,
     create_test_runs,
     get_test_run,
     list_test_records,
     list_test_runs,
     update_test_runs,
+)
+from tests.mcp_server_polarion.tools._shared.guard._builders import (
+    project_enum_response,
+    workitems_response,
 )
 
 
@@ -1421,3 +1429,339 @@ class TestGetTestRun:
         )
 
         assert result.id == "TR-100"
+
+
+class TestBuildTestRecordResource:
+    """``_build_test_record_resource`` unit seam."""
+
+    def test_minimal_spec_sends_test_case_only(self) -> None:
+        resource = _build_test_record_resource(
+            project_id="proj1",
+            spec=TestRecordCreateSpec(test_case_id="MCPT-1"),
+        )
+
+        assert resource == {
+            "type": "testrecords",
+            "relationships": {
+                "testCase": {"data": {"id": "proj1/MCPT-1", "type": "workitems"}}
+            },
+        }
+
+    def test_full_spec_builds_attributes_and_defect(self) -> None:
+        resource = _build_test_record_resource(
+            project_id="proj1",
+            spec=TestRecordCreateSpec(
+                test_case_id="MCPT-1",
+                result="passed",
+                comment="looks good",
+                comment_format="text/plain",
+                defect_id="MCPT-99",
+            ),
+        )
+
+        assert resource == {
+            "type": "testrecords",
+            "attributes": {
+                "result": "passed",
+                "comment": {"type": "text/plain", "value": "looks good"},
+            },
+            "relationships": {
+                "testCase": {"data": {"id": "proj1/MCPT-1", "type": "workitems"}},
+                "defect": {"data": {"id": "proj1/MCPT-99", "type": "workitems"}},
+            },
+        }
+
+    def test_bare_ids_qualified_with_project_id(self) -> None:
+        resource = _build_test_record_resource(
+            project_id="proj1",
+            spec=TestRecordCreateSpec(test_case_id="MCPT-1", defect_id="MCPT-99"),
+        )
+
+        relationships = resource["relationships"]
+        assert relationships["testCase"]["data"]["id"] == "proj1/MCPT-1"  # type: ignore[index,call-overload]
+        assert relationships["defect"]["data"]["id"] == "proj1/MCPT-99"  # type: ignore[index,call-overload]
+
+    def test_already_qualified_ids_pass_through(self) -> None:
+        resource = _build_test_record_resource(
+            project_id="proj1",
+            spec=TestRecordCreateSpec(
+                test_case_id="OtherProj/MCPT-1", defect_id="OtherProj/MCPT-99"
+            ),
+        )
+
+        relationships = resource["relationships"]
+        assert relationships["testCase"]["data"]["id"] == "OtherProj/MCPT-1"  # type: ignore[index,call-overload]
+        assert relationships["defect"]["data"]["id"] == "OtherProj/MCPT-99"  # type: ignore[index,call-overload]
+
+    def test_comment_format_passthrough_no_conversion(self) -> None:
+        resource = _build_test_record_resource(
+            project_id="proj1",
+            spec=TestRecordCreateSpec(
+                test_case_id="MCPT-1",
+                comment="**not markdown**",
+                comment_format="text/html",
+            ),
+        )
+
+        assert resource["attributes"]["comment"] == {  # type: ignore[index,call-overload]
+            "type": "text/html",
+            "value": "**not markdown**",
+        }
+
+    def test_no_result_or_comment_omits_attributes_key(self) -> None:
+        resource = _build_test_record_resource(
+            project_id="proj1",
+            spec=TestRecordCreateSpec(test_case_id="MCPT-1"),
+        )
+
+        assert "attributes" not in resource
+
+
+class TestBuildCreateTestRecordsPayload:
+    """``_build_create_test_records_payload`` unit seam."""
+
+    def test_wraps_resources_in_data_list(self) -> None:
+        payload = _build_create_test_records_payload(
+            project_id="proj1",
+            specs=[
+                TestRecordCreateSpec(test_case_id="MCPT-1"),
+                TestRecordCreateSpec(test_case_id="MCPT-2", result="passed"),
+            ],
+        )
+
+        data = payload["data"]
+        assert isinstance(data, list)
+        assert len(data) == 2
+        first, second = data[0], data[1]
+        assert isinstance(first, dict)
+        assert isinstance(second, dict)
+        assert first["relationships"]["testCase"]["data"]["id"] == "proj1/MCPT-1"  # type: ignore[index,call-overload]
+        assert second["attributes"]["result"] == "passed"  # type: ignore[index,call-overload]
+
+
+class TestCreateTestRecords:
+    """``create_test_records`` tool."""
+
+    async def test_duplicate_test_case_id_rejected_before_any_request(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        with pytest.raises(ValueError, match=r"Duplicate test_case_id\(s\)"):
+            await create_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="run1",
+                items=[
+                    TestRecordCreateSpec(test_case_id="MCPT-1"),
+                    TestRecordCreateSpec(test_case_id="MCPT-1"),
+                ],
+                dry_run=False,
+            )
+        mock_client.get.assert_not_awaited()
+        mock_client.post.assert_not_awaited()
+
+    async def test_bare_and_qualified_same_id_collide(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # "WI-1" bare qualifies to "proj1/WI-1" -- same identity as explicit.
+        with pytest.raises(ValueError, match=r"Duplicate test_case_id\(s\)"):
+            await create_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="run1",
+                items=[
+                    TestRecordCreateSpec(test_case_id="WI-1"),
+                    TestRecordCreateSpec(test_case_id="proj1/WI-1"),
+                ],
+                dry_run=False,
+            )
+        mock_client.post.assert_not_awaited()
+
+    async def test_minimal_create_posts_and_returns_full_ids(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # 201 body per live findings: id only, no attributes echoed.
+        mock_client.post.return_value = {
+            "data": [
+                {
+                    "type": "testrecords",
+                    "id": "MCP_Test_Project/run1/MCP_Test_Project/MCPT-568/0",
+                }
+            ]
+        }
+
+        result = await create_test_records(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            test_run_id="run1",
+            items=[TestRecordCreateSpec(test_case_id="MCPT-568")],
+            dry_run=False,
+        )
+
+        assert result.created is True
+        assert result.dry_run is False
+        assert result.record_ids == [
+            "MCP_Test_Project/run1/MCP_Test_Project/MCPT-568/0"
+        ]
+        assert result.payload_preview is None
+        path = mock_client.post.await_args.args[0]
+        assert path == "/projects/MCP_Test_Project/testruns/run1/testrecords"
+
+    async def test_result_guard_blocks_before_post(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = project_enum_response(
+            "test-result", ["passed", "failed", "blocked"]
+        )
+
+        with pytest.raises(ValueError, match="ghost"):
+            await create_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="run1",
+                items=[TestRecordCreateSpec(test_case_id="MCPT-1", result="ghost")],
+                dry_run=False,
+            )
+
+        mock_client.post.assert_not_awaited()
+
+    async def test_defect_guard_blocks_before_post(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = workitems_response("proj1", [])
+
+        with pytest.raises(ValueError, match="dangling"):
+            await create_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="run1",
+                items=[
+                    TestRecordCreateSpec(test_case_id="MCPT-1", defect_id="MCPT-99999")
+                ],
+                dry_run=False,
+            )
+
+        mock_client.post.assert_not_awaited()
+
+    async def test_dry_run_returns_preview_and_still_runs_guards(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = project_enum_response("test-result", ["passed"])
+
+        result = await create_test_records(
+            mock_ctx,
+            project_id="proj1",
+            test_run_id="run1",
+            items=[TestRecordCreateSpec(test_case_id="MCPT-1", result="passed")],
+            dry_run=True,
+        )
+
+        assert result.created is False
+        assert result.dry_run is True
+        assert result.record_ids == []
+        assert result.payload_preview is not None
+        mock_client.get.assert_awaited()
+        mock_client.post.assert_not_awaited()
+
+    async def test_run_not_found_raises_value_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            await create_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="missing",
+                items=[TestRecordCreateSpec(test_case_id="MCPT-1")],
+                dry_run=False,
+            )
+
+    async def test_auth_error_raises_permission_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.side_effect = PolarionAuthError("auth", status_code=401)
+
+        with pytest.raises(PermissionError):
+            await create_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="run1",
+                items=[TestRecordCreateSpec(test_case_id="MCPT-1")],
+                dry_run=False,
+            )
+
+    async def test_other_error_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Server validates testCase itself; 400 detail must flow through.
+        mock_client.post.side_effect = PolarionError(
+            "Test Case is missing, or the one specified is invalid.",
+            status_code=400,
+        )
+
+        with pytest.raises(RuntimeError, match="Test Case is missing"):
+            await create_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="run1",
+                items=[TestRecordCreateSpec(test_case_id="MCPT-1")],
+                dry_run=False,
+            )
+
+    async def test_id_count_mismatch_raises(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.post.return_value = {"data": []}
+
+        with pytest.raises(RuntimeError, match="list_test_records"):
+            await create_test_records(
+                mock_ctx,
+                project_id="proj1",
+                test_run_id="run1",
+                items=[TestRecordCreateSpec(test_case_id="MCPT-1")],
+                dry_run=False,
+            )
+
+
+class TestCreateTestRecordsFieldValidation:
+    """Bulk bounds + spec constraints via ``TypeAdapter`` rebuild."""
+
+    @staticmethod
+    def _adapter(param_name: str) -> TypeAdapter[object]:
+        hints = get_type_hints(create_test_records)
+        sig = inspect.signature(create_test_records)
+        field_info = sig.parameters[param_name].default
+        return TypeAdapter(Annotated[hints[param_name], field_info])
+
+    def test_empty_items_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("items").validate_python([])
+
+    def test_items_above_max_rejected(self) -> None:
+        specs = [{"test_case_id": f"MCPT-{i}"} for i in range(51)]
+        with pytest.raises(ValidationError):
+            self._adapter("items").validate_python(specs)
+
+    def test_items_at_max_accepted(self) -> None:
+        specs = [{"test_case_id": f"MCPT-{i}"} for i in range(50)]
+        validated = self._adapter("items").validate_python(specs)
+        assert isinstance(validated, list)
+        assert len(validated) == 50
+
+    def test_empty_project_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("project_id").validate_python("")
+
+    def test_empty_test_run_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            self._adapter("test_run_id").validate_python("")
+
+    def test_spec_requires_non_empty_test_case_id(self) -> None:
+        with pytest.raises(ValidationError):
+            TestRecordCreateSpec(test_case_id="")
+
+    def test_extra_spec_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TestRecordCreateSpec(test_case_id="MCPT-1", bogus="x")  # type: ignore[call-arg]

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -1669,7 +1669,10 @@ class TestCreateTestRecords:
             "Not found", status_code=404
         )
 
-        with pytest.raises(ValueError, match="not found"):
+        # 404 ambiguous: run or project may be missing -- message names both.
+        with pytest.raises(
+            ValueError, match=r"Test run 'missing' or project 'proj1' not found"
+        ):
             await create_test_records(
                 mock_ctx,
                 project_id="proj1",


### PR DESCRIPTION
## Summary

Adds `create_test_records`: bulk-create 1-50 test records on a test run via `POST /projects/{p}/testruns/{tr}/testrecords` — record which test cases were executed with what result. Exposes only caller-meaningful fields (`test_case_id`, `result`, `comment`+`comment_format`, `defect_id`); server/auto-fillable fields (`executedBy`, `executed`, `duration`, `testCaseRevision`) intentionally excluded.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Recording test executions needed raw REST; MCP had list/create runs only
- Bulk POST testrecords + test-result enum guard + cached defect existence guard shared via `guard/_targets.py`

## Testing

- 1836 pytest green, mypy/ruff clean, diff-cover 100% on changed lines
- Live-verified against testdrive `MCP_Test_Project` (2026-07-13, automated-type run created + deleted after):
  - minimal/full item → 201, `record_ids` returned as verbatim 5-segment ids
  - server validates `testCase` (400 "Test Case is missing, or the one specified is invalid.") — no client guard needed
  - server does NOT validate `result` (bogus string stored) → guarded via `testing/test-result` enum (passed/failed/blocked)
  - server does NOT validate `defect` (nonexistent WI stored dangling) → existence guard, confirmed ids cached (positives only)
  - duplicate testCase POST auto-increments iteration (no 409); batch-level duplicates rejected client-side
  - comment sent `text/plain` reads back normalized to `text/html`
- Eval: `TRIG-CREATE-TEST-RECORDS` 3/3 PASS; adjacent `TRIG-CREATE-TEST-RUN`, `TRIG-LIST-TEST-RECORDS` re-run PASS
- `dry_run=True` verified live (guards still run, no write)

## Notes for Reviewers

- Review round 1 verdict PASS; round 2 applied review follow-ups in this PR:
  - LOW fixed: create 404 message now names both test run and project (`list_test_runs` / `list_projects` hints)
  - NIT fixed: `_existing_target_ids` private cross-module import removed — shared `guard/_targets.py` (`existing_target_ids` + `missing_work_item_targets`), link-target guard gains the confirmed-WI cache
  - NIT kept: result guard `discovery_hint` wording differs from plan draft; real option list is appended automatically
- Guard cache is positives-only (missing WI may be created later); cache-hit/partial-miss/never-negative paths unit-tested

