### PR TITLE
refactor(tools): unify id/field naming rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,16 @@ CI: `ruff check` → `ruff format --check` → `mypy` → `pytest` (`--cov-fail-
 - No `WARNING:`/`NOTE:` prefixes, no dev-narrative, no banner dividers. CLAUDE.md dev-only — MCP-user info live in `@mcp.tool` docstring. Module docstrings = why module exists; constraints inline next to what they constrain.
 - Comments + dev docstrings caveman-style: drop articles/filler, compress verbs — `# Custom key match standard attr = silent shadow.` One line per point, why not what; never restate self-evident code; multi-line only when each line carry distinct fact. Technical terms/ids/API names/numbers exact; no invented abbreviations. Exempt (LLM-facing, eval-gated): `@mcp.tool` docstrings + `Field(description=...)` — normal prose per Docstrings rule above. `TODO` = `# TODO(#issue): concrete action`, never stray. No dead code; keep comments sync when code change.
 
+## Naming Rules (LLM surface: params + model fields)
+
+- Cross-resource ref = full-noun `<resource>_id` (`project_id`, `work_item_id`, `test_run_id`, `test_case_id`, `comment_id`, `field_id`, `defect_id`, `template_id`). Documents own no id — address = `space_id` + `document_name` pair; `module_*` never on LLM surface (API `moduleName` map inside payload builder only).
+- Other location = `target_*` prefix (`target_project_id`, `target_space_id`, `target_document_name`, `target_work_item_id`).
+- Own id in own Summary/Detail model = bare `id`. Composite resource (work_item_**link**, test_**record**) drop parent prefix in own echo/selector fields (`link_id(s)`, `record_id(s)`); tool names + cross-domain refs stay full.
+- Create spec mirror resource attributes (client-supplied id = bare `id`, e.g. `TestRunCreateSpec.id`); update spec = target selector (`work_item_id`/`test_run_id`/`record_id`) + changed attributes.
+- Polarion camelCase → snake_case split at case boundary exact (`homePageContent` → `home_page_content`, `finishedOn` → `finished_on`); ad-hoc compounds banned (never "homepage").
+- Person fields = `<role>_id`/`<role>_name` parallel scalar pairs (author, assignee(s), last_updated_by, executed_by); list/summary = name only, detail add id.
+- Bools: state field = API-derived (`is_template`, `resolved`, `suspect`); read-expansion flag = `include_*_html`; list filter param describe result set (`templates`) — 1:1 field-name match not required.
+
 ## Polarion API Gotchas
 
 - Baseline: Polarion REST API v2506 — assume that version behavior.

--- a/evals/evaluators/checks.py
+++ b/evals/evaluators/checks.py
@@ -229,7 +229,7 @@ _BODY_WRITE_TO_SOURCE: dict[str, tuple[str, str, str, tuple[str, ...], bool]] = 
     "update_document": (
         "home_page_content_html",
         "get_document",
-        "include_homepage_content_html",
+        "include_home_page_content_html",
         ("project_id", "space_id", "document_name"),
         False,
     ),

--- a/src/mcp_server_polarion/models/test_runs.py
+++ b/src/mcp_server_polarion/models/test_runs.py
@@ -14,10 +14,10 @@ class TestRecordSummary(BaseModel):
     # pytest collect Test*-named classes on import; opt out.
     __test__ = False
 
-    # record_id = resource 5-segment id verbatim (update_test_records input);
-    # never parsed. test_case_id = full "project/WI-id" from
+    # id = resource 5-segment id verbatim; never parsed. Pass as record_id
+    # in update_test_records items. test_case_id = full "project/WI-id" from
     # relationships.testCase; + iteration = record identity within run.
-    record_id: str = ""
+    id: str = ""
     test_case_id: str
     iteration: int = 0
     result: str = ""

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -61,7 +61,7 @@ class DiscoveredDocument(NamedTuple):
     status: str = ""
     updated: str = ""
     author_name: str = ""
-    updated_by_name: str = ""
+    last_updated_by_name: str = ""
 
 
 # 60s cap window where stale entry accept admin-removed option.

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -303,7 +303,7 @@ def parse_work_item_summaries(
 class TestRecordSummaryKwargs(TypedDict):
     """Kwargs shape from ``parse_test_record_summary_kwargs``."""
 
-    record_id: str
+    id: str
     test_case_id: str
     iteration: int
     result: str
@@ -331,7 +331,7 @@ def parse_test_record_summary_kwargs(
     iteration = attributes.get("iteration", 0)
     executed_by_id = extract_relationship_id(relationships, "executedBy")
     return {
-        "record_id": safe_str(item.get("id", "")),
+        "id": safe_str(item.get("id", "")),
         "test_case_id": extract_relationship_id(relationships, "testCase"),
         # bool is int subclass -- reject as iteration.
         "iteration": iteration

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -306,7 +306,7 @@ class _DocumentMeta:
     status: str = ""
     updated: str = ""
     author_id: str = ""
-    updated_by_id: str = ""
+    last_updated_by_id: str = ""
 
 
 def _extract_document_from_module(
@@ -334,7 +334,7 @@ def _extract_document_from_module(
         status=safe_str(attrs.get("status", "")),
         updated=safe_str(attrs.get("updated", "")),
         author_id=extract_relationship_id(relationships, "author"),
-        updated_by_id=extract_relationship_id(relationships, "updatedBy"),
+        last_updated_by_id=extract_relationship_id(relationships, "updatedBy"),
     )
 
 
@@ -395,7 +395,7 @@ async def _discover_documents(
             status=meta.status,
             updated=meta.updated,
             author_name=user_names.get(meta.author_id, ""),
-            updated_by_name=user_names.get(meta.updated_by_id, ""),
+            last_updated_by_name=user_names.get(meta.last_updated_by_id, ""),
         )
         for (space, name), meta in documents.items()
     )
@@ -415,7 +415,7 @@ def _extract_first_resource_id(response: dict[str, object]) -> str | None:
     return full_id or None
 
 
-def _extract_created_module_name(response: dict[str, object]) -> str | None:
+def _extract_created_document_name(response: dict[str, object]) -> str | None:
     """Document name from 201 create response (name may contain ``/``);
     ``None`` on unexpected shape.
     """
@@ -482,7 +482,7 @@ def _build_update_document_payload(  # noqa: PLR0913
 
 def _build_create_document_payload(  # noqa: PLR0913
     *,
-    module_name: str,
+    document_name: str,
     title: str,
     type: str,
     home_page_content_html: str,
@@ -493,7 +493,7 @@ def _build_create_document_payload(  # noqa: PLR0913
 ) -> dict[str, JsonValue]:
     """JSON:API POST body for ``.../spaces/{s}/documents``; skip unset."""
     attributes: dict[str, JsonValue] = {
-        "moduleName": module_name,
+        "moduleName": document_name,
         "title": title,
         "type": type,
     }
@@ -589,7 +589,7 @@ async def list_documents(
             status=doc.status,
             updated=doc.updated,
             author_name=doc.author_name,
-            last_updated_by_name=doc.updated_by_name,
+            last_updated_by_name=doc.last_updated_by_name,
         )
         for doc in page_slice
     ]
@@ -617,14 +617,14 @@ async def get_document(
     document_name: str = Field(
         description="Document name within space_id.",
     ),
-    include_homepage_content_html: bool = Field(
+    include_home_page_content_html: bool = Field(
         default=False,
         description="Fill content_html with raw HTML for round-trip editing.",
     ),
 ) -> DocumentDetail:
     """Get a document's metadata: title/type/status/timestamps/editors/custom fields.
 
-    include_homepage_content_html=True fills content_html with raw
+    include_home_page_content_html=True fills content_html with raw
     homePageContent HTML — the required source for
     update_document(home_page_content_html=...). That body is inline prose
     only — headings and embedded work items render via read_document.
@@ -674,10 +674,10 @@ async def get_document(
     # ids = join keys into included users; surfaced short-form for requery too.
     user_names = parse_included_user_name_map(response)
     author_full = extract_relationship_id(relationships, "author")
-    updated_by_full = extract_relationship_id(relationships, "updatedBy")
+    last_updated_by_full = extract_relationship_id(relationships, "updatedBy")
 
     content_html = ""
-    if include_homepage_content_html:
+    if include_home_page_content_html:
         # Verbatim {type,value} so it round-trip through update_document.
         content_obj = attributes.get("homePageContent", {})
         if isinstance(content_obj, dict):
@@ -691,8 +691,8 @@ async def get_document(
         updated=safe_str(attributes.get("updated", "")),
         author_id=extract_short_id(author_full),
         author_name=user_names.get(author_full, ""),
-        last_updated_by_id=extract_short_id(updated_by_full),
-        last_updated_by_name=user_names.get(updated_by_full, ""),
+        last_updated_by_id=extract_short_id(last_updated_by_full),
+        last_updated_by_name=user_names.get(last_updated_by_full, ""),
         content_html=content_html,
         auto_suspect=bool(attributes.get("autoSuspect", False)),
         uses_outline_numbering=bool(attributes.get("usesOutlineNumbering", False)),
@@ -784,7 +784,7 @@ async def read_document(  # noqa: PLR0913
 
     Interleaves headings, work-item descriptions, and prose. Synthesis
     output: NEVER feed it to update_document — round-trip via
-    get_document(include_homepage_content_html=True). For metadata-only
+    get_document(include_home_page_content_html=True). For metadata-only
     extraction use list_work_items with SQL.
     """
     # read_document_parts handle fetch + error mapping (@mcp.tool return
@@ -881,7 +881,7 @@ async def update_document(  # noqa: PLR0913
         max_length=MAX_BODY_HTML_LEN,
         description=(
             "New body as raw HTML from "
-            "get_document(include_homepage_content_html=True); '' rejected; "
+            "get_document(include_home_page_content_html=True); '' rejected; "
             "anchorless blocks get id= auto-stamped. New tables, captions, or "
             "other Polarion constructs: call get_html_recipes first and adapt "
             "a template."
@@ -913,7 +913,7 @@ async def update_document(  # noqa: PLR0913
     PATCHes only supplied attributes — omitted fields stay unchanged. Fetch
     via get_document BEFORE updating. home_page_content_html is raw Polarion
     HTML, sent verbatim — source from
-    get_document(include_homepage_content_html=True). An empty string is
+    get_document(include_home_page_content_html=True). An empty string is
     rejected — pass '<p></p>' for near-empty.
 
     Body rules:
@@ -1045,7 +1045,7 @@ async def update_document(  # noqa: PLR0913
     tags={"write"},
     timeout=60.0,
     annotations={
-        # Additive: non-destructive, non-idempotent (duplicate module_name 409s).
+        # Additive: non-destructive, non-idempotent (duplicate document_name 409s).
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
@@ -1059,10 +1059,10 @@ async def create_document(  # noqa: PLR0913
         min_length=1,
         description="Space ID ('_default' = default space).",
     ),
-    module_name: str = Field(
+    document_name: str = Field(
         min_length=1,
         description=(
-            "Document identifier (e.g. 'MySpecV1'); unique within space_id, "
+            "Document name (e.g. 'MySpecV1'); unique within space_id, "
             "appears in the document URL."
         ),
     ),
@@ -1105,7 +1105,7 @@ async def create_document(  # noqa: PLR0913
 ) -> DocumentCreateResult:
     """Create a document in a space.
 
-    module_name must be unique in the space — a duplicate name conflicts;
+    document_name must be unique in the space — a duplicate name conflicts;
     check list_documents first. type/status and custom_fields keys are
     validated on write — resolve ids via list_document_enum_options first.
 
@@ -1113,7 +1113,7 @@ async def create_document(  # noqa: PLR0913
     HTML. Markdown tables get native Polarion styling; a paragraph starting
     'Table:' directly after a table becomes a numbered caption widget.
     Post-create edits round-trip raw HTML via
-    get_document(include_homepage_content_html=True) and update_document;
+    get_document(include_home_page_content_html=True) and update_document;
     add work items via move_work_item_to_document.
     """
     client = get_client(ctx)
@@ -1140,7 +1140,7 @@ async def create_document(  # noqa: PLR0913
         )
 
     payload = _build_create_document_payload(
-        module_name=module_name,
+        document_name=document_name,
         title=title,
         type=type,
         home_page_content_html=home_page_content_html,
@@ -1176,7 +1176,7 @@ async def create_document(  # noqa: PLR0913
     except PolarionError as exc:
         raise RuntimeError(f"Failed to create document: {exc.message}") from exc
 
-    new_name = _extract_created_module_name(response)
+    new_name = _extract_created_document_name(response)
     if new_name is None:
         raise RuntimeError(
             "Polarion accepted the create request but returned no document name. "

--- a/src/mcp_server_polarion/tools/guides/html_recipes.md
+++ b/src/mcp_server_polarion/tools/guides/html_recipes.md
@@ -2,7 +2,7 @@
 
 Templates for hand-writing Polarion-native HTML when editing a body fetched
 with `get_work_item(include_description_html=True)` /
-`get_document(include_homepage_content_html=True)`. Splice new blocks in;
+`get_document(include_home_page_content_html=True)`. Splice new blocks in;
 never rewrite existing markup (round-trip bodies are sent verbatim).
 
 Markdown given to `create_work_items` / `create_document` gets tables and

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -721,8 +721,8 @@ async def list_test_records(  # noqa: PLR0913
 
     Filter by result (e.g. 'failed') or omit for all; not-yet-executed
     records have empty result. Lucene query is NOT supported here. Returns
-    summaries — record_id is the exact id update_test_records takes;
-    defect_id links the failure work item.
+    summaries — id is the exact value update_test_records takes as
+    record_id; defect_id links the failure work item.
     """
     client = get_client(ctx)
     params: dict[str, str | int] = {
@@ -841,7 +841,7 @@ async def get_test_run(
     ctx: Context,
     project_id: str = Field(description="Polarion project ID."),
     test_run_id: str = Field(description="Test run ID (e.g. 'TR-2026-01')."),
-    include_homepage_content_html: bool = Field(
+    include_home_page_content_html: bool = Field(
         default=False,
         description="Fill content_html with the run's raw HTML report body.",
     ),
@@ -850,7 +850,7 @@ async def get_test_run(
 
     Returns writable fields (title, status, group_id, custom_fields) plus
     read-only context: test-case selection, template provenance, author, and
-    timestamps. include_homepage_content_html=True fills content_html with
+    timestamps. include_home_page_content_html=True fills content_html with
     the raw HTML report body; it stays empty when use_report_from_template
     is true. Never feed back a blanked (flag=False) body.
     """
@@ -892,7 +892,7 @@ async def get_test_run(
         fallback_id=test_run_id,
         user_names=parse_included_user_name_map(response),
     )
-    if not include_homepage_content_html:
+    if not include_home_page_content_html:
         # Body always travel over wire; blank per flag=False contract.
         detail = detail.model_copy(update={"content_html": ""})
     return detail

--- a/tests/evals/evaluators/test_checks.py
+++ b/tests/evals/evaluators/test_checks.py
@@ -350,7 +350,7 @@ class TestCheckRoundTripSource:
         trajectory = [
             _call(
                 "get_document",
-                {**_DOC_ARGS, "include_homepage_content_html": True},
+                {**_DOC_ARGS, "include_home_page_content_html": True},
             ),
             _call(
                 "update_document",
@@ -370,7 +370,7 @@ class TestCheckRoundTripSource:
         ]
         passed, reason = checks.check_round_trip_source(trajectory, {})
         assert passed is False
-        assert "include_homepage_content_html" in reason
+        assert "include_home_page_content_html" in reason
 
     def test_read_document_does_not_satisfy(self) -> None:
         trajectory = [

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -458,8 +458,8 @@ class TestParseTestRecordSummaries:
             user_names={"proj/jdoe": "J Doe"},
         )
         # Full ids kept -- no extract_short_id on work-item targets.
-        # record_id verbatim -- update_test_records copy it whole.
-        assert kwargs["record_id"] == "proj/TR-1/proj/TC-42/0"
+        # id verbatim -- update_test_records copy it whole (as record_id).
+        assert kwargs["id"] == "proj/TR-1/proj/TC-42/0"
         assert kwargs["test_case_id"] == "proj/TC-42"
         assert kwargs["defect_id"] == "proj/DEF-7"
         assert kwargs["executed_by_name"] == "J Doe"
@@ -515,7 +515,7 @@ class TestParseTestRecordSummaries:
         }
         parsed = parse_test_record_summaries(response)
         assert [r.test_case_id for r in parsed] == ["proj/TC-2"]
-        assert [r.record_id for r in parsed] == ["proj/TR-1/proj/TC-2/0"]
+        assert [r.id for r in parsed] == ["proj/TR-1/proj/TC-2/0"]
 
 
 class TestParseTestRunDetail:

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -102,7 +102,7 @@ async def _call_create_doc(mock_ctx: MagicMock, **overrides: object) -> object:
     defaults: dict[str, object] = {
         "project_id": "MyProj",
         "space_id": "_default",
-        "module_name": "Doc",
+        "document_name": "Doc",
         "title": "x",
         "type": "systemRequirementSpecification",
         "status": None,
@@ -671,7 +671,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="SRS",
-            include_homepage_content_html=True,
+            include_home_page_content_html=True,
         )
 
         assert isinstance(result, DocumentDetail)
@@ -755,10 +755,10 @@ class TestGetDocument:
         assert result.auto_suspect is False
         assert result.uses_outline_numbering is False
 
-    async def test_include_homepage_content_html_false_omits_content(
+    async def test_include_home_page_content_html_false_omits_content(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """include_homepage_content_html=False → body hidden even though ``@all``
+        """include_home_page_content_html=False → body hidden even though ``@all``
         always carry it on wire.
         """
         mock_client.get.return_value = {
@@ -781,7 +781,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="SRS",
-            include_homepage_content_html=False,
+            include_home_page_content_html=False,
         )
 
         assert result.title == "SRS"
@@ -789,10 +789,10 @@ class TestGetDocument:
         assert result.status == "draft"
         assert result.content_html == ""
 
-    async def test_include_homepage_content_html_returns_raw_html(
+    async def test_include_home_page_content_html_returns_raw_html(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        """include_homepage_content_html=True → raw HTML, no markdownify."""
+        """include_home_page_content_html=True → raw HTML, no markdownify."""
         mock_client.get.return_value = {
             "data": {
                 "attributes": {
@@ -812,7 +812,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="Doc",
-            include_homepage_content_html=True,
+            include_home_page_content_html=True,
         )
 
         # Verbatim HTML; no Markdown conversion.
@@ -842,7 +842,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="Doc",
-            include_homepage_content_html=True,
+            include_home_page_content_html=True,
         )
 
         assert result.content_html == raw
@@ -887,7 +887,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="EmptyDoc",
-            include_homepage_content_html=True,
+            include_home_page_content_html=True,
         )
 
         assert result.content_html == ""
@@ -926,7 +926,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="NoContent",
-            include_homepage_content_html=True,
+            include_home_page_content_html=True,
         )
 
         assert result.content_html == ""
@@ -958,7 +958,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="SRS",
-            include_homepage_content_html=False,
+            include_home_page_content_html=False,
         )
 
         # Raw passthrough: rich-text and structured values stay verbatim.
@@ -988,7 +988,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="Plain",
-            include_homepage_content_html=False,
+            include_home_page_content_html=False,
         )
 
         assert result.custom_fields == {}
@@ -1008,7 +1008,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="A",
-            include_homepage_content_html=False,
+            include_home_page_content_html=False,
         )
         _, kwargs_a = mock_client.get.call_args
         assert kwargs_a["params"]["fields[documents]"] == "@all"
@@ -1021,7 +1021,7 @@ class TestGetDocument:
             project_id="proj1",
             space_id="_default",
             document_name="B",
-            include_homepage_content_html=True,
+            include_home_page_content_html=True,
         )
         _, kwargs_b = mock_client.get.call_args
         assert kwargs_b["params"]["fields[documents]"] == "@all"
@@ -2159,7 +2159,7 @@ class TestBuildUpdateDocumentPayload:
         assert "attributes" not in data
         assert data["id"] == "MyProj/S/D"
 
-    def test_homepagecontent_omitted_when_not_passed(self) -> None:
+    def test_home_page_content_omitted_when_not_passed(self) -> None:
         # Omit home_page_content_html leave body untouched.
         payload = _build_update_document_payload(
             project_id="MyProj",
@@ -2471,7 +2471,7 @@ class TestUpdateDocumentValidation:
             )
         mock_client.patch.assert_not_called()
 
-    async def test_custom_fields_homepagecontent_collision_raises(
+    async def test_custom_fields_home_page_content_collision_raises(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         """`homePageContent` collision raise — allow via custom_fields would
@@ -2962,7 +2962,7 @@ class TestBuildCreateDocumentPayload:
 
     def test_minimal_payload_has_only_required_attrs(self) -> None:
         payload = _build_create_document_payload(
-            module_name="MySpec",
+            document_name="MySpec",
             title="My Spec",
             type="req_specification",
             home_page_content_html="",
@@ -2988,7 +2988,7 @@ class TestBuildCreateDocumentPayload:
 
     def test_status_attached_when_set(self) -> None:
         payload = _build_create_document_payload(
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             home_page_content_html="",
@@ -3001,7 +3001,7 @@ class TestBuildCreateDocumentPayload:
 
     def test_home_page_content_wrapped_as_html_block(self) -> None:
         payload = _build_create_document_payload(
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             home_page_content_html="<p>Hi</p>",
@@ -3017,7 +3017,7 @@ class TestBuildCreateDocumentPayload:
 
     def test_skips_none_status_and_empty_body(self) -> None:
         payload = _build_create_document_payload(
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             home_page_content_html="",
@@ -3030,7 +3030,7 @@ class TestBuildCreateDocumentPayload:
 
     def test_custom_fields_inlined_alongside_standard_attrs(self) -> None:
         payload = _build_create_document_payload(
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             home_page_content_html="",
@@ -3046,7 +3046,7 @@ class TestBuildCreateDocumentPayload:
     def test_custom_fields_collision_with_standard_attr_raises(self) -> None:
         with pytest.raises(ValueError, match="title"):
             _build_create_document_payload(
-                module_name="MySpec",
+                document_name="MySpec",
                 title="t",
                 type="generic",
                 home_page_content_html="",
@@ -3056,7 +3056,7 @@ class TestBuildCreateDocumentPayload:
 
     def test_outline_and_autosuspect_attached_when_set(self) -> None:
         payload = _build_create_document_payload(
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             home_page_content_html="",
@@ -3072,7 +3072,7 @@ class TestBuildCreateDocumentPayload:
 
     def test_outline_and_autosuspect_omitted_when_none(self) -> None:
         payload = _build_create_document_payload(
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             home_page_content_html="",
@@ -3085,7 +3085,7 @@ class TestBuildCreateDocumentPayload:
 
     def test_false_autosuspect_and_outline_serialised(self) -> None:
         payload = _build_create_document_payload(
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             home_page_content_html="",
@@ -3110,7 +3110,7 @@ class TestCreateDocumentDryRun:
             mock_ctx,
             project_id="MyProj",
             space_id="_default",
-            module_name="MySpec",
+            document_name="MySpec",
             title="Dry test",
             type="req_specification",
             status=None,
@@ -3157,7 +3157,7 @@ class TestCreateDocumentHappyPath:
             mock_ctx,
             project_id="MyProj",
             space_id="_default",
-            module_name="MySpec",
+            document_name="MySpec",
             title="Real",
             type="req_specification",
             status=None,
@@ -3183,7 +3183,7 @@ class TestCreateDocumentHappyPath:
             mock_ctx,
             project_id="MyProj",
             space_id="_default",
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="req_specification",
             status="draft",
@@ -3213,7 +3213,7 @@ class TestCreateDocumentHappyPath:
             mock_ctx,
             project_id="Proj With Space",
             space_id="My Space",
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             status=None,
@@ -3236,7 +3236,7 @@ class TestCreateDocumentHappyPath:
             mock_ctx,
             project_id="MyProj",
             space_id="_default",
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             status=None,
@@ -3262,7 +3262,7 @@ class TestCreateDocumentHappyPath:
             mock_ctx,
             project_id="MyProj",
             space_id="_default",
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             status=None,
@@ -3299,7 +3299,7 @@ class TestCreateDocumentHappyPath:
             mock_ctx,
             project_id="MyProj",
             space_id="_default",
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             status=None,
@@ -3331,7 +3331,7 @@ class TestCreateDocumentHappyPath:
                 mock_ctx,
                 project_id="MyProj",
                 space_id="_default",
-                module_name="MySpec",
+                document_name="MySpec",
                 title="t",
                 type="generic",
                 status=None,
@@ -3352,7 +3352,7 @@ class TestCreateDocumentHappyPath:
             mock_ctx,
             project_id="MyProj",
             space_id="_default",
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             status=None,
@@ -3378,7 +3378,7 @@ class TestCreateDocumentHappyPath:
             mock_ctx,
             project_id="MyProj",
             space_id="_default",
-            module_name="Folder/Sub/Doc",
+            document_name="Folder/Sub/Doc",
             title="t",
             type="generic",
             status=None,
@@ -3402,7 +3402,7 @@ class TestCreateDocumentHappyPath:
             mock_ctx,
             project_id="MyProj",
             space_id="_default",
-            module_name="MySpec",
+            document_name="MySpec",
             title="t",
             type="generic",
             status=None,
@@ -3425,7 +3425,7 @@ class TestCreateDocumentHappyPath:
                 mock_ctx,
                 project_id="MyProj",
                 space_id="_default",
-                module_name="MySpec",
+                document_name="MySpec",
                 title="t",
                 type="generic",
                 status=None,
@@ -3452,7 +3452,7 @@ class TestCreateDocumentErrorMapping:
                 mock_ctx,
                 project_id="MyProj",
                 space_id="_default",
-                module_name="MySpec",
+                document_name="MySpec",
                 title="t",
                 type="generic",
                 status=None,
@@ -3473,7 +3473,7 @@ class TestCreateDocumentErrorMapping:
                 mock_ctx,
                 project_id="ghost",
                 space_id="ghost_space",
-                module_name="MySpec",
+                document_name="MySpec",
                 title="t",
                 type="generic",
                 status=None,
@@ -3494,7 +3494,7 @@ class TestCreateDocumentErrorMapping:
                 mock_ctx,
                 project_id="MyProj",
                 space_id="_default",
-                module_name="MySpec",
+                document_name="MySpec",
                 title="t",
                 type="generic",
                 status=None,
@@ -3517,7 +3517,7 @@ class TestCreateDocumentResponseParsing:
                 mock_ctx,
                 project_id="MyProj",
                 space_id="_default",
-                module_name="MySpec",
+                document_name="MySpec",
                 title="t",
                 type="generic",
                 status=None,
@@ -3536,7 +3536,7 @@ class TestCreateDocumentResponseParsing:
                 mock_ctx,
                 project_id="MyProj",
                 space_id="_default",
-                module_name="MySpec",
+                document_name="MySpec",
                 title="t",
                 type="generic",
                 status=None,
@@ -3558,7 +3558,7 @@ class TestCreateDocumentResponseParsing:
                 mock_ctx,
                 project_id="MyProj",
                 space_id="_default",
-                module_name="MySpec",
+                document_name="MySpec",
                 title="t",
                 type="generic",
                 status=None,
@@ -3586,12 +3586,12 @@ class TestCreateDocumentFieldValidation:
         with pytest.raises(ValidationError):
             self._adapter_for("space_id").validate_python("")
 
-    def test_module_name_rejects_empty_string(self) -> None:
+    def test_document_name_rejects_empty_string(self) -> None:
         with pytest.raises(ValidationError):
-            self._adapter_for("module_name").validate_python("")
+            self._adapter_for("document_name").validate_python("")
 
-    def test_module_name_accepts_non_empty(self) -> None:
-        assert self._adapter_for("module_name").validate_python("MySpec") == "MySpec"
+    def test_document_name_accepts_non_empty(self) -> None:
+        assert self._adapter_for("document_name").validate_python("MySpec") == "MySpec"
 
     def test_title_rejects_empty_string(self) -> None:
         with pytest.raises(ValidationError):
@@ -3623,7 +3623,7 @@ class TestCreateDocumentDocstringGuidance:
     enum-resolution steer needed; uniqueness is not.
     """
 
-    def test_docstring_mentions_module_name_uniqueness(self) -> None:
+    def test_docstring_mentions_document_name_uniqueness(self) -> None:
         document = create_document.__doc__ or ""
         assert "unique" in document.lower()
         assert "409" in document or "conflict" in document.lower()
@@ -4002,7 +4002,7 @@ class TestEnumGuardCreateDocument:
         with pytest.raises(ValueError, match="type='productRequirementSpecification'"):
             await _call_create_doc(
                 mock_ctx,
-                module_name="NewSpec",
+                document_name="NewSpec",
                 type="productRequirementSpecification",
             )
         mock_client.post.assert_not_called()
@@ -4031,7 +4031,10 @@ class TestEnumGuardCreateDocument:
         }
 
         result = await _call_create_doc(
-            mock_ctx, module_name="NewSpec", type=dtype, custom_fields={"version": "2"}
+            mock_ctx,
+            document_name="NewSpec",
+            type=dtype,
+            custom_fields={"version": "2"},
         )
 
         assert result.created is True  # type: ignore[attr-defined]
@@ -4063,7 +4066,7 @@ class TestEnumGuardCreateDocument:
         with pytest.raises(ValueError, match=r"'docRisk'.*'severe'"):
             await _call_create_doc(
                 mock_ctx,
-                module_name="NewSpec",
+                document_name="NewSpec",
                 type=dtype,
                 custom_fields={"docRisk": "severe"},
             )
@@ -4087,7 +4090,7 @@ class TestEnumGuardCreateDocument:
         with pytest.raises(ValueError, match="ghostField"):
             await _call_create_doc(
                 mock_ctx,
-                module_name="NewSpec",
+                document_name="NewSpec",
                 type=dtype,
                 custom_fields={"ghostField": "x"},
             )
@@ -4109,7 +4112,7 @@ class TestEnumGuardCreateDocument:
         with pytest.raises(RuntimeError, match="Refusing the write"):
             await _call_create_doc(
                 mock_ctx,
-                module_name="NewSpec",
+                document_name="NewSpec",
                 type=dtype,
                 custom_fields={"version": "2"},
             )

--- a/tests/mcp_server_polarion/tools/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/test_test_runs.py
@@ -443,7 +443,7 @@ class TestListTestRecords:
 
         first = result.items[0]
         # Full work-item ids preserved -- never derived from 5-segment record id.
-        assert first.record_id == "proj1/TR-001/proj1/TC-42/0"
+        assert first.id == "proj1/TR-001/proj1/TC-42/0"
         assert first.test_case_id == "proj1/TC-42"
         assert first.iteration == 0
         assert first.result == "failed"
@@ -1761,7 +1761,7 @@ class TestGetTestRun:
             mock_ctx,
             project_id="proj1",
             test_run_id="TR-100",
-            include_homepage_content_html=True,
+            include_home_page_content_html=True,
         )
 
         assert isinstance(result, TestRunDetail)
@@ -1798,7 +1798,7 @@ class TestGetTestRun:
             mock_ctx,
             project_id="proj1",
             test_run_id="TR-100",
-            include_homepage_content_html=False,
+            include_home_page_content_html=False,
         )
 
         args, kwargs = mock_client.get.call_args
@@ -1807,7 +1807,7 @@ class TestGetTestRun:
         assert kwargs["params"]["include"] == "author"
         assert kwargs["params"]["fields[users]"] == "name"
 
-    async def test_include_homepage_content_html_false_blanks_field(
+    async def test_include_home_page_content_html_false_blanks_field(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         """Flag off blank body — body still travel (``@all`` for customs)."""
@@ -1817,7 +1817,7 @@ class TestGetTestRun:
             mock_ctx,
             project_id="proj1",
             test_run_id="TR-100",
-            include_homepage_content_html=False,
+            include_home_page_content_html=False,
         )
 
         assert result.content_html == ""
@@ -1836,7 +1836,7 @@ class TestGetTestRun:
                 mock_ctx,
                 project_id="proj1",
                 test_run_id="TR-404",
-                include_homepage_content_html=False,
+                include_home_page_content_html=False,
             )
 
     async def test_auth_error_raises_permission_error(
@@ -1849,7 +1849,7 @@ class TestGetTestRun:
                 mock_ctx,
                 project_id="proj1",
                 test_run_id="TR-100",
-                include_homepage_content_html=False,
+                include_home_page_content_html=False,
             )
 
     async def test_other_error_raises_runtime_error(
@@ -1862,7 +1862,7 @@ class TestGetTestRun:
                 mock_ctx,
                 project_id="proj1",
                 test_run_id="TR-100",
-                include_homepage_content_html=False,
+                include_home_page_content_html=False,
             )
 
     async def test_non_dict_data_falls_back_to_arg_id(
@@ -1874,7 +1874,7 @@ class TestGetTestRun:
             mock_ctx,
             project_id="proj1",
             test_run_id="TR-100",
-            include_homepage_content_html=False,
+            include_home_page_content_html=False,
         )
 
         assert result.id == "TR-100"


### PR DESCRIPTION
## Summary

2026-07-15 naming audit found LLM-facing id/field naming drift across the 38 tools. This PR fixes the 4 rule violations and codifies the naming rulebook (R1-R8) as a new CLAUDE.md "Naming Rules" section so future tools stay consistent. HTTP payload shapes are untouched -- API names (`moduleName`, `homePageContent`) stay mapped at the payload/parse seams.

Renames:
1. `create_document` param `module_name` -> `document_name` (R1; now symmetric with `DocumentCreateResult.document_name` and every other document tool)
2. `include_homepage_content_html` -> `include_home_page_content_html` in `get_document`/`get_test_run` + all cross-referencing docstrings, `evals/evaluators/checks.py`, `html_recipes.md` (R6: mechanical camelCase split, "homepage" compound banned)
3. `TestRecordSummary.record_id` -> `id` (R3: own id in own model = bare `id`; description keeps the "pass as record_id in update_test_records" signal)
4. Internal `DiscoveredDocument.updated_by_name`/`_DocumentMeta.updated_by_id` -> `last_updated_by_*`, helper `_extract_created_module_name` -> `_extract_created_document_name` (R7 alignment, no LLM surface change)

Explicitly legitimized by the rulebook (unchanged): `TestRunCreateSpec.id` (R5), `templates` filter (R8), `link_ids`/`record_ids` + `TestRecordUpdateSpec.record_id` (R4), `test_case_id`/`defect_id` (R1), `custom_fields.py` `"moduleName"` literal (API seam).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Audit found LLM-facing naming drift (module_name, homepage compound, record_id vs bare id)
- Rename 4 violations, codify rules as CLAUDE.md Naming Rules; API payload keys unchanged

## Testing

- Full suite 1947 passed; ruff check / ruff format --check / mypy clean; diff-cover 100% on changed lines
- All renames done TDD (RED unexpected-kwarg/assertion failures captured before each production rename)
- Payload-seam tests assert byte-identical `moduleName`/`homePageContent` emission; parse paths unchanged -- no live test needed (no HTTP-shape change)
- pipeline-reviewer verdict: PASS round 1 (zero CRITICAL/MEDIUM)

## Notes for Reviewers

- Breaking for MCP clients pinning old param names -> next deploy should bump 1.6.0 to 2.0.0; full LLM eval rerun stays a deploy-time gate (docstring contract/style gates pass now)
- NIT (unfixed, cosmetic): test helper `_module_resource` keeps param `updated_by_id` -- it mirrors the API `updatedBy` relationship, not the renamed internal field (tests/mcp_server_polarion/tools/test_documents.py:180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
