### PR TITLE
docs(skill): harden dev-pipeline from run audit

### DIFF
--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -35,7 +35,7 @@ Subagents share **no memory and no conversation history**. Three channels only:
    |---|---|---|
    | `.pipeline/spec.md` | orchestrator (Stage 1, draft before approval; approval freezes it) | pattern-scout, pipeline-implementer, pipeline-reviewer |
    | `.pipeline/plan.md` | orchestrator (Stage 2, full text shown before approval — via ExitPlanMode or quoted draft; approval freezes it) | pipeline-implementer, pipeline-reviewer |
-   | `.pipeline/review-round-N.md` | orchestrator (Stage 5, from reviewer report) | pipeline-implementer (Stage 6), user on escalation |
+   | `.pipeline/review-round-N.md` | orchestrator (Stage 5, reviewer report pasted verbatim) | pipeline-implementer (Stage 6), user on escalation |
 
 Follow-up questions to an agent you already spawned: `SendMessage` to its id —
 a fresh Agent call starts cold and re-derives everything.
@@ -85,10 +85,18 @@ sequentially, in one Agent call each.
    and fill its slots from the report. The template fixes the required
    sections — don't invent a new shape; they are the standard
    pipeline-reviewer judges the diff against.
-3. **Show the user the full spec, then ask approval.** The approval request
-   quotes the spec content (or the revised sections on a redo) in the reply —
-   the user approves text they have read, never a bare "spec ready, approve?"
-   prompt. Fold feedback back into `.pipeline/spec.md`; approval freezes it.
+3. **If an UNVERIFIED item decides spec content** — whether a field exists,
+   whether a guard is needed, which enum backs a value — **and the server is
+   reachable, live-verify it before asking approval**: smoke the endpoint
+   directly with throwaway fixtures, delete them after. Waiting for Stage 4
+   freezes guesses a five-minute probe can settle (one run flipped three
+   guard decisions this way). A failed probe on one endpoint is not "access
+   is dead" — probe the exact resource the tool will touch before concluding.
+4. **Show the user the full spec, then ask approval.** The approval request
+   quotes `.pipeline/spec.md` verbatim — the full file text, not a summary or
+   translation (on a redo, the revised sections verbatim) — the user approves
+   text they have read, never a bare "spec ready, approve?" prompt. Fold
+   feedback back into `.pipeline/spec.md`; approval freezes it.
    Spec changes are cheap here, expensive later.
 
 ## Stage 2 — Plan
@@ -102,8 +110,9 @@ sequentially, in one Agent call each.
    Verification. Use plan mode when available — ExitPlanMode already puts the
    full plan in front of the user for approval; write it to
    `.pipeline/plan.md` right after. Without plan mode, copy the template to
-   `.pipeline/plan.md`, fill it, and quote it in the approval request — same
-   rule as the spec: the user approves text they have read.
+   `.pipeline/plan.md`, fill it, and quote it verbatim in the approval
+   request — same rule as the spec: full file text, not a condensed
+   rendition; the user approves text they have read.
 
 ## Stage 3 — Implement (TDD)
 
@@ -117,7 +126,10 @@ was not done TDD; reject it and rerun.
 
 Keep cross-task integration (imports, registration lists like
 `EXPECTED_TOOL_NAMES`, eval coverage entry) in the main thread, where the
-whole picture lives.
+whole picture lives. The TDD law reaches here too: eval-harness handlers and
+any other executable glue get their failing test before the code —
+diff-cover gates `evals/harness` like `src/`, and a bounced gate is the
+expensive way to rediscover that.
 
 ## Stage 4 — Gates (main thread; all must pass before review)
 
@@ -138,7 +150,9 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
    `.pipeline/plan.md` paths and the diff scope (`git diff origin/main...HEAD`).
    Give it the spec and plan — **never** the implementer reports or your
    implementation narrative (context bleed defeats the fresh eyes).
