### PR TITLE
test(evals): pin attachment content arg-threading

### DIFF
--- a/evals/cases/orchestration.py
+++ b/evals/cases/orchestration.py
@@ -19,7 +19,9 @@ from evals.cases._shared import Step, make_case
 from evals.harness.fixtures import (
     CHILD_REQ_ID,
     DOC,
+    DOC_ATTACHMENT_ID,
     FLOATING_TASK_ID,
+    PROJECT,
     SPACE,
 )
 
@@ -199,6 +201,32 @@ CASES: list[Case] = [
                 "observed_arg": "document_name",
                 "observed_in": "list_documents",
                 "observed_path": "items[].document_name",
+            },
+        ],
+        read_only=True,
+    ),
+    _case(
+        "ORCH-DOC-ATTACHMENT-FETCH",
+        f"Show me the diagram image attached to the document '{DOC}' in "
+        f"space '{SPACE}'.",
+        # Doc body carry no attachment ref -- id only discoverable via
+        # listing, so threaded attachment_id provably observed.
+        intent="Discover the attachment via list_document_attachments -> fetch "
+        "its content with the full address threaded exactly (project/space/"
+        "document/attachment id, observed from the listing); read-only.",
+        steps=[
+            {"tool": "list_document_attachments", "match": {"document_name": DOC}},
+            {
+                "tool": "get_document_attachment_content",
+                "match": {
+                    "project_id": PROJECT,
+                    "space_id": SPACE,
+                    "document_name": DOC,
+                    "attachment_id": DOC_ATTACHMENT_ID,
+                },
+                "observed_arg": "attachment_id",
+                "observed_in": "list_document_attachments",
+                "observed_path": "items[].id",
             },
         ],
         read_only=True,


### PR DESCRIPTION
## Summary

Pins arg-threading for `get_document_attachment_content` at eval level. The existing trigger case (TRIG-DOC-ATTACHMENT-CONTENT) asserts routing only; nothing verified the spec'd call args (`project_id`/`space_id`/`document_name`/`attachment_id`) reach the tool intact. New orchestration case ORCH-DOC-ATTACHMENT-FETCH: the agent must discover the attachment via `list_document_attachments`, then fetch its content with `match` pinning all four address args on the seeded harness fixture ids and `attachment_id` threaded from the observed listing result (the fake doc body carries no attachment ref, so the id is only discoverable by listing). Orchestration chosen per evals/README.md — id threading between steps is that category's charter, and `ordered_trajectory` is the only check with per-step `match`. `DEFERRED` in `tests/evals/test_coverage.py` is empty and both tools were already covered, so no coverage bookkeeping changes. Closes #202

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- No eval pinned the spec'd call args of get_document_attachment_content; the trigger case checks routing only.
- Add ORCH-DOC-ATTACHMENT-FETCH: match on project/space/document/attachment ids, threaded from the attachment listing.

## Testing

- `uv run pytest` — 2296 passed (structural case-shape + coverage tests validate the new case wiring).
- `uv run ruff check .`, `ruff format --check .`, `mypy src/` — clean.
- Coverage + `diff-cover --compare-branch=origin/main --fail-under=90` — pass (case-list data lines carry no measurable statements).
- No live single-case eval run: `OPENAI_API_KEY` absent in this environment and no local model endpoint serving; case verified structurally only (`evals.run --list` shows it registered under orchestration).

## Notes for Reviewers

- Case is read-only (`read_only=True`), mirrors the R-group discovery cases; min_pass_rate 0.8 per category.
