### PR TITLE
docs(skill): harden dev-pipeline from run audits

### DIFF
--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -90,13 +90,14 @@ sequentially, in one Agent call each.
    credentials work, burn it down before asking approval.** Probe a
    project-scoped endpoint first (global ones can 403 on a scoped token),
    then settle the researcher's UNVERIFIED items with cheap reads and scratch
-   writes (create a disposable resource, probe, delete it). A failed probe on
+   writes (create a disposable resource, probe, delete it — where the API
+   allows delete; documents are not REST-deletable). A failed probe on
    one endpoint is not "access is dead" — probe the exact resource the tool
    will touch before concluding. A fact settled at spec time is a design
    decision made once; the same fact discovered after implementation is a
-   review-fix round. (Run 2026-07-13: a pre-approval probe found the real
-   enum path and two silent-ghost writes — flipped a guard from "deferred"
-   to "shipped" before any code existed.)
+   review-fix round. (update_test_records run, 2026-07-13: a pre-approval
+   probe found the real enum path and two silent-ghost writes — flipped a
+   guard from "deferred" to "shipped" before any code existed.)
 4. **Show the user the full spec, then ask approval.** The approval request
    quotes `.pipeline/spec.md` verbatim — the full file text, not a summary or
    translation (on a redo, the revised sections verbatim) — the user approves
@@ -181,8 +182,11 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 
 ## Stage 7 — Ship (main thread)
 
-- Commit: `type(scope): summary` ≤50 chars + 2-bullet body (motivation,
-  change), bullets ≤120 chars — hook enforces. `.pipeline/` stays uncommitted.
+- Commit message format — defined here, used from Stage 5.1 onward:
+  `type(scope): summary` ≤50 chars + 2-bullet body (motivation, change),
+  bullets ≤120 chars — hook enforces. Work is already committed by review
+  time; commit here only what is still uncommitted. `.pipeline/` stays
+  uncommitted.
 - PR: flip template checkboxes `[ ]`→`[x]`, keep unchecked options, record
   live-test evidence and unfixed LOW/NIT findings in Notes. Squash merge only.
 - CI: after opening the PR, `gh pr checks <PR#> --watch --fail-fast` until
@@ -208,7 +212,7 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 | "Opus everywhere to be safe" | Model choice is a cost/judgment trade-off; sonnet ships code volume fine, opus earns its cost only on judgment stages. |
 | "Main-thread glue is too small for TDD" | A fake-server handler shipped code-first once and diff-cover bounced the gate; the failing test first was the cheaper path. |
 | "The user approved my summary of it" | A summary is your interpretation. Approval binds only the file text they actually read — quote it verbatim. |
-| "Live checks belong in Stage 4" | When an UNVERIFIED item shapes the spec, a smoke probe before freeze beats re-planning after it — one run flipped three guard decisions that way. |
+| "Live checks belong in Stage 4" | When an UNVERIFIED item shapes the spec, a smoke probe before freeze beats re-planning after it — the create_test_records run flipped three guard decisions that way. |
 
 ## Red Flags
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -155,9 +155,11 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 
 ## Stage 5 — Review (loop entry)
 
-1. **Commit the work first**, in Stage 7's message format — the reviewer
-   diffs `origin/main...HEAD`, and uncommitted changes are invisible to that
-   range. Fix rounds add commits; squash merge collapses them at the end.
+1. **Commit the work first**, in the repo commit format (CLAUDE.md Repo
+   Conventions; full rules `.github/CONTRIBUTING.md`, commit-msg hook
+   enforces) — the reviewer diffs `origin/main...HEAD`, and uncommitted
+   changes are invisible to that range. Fix rounds add commits; squash merge
+   collapses them at the end.
 2. **Invoke `pipeline-reviewer`** with: `.pipeline/spec.md` and
    `.pipeline/plan.md` paths and the diff scope (`git diff origin/main...HEAD`).
    Give it the spec and plan — **never** the implementer reports or your
@@ -182,13 +184,11 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 
 ## Stage 7 — Ship (main thread)
 
-- Commit message format — defined here, used from Stage 5.1 onward:
-  `type(scope): summary` ≤50 chars + 2-bullet body (motivation, change),
-  bullets ≤120 chars — hook enforces. Work is already committed by review
-  time; commit here only what is still uncommitted. `.pipeline/` stays
-  uncommitted.
-- PR: flip template checkboxes `[ ]`→`[x]`, keep unchecked options, record
-  live-test evidence and unfixed LOW/NIT findings in Notes. Squash merge only.
+- Work is already committed by review time (Stage 5.1); commit here only what
+  is still uncommitted. Commit format, PR checklist handling, squash-merge
+  rule: CLAUDE.md Repo Conventions / `.github/CONTRIBUTING.md` — restating
+  them here would be a third copy that drifts. `.pipeline/` stays uncommitted.
+- PR Notes: record live-test evidence and unfixed LOW/NIT findings.
 - CI: after opening the PR, `gh pr checks <PR#> --watch --fail-fast` until
   every check is green — merge is blocked on red anyway, but an unwatched red
   PR rots until a human notices; catch it while the session context is hot.
