### PR TITLE
fix(coverage): anchor ellipsis exclude regex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,5 +108,7 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "raise NotImplementedError",
     "@overload",
-    '\.\.\.',
+    # Statement-only Ellipsis stub; bare pattern matched "..." inside Field
+    # description strings = whole tool bodies dropped from measurement (#212).
+    '^\s*\.\.\.\s*$',
 ]

--- a/tests/test_coverage_config.py
+++ b/tests/test_coverage_config.py
@@ -1,0 +1,62 @@
+r"""Guard pyproject coverage ``exclude_lines`` vs false-positive block drops.
+
+Bare ``\.\.\.`` pattern once matched literal ``...`` inside Field description
+strings in tools/documents.py signatures — coverage block-exclusion dropped
+whole update_document/create_document bodies from measurement (#212).
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+# Mirror [tool.coverage.run] source.
+COVERAGE_SOURCE_DIRS = ("src/mcp_server_polarion", "evals")
+
+
+def _exclude_patterns() -> list[re.Pattern[str]]:
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    raw = tomllib.loads(pyproject_text)["tool"]["coverage"]["report"]["exclude_lines"]
+    assert isinstance(raw, list)
+    return [re.compile(pattern) for pattern in raw]
+
+
+def _is_intended_exclusion(line: str) -> bool:
+    # Whole-line construct per configured pattern; anything else = pattern
+    # bleed into strings/comments/signatures.
+    stripped = line.strip()
+    return (
+        stripped == "..."
+        or "pragma: no cover" in stripped
+        or stripped.startswith("if TYPE_CHECKING:")
+        or stripped.startswith("raise NotImplementedError")
+        or stripped.startswith("@overload")
+    )
+
+
+def test_exclude_patterns_match_only_intended_lines() -> None:
+    patterns = _exclude_patterns()
+    offenders: list[str] = []
+    for source_dir in COVERAGE_SOURCE_DIRS:
+        for path in sorted((REPO_ROOT / source_dir).rglob("*.py")):
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for lineno, line in enumerate(lines, start=1):
+                matched = any(p.search(line) for p in patterns)
+                if matched and not _is_intended_exclusion(line):
+                    rel = path.relative_to(REPO_ROOT)
+                    offenders.append(f"{rel}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "exclude_lines pattern hits non-stub source lines — coverage silently "
+        "drops their whole block from measurement:\n" + "\n".join(offenders)
+    )
+
+
+def test_ellipsis_pattern_statement_only() -> None:
+    patterns = _exclude_patterns()
+    stub_body = "        ..."
+    # Verbatim offender line from update_document signature (#212).
+    prose = '        description="Enable auto outline numbers (1, 1.1, ...).",'
+    assert any(p.search(stub_body) for p in patterns)
+    assert not any(p.search(prose) for p in patterns)


### PR DESCRIPTION
## Summary

Coverage `exclude_lines` carried a bare `\.\.\.` regex meant for Ellipsis-body stubs. It also matched literal `...` inside `Field(description=...)` strings in the `update_document`/`create_document` signatures, so coverage.py block-exclusion dropped both tool bodies (355 lines) from measurement and diff-cover silently omitted changed lines in `tools/documents.py`. Anchoring the pattern to statement-only ellipsis restores measurement: excluded lines in `documents.py` go 355 -> 0, all 67 executable body lines now measured (and executed), module reports 92%, total stays 91% (>= 90 gate). Closes #212

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- Bare `\.\.\.` exclude regex matched `...` in Field description strings, dropping whole tool bodies from coverage.
- Anchor pattern to `^\s*\.\.\.\s*$`; add test pinning exclude patterns to intended whole-line forms.

## Testing

- New `tests/test_coverage_config.py` fails on old config (both tests), passes after fix; scans all coverage sources for pattern bleed and pins the verbatim #212 offender line.
- Before/after coverage JSON on `tools/documents.py`: excluded 355 -> 0; `update_document`/`create_document` bodies fully measured.
- Full gates: `uv run pytest` (2225 passed, 11 skipped), ruff check/format, mypy, `--cov` + diff-cover `--fail-under=90` all green; total coverage 91%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
