### PR TITLE
fix(hooks): extract heredoc PR body untruncated

### DIFF
--- a/.claude/hooks/validate_issue.py
+++ b/.claude/hooks/validate_issue.py
@@ -57,6 +57,14 @@ GH_API_RE = re.compile(r"\bgh\s+api\b")
 # \b cover item paths (/issues/5) and creation POST (/issues, no trailing slash).
 ISSUES_PATH_RE = re.compile(r"/issues\b")
 
+# --body "$(cat <<'EOF' ...)" form: shlex know neither $() nor heredoc — first
+# inner double quote end token early, truncated body get validated. Detect on
+# raw cmd, slice payload direct. --body-file never match ([=\s] after flag).
+BODY_HEREDOC_RE = re.compile(
+    r"(?<!\S)(?:--body|-b)[=\s]+[\"']?\$\(\s*cat\s*<<-?\s*"
+    r"(?:'(?P<sq>[^']+)'|\"(?P<dq>[^\"]+)\"|(?P<bare>\w+))"
+)
+
 TEMPLATE_DIR = Path(".github/ISSUE_TEMPLATE")
 # Form yml simple enough for line parsing — hook run on system python3, no PyYAML.
 TEMPLATE_LABELS_RE = re.compile(r"^labels:\s*\[(.*)\]", re.MULTILINE)
@@ -154,6 +162,11 @@ def classify(cmd: str) -> str | None:
 
 
 def extract_body(cmd: str) -> str | None:
+    heredoc = BODY_HEREDOC_RE.search(cmd)
+    if heredoc is not None:
+        # Never fall through to shlex here — truncated token would validate.
+        return _heredoc_payload(cmd, heredoc)
+
     try:
         argv = shlex.split(cmd)
     except ValueError:
@@ -188,6 +201,23 @@ def extract_body(cmd: str) -> str | None:
             return _read_file(nxt)
         i += 1
     return None
+
+
+def _heredoc_payload(cmd: str, opener: re.Match[str]) -> str | None:
+    """Slice heredoc payload out of raw cmd — lines between BODY_HEREDOC_RE
+    match and closing marker line. Malformed (no newline / no close) = None;
+    shell would error on same command, nothing sound to validate.
+    """
+    marker = opener.group("sq") or opener.group("dq") or opener.group("bare")
+    nl = cmd.find("\n", opener.end())
+    if nl == -1:
+        return None
+    rest = cmd[nl + 1 :]
+    # \t* = <<- tab-stripped close; trailing \n strip mirror $() behavior.
+    close = re.search(rf"^\t*{re.escape(marker)}\s*$", rest, re.MULTILINE)
+    if close is None:
+        return None
+    return rest[: close.start()].rstrip("\n")
 
 
 def _read_file(path: str) -> str | None:

--- a/.claude/hooks/validate_issue.py
+++ b/.claude/hooks/validate_issue.py
@@ -61,7 +61,7 @@ ISSUES_PATH_RE = re.compile(r"/issues\b")
 # inner double quote end token early, truncated body get validated. Detect on
 # raw cmd, slice payload direct. --body-file never match ([=\s] after flag).
 BODY_HEREDOC_RE = re.compile(
-    r"(?<!\S)(?:--body|-b)[=\s]+[\"']?\$\(\s*cat\s*<<-?\s*"
+    r"(?<!\S)(?:--body|-b)[=\s]+[\"']?\$\(\s*cat\s*<<(?P<dash>-)?\s*"
     r"(?:'(?P<sq>[^']+)'|\"(?P<dq>[^\"]+)\"|(?P<bare>\w+))"
 )
 
@@ -213,11 +213,13 @@ def _heredoc_payload(cmd: str, opener: re.Match[str]) -> str | None:
     if nl == -1:
         return None
     rest = cmd[nl + 1 :]
-    # \t* = <<- tab-stripped close; trailing \n strip mirror $() behavior.
-    close = re.search(rf"^\t*{re.escape(marker)}\s*$", rest, re.MULTILINE)
+    # Shell close bare << at column 0 only; <<- allow leading tabs.
+    indent = r"\t*" if opener.group("dash") else ""
+    close = re.search(rf"^{indent}{re.escape(marker)}\s*$", rest, re.MULTILINE)
     if close is None:
         return None
-    return rest[: close.start()].rstrip("\n")
+    # Trailing newline strip mirror $(); \r keep CRLF input clean.
+    return rest[: close.start()].rstrip("\r\n")
 
 
 def _read_file(path: str) -> str | None:

--- a/.claude/hooks/validate_pr.py
+++ b/.claude/hooks/validate_pr.py
@@ -58,6 +58,14 @@ PR_CREATE_EDIT_RE = re.compile(r"\bgh\s+pr\s+(create|edit)\b")
 PR_COMMENT_RE = re.compile(r"\bgh\s+pr\s+comment\b")
 GH_API_RE = re.compile(r"\bgh\s+api\b")
 
