### PR TITLE
docs(skills): add comment-density simplify angle

### DIFF
--- a/.claude/agents/pipeline-simplifier.md
+++ b/.claude/agents/pipeline-simplifier.md
@@ -1,6 +1,6 @@
 ---
 name: pipeline-simplifier
-description: Behavior-preserving cleanup pass for dev-pipeline Stage 5 — sweeps the branch diff for reuse, simplification, efficiency, and altitude issues, applies the fixes itself, and reports each change with a one-line rationale. Invoke once per pipeline run, after gates first pass and before the first review round. Quality only — never hunts correctness bugs; behavior stays pinned by the Stage 3 tests. Instructions vendored from the Claude Code built-in /simplify so the pipeline does not depend on it.
+description: Behavior-preserving cleanup pass for dev-pipeline Stage 5 — sweeps the branch diff for reuse, simplification, efficiency, altitude, and comment-density issues, applies the fixes itself, and reports each change with a one-line rationale. Invoke once per pipeline run, after gates first pass and before the first review round. Quality only — never hunts correctness bugs; behavior stays pinned by the Stage 3 tests. Instructions vendored from the Claude Code built-in /simplify so the pipeline does not depend on it.
 tools: Read, Edit, Write, Grep, Glob, Bash
 model: sonnet
 ---
@@ -8,7 +8,7 @@ model: sonnet
 # Pipeline Simplifier
 
 You improve the quality of the changed code, not hunt for bugs. Review the
-diff for the four angles below, then fix what you find. Correctness bugs are
+diff for the five angles below, then fix what you find. Correctness bugs are
 the Stage 6 reviewer's job — leave them alone.
 
 ## Input contract (the prompt must give you)
@@ -18,7 +18,7 @@ the Stage 6 reviewer's job — leave them alone.
   empty range means it didn't — say so and stop, never widen scope yourself
   (`git diff HEAD` would miss untracked files anyway).
 
-## Review angles — run all four yourself, sequentially
+## Review angles — run all five yourself, sequentially
 
 You cannot spawn agents; cover each angle as its own pass over the diff.
 
@@ -34,6 +34,16 @@ You cannot spawn agents; cover each angle as its own pass over the diff.
    Use the cheaper alternative.
 4. **Altitude** — special cases layered on shared infrastructure instead of a
    fix to the underlying mechanism. Generalize rather than patch on top.
+5. **Comment density** — verbose developer comments and dev docstrings in the
+   diff. Apply the CLAUDE.md comment rules: why not what, one distinct fact
+   per line, caveman-compressed (drop articles/filler); delete comments that
+   restate the code. Diff scope only — never tidy unchanged files (repo-wide
+   sweeps belong to `/compress-code-comments`).
+   Never touch: `@mcp.tool` function docstrings and `Field(description=...)`
+   strings — LLM-facing and eval-gated, editing them can fail the deploy-gate
+   evals; and functional pseudo-comments (`# noqa`, `# type: ignore[...]`,
+   `# pragma: no cover`, `# fmt:`/`# ruff:`/`# isort:` directives, shebangs,
+   license headers) — preserve verbatim, including position on the line.
 
 ## Boundaries
 

--- a/.claude/agents/pipeline-simplifier.md
+++ b/.claude/agents/pipeline-simplifier.md
@@ -34,16 +34,11 @@ You cannot spawn agents; cover each angle as its own pass over the diff.
    Use the cheaper alternative.
 4. **Altitude** — special cases layered on shared infrastructure instead of a
    fix to the underlying mechanism. Generalize rather than patch on top.
-5. **Comment density** — verbose developer comments and dev docstrings in the
-   diff. Apply the CLAUDE.md comment rules: why not what, one distinct fact
-   per line, caveman-compressed (drop articles/filler); delete comments that
-   restate the code. Diff scope only — never tidy unchanged files (repo-wide
-   sweeps belong to `/compress-code-comments`).
-   Never touch: `@mcp.tool` function docstrings and `Field(description=...)`
-   strings — LLM-facing and eval-gated, editing them can fail the deploy-gate
-   evals; and functional pseudo-comments (`# noqa`, `# type: ignore[...]`,
-   `# pragma: no cover`, `# fmt:`/`# ruff:`/`# isort:` directives, shebangs,
-   license headers) — preserve verbatim, including position on the line.
+5. **Comment density** — verbose comments or dev docstrings. Compress to the
+   CLAUDE.md comment rules (why not what, one line per fact); delete what
+   restates the code. Never touch `@mcp.tool` docstrings or
+   `Field(description=...)` (eval-gated LLM surface), nor functional
+   directives (`# noqa`, `# type: ignore`, `# pragma`, `# fmt:`).
 
 ## Boundaries
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -185,9 +185,8 @@ complexity):
 2. **Invoke `pipeline-simplifier`** with the worktree path and the diff scope
    (`git diff origin/main...HEAD`). It sweeps reuse/simplification/efficiency/
    altitude/comment-density and applies the fixes itself — quality only, no
-   bug hunting; behavior stays pinned by the Stage 3 tests. The comment pass
-   never touches `@mcp.tool` docstrings or `Field(description=...)`
-   (eval-gated LLM surface). Expect its CHANGED / SKIPPED / TESTS report back.
+   bug hunting; behavior stays pinned by the Stage 3 tests. Expect its
+   CHANGED / SKIPPED / TESTS report back.
 3. Re-run Stage 4 gates in the main thread, then commit the simplify edits.
    Gates red on a simplify edit (diff-cover counts its changed lines too):
    `SendMessage` the simplifier to fix or revert that edit — it holds the

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -184,9 +184,10 @@ complexity):
    skipping this turns the pass into a silent no-op.
 2. **Invoke `pipeline-simplifier`** with the worktree path and the diff scope
    (`git diff origin/main...HEAD`). It sweeps reuse/simplification/efficiency/
-   altitude and applies the fixes itself — quality only, no bug hunting;
-   behavior stays pinned by the Stage 3 tests. Expect its CHANGED / SKIPPED /
-   TESTS report back.
+   altitude/comment-density and applies the fixes itself — quality only, no
+   bug hunting; behavior stays pinned by the Stage 3 tests. The comment pass
+   never touches `@mcp.tool` docstrings or `Field(description=...)`
+   (eval-gated LLM surface). Expect its CHANGED / SKIPPED / TESTS report back.
 3. Re-run Stage 4 gates in the main thread, then commit the simplify edits.
    Gates red on a simplify edit (diff-cover counts its changed lines too):
    `SendMessage` the simplifier to fix or revert that edit — it holds the


### PR DESCRIPTION
## Summary

Adds a fifth review angle — comment density — to the dev-pipeline Stage 5 simplifier, so verbose developer comments in the branch diff get compressed to the CLAUDE.md caveman style before review. The implementer is already instructed to follow the comment rules at generation time; this pass is the safety net for drift, which the Stage 6 reviewer never covers (style findings demote to LOW).

## Type of Change

<!-- Flip [ ] -> [x] for matching items. Do not delete unchecked options. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Implementer comment-style drift reached review untouched; reviewer demotes style findings to LOW
- Add fifth simplifier angle with eval-gated never-touch list; sync dev-pipeline Stage 5 wording

## Testing

Docs-only change to agent/skill instruction files; no code paths affected. Verified the never-touch boundary mirrors compress-code-comments SKILL.md (`@mcp.tool` docstrings, `Field(description=...)`, functional pseudo-comments).

## Notes for Reviewers

Diff scope stays `origin/main...HEAD` only — repo-wide comment sweeps remain the job of `/compress-code-comments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)