### PR TITLE
chore(hooks): enforce issue title convention

### DIFF
--- a/.claude/hooks/validate_issue.py
+++ b/.claude/hooks/validate_issue.py
@@ -13,6 +13,9 @@ Rules:
      '### <field label>' heading for every required field of that form
      (GitHub renders form submissions in that shape). Interactive/--web
      creation has no body to inspect — the web chooser enforces the form.
+  3. Title shape — 'scope: imperative summary', mirroring the commit
+     convention minus the type (issue type = label). Scope prefix make the
+     queue scannable by area; cap keep titles readable in list views.
 
 Regex + body/title parsers duplicated in validate_pr.py — standalone
 scripts, no shared import; keep in sync.
@@ -42,6 +45,11 @@ EMOJI_RE = re.compile(
     "\U0000fe00-\U0000fe0f"  # variation selectors
     "\U0000200d]"  # zero-width joiner (emoji sequences)
 )
+
+# Title = "scope: summary" / "scope(subscope): summary"; lowercase scope keep
+# it parallel to commit scopes.
+TITLE_SHAPE_RE = re.compile(r"^[a-z0-9_]+(\([a-z0-9_./-]+\))?: \S")
+MAX_TITLE_LEN = 72
 
 ISSUE_CREATE_RE = re.compile(r"\bgh\s+issue\s+create\b")
 ISSUE_OTHER_RE = re.compile(r"\bgh\s+issue\s+(edit|comment)\b")
@@ -82,6 +90,8 @@ def main() -> int:
             "typographic punctuation). Per repo convention PR/issue/commit "
             "artifacts must be in English."
         )