@@ -225,7 +225,8 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 - `.pipeline/` files committed, or a subagent prompted without the file paths
   it needs (it cannot see the conversation).
 - `git worktree add` or bare `git stash` in a session that has native tools.
-- Branch named `feature/…` (hook rejects) or commit bullets over 120 chars.
+- Branch named `feature/…` — pre-push hook rejects it, but only at push time;
+  rename at Stage 0.
 - Findings "fixed" without gates re-run before re-review.
 - Main-thread integration code (eval-harness handler, registration) written
   before its failing test.

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -35,7 +35,7 @@ Subagents share **no memory and no conversation history**. Three channels only:
    |---|---|---|
    | `.pipeline/spec.md` | orchestrator (Stage 1, draft before approval; approval freezes it) | pattern-scout, pipeline-implementer, pipeline-reviewer |
    | `.pipeline/plan.md` | orchestrator (Stage 2, full text shown before approval — via ExitPlanMode or quoted draft; approval freezes it) | pipeline-implementer, pipeline-reviewer |
-   | `.pipeline/review-round-N.md` | orchestrator (Stage 5, from reviewer report) | pipeline-implementer (Stage 6), user on escalation |
+   | `.pipeline/review-round-N.md` | orchestrator (Stage 5, reviewer report pasted verbatim) | pipeline-implementer (Stage 6), user on escalation |
 
 Follow-up questions to an agent you already spawned: `SendMessage` to its id —
 a fresh Agent call starts cold and re-derives everything.
@@ -85,18 +85,23 @@ sequentially, in one Agent call each.
    and fill its slots from the report. The template fixes the required
    sections — don't invent a new shape; they are the standard
    pipeline-reviewer judges the diff against.
-3. **If live credentials work, burn down UNVERIFIED before approval.** Probe a
-   project-scoped endpoint first (global ones can 403 on a scoped token), then
-   settle the researcher's UNVERIFIED items with cheap reads and scratch
-   writes (create a disposable resource, probe, delete it). A fact settled at
-   spec time is a design decision made once; the same fact discovered after
-   implementation is a review-fix round. (Run 2026-07-13: a pre-approval probe
-   found the real enum path and two silent-ghost writes — flipped a guard from
-   "deferred" to "shipped" before any code existed.)
+3. **If an UNVERIFIED item decides spec content** — whether a field exists,
+   whether a guard is needed, which enum backs a value — **and live
+   credentials work, burn it down before asking approval.** Probe a
+   project-scoped endpoint first (global ones can 403 on a scoped token),
+   then settle the researcher's UNVERIFIED items with cheap reads and scratch
+   writes (create a disposable resource, probe, delete it). A failed probe on
+   one endpoint is not "access is dead" — probe the exact resource the tool
+   will touch before concluding. A fact settled at spec time is a design
+   decision made once; the same fact discovered after implementation is a
+   review-fix round. (Run 2026-07-13: a pre-approval probe found the real
+   enum path and two silent-ghost writes — flipped a guard from "deferred"
+   to "shipped" before any code existed.)
 4. **Show the user the full spec, then ask approval.** The approval request
-   quotes the spec content (or the revised sections on a redo) in the reply —
-   the user approves text they have read, never a bare "spec ready, approve?"
-   prompt. Fold feedback back into `.pipeline/spec.md`; approval freezes it.
+   quotes `.pipeline/spec.md` verbatim — the full file text, not a summary or
+   translation (on a redo, the revised sections verbatim) — the user approves
+   text they have read, never a bare "spec ready, approve?" prompt. Fold
+   feedback back into `.pipeline/spec.md`; approval freezes it.
    Spec changes are cheap here, expensive later.
 
 ## Stage 2 — Plan
@@ -110,8 +115,9 @@ sequentially, in one Agent call each.
    Verification. Use plan mode when available — ExitPlanMode already puts the
    full plan in front of the user for approval; write it to
    `.pipeline/plan.md` right after. Without plan mode, copy the template to
-   `.pipeline/plan.md`, fill it, and quote it in the approval request — same
-   rule as the spec: the user approves text they have read.
+   `.pipeline/plan.md`, fill it, and quote it verbatim in the approval
+   request — same rule as the spec: full file text, not a condensed
+   rendition; the user approves text they have read.
 
 ## Stage 3 — Implement (TDD)
 
@@ -128,7 +134,10 @@ ImportError there means the test never exercised the behavior.
 
 Keep cross-task integration (imports, registration lists like
 `EXPECTED_TOOL_NAMES`, eval coverage entry) in the main thread, where the