-2. Save its report to `.pipeline/review-round-N.md`; relay findings to the user.
+2. Save its report verbatim to `.pipeline/review-round-N.md` — full text, not
+   a paraphrase (Stage 6's implementer and any escalation read it); relay
+   findings to the user.
 3. **Stop criterion — the only exit:** verdict PASS (zero CRITICAL/MEDIUM
    actionable findings). LOW/NIT go to PR notes, not necessarily fixed.
    PASS → Stage 7. FAIL → Stage 6.
@@ -181,12 +195,16 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 | "One more fix round, no re-review" | Fixes are new code; new code gets reviewed. That's why the loop exists. |
 | "Subagent for the gate commands too" | Gates are deterministic bash. A subagent burns tokens to relay an exit code. |
 | "Opus everywhere to be safe" | Model choice is a cost/judgment trade-off; sonnet ships code volume fine, opus earns its cost only on judgment stages. |
+| "Main-thread glue is too small for TDD" | A fake-server handler shipped code-first once and diff-cover bounced the gate; the failing test first was the cheaper path. |
+| "The user approved my summary of it" | A summary is your interpretation. Approval binds only the file text they actually read — quote it verbatim. |
+| "Live checks belong in Stage 4" | When an UNVERIFIED item shapes the spec, a smoke probe before freeze beats re-planning after it — one run flipped three guard decisions that way. |
 
 ## Red Flags
 
 - Production code written before its failing test exists.
 - Implementer report accepted without RED evidence.
-- Approval requested without the full spec/plan text in front of the user.
+- Approval requested without the full spec/plan text in front of the user —
+  or over a summary/translation instead of the frozen file's verbatim text.
 - Reviewer given implementer reports or conversation summaries (context bleed).
 - Review round 4+ still producing MEDIUM findings — escalate, don't grind.
 - `.pipeline/` files committed, or a subagent prompted without the file paths
@@ -194,11 +212,19 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 - `git worktree add` or bare `git stash` in a session that has native tools.
 - Branch named `feature/…` (hook rejects) or commit bullets over 120 chars.
 - Findings "fixed" without gates re-run before re-review.
+- Main-thread integration code (eval-harness handler, registration) written
+  before its failing test.
+- `.pipeline/review-round-N.md` holding a paraphrase instead of the
+  reviewer's full report.
+- Spec frozen with an UNVERIFIED item that decides tool shape while the
+  live server was reachable.
 
 ## Verification (pipeline exit checklist)
 
 - [ ] Worktree isolated, branch `<type>/<kebab>`, baseline was green at start
-- [ ] Spec and plan each shown in full to the user, approved, frozen in `.pipeline/`
+- [ ] Spec and plan each shown to the user verbatim (full file text), approved,
+      frozen in `.pipeline/`; reviewer reports stored verbatim in
+      `.pipeline/review-round-*.md`
 - [ ] Every implementer report carried RED-then-GREEN evidence
 - [ ] All five gate commands pass (pytest, ruff check, ruff format --check,
       mypy, diff-cover); diff-cover ≥90% on changed lines


### PR DESCRIPTION
## Summary

Post-run audit of the create_test_records pipeline run (PR #178) found 4 drift points the skill text permitted, plus 1 beneficial deviation worth codifying. This folds all 5 back into the skill so the next run can't repeat them.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- create_test_records run showed 4 drift points the skill text allowed
- Verbatim approvals/reports, TDD on main-thread glue, pre-freeze live probes

## Testing

- RED baseline: the audited run itself — each edit targets a deviation actually observed (condensed plan approval, code-first fake-server handler, paraphrased review report, late live verification)
- GREEN: fresh-context agent read only the edited SKILL.md and answered 4 scenario questions — all 4 recovered the new rules with correct section citations, no ambiguity reported (single-rep retrieval check; structural edits, not behavior-shaping prose)

## Notes for Reviewers

Edits per observed failure:
1. Spec/plan approval must quote the frozen file verbatim — full text, no summary/translation (Stage 1.4, Stage 2.2, Red Flags)
2. New Stage 1.3: UNVERIFIED items that decide spec shape get live-verified before freeze when the server is reachable (this run flipped 3 guard decisions that way)
3. TDD law extended to main-thread cross-task glue — diff-cover gates evals/harness like src/ (Stage 3, rationalization table)
4. review-round-N.md holds the reviewer report verbatim, not a paraphrase (handoff table, Stage 5.2, Red Flags)
5. Exit checklist updated to match