+    if title is not None:
+        errors.extend(title_errors(title))
     if body is not None and has_disallowed_non_ascii(body):
         errors.append(
             "Body contains non-ASCII characters (other than emoji and "
@@ -99,6 +109,27 @@ def main() -> int:
         return 2
 
     return 0
+
+
+def title_errors(title: str) -> list[str]:
+    """Title must read 'scope: imperative summary' and stay scannable."""
+    errors: list[str] = []
+    if not TITLE_SHAPE_RE.match(title):
+        errors.append(
+            "Title must start with a lowercase scope then ': ' — "
+            "'scope: imperative summary' or 'scope(subscope): summary', "
+            "mirroring the commit convention minus the type (the issue type "
+            f"is its label). Got: {title!r}"
+        )
+    if len(title) > MAX_TITLE_LEN:
+        errors.append(
+            f"Title is {len(title)} chars (limit: {MAX_TITLE_LEN}). Put the "
+            "detail in the body — the title only has to say which area and "
+            "what work."
+        )
+    if title.endswith("."):
+        errors.append("Title must not end with a period.")
+    return errors
 
 
 def has_disallowed_non_ascii(body: str) -> bool:

--- a/.claude/hooks/validate_issue.py
+++ b/.claude/hooks/validate_issue.py
@@ -13,9 +13,8 @@ Rules:
      '### <field label>' heading for every required field of that form
      (GitHub renders form submissions in that shape). Interactive/--web
      creation has no body to inspect — the web chooser enforces the form.
-  3. Title shape — 'scope: imperative summary', mirroring the commit
-     convention minus the type (issue type = label). Scope prefix make the
-     queue scannable by area; cap keep titles readable in list views.
+  3. Title shape — 'scope: imperative summary', commit convention minus
+     type (issue type = label). Scope prefix make queue scannable by area.
 
 Regex + body/title parsers duplicated in validate_pr.py — standalone
 scripts, no shared import; keep in sync.
@@ -46,8 +45,7 @@ EMOJI_RE = re.compile(
     "\U0000200d]"  # zero-width joiner (emoji sequences)
 )
 
-# Title = "scope: summary" / "scope(subscope): summary"; lowercase scope keep
-# it parallel to commit scopes.
+# Lowercase scope keep it parallel to commit scopes.
 TITLE_SHAPE_RE = re.compile(r"^[a-z0-9_-]+(\([a-z0-9_./-]+\))?: \S")
 # Scope shape right, nothing after colon — wrong-scope message would mislead.
 TITLE_NO_SUMMARY_RE = re.compile(r"^[a-z0-9_-]+(\([a-z0-9_./-]+\))?:\s*$")

--- a/.claude/hooks/validate_issue.py
+++ b/.claude/hooks/validate_issue.py
@@ -197,14 +197,27 @@ def extract_title(cmd: str) -> str | None:
     except ValueError:
         return None
 
+    # gh api: -t = --template (output format) — title travel as title= field.
+    api = GH_API_RE.search(cmd) is not None
     i = 0
     while i < len(argv):
         a = argv[i]
         nxt = argv[i + 1] if i + 1 < len(argv) else None
-        if a in {"--title", "-t"} and nxt is not None:
-            return nxt
-        if a.startswith("--title="):
-            return a[len("--title=") :]
+        if api:
+            if (
+                a in {"-F", "-f", "--field", "--raw-field"}
+                and nxt is not None
+                and nxt.startswith("title=")
+            ):
+                val = nxt[len("title=") :]
+                if val.startswith("@"):
+                    return _read_file(val[1:])
+                return val
+        else:
+            if a in {"--title", "-t"} and nxt is not None:
+                return nxt
+            if a.startswith("--title="):
+                return a[len("--title=") :]
         i += 1
     return None
 

--- a/.claude/hooks/validate_issue.py
+++ b/.claude/hooks/validate_issue.py
@@ -48,7 +48,9 @@ EMOJI_RE = re.compile(
 
 # Title = "scope: summary" / "scope(subscope): summary"; lowercase scope keep
 # it parallel to commit scopes.
-TITLE_SHAPE_RE = re.compile(r"^[a-z0-9_]+(\([a-z0-9_./-]+\))?: \S")
+TITLE_SHAPE_RE = re.compile(r"^[a-z0-9_-]+(\([a-z0-9_./-]+\))?: \S")
+# Scope shape right, nothing after colon — wrong-scope message would mislead.
+TITLE_NO_SUMMARY_RE = re.compile(r"^[a-z0-9_-]+(\([a-z0-9_./-]+\))?:\s*$")
 MAX_TITLE_LEN = 72
 
 ISSUE_CREATE_RE = re.compile(r"\bgh\s+issue\s+create\b")
@@ -115,12 +117,18 @@ def title_errors(title: str) -> list[str]:
     """Title must read 'scope: imperative summary' and stay scannable."""
     errors: list[str] = []
     if not TITLE_SHAPE_RE.match(title):
-        errors.append(
-            "Title must start with a lowercase scope then ': ' — "
-            "'scope: imperative summary' or 'scope(subscope): summary', "
-            "mirroring the commit convention minus the type (the issue type "
-            f"is its label). Got: {title!r}"
-        )
+        if TITLE_NO_SUMMARY_RE.match(title):
+            errors.append(
+                "Title has a scope but no summary — put an imperative "
+                f"summary after ': '. Got: {title!r}"
+            )
+        else:
+            errors.append(
+                "Title must start with a lowercase scope then ': ' — "
+                "'scope: imperative summary' or 'scope(subscope): summary', "
+                "mirroring the commit convention minus the type (the issue "
+                f"type is its label). Got: {title!r}"
+            )
     if len(title) > MAX_TITLE_LEN:
         errors.append(
             f"Title is {len(title)} chars (limit: {MAX_TITLE_LEN}). Put the "

--- a/.claude/hooks/validate_pr.py
+++ b/.claude/hooks/validate_pr.py
@@ -178,14 +178,27 @@ def extract_title(cmd: str) -> str | None:
     except ValueError:
         return None
 
+    # gh api: -t = --template (output format) — title travel as title= field.
+    api = GH_API_RE.search(cmd) is not None
     i = 0
     while i < len(argv):
         a = argv[i]
         nxt = argv[i + 1] if i + 1 < len(argv) else None
-        if a in {"--title", "-t"} and nxt is not None:
-            return nxt
-        if a.startswith("--title="):
-            return a[len("--title=") :]
+        if api:
+            if (
+                a in {"-F", "-f", "--field", "--raw-field"}
+                and nxt is not None
+                and nxt.startswith("title=")
+            ):
+                val = nxt[len("title=") :]
+                if val.startswith("@"):
+                    return _read_file(val[1:])
+                return val
+        else:
+            if a in {"--title", "-t"} and nxt is not None:
+                return nxt
+            if a.startswith("--title="):
+                return a[len("--title=") :]
         i += 1
     return None
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -200,9 +200,11 @@ mocks so tests mirror reality (e.g. an endpoint that omits `meta.totalCount`).
   them here would be a third copy that drifts. `.pipeline/` stays uncommitted.
 - **Export follow-ups before cleanup** — `.pipeline/` dies with the worktree,
   so each `.pipeline/followups.md` item becomes an issue:
-  `gh issue create --label follow-up` with `### Origin` / `### Finding` /
-  `### Suggested fix` body sections (validate_issue.py hook checks the shape
-  against `.github/ISSUE_TEMPLATE/follow_up.yml`). One issue per item —
+  `gh issue create --label follow-up`, title in `scope: imperative summary`
+  form (`scope(subscope): …` allowed, ≤72 chars), body with `### Origin` /
+  `### Finding` / `### Suggested fix` sections (validate_issue.py hook
+  enforces the title shape and checks the body against
+  `.github/ISSUE_TEMPLATE/follow_up.yml`). One issue per item —
   independently closeable. An item the user explicitly drops instead is noted
   in PR notes, not filed.
 - PR Notes: record live-test evidence, NIT findings, and links to the filed

--- a/tests/claude_hooks/test_validate_issue.py
+++ b/tests/claude_hooks/test_validate_issue.py
@@ -254,6 +254,46 @@ class TestTemplateErrors:
         assert hook.template_errors([], "anything", {}) == []
 
 
+class TestTitleErrors:
+    def test_scope_and_summary(self) -> None:
+        assert hook.title_errors("evals: model meta omission") == []
+
+    def test_subscope(self) -> None:
+        assert hook.title_errors("tools(attachments): re-measure upload") == []
+
+    def test_missing_scope(self) -> None:
+        errs = hook.title_errors("Re-measure upload on another instance")
+        assert any("scope" in e for e in errs)
+
+    def test_uppercase_scope_rejected(self) -> None:
+        errs = hook.title_errors("Tools: re-measure upload")
+        assert any("scope" in e for e in errs)
+
+    def test_colon_without_space_rejected(self) -> None:
+        errs = hook.title_errors("tools:re-measure upload")
+        assert any("scope" in e for e in errs)
+
+    def test_empty_summary_rejected(self) -> None:
+        errs = hook.title_errors("tools: ")
+        assert any("scope" in e for e in errs)
+
+    def test_over_length_rejected(self) -> None:
+        errs = hook.title_errors("evals(harness): " + "x" * 60)
+        assert any("72" in e for e in errs)
+
+    def test_at_length_limit_allowed(self) -> None:
+        title = "evals(harness): " + "x" * (72 - len("evals(harness): "))
+        assert len(title) == 72
+        assert hook.title_errors(title) == []
+
+    def test_trailing_period_rejected(self) -> None:
+        errs = hook.title_errors("tools: re-measure upload.")
+        assert any("period" in e for e in errs)
+
+    def test_identifier_in_summary_allowed(self) -> None:
+        assert hook.title_errors("evals(cases): loosen TRIG-DOC reject list") == []
+
+
 class TestNonAsciiDetection:
     def test_blocks_korean(self) -> None:
         assert hook.has_disallowed_non_ascii("후속 작업")

--- a/tests/claude_hooks/test_validate_issue.py
+++ b/tests/claude_hooks/test_validate_issue.py
@@ -189,6 +189,20 @@ class TestExtractTitle:
     def test_absent(self) -> None:
         assert hook.extract_title("gh issue edit 5 --body y") is None
 
+    def test_api_template_flag_is_not_a_title(self) -> None:
+        # Under gh api, -t = --template (output format), never a title.
+        assert hook.extract_title("gh api /repos/o/r/issues/5 -t '{{.title}}'") is None
+
+    def test_api_field_title(self) -> None:
+        cmd = "gh api /repos/o/r/issues -f title='tools: fix upload'"
+        assert hook.extract_title(cmd) == "tools: fix upload"
+
+    def test_api_field_title_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "t.txt"
+        f.write_text("tools: filed title")
+        cmd = f"gh api /repos/o/r/issues -F title=@{f}"
+        assert hook.extract_title(cmd) == "tools: filed title"
+
 
 class TestLoadTemplateMap:
     def test_builds_label_to_required_fields(self, template_dir: Path) -> None:

--- a/tests/claude_hooks/test_validate_issue.py
+++ b/tests/claude_hooks/test_validate_issue.py
@@ -291,6 +291,15 @@ class TestTitleErrors:
         errs = hook.title_errors("tools: ")
         assert any("scope" in e for e in errs)
 
+    def test_hyphen_scope_allowed(self) -> None:
+        assert hook.title_errors("dev-pipeline: fix stage export") == []
+
+    def test_empty_summary_gets_pointed_message(self) -> None:
+        # Scope was right — wrong-scope message would mislead.
+        errs = hook.title_errors("tools: ")
+        assert any("no summary" in e for e in errs)
+        assert not any("must start" in e for e in errs)
+
     def test_over_length_rejected(self) -> None:
         errs = hook.title_errors("evals(harness): " + "x" * 60)
         assert any("72" in e for e in errs)

--- a/tests/claude_hooks/test_validate_pr.py
+++ b/tests/claude_hooks/test_validate_pr.py
@@ -106,6 +106,20 @@ class TestExtractTitle:
     def test_absent(self) -> None:
         assert body.extract_title("gh pr edit 5 --body y") is None
 
+    def test_api_template_flag_is_not_a_title(self) -> None:
+        # Under gh api, -t = --template (output format), never a title.
+        assert body.extract_title("gh api /repos/o/r/pulls/5 -t '{{.title}}'") is None
+
+    def test_api_field_title(self) -> None:
+        cmd = "gh api /repos/o/r/pulls/5 -f title='fix: x'"
+        assert body.extract_title(cmd) == "fix: x"
+
+    def test_api_field_title_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "t.txt"
+        f.write_text("fix: filed title")
+        cmd = f"gh api /repos/o/r/pulls/5 -F title=@{f}"
+        assert body.extract_title(cmd) == "fix: filed title"
+
 
 class TestTitleErrors:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Issue bodies already match their template form, but titles had no convention. The five follow-ups filed from PR #193 came out in three different voices and ranged from 75 to 94 chars, so the queue could not be scanned by area:

```
Re-measure document attachment upload and delete on a non-testdrive instance
meta.totalCount emission rule is imprecise, and the fake attachment route never models omission
TRIG-DOC-ATTACHMENTS rejects read_document while the tool docstring points at it
Fake-Polarion document sub-resource routes answer 200 for unseeded documents
Fake-Polarion attachment route emits a project relationship the real request never sees
```

`validate_issue.py` now enforces the same shape the commit convention already uses, minus the type (an issue's type is its label):

```
scope: imperative summary
scope(subscope): imperative summary
```

Those five issues (#194-#198) were retitled by hand; the queue now reads:

```
tools(attachments): re-measure upload/delete off testdrive
evals(harness): model meta.totalCount omission in fake route
evals(cases): loosen TRIG-DOC-ATTACHMENTS reject list
evals(harness): drop project rel from attachment route
evals(harness): 404 unseeded docs on sub-resource routes
```

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- Follow-up issue titles drifted in voice and length, so the queue was hard to scan by area.
- validate_issue.py now requires "scope: summary", caps length at 72, and rejects a trailing period.

## Testing

Ten new `TestTitleErrors` cases, written before the implementation: valid scope and subscope forms, missing scope, uppercase scope, colon without a space, empty summary, over-length, exactly-at-limit, trailing period, and an uppercase identifier inside the summary (`TRIG-DOC`) which must stay legal.

Full gates: `pytest` 1957 passed, `ruff check`, `ruff format --check`, `mypy src/` clean. `diff-cover` reports no lines because `.claude/hooks/` is outside the coverage targets — pre-existing, hooks are tested but not measured.

End-to-end through `main()` with a real hook payload on stdin: a bad title exits 2 with the guidance message, a conforming title exits 0.

Review fix added six `TestExtractTitle` cases across both hook test files (RED first), and re-verified end-to-end: `gh api .../issues/123 -t '{{.title}}'` now exits 0, a freeform `gh api .../issues -f title=...` exits 2, a conforming one exits 0. Two further `TestTitleErrors` cases (hyphenated scope legal, empty summary gets a pointed message) followed the same RED-first flow.

## Notes for Reviewers

Scope of enforcement: the hook only intercepts Bash `gh issue create/edit/comment` and `gh api` paths hitting `/issues` — that is, issues filed by Claude Code in this repo. Humans filing through the GitHub web form are unaffected, so this adds no contributor friction.

Deliberately not enforced: a scope allowlist. Structure is checked (lowercase, optional parenthesized subscope, `: `), but the vocabulary is left open so a new area does not need a hook change to file its first issue.

Review fix: `extract_title` was not `gh api`-aware — under `gh api`, `-t` means `--template`, so an output-formatting flag was parsed as a title and shape-checked (blocking read-only calls like `gh api .../issues/123 -t '{{.title}}'`), while `-f title=` fields escaped the title checks entirely. It now mirrors `extract_body`'s field handling (`title=` fields, `@file` included; `-t`/`--title` ignored under api). `validate_pr.py` carries the duplicated parser and got the same fix per its keep-in-sync note. Two smaller review items landed too: the scope character class now allows hyphens (`dev-pipeline: …`), matching what the subscope already accepted, and a scope-only title (`tools: `) gets a dedicated no-summary message instead of the misleading wrong-scope one.

Docs: the dev-pipeline skill's Stage 8 follow-up export now states the title form inline, next to the body-shape sentence that already cited this hook. CONTRIBUTING.md still omits the rule — the hook's rejection message states it in full, which is enough while enforcement is Claude-only; worth revisiting if humans ever need to follow it.

Depends on nothing; #193 is independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

