### PR TITLE
docs(readme): sync tool count prose to 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for **P
 
 ## Features
 
-- **34 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
+- **35 tools** covering read and write across documents, work items, test runs, traceability links, and comments.
 - **Read** — render documents as Markdown, search with Lucene or SQL, walk incoming/outgoing links, resolve enum options.
 - **Write** — create and update work items, documents, and test runs, manage links, reorganize document structure, post comments.
 - **Safe writes** — every write tool supports `dry_run`, and pre-write guards validate fields, enum values, and link targets before hitting Polarion.

--- a/tests/mcp_server_polarion/test_mcp_transport.py
+++ b/tests/mcp_server_polarion/test_mcp_transport.py
@@ -443,3 +443,16 @@ class TestReadmeToolTable:
             f"README {section} tool table out of sync — "
             f"add rows for {missing}; drop stale rows {stale}"
         )
+
+    def test_prose_count_matches_registration(self) -> None:
+        # Tables marker-synced above; prose "**N tools**" claim drift silent
+        # without this (went stale at #178).
+        readme = _README_PATH.read_text(encoding="utf-8")
+        claims = re.findall(r"\*\*(\d+) tools?\*\*", readme)
+        assert len(claims) == 1, (
+            f"README must claim tool count once as '**N tools**', found {claims}"
+        )
+        assert int(claims[0]) == len(EXPECTED_TOOL_NAMES), (
+            f"README claims {claims[0]} tools; registered {len(EXPECTED_TOOL_NAMES)} — "
+            f"update the '**N tools**' line"
+        )


### PR DESCRIPTION
## Summary

README prose claimed **34 tools** while 35 are registered — the count went stale when #178 added `create_test_records`. The marker-synced tool tables were updated by their contract test, but the prose count had no guard. Fixes the number and pins it with a test.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- README tool-count prose drifted silently — tables are test-synced, the prose claim was not
- Bump prose to 35; add test asserting the **N tools** claim equals len(EXPECTED_TOOL_NAMES)

## Testing

- TDD: new test failed on stale README (`assert 34 == 35`), passes after fix
- `ruff check`, `ruff format --check`, `mypy src/`, full pytest (1764 passed), `diff-cover` (no measurable lines — test + docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