+# --body "$(cat <<'EOF' ...)" form: shlex know neither $() nor heredoc — first
+# inner double quote end token early, truncated body get validated. Detect on
+# raw cmd, slice payload direct. --body-file never match ([=\s] after flag).
+BODY_HEREDOC_RE = re.compile(
+    r"(?<!\S)(?:--body|-b)[=\s]+[\"']?\$\(\s*cat\s*<<-?\s*"
+    r"(?:'(?P<sq>[^']+)'|\"(?P<dq>[^\"]+)\"|(?P<bare>\w+))"
+)
+
 
 def main() -> int:
     try:
@@ -129,6 +137,11 @@ def classify(cmd: str) -> str | None:
 
 
 def extract_body(cmd: str) -> str | None:
+    heredoc = BODY_HEREDOC_RE.search(cmd)
+    if heredoc is not None:
+        # Never fall through to shlex here — truncated token would validate.
+        return _heredoc_payload(cmd, heredoc)
+
     try:
         argv = shlex.split(cmd)
     except ValueError:
@@ -163,6 +176,23 @@ def extract_body(cmd: str) -> str | None:
             return _read_file(nxt)
         i += 1
     return None
+
+
+def _heredoc_payload(cmd: str, opener: re.Match[str]) -> str | None:
+    """Slice heredoc payload out of raw cmd — lines between BODY_HEREDOC_RE
+    match and closing marker line. Malformed (no newline / no close) = None;
+    shell would error on same command, nothing sound to validate.
+    """
+    marker = opener.group("sq") or opener.group("dq") or opener.group("bare")
+    nl = cmd.find("\n", opener.end())
+    if nl == -1:
+        return None
+    rest = cmd[nl + 1 :]
+    # \t* = <<- tab-stripped close; trailing \n strip mirror $() behavior.
+    close = re.search(rf"^\t*{re.escape(marker)}\s*$", rest, re.MULTILINE)
+    if close is None:
+        return None
+    return rest[: close.start()].rstrip("\n")
 
 
 def _read_file(path: str) -> str | None:

--- a/.claude/hooks/validate_pr.py
+++ b/.claude/hooks/validate_pr.py
@@ -62,7 +62,7 @@ GH_API_RE = re.compile(r"\bgh\s+api\b")
 # inner double quote end token early, truncated body get validated. Detect on
 # raw cmd, slice payload direct. --body-file never match ([=\s] after flag).
 BODY_HEREDOC_RE = re.compile(
-    r"(?<!\S)(?:--body|-b)[=\s]+[\"']?\$\(\s*cat\s*<<-?\s*"
+    r"(?<!\S)(?:--body|-b)[=\s]+[\"']?\$\(\s*cat\s*<<(?P<dash>-)?\s*"
     r"(?:'(?P<sq>[^']+)'|\"(?P<dq>[^\"]+)\"|(?P<bare>\w+))"
 )
 
@@ -188,11 +188,13 @@ def _heredoc_payload(cmd: str, opener: re.Match[str]) -> str | None:
     if nl == -1:
         return None
     rest = cmd[nl + 1 :]
-    # \t* = <<- tab-stripped close; trailing \n strip mirror $() behavior.
-    close = re.search(rf"^\t*{re.escape(marker)}\s*$", rest, re.MULTILINE)
+    # Shell close bare << at column 0 only; <<- allow leading tabs.
+    indent = r"\t*" if opener.group("dash") else ""
+    close = re.search(rf"^{indent}{re.escape(marker)}\s*$", rest, re.MULTILINE)
     if close is None:
         return None
-    return rest[: close.start()].rstrip("\n")
+    # Trailing newline strip mirror $(); \r keep CRLF input clean.
+    return rest[: close.start()].rstrip("\r\n")
 
 
 def _read_file(path: str) -> str | None:

--- a/tests/claude_hooks/test_validate_issue.py
+++ b/tests/claude_hooks/test_validate_issue.py
@@ -176,6 +176,37 @@ class TestExtractBody:
         assert hook.extract_body("gh issue create --title only") is None
 
 
