### PR TITLE
docs(skills): link approvals + simplify stage

### DIFF
--- a/.claude/agents/pipeline-implementer.md
+++ b/.claude/agents/pipeline-implementer.md
@@ -1,6 +1,6 @@
 ---
 name: pipeline-implementer
-description: Executes one bounded implementation task from an approved dev-pipeline plan, strictly TDD (failing test seen before production code). Invoke during dev-pipeline Stage 3 with a plan excerpt, and Stage 6 with review findings to fix. Refuses scope outside the given task. Tool list is code-work only — no live Polarion MCP tools; verification runs through the test suite, never the real server.
+description: Executes one bounded implementation task from an approved dev-pipeline plan, strictly TDD (failing test seen before production code). Invoke during dev-pipeline Stage 3 with a plan excerpt, and Stage 7 with review findings to fix. Refuses scope outside the given task. Tool list is code-work only — no live Polarion MCP tools; verification runs through the test suite, never the real server.
 tools: Read, Edit, Write, Grep, Glob, Bash
 model: sonnet
 ---
@@ -16,7 +16,7 @@ from what the user approved.
 - Path to the approved plan and spec (`.pipeline/plan.md`, `.pipeline/spec.md`)
   — read them before touching code.
 - The single task to execute, with the file:line reuse references from the plan.
-- In fix mode (Stage 6): the findings list to address instead of a plan task.
+- In fix mode (Stage 7): the findings list to address instead of a plan task.
 
 If any of these are missing, say so and stop — do not guess the task.
 
@@ -55,5 +55,5 @@ If any of these are missing, say so and stop — do not guess the task.
 
 ## Composition
 
-- Invoke via `dev-pipeline` Stage 3 (build) and Stage 6 (fix).
+- Invoke via `dev-pipeline` Stage 3 (build) and Stage 7 (fix).
 - Do not invoke from another subagent.

--- a/.claude/agents/pipeline-reviewer.md
+++ b/.claude/agents/pipeline-reviewer.md
@@ -33,9 +33,12 @@ justifications, and your value is not sharing them.
    every new behavior's test one that could ever have failed? Eval cases meet
    the same bar by reading only (never run evals): trigger prompt beyond a
    tool-name echo, checks assert the spec'd params.
