### PR TITLE
fix(tools): add recovery hints to link/enum errors

### DIFF
--- a/src/mcp_server_polarion/tools/enum.py
+++ b/src/mcp_server_polarion/tools/enum.py
@@ -56,7 +56,8 @@ async def _list_enum_options(  # noqa: PLR0913
     except PolarionNotFoundError as exc:
         raise ValueError(
             f"No enum options for field '{field_id}' on {type_label} type "
-            f"'{type_id}' in project '{project_id}'."
+            f"'{type_id}' in project '{project_id}' -- field unknown or not "
+            f"enum-typed."
         ) from exc
     except PolarionAuthError as exc:
         raise PermissionError(

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -628,10 +628,13 @@ async def update_work_item_link(  # noqa: PLR0913
             "Cannot update work item link -- check your POLARION_TOKEN permissions."
         ) from exc
     except PolarionNotFoundError as exc:
-        raise ValueError(f"Link not found (HTTP 404): {exc.message}") from exc
+        raise ValueError(
+            f"Link '{link_id}' not found -- check role/target via "
+            f"`list_work_item_links`."
+        ) from exc
     except PolarionError as exc:
         raise RuntimeError(
-            f"Patch failed (HTTP {exc.status_code}): {exc.message}"
+            f"Failed to update work item link '{link_id}': {exc.message}"
         ) from exc
 
     return WorkItemLinkUpdateResult(

--- a/tests/mcp_server_polarion/tools/test_enum.py
+++ b/tests/mcp_server_polarion/tools/test_enum.py
@@ -209,7 +209,7 @@ class TestListWorkItemEnumOptions:
             status_code=404,
         )
 
-        with pytest.raises(ValueError, match="No enum options"):
+        with pytest.raises(ValueError, match=r"No enum options.*not enum-typed"):
             await list_work_item_enum_options(
                 mock_ctx,
                 project_id="MCP_Test_Project",
@@ -445,7 +445,7 @@ class TestListDocumentEnumOptions:
             status_code=404,
         )
 
-        with pytest.raises(ValueError, match="No enum options"):
+        with pytest.raises(ValueError, match=r"No enum options.*not enum-typed"):
             await list_document_enum_options(
                 mock_ctx,
                 project_id="MCP_Test_Project",

--- a/tests/mcp_server_polarion/tools/test_links.py
+++ b/tests/mcp_server_polarion/tools/test_links.py
@@ -1539,7 +1539,7 @@ class TestUpdateWorkItemLinkErrors:
             "no such link", status_code=404
         )
 
-        with pytest.raises(ValueError, match="404"):
+        with pytest.raises(ValueError, match="list_work_item_links"):
             await update_work_item_link(
                 mock_ctx,
                 project_id="MyProj",
@@ -1557,7 +1557,9 @@ class TestUpdateWorkItemLinkErrors:
     ) -> None:
         mock_client.patch.side_effect = PolarionError("bad revision", status_code=400)
 
-        with pytest.raises(RuntimeError, match="400"):
+        with pytest.raises(
+            RuntimeError, match=r"Failed to update work item link.*bad revision"
+        ):
             await update_work_item_link(
                 mock_ctx,
                 project_id="MyProj",


### PR DESCRIPTION
## Summary

External review flagged inconsistent error-recovery hints. Survey of all 141 raise sites found the next-action-hint pattern already near-universal; three stragglers fixed so every tool error tells the LLM how to recover.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- update_work_item_link 404 and list_*_enum_options 404 lacked next-action hints, breaking LLM self-recovery loop
- name link id + list_work_item_links hint; diagnose enum 404 as field unknown/non-enum; align patch error wording

## Testing

Error-path tests tightened to assert the new hint substrings (TDD, red first). Full suite 1947 passed; ruff, format, mypy clean; diff-cover changed lines 100%.

## Notes for Reviewers

Deliberately no sample-fetch hint on the enum 404: unset custom fields are absent from item attributes, so a get_work_item probe can falsely suggest the field does not exist. Message keeps the config-backed diagnosis only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)