+class TestHeredocBody:
+    def test_inner_double_quotes_keep_full_payload(self) -> None:
+        # shlex-only path truncate at first inner quote — regression #211.
+        cmd = (
+            "gh issue create --title 'tools: x' --body \"$(cat <<'EOF'\n"
+            "### Origin\n\n"
+            'PR "quoted" #210\n\n'
+            "### Finding\n\ndetail\n"
+            "EOF\n"
+            ')"'
+        )
+        assert hook.extract_body(cmd) == (
+            '### Origin\n\nPR "quoted" #210\n\n### Finding\n\ndetail'
+        )
+
+    def test_missing_close_marker_extracts_nothing(self) -> None:
+        # No close = shell error anyway — never validate half a body.
+        cmd = "gh issue create --body \"$(cat <<'EOF'\n### Origin\n)\""
+        assert hook.extract_body(cmd) is None
+
+    def test_body_file_beside_unrelated_heredoc(self, tmp_path: Path) -> None:
+        f = tmp_path / "b.md"
+        f.write_text("from file")
+        cmd = f"cat <<'EOF' >/dev/null\nnoise\nEOF\ngh issue create --body-file {f}"
+        assert hook.extract_body(cmd) == "from file"
+
+    def test_plain_quoted_body_untouched(self) -> None:
+        # No $(cat <<...) after flag — shlex path stay in charge.
+        assert hook.extract_body('gh issue create --body "simple"') == "simple"
+
+
 class TestExtractTitle:
     def test_long_flag(self) -> None:
         assert hook.extract_title("gh issue create --title 'follow up'") == "follow up"

--- a/tests/claude_hooks/test_validate_issue.py
+++ b/tests/claude_hooks/test_validate_issue.py
@@ -191,6 +191,32 @@ class TestHeredocBody:
             '### Origin\n\nPR "quoted" #210\n\n### Finding\n\ndetail'
         )
 
+    def test_double_quoted_marker(self) -> None:
+        cmd = 'gh issue create --body "$(cat <<"EOF"\nplain text\nEOF\n)"'
+        assert hook.extract_body(cmd) == "plain text"
+
+    def test_crlf_body_no_trailing_cr(self) -> None:
+        cmd = (
+            "gh issue create --body \"$(cat <<'EOF'\r\n"
+            "### Origin\r\n\r\n"
+            'PR "quoted" #210\r\n'
+            "EOF\r\n"
+            ')"'
+        )
+        extracted = hook.extract_body(cmd)
+        assert extracted is not None
+        assert not extracted.endswith("\r")
+        assert extracted.startswith("### Origin")
+
+    def test_bare_heredoc_skips_tab_indented_close(self) -> None:
+        # Shell close bare << at column 0 only — indented marker = still open.
+        cmd = "gh issue create --body \"$(cat <<'EOF'\n### Origin\n\tEOF\n)\""
+        assert hook.extract_body(cmd) is None
+
+    def test_dash_heredoc_accepts_tab_indented_close(self) -> None:
+        cmd = "gh issue create --body \"$(cat <<-'EOF'\n### Origin\n\tEOF\n)\""
+        assert hook.extract_body(cmd) == "### Origin"
+
     def test_missing_close_marker_extracts_nothing(self) -> None:
         # No close = shell error anyway — never validate half a body.
         cmd = "gh issue create --body \"$(cat <<'EOF'\n### Origin\n)\""

--- a/tests/claude_hooks/test_validate_pr.py
+++ b/tests/claude_hooks/test_validate_pr.py
@@ -123,6 +123,33 @@ class TestHeredocBody:
         cmd = "gh pr edit 5 --body=\"$(cat <<'EOF'\nplain text\nEOF\n)\""
         assert body.extract_body(cmd) == "plain text"
 
+    def test_double_quoted_marker(self) -> None:
+        cmd = 'gh pr create --body "$(cat <<"EOF"\nplain text\nEOF\n)"'
+        assert body.extract_body(cmd) == "plain text"
+
+    def test_crlf_body_no_trailing_cr(self) -> None:
+        cmd = (
+            "gh pr create --body \"$(cat <<'EOF'\r\n"
+            "## Changes\r\n"
+            '- said "quote" one\r\n'
+            "- two\r\n"
+            "EOF\r\n"
+            ')"'
+        )
+        extracted = body.extract_body(cmd)
+        assert extracted is not None
+        assert not extracted.endswith("\r")
+        assert body.changes_format_errors(extracted) == []
+
+    def test_bare_heredoc_skips_tab_indented_close(self) -> None:
+        # Shell close bare << at column 0 only — indented marker = still open.
+        cmd = "gh pr create --body \"$(cat <<'EOF'\n- one\n\tEOF\n)\""
+        assert body.extract_body(cmd) is None
+
+    def test_dash_heredoc_accepts_tab_indented_close(self) -> None:
+        cmd = "gh pr create --body \"$(cat <<-'EOF'\n- one\n\tEOF\n)\""
+        assert body.extract_body(cmd) == "- one"
+
     def test_odd_quote_count_still_extracts(self) -> None:
         # Lone inner quote = shlex ValueError; heredoc slice unaffected.
         cmd = 'gh pr create --body "$(cat <<\'EOF\'\nsaid "partial\nEOF\n)"'