-6. **Compat** — shipped LLM surface changed (tool names, param
+6. **Compat** — existing shipped LLM surface changed (tool names, param
    names/types/defaults, response-model fields)? Compare the `origin/main`
-   side. Spec-sanctioned → `## BREAKING`; unsanctioned → spec-fidelity
+   side. Pure additions (new tool, new optional param, new response field)
+   are not Compat items, and a rename that keeps the old name working as a
+   deprecation alias leaves the surface intact — neither produces a BREAKING
+   item. Spec-sanctioned → `## BREAKING`; unsanctioned → spec-fidelity
    finding.
 
 Verify suspicions before reporting: read the surrounding code, run a focused

--- a/.claude/agents/pipeline-reviewer.md
+++ b/.claude/agents/pipeline-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: pipeline-reviewer
-description: Fresh-context branch-diff reviewer for dev-pipeline Stage 5 — severity-tagged findings judged against the approved spec and plan, ending in an explicit PASS/FAIL verdict on the loop's stop criterion. Invoke after gates pass, and again after every fix round. Never edits files; Bash is for the diff and focused test runs only.
+description: Fresh-context branch-diff reviewer for dev-pipeline Stage 6 — severity-tagged findings judged against the approved spec and plan, ending in an explicit PASS/FAIL verdict on the loop's stop criterion. Invoke after gates pass, and again after every fix round. Never edits files; Bash is for the diff and focused test runs only.
 tools: Read, Grep, Glob, Bash
 model: opus
 ---
@@ -58,5 +58,5 @@ honest about them but don't inflate severity to force a fix round.
 
 ## Composition
 
-- Invoke via `dev-pipeline` Stage 5 (and each re-review after Stage 6).
+- Invoke via `dev-pipeline` Stage 6 (and each re-review after Stage 7).
 - Do not invoke from another subagent; never give it the implementer's report.

--- a/.claude/agents/pipeline-reviewer.md
+++ b/.claude/agents/pipeline-reviewer.md
@@ -19,16 +19,24 @@ justifications, and your value is not sharing them.
 
 ## Review axes (this repo's flavor)
 
-1. **Correctness** — edge cases, error paths, wrong-but-plausible parsing.
+1. **Correctness** — edge cases, error paths, wrong-but-plausible parsing;
+   dry_run return and live send must be one builder output (a one-path-only
+   transform is a finding).
 2. **Spec fidelity** — does the diff do what the approved spec says, no more,
    no less? Scope creep is a finding.
 3. **Convention** — `CLAUDE.md` rules: typing, error mapping, payload rules,
-   docstring template, comment style.
+   docstring template, comment style, Naming Rules (LLM surface).
 4. **Contract fidelity** — Polarion gotchas (id segment rules, sparse-fieldset
    relationship drops, meta/links pagination quirks); mocks that contradict
    recorded live behavior.
 5. **Test honesty** — do tests pin behavior or mirror the implementation? Is
-   every new behavior's test one that could ever have failed?
+   every new behavior's test one that could ever have failed? Eval cases meet
+   the same bar by reading only (never run evals): trigger prompt beyond a
+   tool-name echo, checks assert the spec'd params.
+6. **Compat** — shipped LLM surface changed (tool names, param
+   names/types/defaults, response-model fields)? Compare the `origin/main`
+   side. Spec-sanctioned → `## BREAKING`; unsanctioned → spec-fidelity
+   finding.
 
 Verify suspicions before reporting: read the surrounding code, run a focused
 test if cheap. A finding you didn't verify gets marked PLAUSIBLE, not stated
@@ -43,6 +51,9 @@ as fact.
 
 ## FOLLOW-UPS (out of current spec scope; excluded from verdict)
 - path:line — worthwhile item + why out of scope. Fix: concrete suggestion.
+
+## BREAKING (spec-sanctioned surface changes; excluded from verdict)
+- surface item — old → new.
 
 ## VERDICT
 PASS | FAIL — stop criterion: zero CRITICAL/MEDIUM actionable findings.

--- a/.claude/agents/pipeline-simplifier.md
+++ b/.claude/agents/pipeline-simplifier.md
@@ -44,6 +44,9 @@ You cannot spawn agents; cover each angle as its own pass over the diff.
   delete an assertion — the tests are what pins behavior while you edit.
 - Run `uv run pytest` after your edits; a red suite means a fix changed
   behavior — revert that fix before reporting.
+- The orchestrator runs the full gate suite after your report; a failure
+  (ruff, mypy, diff-cover) comes back to you via SendMessage — fix or revert
+  the offending edit, rerun `uv run pytest`, and report the delta.
 - Never commit — the orchestrator owns git.
 
 ## Report format

--- a/.claude/agents/pipeline-simplifier.md
+++ b/.claude/agents/pipeline-simplifier.md
@@ -1,0 +1,63 @@
+---
+name: pipeline-simplifier
+description: Behavior-preserving cleanup pass for dev-pipeline Stage 5 — sweeps the branch diff for reuse, simplification, efficiency, and altitude issues, applies the fixes itself, and reports each change with a one-line rationale. Invoke once per pipeline run, after gates first pass and before the first review round. Quality only — never hunts correctness bugs; behavior stays pinned by the Stage 3 tests. Instructions vendored from the Claude Code built-in /simplify so the pipeline does not depend on it.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: sonnet
+---
+
+# Pipeline Simplifier
+
+You improve the quality of the changed code, not hunt for bugs. Review the
+diff for the four angles below, then fix what you find. Correctness bugs are
+the Stage 6 reviewer's job — leave them alone.
+
+## Input contract (the prompt must give you)
+
+- The worktree path and the diff scope — `git diff origin/main...HEAD` unless
+  the prompt narrows it. If that range is empty, include `git diff HEAD`
+  working-tree changes in scope.
+
+## Review angles — run all four yourself, sequentially
+
+You cannot spawn agents; cover each angle as its own pass over the diff.
+
+1. **Reuse** — new code re-implementing something the codebase already has.
+   Grep `tools/_shared/`, `utils/`, and files adjacent to the change; call the
+   existing helper instead.
+2. **Simplification** — redundant or derivable state, copy-paste with slight
+   variation, deep nesting, dead code left behind. Replace with the simpler
+   form that does the same job.
+3. **Efficiency** — redundant computation or repeated I/O, independent
+   operations run sequentially, blocking work added to startup or hot paths,
+   long-lived objects built from closures that keep the enclosing scope alive.
+   Use the cheaper alternative.
+4. **Altitude** — special cases layered on shared infrastructure instead of a
+   fix to the underlying mechanism. Generalize rather than patch on top.
+
+## Boundaries
+
+- Behavior-preserving only. Skip any fix that would change intended behavior,
+  reach well outside the diff, or that you judge a false positive — record the
+  skip in the report instead of arguing with it.
+- Run `uv run pytest` after your edits; a red suite means a fix changed
+  behavior — revert that fix before reporting.
+- Never commit — the orchestrator owns git.
+
+## Report format
+
+```
+## CHANGED
+- path — one-line rationale (angle + what it replaced)
+
+## SKIPPED
+- path:line — finding + why skipped (or empty)
+
+## TESTS
+- pytest summary line after edits
+```
+
+## Composition
+
+- Invoke via `dev-pipeline` Stage 5, once per pipeline run — never repeated
+  after Stage 7 fix rounds.
+- Do not invoke from another subagent.

--- a/.claude/agents/pipeline-simplifier.md
+++ b/.claude/agents/pipeline-simplifier.md
@@ -14,8 +14,9 @@ the Stage 6 reviewer's job — leave them alone.
 ## Input contract (the prompt must give you)
 
 - The worktree path and the diff scope — `git diff origin/main...HEAD` unless
-  the prompt narrows it. If that range is empty, include `git diff HEAD`
-  working-tree changes in scope.
+  the prompt narrows it. The orchestrator commits before invoking you; an
+  empty range means it didn't — say so and stop, never widen scope yourself
+  (`git diff HEAD` would miss untracked files anyway).
 
 ## Review angles — run all four yourself, sequentially
 
@@ -39,6 +40,8 @@ You cannot spawn agents; cover each angle as its own pass over the diff.
 - Behavior-preserving only. Skip any fix that would change intended behavior,
   reach well outside the diff, or that you judge a false positive — record the
   skip in the report instead of arguing with it.
+- Test files in the diff may be simplified structurally, but never loosen or
+  delete an assertion — the tests are what pins behavior while you edit.
 - Run `uv run pytest` after your edits; a red suite means a fix changed
   behavior — revert that fix before reporting.
 - Never commit — the orchestrator owns git.

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -14,7 +14,7 @@ agents, and merges their reports. Subagents never spawn other subagents
 ```
  0.Worktree → 1.Spec →(approve)→ 2.Plan →(approve)→ 3.Implement(TDD) → 4.Gates
                                                           ▲                │
-                                                          │                ▼
+                                                          │                ▼ (4½.Simplify, first pass only)
                                               6.Fix ◄─(findings)─ 5.Review ─(clean)→ 7.Ship
 ```
 
@@ -33,8 +33,8 @@ Subagents share **no memory and no conversation history**. Three channels only:
 
    | File | Written by | Read by |
    |---|---|---|
-   | `.pipeline/spec.md` | orchestrator (Stage 1, draft before approval; approval freezes it) | pattern-scout, pipeline-implementer, pipeline-reviewer |
-   | `.pipeline/plan.md` | orchestrator (Stage 2, full text shown before approval — via ExitPlanMode or quoted draft; approval freezes it) | pipeline-implementer, pipeline-reviewer |
+   | `.pipeline/spec.md` | orchestrator (Stage 1, draft before approval; approved via file link — single copy; approval freezes it) | pattern-scout, pipeline-implementer, pipeline-reviewer |
+   | `.pipeline/plan.md` | orchestrator (Stage 2, approved via file link — single copy; approval freezes it) | pipeline-implementer, pipeline-reviewer |
    | `.pipeline/review-round-N.md` | orchestrator (Stage 5, reviewer report pasted verbatim) | pipeline-implementer (Stage 6), user on escalation |
    | `.pipeline/followups.md` | orchestrator (Stage 5, FOLLOW-UPS + unfixed LOW accumulated per round, deduped) | orchestrator (Stage 7 issue export) |
 
@@ -52,6 +52,7 @@ a fresh Agent call starts cold and re-derives everything.
 | 2 Plan design | main thread (Plan agent for big scope) | opus for Plan agent | architecture trade-offs |
 | 3 Implement | `pipeline-implementer` × 1 per plan task | sonnet | code volume; escalate model per rule below |
 | 4 Gates | main thread | — | deterministic bash; a subagent relays an exit code for tokens |
+| 4½ Simplify | `general-purpose` invoking the built-in `/simplify` skill | sonnet | code-volume edits over the whole diff; report-only return keeps orchestrator context lean |
 | 5 Review | `pipeline-reviewer` | opus | judgment-heavy; fresh context avoids implementer blindness |
 | 6 Fix | `pipeline-implementer` (fix mode) | sonnet | bounded edits from findings list |
 
@@ -104,11 +105,14 @@ sequentially, in one Agent call each.
    review-fix round. (update_test_records run, 2026-07-13: a pre-approval
    probe found the real enum path and two silent-ghost writes — flipped a
    guard from "deferred" to "shipped" before any code existed.)
-5. **Show the user the full spec, then ask approval.** The approval request
-   quotes `.pipeline/spec.md` verbatim — the full file text, not a summary or
-   translation (on a redo, the revised sections verbatim) — the user approves
-   text they have read, never a bare "spec ready, approve?" prompt. Fold
-   feedback back into `.pipeline/spec.md`; approval freezes it.
+5. **Ask approval over the file, not a re-print.** Post a clickable link to
+   `.pipeline/spec.md`, ask the user to read it in the editor, and collect the
+   decision via AskUserQuestion. Never a summary or translation — approval
+   binds only the frozen file's own text — and never a bare "spec ready,
+   approve?" prompt without the link. The file was already written once;
+   quoting it in chat pays output tokens for a second copy. On a redo, quote
+   just the revised sections so the delta is visible in place. Fold feedback
+   back into `.pipeline/spec.md`; approval freezes it.
    Spec changes are cheap here, expensive later.
 
 ## Stage 2 — Plan
@@ -119,12 +123,11 @@ sequentially, in one Agent call each.
 2. Draft the plan in the main thread (or a Plan agent for large scope) in the
    shape of [plan-template.md](references/plan-template.md) — one implementer task per
    Changes entry, live-test items from the spec's UNVERIFIED list under
-   Verification. Use plan mode when available — ExitPlanMode already puts the
-   full plan in front of the user for approval; write it to
-   `.pipeline/plan.md` right after. Without plan mode, copy the template to
-   `.pipeline/plan.md`, fill it, and quote it verbatim in the approval
-   request — same rule as the spec: full file text, not a condensed
-   rendition; the user approves text they have read.
+   Verification. Copy the template to `.pipeline/plan.md`, fill it, and ask
+   approval the Stage 1.5 way: file link + AskUserQuestion, no re-print, redo
+   rounds quote only the revised sections. Skip plan mode here even when
+   available — ExitPlanMode ships the full plan text as a tool parameter, a
+   second paid copy of a file that already exists.
 
 ## Stage 3 — Implement (TDD)
 
@@ -158,6 +161,25 @@ Contract-boundary changes (include/fields/parse/auth or any new HTTP shape)
 additionally need a **live test** against the real server — mocks encode your
 assumptions, they cannot falsify them. Feed live findings back into fakes and
 mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
+
+## Stage 4½ — Simplify (first pass only)
+
+Once, after gates first go green and before the first review round — never
+repeated after Stage 6 fix rounds (those are bounded edits, not new
+complexity):
+
+1. **Spawn a `general-purpose` subagent (sonnet)** whose prompt says: invoke
+   the built-in `/simplify` skill over the `git diff origin/main...HEAD` scope
+   in this worktree, apply its fixes, and report changed files with a one-line
+   rationale each. `/simplify` hunts reuse/simplification/efficiency and
+   applies the fixes itself — quality only, no bug hunting; behavior stays
+   pinned by the Stage 3 tests.
+2. Re-run Stage 4 gates in the main thread, then commit.
+
+Why before review, not after: reviewer rounds stop burning on quality
+findings (those demote to LOW → followups and rarely get fixed), and the
+simplify edits themselves still pass through Stage 5 — new code gets
+reviewed. Placing it after PASS would ship unreviewed edits.
 
 ## Stage 5 — Review (loop entry)
 
@@ -229,15 +251,18 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 | "Subagent for the gate commands too" | Gates are deterministic bash. A subagent burns tokens to relay an exit code. |
 | "Opus everywhere to be safe" | Model choice is a cost/judgment trade-off; sonnet ships code volume fine, opus earns its cost only on judgment stages. |
 | "Main-thread glue is too small for TDD" | A fake-server handler shipped code-first once and diff-cover bounced the gate; the failing test first was the cheaper path. |
-| "The user approved my summary of it" | A summary is your interpretation. Approval binds only the file text they actually read — quote it verbatim. |
+| "The user approved my summary of it" | A summary is your interpretation. Approval binds only the frozen file's text — link the file and have them read it, never summarize. |
 | "Live checks belong in Stage 4" | When an UNVERIFIED item shapes the spec, a smoke probe before freeze beats re-planning after it — the create_test_records run flipped three guard decisions that way. |
+| "The reviewer will catch the complexity" | Quality findings demote to LOW → followups and rarely get fixed. The Stage 4½ simplify pass before review is the cheap path. |
 
 ## Red Flags
 
 - Production code written before its failing test exists.
 - Implementer report accepted without RED evidence.
-- Approval requested without the full spec/plan text in front of the user —
-  or over a summary/translation instead of the frozen file's verbatim text.
+- Approval requested over a summary/translation instead of the frozen file —
+  link the file itself; redo rounds quote only the revised sections.
+- Spec or plan re-printed in full in chat — the file is the single paid copy;
+  approval goes through its link.
 - Reviewer given implementer reports or conversation summaries (context bleed).
 - Review round 4+ still producing MEDIUM findings — escalate, don't grind.
 - `.pipeline/` files committed, or a subagent prompted without the file paths
@@ -258,12 +283,13 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 ## Verification (pipeline exit checklist)
 
 - [ ] Worktree isolated, branch `<type>/<kebab>`, baseline was green at start
-- [ ] Spec and plan each shown to the user verbatim (full file text), approved,
-      frozen in `.pipeline/`; reviewer reports stored verbatim in
-      `.pipeline/review-round-*.md`
+- [ ] Spec and plan each approved via frozen-file link (never a summary or
+      full re-print), frozen in `.pipeline/`; reviewer reports stored verbatim
+      in `.pipeline/review-round-*.md`
 - [ ] Every implementer report carried RED-then-GREEN evidence
 - [ ] All five gate commands pass (pytest, ruff check, ruff format --check,
       mypy, diff-cover); diff-cover ≥90% on changed lines
+- [ ] Stage 4½ `/simplify` pass ran once (subagent), gates re-run green after
 - [ ] Live test done for contract-boundary changes, findings folded into mocks
 - [ ] Final `pipeline-reviewer` verdict is PASS (zero CRITICAL/MEDIUM)
 - [ ] Every `.pipeline/followups.md` item filed as a `follow-up` issue (or

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -154,7 +154,7 @@ any other executable glue get their failing test before the code —
 diff-cover gates `evals/harness` like `src/`, and a bounced gate is the
 expensive way to rediscover that.
 
-## Stage 4 — Gates (main thread; all must pass before review)
+## Stage 4 — Gates (main thread; all must pass before advancing)
 
 ```bash
 uv run pytest --cov=src/mcp_server_polarion --cov=evals --cov-report=xml

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -12,10 +12,14 @@ agents, and merges their reports. Subagents never spawn other subagents
 (hard rule here — every paraphrase hop loses information).
 
 ```
- 0.Worktree → 1.Spec →(approve)→ 2.Plan →(approve)→ 3.Implement(TDD) → 4.Gates
-                                                          ▲                │
-                                                          │                ▼ (5.Simplify, first pass only)
-                                              7.Fix ◄─(findings)─ 6.Review ─(clean)→ 8.Ship
+ 0.Worktree → 1.Spec →(approve)→ 2.Plan →(approve)→ 3.Implement(TDD) → 4.Gates ◄─┐
+                                                                       │         │ (re-run)
+                                              (5.Simplify, first pass) ▼         │
+                                              7.Fix ◄─(findings)─ 6.Review       │
+                                                │                    │(clean)    │
+                                                └────────────────────┼───────────┘
+                                                                     ▼
+                                                                  8.Ship
 ```
 
 ## Data handoff — how stages talk

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -173,12 +173,20 @@ Once, after gates first go green and before the first review round — never
 repeated after Stage 7 fix rounds (those are bounded edits, not new
 complexity):
 
-1. **Invoke `pipeline-simplifier`** with the worktree path and the diff scope
+1. **Commit the work first**, in the repo commit format (CLAUDE.md Repo
+   Conventions; full rules `.github/CONTRIBUTING.md`, commit-msg hook
+   enforces) — the simplifier diffs `origin/main...HEAD`, and uncommitted
+   work is invisible to that range; a new tool is mostly untracked files, so
+   skipping this turns the pass into a silent no-op.
+2. **Invoke `pipeline-simplifier`** with the worktree path and the diff scope
    (`git diff origin/main...HEAD`). It sweeps reuse/simplification/efficiency/
    altitude and applies the fixes itself — quality only, no bug hunting;
    behavior stays pinned by the Stage 3 tests. Expect its CHANGED / SKIPPED /
    TESTS report back.
-2. Re-run Stage 4 gates in the main thread, then commit.
+3. Re-run Stage 4 gates in the main thread, then commit the simplify edits.
+   Gates red on a simplify edit (diff-cover counts its changed lines too):
+   `SendMessage` the simplifier to fix or revert that edit — it holds the
+   context; don't spawn an implementer for it.
 
 Why before review, not after: reviewer rounds stop burning on quality
 findings (those demote to LOW → followups and rarely get fixed), and the
@@ -187,11 +195,10 @@ reviewed. Placing it after PASS would ship unreviewed edits.
 
 ## Stage 6 — Review (loop entry)
 
-1. **Commit the work first**, in the repo commit format (CLAUDE.md Repo
-   Conventions; full rules `.github/CONTRIBUTING.md`, commit-msg hook
-   enforces) — the reviewer diffs `origin/main...HEAD`, and uncommitted
-   changes are invisible to that range. Fix rounds add commits; squash merge
-   collapses them at the end.
+1. **Commit anything still uncommitted** — the reviewer diffs
+   `origin/main...HEAD`, and uncommitted changes are invisible to that range.
+   The first pass is already committed by Stage 5; fix rounds add their
+   commits here. Squash merge collapses them at the end.
 2. **Invoke `pipeline-reviewer`** with: `.pipeline/spec.md` and
    `.pipeline/plan.md` paths and the diff scope (`git diff origin/main...HEAD`).
    Give it the spec and plan — **never** the implementer reports or your
@@ -220,8 +227,8 @@ reviewed. Placing it after PASS would ship unreviewed edits.
 
 ## Stage 8 — Ship (main thread)
 
-- Work is already committed by review time (Stage 6.1); commit here only what
-  is still uncommitted. Commit format, PR checklist handling, squash-merge
+- Work is already committed by review time (Stage 5.1, fix rounds 6.1);
+  commit here only what is still uncommitted. Commit format, PR checklist handling, squash-merge
   rule: CLAUDE.md Repo Conventions / `.github/CONTRIBUTING.md` — restating
   them here would be a third copy that drifts. `.pipeline/` stays uncommitted.
 - **Export follow-ups before cleanup** — `.pipeline/` dies with the worktree,
@@ -267,6 +274,8 @@ reviewed. Placing it after PASS would ship unreviewed edits.
   link the file itself; redo rounds quote only the revised sections.
 - Spec or plan re-printed in full in chat — the file is the single paid copy;
   approval goes through its link.
+- Simplifier invoked over uncommitted work — `origin/main...HEAD` is empty,
+  the pass silently no-ops; commit first (Stage 5.1).
 - Reviewer given implementer reports or conversation summaries (context bleed).
 - Review round 4+ still producing MEDIUM findings — escalate, don't grind.
 - `.pipeline/` files committed, or a subagent prompted without the file paths

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -106,8 +106,10 @@ sequentially, in one Agent call each.
    probe found the real enum path and two silent-ghost writes — flipped a
    guard from "deferred" to "shipped" before any code existed.)
 5. **Ask approval over the file, not a re-print.** Post a clickable link to
-   `.pipeline/spec.md`, ask the user to read it in the editor, and collect the
-   decision via AskUserQuestion. Never a summary or translation — approval
+   `.pipeline/spec.md` — as an absolute path: the worktree sits outside the
+   editor's workspace root, so a workspace-relative link may not open — ask
+   the user to read it in the editor, and collect the decision via
+   AskUserQuestion. Never a summary or translation — approval
    binds only the frozen file's own text — and never a bare "spec ready,
    approve?" prompt without the link. The file was already written once;
    quoting it in chat pays output tokens for a second copy. On a redo, quote
@@ -124,10 +126,13 @@ sequentially, in one Agent call each.
    shape of [plan-template.md](references/plan-template.md) — one implementer task per
    Changes entry, live-test items from the spec's UNVERIFIED list under
    Verification. Copy the template to `.pipeline/plan.md`, fill it, and ask
-   approval the Stage 1.5 way: file link + AskUserQuestion, no re-print, redo
-   rounds quote only the revised sections. Skip plan mode here even when
-   available — ExitPlanMode ships the full plan text as a tool parameter, a
-   second paid copy of a file that already exists.
+   approval the Stage 1 step 5 way: file link (absolute path) +
+   AskUserQuestion, no re-print, redo rounds quote only the revised sections.
+   Don't enter plan mode here — ExitPlanMode ships the full plan text as a
+   tool parameter, a second paid copy of a file that already exists. If the
+   session is already in plan mode (user-toggled), ExitPlanMode is the only
+   way out: keep its plan text to a short pointer at `.pipeline/plan.md`;
+   approval still binds the file.
 
 ## Stage 3 — Implement (TDD)
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -210,7 +210,10 @@ reviewed. Placing it after PASS would ship unreviewed edits.
    `.pipeline/followups.md`, deduped across rounds (drop an item a later
    round fixed). NIT stays PR-notes-only. This file is the only thing that
    survives worktree cleanup — via the Stage 8 export.
-5. **Stop criterion — the only exit:** verdict PASS (zero CRITICAL/MEDIUM
+5. BREAKING items ride in the round file to Stage 8 for the PR notes. They
+   never block the verdict; a shipped-surface change the spec did not
+   sanction is a spec-fidelity finding instead, and does block.
+6. **Stop criterion — the only exit:** verdict PASS (zero CRITICAL/MEDIUM
    actionable findings). LOW/NIT don't block, but unfixed LOW must be in
    `.pipeline/followups.md` by now. PASS → Stage 8. FAIL → Stage 7.
 
@@ -240,6 +243,11 @@ reviewed. Placing it after PASS would ship unreviewed edits.
   in PR notes, not filed.
 - PR Notes: record live-test evidence, NIT findings, and links to the filed
   follow-up issues; add `Fixes #N` for any follow-up issue this PR resolved.
+  List every reviewer BREAKING item verbatim, plus the consequence once: a
+  release containing these must bump major and rerun the full eval suite —
+  the deploy skill reads version policy from here. (Deferring via a
+  deprecation alias is a spec decision; an aliased rename never breaks the
+  surface, so it produces no BREAKING item at all.)
 - CI: after opening the PR, `gh pr checks <PR#> --watch --fail-fast` until
   every check is green — merge is blocked on red anyway, but an unwatched red
   PR rots until a human notices; catch it while the session context is hot.
@@ -308,6 +316,8 @@ reviewed. Placing it after PASS would ship unreviewed edits.
 - [ ] Final `pipeline-reviewer` verdict is PASS (zero CRITICAL/MEDIUM)
 - [ ] Every `.pipeline/followups.md` item filed as a `follow-up` issue (or
       explicitly dropped with the user) before worktree cleanup
+- [ ] Reviewer BREAKING items (if any) listed in PR notes with the deploy
+      consequence stated there
 - [ ] PR open with template filled, NIT + live evidence + follow-up issue
       links recorded
 - [ ] PR CI checks all green (`gh pr checks <PR#> --watch --fail-fast`),

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: dev-pipeline
-description: Full feature-development pipeline for this repo — isolated worktree, spec, implementation plan, TDD build, quality gates, then a review→fix loop that only stops when review passes. Each stage delegates to a named project subagent (spec-researcher, pattern-scout, pipeline-implementer, pipeline-reviewer) with a stage-appropriate model. Use when starting any new MCP tool, feature, or multi-file change from scratch; when the user says "new tool/feature" (any language), "run the pipeline", or asks to develop something "the same way as list_test_records". Triggers on `/dev-pipeline`. NOT for one-file tweaks, doc edits, or work already mid-flight — jump to the matching stage instead.
+description: Full feature-development pipeline for this repo — isolated worktree, spec, implementation plan, TDD build, quality gates, then a review→fix loop that only stops when review passes. Each stage delegates to a named project subagent (spec-researcher, pattern-scout, pipeline-implementer, pipeline-simplifier, pipeline-reviewer) with a stage-appropriate model. Use when starting any new MCP tool, feature, or multi-file change from scratch; when the user says "new tool/feature" (any language), "run the pipeline", or asks to develop something "the same way as list_test_records". Triggers on `/dev-pipeline`. NOT for one-file tweaks, doc edits, or work already mid-flight — jump to the matching stage instead.
 ---
 
 # Dev Pipeline
 
 Encode the sequence that shipped `list_test_records` (PR #170): worktree → spec →
-plan → TDD implement → gates → review loop → ship. Main session is the
+plan → TDD implement → gates → simplify → review loop → ship. Main session is the
 **orchestrator**: it sequences stages, holds user approvals, spawns the stage
 agents, and merges their reports. Subagents never spawn other subagents
 (hard rule here — every paraphrase hop loses information).
@@ -14,8 +14,8 @@ agents, and merges their reports. Subagents never spawn other subagents
 ```
  0.Worktree → 1.Spec →(approve)→ 2.Plan →(approve)→ 3.Implement(TDD) → 4.Gates
                                                           ▲                │
-                                                          │                ▼ (4½.Simplify, first pass only)
-                                              6.Fix ◄─(findings)─ 5.Review ─(clean)→ 7.Ship
+                                                          │                ▼ (5.Simplify, first pass only)
+                                              7.Fix ◄─(findings)─ 6.Review ─(clean)→ 8.Ship
 ```
 
 ## Data handoff — how stages talk
@@ -35,8 +35,8 @@ Subagents share **no memory and no conversation history**. Three channels only:
    |---|---|---|
    | `.pipeline/spec.md` | orchestrator (Stage 1, draft before approval; approved via file link — single copy; approval freezes it) | pattern-scout, pipeline-implementer, pipeline-reviewer |
    | `.pipeline/plan.md` | orchestrator (Stage 2, approved via file link — single copy; approval freezes it) | pipeline-implementer, pipeline-reviewer |
-   | `.pipeline/review-round-N.md` | orchestrator (Stage 5, reviewer report pasted verbatim) | pipeline-implementer (Stage 6), user on escalation |
-   | `.pipeline/followups.md` | orchestrator (Stage 5, FOLLOW-UPS + unfixed LOW accumulated per round, deduped) | orchestrator (Stage 7 issue export) |
+   | `.pipeline/review-round-N.md` | orchestrator (Stage 6, reviewer report pasted verbatim) | pipeline-implementer (Stage 7), user on escalation |
+   | `.pipeline/followups.md` | orchestrator (Stage 6, FOLLOW-UPS + unfixed LOW accumulated per round, deduped) | orchestrator (Stage 8 issue export) |
 
 Follow-up questions to an agent you already spawned: `SendMessage` to its id —
 a fresh Agent call starts cold and re-derives everything.
@@ -52,9 +52,9 @@ a fresh Agent call starts cold and re-derives everything.
 | 2 Plan design | main thread (Plan agent for big scope) | opus for Plan agent | architecture trade-offs |
 | 3 Implement | `pipeline-implementer` × 1 per plan task | sonnet | code volume; escalate model per rule below |
 | 4 Gates | main thread | — | deterministic bash; a subagent relays an exit code for tokens |
-| 4½ Simplify | `general-purpose` invoking the built-in `/simplify` skill | sonnet | code-volume edits over the whole diff; report-only return keeps orchestrator context lean |
-| 5 Review | `pipeline-reviewer` | opus | judgment-heavy; fresh context avoids implementer blindness |
-| 6 Fix | `pipeline-implementer` (fix mode) | sonnet | bounded edits from findings list |
+| 5 Simplify | `pipeline-simplifier` | sonnet | code-volume edits over the whole diff; report-only return keeps orchestrator context lean |
+| 6 Review | `pipeline-reviewer` | opus | judgment-heavy; fresh context avoids implementer blindness |
+| 7 Fix | `pipeline-implementer` (fix mode) | sonnet | bounded edits from findings list |
 
 Escalation rule: move one model tier up (`model` param on the Agent call
 overrides the definition) when a stage keeps failing or the domain is
@@ -167,26 +167,25 @@ additionally need a **live test** against the real server — mocks encode your
 assumptions, they cannot falsify them. Feed live findings back into fakes and
 mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
 
-## Stage 4½ — Simplify (first pass only)
+## Stage 5 — Simplify (first pass only)
 
 Once, after gates first go green and before the first review round — never
-repeated after Stage 6 fix rounds (those are bounded edits, not new
+repeated after Stage 7 fix rounds (those are bounded edits, not new
 complexity):
 
-1. **Spawn a `general-purpose` subagent (sonnet)** whose prompt says: invoke
-   the built-in `/simplify` skill over the `git diff origin/main...HEAD` scope
-   in this worktree, apply its fixes, and report changed files with a one-line
-   rationale each. `/simplify` hunts reuse/simplification/efficiency and
-   applies the fixes itself — quality only, no bug hunting; behavior stays
-   pinned by the Stage 3 tests.
+1. **Invoke `pipeline-simplifier`** with the worktree path and the diff scope
+   (`git diff origin/main...HEAD`). It sweeps reuse/simplification/efficiency/
+   altitude and applies the fixes itself — quality only, no bug hunting;
+   behavior stays pinned by the Stage 3 tests. Expect its CHANGED / SKIPPED /
+   TESTS report back.
 2. Re-run Stage 4 gates in the main thread, then commit.
 
 Why before review, not after: reviewer rounds stop burning on quality
 findings (those demote to LOW → followups and rarely get fixed), and the
-simplify edits themselves still pass through Stage 5 — new code gets
+simplify edits themselves still pass through Stage 6 — new code gets
 reviewed. Placing it after PASS would ship unreviewed edits.
 
-## Stage 5 — Review (loop entry)
+## Stage 6 — Review (loop entry)
 
 1. **Commit the work first**, in the repo commit format (CLAUDE.md Repo
    Conventions; full rules `.github/CONTRIBUTING.md`, commit-msg hook
@@ -198,30 +197,30 @@ reviewed. Placing it after PASS would ship unreviewed edits.
    Give it the spec and plan — **never** the implementer reports or your
    implementation narrative (context bleed defeats the fresh eyes).
 3. Save its report verbatim to `.pipeline/review-round-N.md` — full text, not
-   a paraphrase (Stage 6's implementer and any escalation read it); relay
+   a paraphrase (Stage 7's implementer and any escalation read it); relay
    findings to the user.
 4. Append the round's FOLLOW-UPS and any LOW items you won't fix to
    `.pipeline/followups.md`, deduped across rounds (drop an item a later
    round fixed). NIT stays PR-notes-only. This file is the only thing that
-   survives worktree cleanup — via the Stage 7 export.
+   survives worktree cleanup — via the Stage 8 export.
 5. **Stop criterion — the only exit:** verdict PASS (zero CRITICAL/MEDIUM
    actionable findings). LOW/NIT don't block, but unfixed LOW must be in
-   `.pipeline/followups.md` by now. PASS → Stage 7. FAIL → Stage 6.
+   `.pipeline/followups.md` by now. PASS → Stage 8. FAIL → Stage 7.
 
-## Stage 6 — Fix, then back to review
+## Stage 7 — Fix, then back to review
 
 - **Invoke `pipeline-implementer` in fix mode** with the
   `.pipeline/review-round-N.md` path and the CRITICAL/MEDIUM items to address;
   behavior changes go through RED→GREEN again, never patch-and-hope.
-- Re-run Stage 4 gates, then **return to Stage 5** — a fresh
+- Re-run Stage 4 gates, then **return to Stage 6** — a fresh
   `pipeline-reviewer` spawn over the new diff, not a reply to the old one.
 - Loop cap: after 3 review rounds with open findings, stop and escalate to the
   user with `.pipeline/review-round-*.md` — grinding further usually means the
   spec or plan is wrong, not the code.
 
-## Stage 7 — Ship (main thread)
+## Stage 8 — Ship (main thread)
 
-- Work is already committed by review time (Stage 5.1); commit here only what
+- Work is already committed by review time (Stage 6.1); commit here only what
   is still uncommitted. Commit format, PR checklist handling, squash-merge
   rule: CLAUDE.md Repo Conventions / `.github/CONTRIBUTING.md` — restating
   them here would be a third copy that drifts. `.pipeline/` stays uncommitted.
@@ -240,7 +239,7 @@ reviewed. Placing it after PASS would ship unreviewed edits.
   Right after `gh pr create` it can exit "no checks reported" before check
   runs register — wait a few seconds and rerun, don't skip the watch.
   A red check is a Stage 4 gate failure, not a review finding: fix, re-run
-  gates, and if code changed re-enter Stage 5. Protection is strict-mode, so
+  gates, and if code changed re-enter Stage 6. Protection is strict-mode, so
   if main moved, update the branch and let checks re-run.
 
 ## Common Rationalizations
@@ -258,7 +257,7 @@ reviewed. Placing it after PASS would ship unreviewed edits.
 | "Main-thread glue is too small for TDD" | A fake-server handler shipped code-first once and diff-cover bounced the gate; the failing test first was the cheaper path. |
 | "The user approved my summary of it" | A summary is your interpretation. Approval binds only the frozen file's text — link the file and have them read it, never summarize. |
 | "Live checks belong in Stage 4" | When an UNVERIFIED item shapes the spec, a smoke probe before freeze beats re-planning after it — the create_test_records run flipped three guard decisions that way. |
-| "The reviewer will catch the complexity" | Quality findings demote to LOW → followups and rarely get fixed. The Stage 4½ simplify pass before review is the cheap path. |
+| "The reviewer will catch the complexity" | Quality findings demote to LOW → followups and rarely get fixed. The Stage 5 simplify pass before review is the cheap path. |
 
 ## Red Flags
 
@@ -294,7 +293,8 @@ reviewed. Placing it after PASS would ship unreviewed edits.
 - [ ] Every implementer report carried RED-then-GREEN evidence
 - [ ] All five gate commands pass (pytest, ruff check, ruff format --check,
       mypy, diff-cover); diff-cover ≥90% on changed lines
-- [ ] Stage 4½ `/simplify` pass ran once (subagent), gates re-run green after
+- [ ] Stage 5 simplify pass ran once (`pipeline-simplifier`), gates re-run
+      green after
 - [ ] Live test done for contract-boundary changes, findings folded into mocks
 - [ ] Final `pipeline-reviewer` verdict is PASS (zero CRITICAL/MEDIUM)
 - [ ] Every `.pipeline/followups.md` item filed as a `follow-up` issue (or


### PR DESCRIPTION
## Summary

Two dev-pipeline improvements found during the latest pipeline run: approval requests re-printed full spec/plan text in chat (paying output tokens for a second copy of a file that already exists), and quality findings from review demoted to LOW/followups where they rarely get fixed. Also folds in the pending reviewer-compat work from the main checkout: a Compat review axis with a BREAKING report lane feeding deploy's version policy.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Chat re-prints of spec/plan double output-token cost; quality and compat issues drown as LOW/followups in review
- Approvals become file link + AskUserQuestion; new Stage 5 simplify pass and reviewer Compat/BREAKING lane added

## Testing

Doc-only (`.claude/skills/`, `.claude/agents/`), no `src/` contact. Grep-verified remaining "verbatim"/"ExitPlanMode" mentions are intentional (file-channel storage rules, already-in-plan-mode escape hatch); no stale half-stage/Stage-number references after renumbering; BREAKING flow references (Stage 6 step 5, Stage 8 notes, exit checklist) consistent.

## Notes for Reviewers

- Simplify runs via new `pipeline-simplifier` agent (`.claude/agents/`) with instructions vendored from the built-in `/simplify` — no built-in dependency. Half-stage numbering dropped entirely: Simplify is full Stage 5, Review/Fix/Ship shifted to 6/7/8, agent definitions synced.
- Stage 5 Simplify follows addyosmani/agent-skills `code-simplification`: behavior-preserving, placed before review so simplify edits still pass Stage 6.
- Review fixes applied in-branch: "Stage 1.5" wording replaced (nonexistent half-stage misread), file links required absolute (worktree sits outside workspace root), user-toggled plan-mode edge handled via ExitPlanMode pointer-text rule.
- Second review round (post-open) applied in-branch: pipeline's first commit moved to Stage 5.1 — the simplifier's `origin/main...HEAD` scope was empty before any commit, a silent no-op on untracked new files; simplifier now fails loud on an empty range. Plus gate-red-after-simplify remediation via SendMessage to the simplifier, and a no-assertion-weakening boundary for simplifier edits over test files.
- Reviewer Compat axis + BREAKING section ported from pending main-checkout edits (stage numbers adapted): spec-sanctioned surface changes ride the round file to Stage 8 PR notes with the major-bump + full-eval-rerun consequence; unsanctioned ones are spec-fidelity findings and block. Correctness/convention/test-honesty axes sharpened alongside (dry_run single-builder rule, Naming Rules, eval-case read-only bar).
- BREAKING is deliberately verdict-excluded: it records a spec decision for deploy, not a defect; an aliased rename produces no BREAKING item at all.
- `pipeline-simplifier` runs the four cleanup angles (reuse/simplification/efficiency/altitude) sequentially itself — subagents cannot spawn agents, so the built-in's 4-parallel-agent fan-out does not carry over.
- Not adopted from the reference: separate simplification PRs (one in-pipeline pass suffices here) and the Rule-of-500 codemod rule (irrelevant at this repo's diff scale).
- Effectiveness check lands on the next pipeline run: approvals via link + AskUserQuestion, Stage 5 runs exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