-whole picture lives.
+whole picture lives. The TDD law reaches here too: eval-harness handlers and
+any other executable glue get their failing test before the code —
+diff-cover gates `evals/harness` like `src/`, and a bounced gate is the
+expensive way to rediscover that.
 
 ## Stage 4 — Gates (main thread; all must pass before review)
 
@@ -152,7 +161,9 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
    `.pipeline/plan.md` paths and the diff scope (`git diff origin/main...HEAD`).
    Give it the spec and plan — **never** the implementer reports or your
    implementation narrative (context bleed defeats the fresh eyes).
-3. Save its report to `.pipeline/review-round-N.md`; relay findings to the user.
+3. Save its report verbatim to `.pipeline/review-round-N.md` — full text, not
+   a paraphrase (Stage 6's implementer and any escalation read it); relay
+   findings to the user.
 4. **Stop criterion — the only exit:** verdict PASS (zero CRITICAL/MEDIUM
    actionable findings). LOW/NIT go to PR notes, not necessarily fixed.
    PASS → Stage 7. FAIL → Stage 6.
@@ -195,12 +206,16 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 | "One more fix round, no re-review" | Fixes are new code; new code gets reviewed. That's why the loop exists. |
 | "Subagent for the gate commands too" | Gates are deterministic bash. A subagent burns tokens to relay an exit code. |
 | "Opus everywhere to be safe" | Model choice is a cost/judgment trade-off; sonnet ships code volume fine, opus earns its cost only on judgment stages. |
+| "Main-thread glue is too small for TDD" | A fake-server handler shipped code-first once and diff-cover bounced the gate; the failing test first was the cheaper path. |
+| "The user approved my summary of it" | A summary is your interpretation. Approval binds only the file text they actually read — quote it verbatim. |
+| "Live checks belong in Stage 4" | When an UNVERIFIED item shapes the spec, a smoke probe before freeze beats re-planning after it — one run flipped three guard decisions that way. |
 
 ## Red Flags
 
 - Production code written before its failing test exists.
 - Implementer report accepted without RED evidence.
-- Approval requested without the full spec/plan text in front of the user.
+- Approval requested without the full spec/plan text in front of the user —
+  or over a summary/translation instead of the frozen file's verbatim text.
 - Reviewer given implementer reports or conversation summaries (context bleed).
 - Review round 4+ still producing MEDIUM findings — escalate, don't grind.
 - `.pipeline/` files committed, or a subagent prompted without the file paths
@@ -208,11 +223,19 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 - `git worktree add` or bare `git stash` in a session that has native tools.
 - Branch named `feature/…` (hook rejects) or commit bullets over 120 chars.
 - Findings "fixed" without gates re-run before re-review.
+- Main-thread integration code (eval-harness handler, registration) written
+  before its failing test.
+- `.pipeline/review-round-N.md` holding a paraphrase instead of the
+  reviewer's full report.
+- Spec frozen with an UNVERIFIED item that decides tool shape while the
+  live server was reachable.
 
 ## Verification (pipeline exit checklist)
 
 - [ ] Worktree isolated, branch `<type>/<kebab>`, baseline was green at start
-- [ ] Spec and plan each shown in full to the user, approved, frozen in `.pipeline/`
+- [ ] Spec and plan each shown to the user verbatim (full file text), approved,
+      frozen in `.pipeline/`; reviewer reports stored verbatim in
+      `.pipeline/review-round-*.md`
 - [ ] Every implementer report carried RED-then-GREEN evidence
 - [ ] All five gate commands pass (pytest, ruff check, ruff format --check,
       mypy, diff-cover); diff-cover ≥90% on changed lines

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -85,7 +85,15 @@ sequentially, in one Agent call each.
    and fill its slots from the report. The template fixes the required
    sections — don't invent a new shape; they are the standard
    pipeline-reviewer judges the diff against.
-3. **Show the user the full spec, then ask approval.** The approval request
+3. **If live credentials work, burn down UNVERIFIED before approval.** Probe a
+   project-scoped endpoint first (global ones can 403 on a scoped token), then
+   settle the researcher's UNVERIFIED items with cheap reads and scratch
+   writes (create a disposable resource, probe, delete it). A fact settled at
+   spec time is a design decision made once; the same fact discovered after
+   implementation is a review-fix round. (Run 2026-07-13: a pre-approval probe
+   found the real enum path and two silent-ghost writes — flipped a guard from
+   "deferred" to "shipped" before any code existed.)
+4. **Show the user the full spec, then ask approval.** The approval request
    quotes the spec content (or the revised sections on a redo) in the reply —
    the user approves text they have read, never a bare "spec ready, approve?"
    prompt. Fold feedback back into `.pipeline/spec.md`; approval freezes it.
@@ -113,7 +121,10 @@ For each plan task, in dependency order: **invoke `pipeline-implementer`**
 with the `.pipeline/spec.md` + `.pipeline/plan.md` paths, the single task
 excerpt, and its file:line references. Expect CHANGED / EVIDENCE (RED then
 GREEN output) / DEVIATIONS back — a report without RED evidence means the task
-was not done TDD; reject it and rerun.
+was not done TDD; reject it and rerun. RED form depends on the task: a
+brand-new symbol or module may show a collection-time ImportError as its RED;
+changed behavior on existing code needs an assertion-level failure — an
+ImportError there means the test never exercised the behavior.
 
 Keep cross-task integration (imports, registration lists like
 `EXPECTED_TOOL_NAMES`, eval coverage entry) in the main thread, where the
@@ -134,12 +145,15 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 
 ## Stage 5 — Review (loop entry)
 
-1. **Invoke `pipeline-reviewer`** with: `.pipeline/spec.md` and
+1. **Commit the work first**, in Stage 7's message format — the reviewer
+   diffs `origin/main...HEAD`, and uncommitted changes are invisible to that
+   range. Fix rounds add commits; squash merge collapses them at the end.
+2. **Invoke `pipeline-reviewer`** with: `.pipeline/spec.md` and
    `.pipeline/plan.md` paths and the diff scope (`git diff origin/main...HEAD`).
    Give it the spec and plan — **never** the implementer reports or your
    implementation narrative (context bleed defeats the fresh eyes).
-2. Save its report to `.pipeline/review-round-N.md`; relay findings to the user.
-3. **Stop criterion — the only exit:** verdict PASS (zero CRITICAL/MEDIUM
+3. Save its report to `.pipeline/review-round-N.md`; relay findings to the user.
+4. **Stop criterion — the only exit:** verdict PASS (zero CRITICAL/MEDIUM
    actionable findings). LOW/NIT go to PR notes, not necessarily fixed.
    PASS → Stage 7. FAIL → Stage 6.
 


### PR DESCRIPTION
## Summary

Consolidates #179 and #180 (both edited the same SKILL.md with an overlapping Stage-1 lesson). Codifies the lessons from auditing the first two full dev-pipeline runs — update_test_records (PR #177) and create_test_records (PR #178) — against the skill text. Each edit is anchored to an observed gap, not a hypothetical. Also deduplicates the commit/PR format rules out of Stage 7 into a Repo Conventions pointer.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Two pipeline-run audits (#177, #178) found unwritten points the skill text permitted or lacked
- Commit-first review, RED-form rule, pre-approval probes, verbatim handoffs; commit format deduped to pointer

## Testing

Doc-only. Baseline evidence = the two audited runs:

- From the #177 audit: (1) Stage 5 reviewer diffs `origin/main...HEAD` but Stage 7 owned the commit — orchestrator had to improvise an early commit; (2) all four implementer reports returned collection ImportError as RED with no rule to judge acceptability; (3) a user-directed pre-approval live probe flipped the result-enum guard from "deferred" to "shipped" before any code existed.
- From the #178 audit: condensed plan approval, code-first fake-server handler, paraphrased review report, late live verification — each now has an explicit rule.
- GREEN (from #180): fresh-context agent read only the edited SKILL.md and answered 4 scenario questions — all 4 recovered the new rules with correct section citations (single-rep retrieval check; that check predates the merged Stage-1.3 wording, which unions both PRs' text without dropping any rule).
- GREEN (dedup edit): fresh-context agent re-ran a 4-question retrieval check against the deduped text — recovered the commit-first rule and, via the new pointer, CONTRIBUTING.md's ≤120-char bullet limit and the commit-msg hook's reject behavior; also reproduced the drift argument unprompted.

## Notes for Reviewers

- Overlap resolution: both PRs added a Stage-1 pre-approval live-probe step; merged into one step 3 keeping the union — #180's trigger condition ("UNVERIFIED item decides spec content") + #179's probe method/rationale/run anecdote + #180's "failed probe on one endpoint is not access-is-dead".
- Deliberately NOT changed (from #179): the sequential-implementation rule (one observed parallel deviation was harmless but the conservative wording is correct as written).
- Dedup rationale: commit format / PR checkbox / squash rules were stated in four places (CONTRIBUTING.md, CLAUDE.md — loaded every session — the skill, and the enforcing hooks). Stage 5.1 and Stage 7 now point at Repo Conventions and keep only pipeline-specific ship steps (`.pipeline/` uncommitted, leftover-only commit, PR Notes content, CI watch). Red-flag "commit bullets over 120 chars" dropped — commit-msg hook rejects instantly, so the flag had no early-warning value; the `feature/` branch flag stays because the pre-push hook only fires at push time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