--- a/tests/claude_hooks/test_validate_pr.py
+++ b/tests/claude_hooks/test_validate_pr.py
@@ -93,6 +93,57 @@ class TestBodyExtractBody:
         assert body.extract_body("gh pr edit --title only") is None
 
 
+HEREDOC_CMD = (
+    "gh pr create --title 'fix: x' --body \"$(cat <<'EOF'\n"
+    "## Changes\n"
+    '- Pipeline said "run gates" before push\n'
+    "- second bullet\n"
+    "EOF\n"
+    ')"'
+)
+
+
+class TestHeredocBody:
+    def test_inner_double_quotes_keep_full_payload(self) -> None:
+        # shlex-only path truncate at first inner quote — regression #211.
+        assert body.extract_body(HEREDOC_CMD) == (
+            '## Changes\n- Pipeline said "run gates" before push\n- second bullet'
+        )
+
+    def test_inner_double_quotes_count_real_bullets(self) -> None:
+        extracted = body.extract_body(HEREDOC_CMD)
+        assert extracted is not None
+        assert body.changes_format_errors(extracted) == []
+
+    def test_unquoted_marker(self) -> None:
+        cmd = 'gh pr create --body "$(cat <<PR_BODY\nplain text\nPR_BODY\n)"'
+        assert body.extract_body(cmd) == "plain text"
+
+    def test_body_equals_form(self) -> None:
+        cmd = "gh pr edit 5 --body=\"$(cat <<'EOF'\nplain text\nEOF\n)\""
+        assert body.extract_body(cmd) == "plain text"
+
+    def test_odd_quote_count_still_extracts(self) -> None:
+        # Lone inner quote = shlex ValueError; heredoc slice unaffected.
+        cmd = 'gh pr create --body "$(cat <<\'EOF\'\nsaid "partial\nEOF\n)"'
+        assert body.extract_body(cmd) == 'said "partial'
+
+    def test_missing_close_marker_extracts_nothing(self) -> None:
+        # No close = shell error anyway — never validate half a body.
+        cmd = "gh pr create --body \"$(cat <<'EOF'\n- one\n)\""
+        assert body.extract_body(cmd) is None
+
+    def test_body_file_beside_unrelated_heredoc(self, tmp_path: Path) -> None:
+        f = tmp_path / "b.md"
+        f.write_text("from file")
+        cmd = f"cat <<'EOF' >/dev/null\nnoise\nEOF\ngh pr create --body-file {f}"
+        assert body.extract_body(cmd) == "from file"
+
+    def test_plain_quoted_body_untouched(self) -> None:
+        # No $(cat <<...) after flag — shlex path stay in charge.
+        assert body.extract_body('gh pr create --body "simple"') == "simple"
+
+
 class TestExtractTitle:
     def test_long_flag(self) -> None:
         assert body.extract_title("gh pr create --title 'fix: x'") == "fix: x"


### PR DESCRIPTION
## Summary

Closes #211. `extract_body` in `validate_pr.py` / `validate_issue.py` re-parsed the Bash command with `shlex.split`, which understands neither `$(...)` nor heredocs — with the common `--body "$(cat <<'EOF' ... EOF)"` form the first double quote inside the body text ended the token early. The hooks then validated a truncated body: false-positive block observed on PR #210 (`## Changes` kept only one bullet), and a truncated body could equally pass checks the full body would fail.

Fix: detect the `--body "$(cat <<MARKER ...)"` form on the raw command string first (regex accepts `-b`, `--body=`, quoted/unquoted markers, `<<-`) and slice the payload directly between the marker line and its closing marker line, mirroring `$()` trailing-newline stripping. Malformed heredoc (no closing marker) extracts nothing instead of falling through to a truncated shlex token — the shell would reject that command anyway. Helper duplicated identically in both standalone hook scripts per their existing keep-in-sync convention. `--body-file` and plain quoted `--body "..."` paths are untouched.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- shlex stops at first inner double quote, so hooks validated truncated heredoc PR/issue bodies (false block on #210)
- detect heredoc --body form on raw command and slice payload between markers in validate_pr.py + validate_issue.py

## Testing

`uv run pytest` (2235 passed), `ruff check` + `ruff format` + `mypy src/` clean, coverage + diff-cover gate run (hook files outside gated dirs; no coverage-bearing lines in diff). New `TestHeredocBody` suites in both hook test files: inner-quote heredoc yields full payload and counts real bullets, unquoted marker, `--body=` form, odd quote count (shlex ValueError path), missing close marker yields None, `--body-file` beside unrelated heredoc unaffected, plain quoted body unchanged. Also verified end-to-end via hook stdin: full-template heredoc body with inner quotes passes, one-bullet heredoc body still blocks.
