### PR TITLE
fix(tools): guard created-id count on bulk echoes

### DIFF
--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -98,29 +98,8 @@ def extract_short_id(full_id: str) -> str:
     return full_id.rsplit("/", maxsplit=1)[-1]
 
 
-def extract_created_short_ids(response: dict[str, object]) -> list[str]:
-    """Short resource ids from bulk 201 response; rely on Polarion echoing
-    ``data`` in submission order (call-site count check catch missing ids,
-    not reordered).
-    """
-    data = response.get("data")
-    if not isinstance(data, list):
-        return []
-    ids: list[str] = []
-    for item in data:
-        if isinstance(item, dict):
-            full_id = safe_str(item.get("id", ""))
-            if full_id:
-                ids.append(extract_short_id(full_id))
-    return ids
-
-
-def extract_created_full_ids(response: dict[str, object]) -> list[str]:
-    """Verbatim resource ids from bulk 201 response -- testrecord ids are
-    5 segments (project/testRun/testCaseProject/testCaseId/iteration);
-    ``extract_created_short_ids`` would rsplit to the bare iteration index,
-    losing test case + run context. Collect ``data[].id`` as-is, never split.
-    """
+def _collect_created_ids(response: dict[str, object]) -> list[str]:
+    """``data[].id`` verbatim, echo order; malformed entries skipped."""
     data = response.get("data")
     if not isinstance(data, list):
         return []
@@ -130,6 +109,45 @@ def extract_created_full_ids(response: dict[str, object]) -> list[str]:
             full_id = safe_str(item.get("id", ""))
             if full_id:
                 ids.append(full_id)
+    return ids
+
+
+def _guard_created_count(
+    ids: list[str], *, expected_count: int, list_tool: str
+) -> None:
+    """201 echo count != submission count = possible partial create --
+    silently short id list would hide it. Fail loud, name the verify tool.
+    """
+    if len(ids) != expected_count:
+        raise RuntimeError(
+            f"Polarion accepted the bulk create but returned {len(ids)} "
+            f"ids for {expected_count} submitted entries. The batch may be "
+            f"partially created; verify with {list_tool} before retrying."
+        )
+
+
+def extract_created_short_ids(
+    response: dict[str, object], *, expected_count: int, list_tool: str
+) -> list[str]:
+    """Short resource ids from bulk 201 response; rely on Polarion echoing
+    ``data`` in submission order (count guard catch missing ids, not
+    reordered).
+    """
+    ids = [extract_short_id(full_id) for full_id in _collect_created_ids(response)]
+    _guard_created_count(ids, expected_count=expected_count, list_tool=list_tool)
+    return ids
+
+
+def extract_created_full_ids(
+    response: dict[str, object], *, expected_count: int, list_tool: str
+) -> list[str]:
+    """Verbatim resource ids from bulk 201 response -- composite ids
+    (testrecord project/testRun/testCaseProject/testCaseId/iteration,
+    linkedworkitem 5-segment) lose context under
+    ``extract_created_short_ids`` rsplit. Collect as-is, never split.
+    """
+    ids = _collect_created_ids(response)
+    _guard_created_count(ids, expected_count=expected_count, list_tool=list_tool)
     return ids
 
 

--- a/src/mcp_server_polarion/tools/attachments.py
+++ b/src/mcp_server_polarion/tools/attachments.py
@@ -512,13 +512,11 @@ async def create_document_attachments(  # noqa: PLR0913
             f"Failed to create document attachments: {exc.message}"
         ) from exc
 
-    attachment_ids = extract_created_short_ids(response)
-    if not attachment_ids:
-        raise RuntimeError(
-            "Polarion returned no attachment IDs after creation."
-            " The POST may have succeeded -- verify with"
-            " `list_document_attachments`."
-        )
+    attachment_ids = extract_created_short_ids(
+        response,
+        expected_count=len(attachments),
+        list_tool="list_document_attachments",
+    )
 
     return AttachmentsCreateResult(
         created=True,

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -31,11 +31,10 @@ from mcp_server_polarion.tools._shared.fields import (
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     get_client,
-    safe_str,
 )
 from mcp_server_polarion.tools._shared.pagination import DEFAULT_PAGE_SIZE
 from mcp_server_polarion.tools._shared.parse import (
-    extract_short_id,
+    extract_created_short_ids,
     parse_comments_page,
 )
 
@@ -113,19 +112,6 @@ def _build_work_item_comments_payload(
         comment_type="workitem_comments",
         parent_prefix=f"{project_id}/{work_item_id}",
     )
-
-
-def _extract_created_comment_ids(response: object) -> list[str]:
-    """Short ids from comment-create POST response (``data`` list)."""
-    raw_data = response.get("data", []) if isinstance(response, dict) else []
-    comment_ids: list[str] = []
-    if isinstance(raw_data, list):
-        for entry in raw_data:
-            if isinstance(entry, dict):
-                full_id = safe_str(entry.get("id", ""))
-                if full_id:
-                    comment_ids.append(extract_short_id(full_id))
-    return comment_ids
 
 
 def _build_comment_update_payload(
@@ -365,12 +351,9 @@ async def create_document_comments(  # noqa: PLR0913
             f"Failed to create document comments: {exc.message}"
         ) from exc
 
-    comment_ids = _extract_created_comment_ids(response)
-    if not comment_ids:
-        raise RuntimeError(
-            "Polarion returned no comment IDs after creation."
-            " The POST may have succeeded — verify with `list_document_comments`."
-        )
+    comment_ids = extract_created_short_ids(
+        response, expected_count=len(comments), list_tool="list_document_comments"
+    )
 
     return CommentsCreateResult(
         created=True,
@@ -450,12 +433,9 @@ async def create_work_item_comments(
             f"Failed to create work item comments: {exc.message}"
         ) from exc
 
-    comment_ids = _extract_created_comment_ids(response)
-    if not comment_ids:
-        raise RuntimeError(
-            "Polarion returned no comment IDs after creation."
-            " The POST may have succeeded — verify with `list_work_item_comments`."
-        )
+    comment_ids = extract_created_short_ids(
+        response, expected_count=len(comments), list_tool="list_work_item_comments"
+    )
 
     return CommentsCreateResult(
         created=True,

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -46,6 +46,7 @@ from mcp_server_polarion.tools._shared.pagination import (
     make_page,
 )
 from mcp_server_polarion.tools._shared.parse import (
+    extract_created_full_ids,
     extract_relationship_id,
     extract_short_id,
     parse_included_work_item_map,
@@ -55,22 +56,6 @@ from mcp_server_polarion.tools._shared.parse import (
 )
 
 logger = logging.getLogger("mcp_server_polarion.tools.links")
-
-
-def _extract_created_link_ids(response: dict[str, object]) -> list[str]:
-    """Composite link ids verbatim, input order, from bulk create response —
-    the path ids for later PATCH / DELETE. Empty on malformed shapes.
-    """
-    data = response.get("data")
-    if not isinstance(data, list):
-        return []
-    ids: list[str] = []
-    for item in data:
-        if isinstance(item, dict):
-            item_id = item.get("id")
-            if isinstance(item_id, str):
-                ids.append(item_id)
-    return ids
 
 
 def _build_create_links_payload(
@@ -441,14 +426,10 @@ async def create_work_item_links(
     except PolarionError as exc:
         raise RuntimeError(f"Failed to create work item links: {exc.message}") from exc
 
-    link_ids = _extract_created_link_ids(response)
-    if len(link_ids) != len(links):
-        raise RuntimeError(
-            f"Polarion accepted the bulk create-link request but returned "
-            f"{len(link_ids)} ids for {len(links)} requested links. The batch "
-            "may be partially created; verify with list_work_item_links before "
-            "retrying."
-        )
+    # Composite link ids verbatim = path ids for later PATCH / DELETE.
+    link_ids = extract_created_full_ids(
+        response, expected_count=len(links), list_tool="list_work_item_links"
+    )
 
     return WorkItemLinksCreateResult(
         created=True,

--- a/src/mcp_server_polarion/tools/test_records.py
+++ b/src/mcp_server_polarion/tools/test_records.py
@@ -190,13 +190,9 @@ async def create_test_records(
     except PolarionError as exc:
         raise RuntimeError(f"Failed to create test records: {exc.message}") from exc
 
-    new_ids = extract_created_full_ids(response)
-    if len(new_ids) != len(items):
-        raise RuntimeError(
-            f"Polarion accepted the bulk create but returned {len(new_ids)} "
-            f"ids for {len(items)} requested records. The batch may be "
-            "partially created; verify with list_test_records before retrying."
-        )
+    new_ids = extract_created_full_ids(
+        response, expected_count=len(items), list_tool="list_test_records"
+    )
 
     return TestRecordsCreateResult(
         created=True,

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -174,13 +174,9 @@ async def create_test_runs(
     except PolarionError as exc:
         raise RuntimeError(f"Failed to create test runs: {exc.message}") from exc
 
-    new_ids = extract_created_short_ids(response)
-    if len(new_ids) != len(items):
-        raise RuntimeError(
-            f"Polarion accepted the bulk create but returned {len(new_ids)} "
-            f"ids for {len(items)} requested runs. The batch may be partially "
-            "created; verify with list_test_runs before retrying."
-        )
+    new_ids = extract_created_short_ids(
+        response, expected_count=len(items), list_tool="list_test_runs"
+    )
 
     return TestRunsCreateResult(
         created=True,

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -308,13 +308,9 @@ async def create_work_items(
     except PolarionError as exc:
         raise RuntimeError(f"Failed to create work items: {exc.message}") from exc
 
-    new_ids = extract_created_short_ids(response)
-    if len(new_ids) != len(items):
-        raise RuntimeError(
-            f"Polarion accepted the bulk create but returned {len(new_ids)} "
-            f"ids for {len(items)} requested items. The batch may be partially "
-            "created; verify with list_work_items before retrying."
-        )
+    new_ids = extract_created_short_ids(
+        response, expected_count=len(items), list_tool="list_work_items"
+    )
 
     return WorkItemsCreateResult(
         created=True,

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -5,6 +5,8 @@ text-format branches, phantom-editor skip.
 
 from __future__ import annotations
 
+import pytest
+
 from mcp_server_polarion.models import Attachment, Comment, WorkItemSummary
 from mcp_server_polarion.tools._shared.parse import (
     _parse_attachment,
@@ -111,13 +113,32 @@ class TestExtractCreatedShortIds:
                 {"type": "testruns", "id": "MyProj/TR-043"},
             ]
         }
-        assert extract_created_short_ids(response) == ["MCPT-042", "TR-043"]
+        assert extract_created_short_ids(
+            response, expected_count=2, list_tool="list_work_items"
+        ) == ["MCPT-042", "TR-043"]
 
-    def test_returns_empty_when_data_missing(self) -> None:
-        assert extract_created_short_ids({}) == []
+    def test_short_echo_raises_with_counts_and_list_tool(self) -> None:
+        response: dict[str, object] = {
+            "data": [{"type": "workitems", "id": "MyProj/MCPT-1"}]
+        }
+        with pytest.raises(
+            RuntimeError, match=r"1 ids for 2 submitted.*list_work_items"
+        ):
+            extract_created_short_ids(
+                response, expected_count=2, list_tool="list_work_items"
+            )
 
-    def test_returns_empty_when_data_not_a_list(self) -> None:
-        assert extract_created_short_ids({"data": {"id": "MyProj/MCPT-1"}}) == []
+    def test_data_missing_raises_zero_count(self) -> None:
+        with pytest.raises(RuntimeError, match="0 ids for 1 submitted"):
+            extract_created_short_ids({}, expected_count=1, list_tool="list_x")
+
+    def test_data_not_a_list_raises_zero_count(self) -> None:
+        with pytest.raises(RuntimeError, match="0 ids for 1 submitted"):
+            extract_created_short_ids(
+                {"data": {"id": "MyProj/MCPT-1"}},
+                expected_count=1,
+                list_tool="list_x",
+            )
 
     def test_skips_entries_missing_id_or_not_dict(self) -> None:
         response: dict[str, object] = {
@@ -127,11 +148,24 @@ class TestExtractCreatedShortIds:
                 "not a dict",
             ]
         }
-        assert extract_created_short_ids(response) == ["MCPT-1"]
+        assert extract_created_short_ids(
+            response, expected_count=1, list_tool="list_x"
+        ) == ["MCPT-1"]
+
+    def test_skipped_entries_shrink_echo_below_expected(self) -> None:
+        # Malformed entries drop from echo -- guard count them missing.
+        response: dict[str, object] = {
+            "data": [
+                {"type": "workitems", "id": "MyProj/MCPT-1"},
+                {"type": "workitems"},
+            ]
+        }
+        with pytest.raises(RuntimeError, match="1 ids for 2 submitted"):
+            extract_created_short_ids(response, expected_count=2, list_tool="list_x")
 
 
 class TestExtractCreatedFullIds:
-    """Tests for `extract_created_full_ids` (testrecord 5-segment ids)."""
+    """Tests for `extract_created_full_ids` (composite 5-segment ids)."""
 
     def test_extracts_full_ids_verbatim_in_order(self) -> None:
         # 5-segment testrecord id: project/testRun/testCaseProject/testCaseId/
@@ -148,16 +182,35 @@ class TestExtractCreatedFullIds:
                 },
             ]
         }
-        assert extract_created_full_ids(response) == [
+        assert extract_created_full_ids(
+            response, expected_count=2, list_tool="list_test_records"
+        ) == [
             "MCP_Test_Project/run1/MCP_Test_Project/MCPT-568/0",
             "MCP_Test_Project/run1/MCP_Test_Project/MCPT-569/1",
         ]
 
-    def test_returns_empty_when_data_missing(self) -> None:
-        assert extract_created_full_ids({}) == []
+    def test_short_echo_raises_with_counts_and_list_tool(self) -> None:
+        response: dict[str, object] = {
+            "data": [{"type": "testrecords", "id": "p/r/p/WI-1/0"}]
+        }
+        with pytest.raises(
+            RuntimeError, match=r"1 ids for 2 submitted.*list_test_records"
+        ):
+            extract_created_full_ids(
+                response, expected_count=2, list_tool="list_test_records"
+            )
 
-    def test_returns_empty_when_data_not_a_list(self) -> None:
-        assert extract_created_full_ids({"data": {"id": "p/r/p/WI-1/0"}}) == []
+    def test_data_missing_raises_zero_count(self) -> None:
+        with pytest.raises(RuntimeError, match="0 ids for 1 submitted"):
+            extract_created_full_ids({}, expected_count=1, list_tool="list_x")
+
+    def test_data_not_a_list_raises_zero_count(self) -> None:
+        with pytest.raises(RuntimeError, match="0 ids for 1 submitted"):
+            extract_created_full_ids(
+                {"data": {"id": "p/r/p/WI-1/0"}},
+                expected_count=1,
+                list_tool="list_x",
+            )
 
     def test_skips_entries_missing_id_or_not_dict(self) -> None:
         response: dict[str, object] = {
@@ -167,7 +220,9 @@ class TestExtractCreatedFullIds:
                 "not a dict",
             ]
         }
-        assert extract_created_full_ids(response) == ["p/r/p/WI-1/0"]
+        assert extract_created_full_ids(
+            response, expected_count=1, list_tool="list_x"
+        ) == ["p/r/p/WI-1/0"]
 
 
 class TestParseIncludedWorkItemMap:

--- a/tests/mcp_server_polarion/tools/_shared/test_parse.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_parse.py
@@ -224,6 +224,17 @@ class TestExtractCreatedFullIds:
             response, expected_count=1, list_tool="list_x"
         ) == ["p/r/p/WI-1/0"]
 
+    def test_skipped_entries_shrink_echo_below_expected(self) -> None:
+        # Malformed entries drop from echo -- guard count them missing.
+        response: dict[str, object] = {
+            "data": [
+                {"type": "testrecords", "id": "p/r/p/WI-1/0"},
+                {"type": "testrecords"},
+            ]
+        }
+        with pytest.raises(RuntimeError, match="1 ids for 2 submitted"):
+            extract_created_full_ids(response, expected_count=2, list_tool="list_x")
+
 
 class TestParseIncludedWorkItemMap:
     """Tests for `parse_included_work_item_map`."""

--- a/tests/mcp_server_polarion/tools/test_attachments.py
+++ b/tests/mcp_server_polarion/tools/test_attachments.py
@@ -1268,13 +1268,44 @@ class TestCreateDocumentAttachmentsHappyPath:
         path.write_bytes(b"a")
         mock_client.post_multipart = AsyncMock(return_value={"data": []})
 
-        with pytest.raises(RuntimeError, match="list_document_attachments"):
+        with pytest.raises(
+            RuntimeError, match=r"0 ids for 1 submitted.*list_document_attachments"
+        ):
             await create_document_attachments(
                 mock_ctx,
                 project_id="P",
                 space_id="S",
                 document_name="D",
                 attachments=[DocumentAttachmentSpec(file_path=str(path))],
+                dry_run=False,
+            )
+
+    async def test_short_id_echo_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock, tmp_path: Path
+    ) -> None:
+        """201 echoing fewer ids than uploaded must raise, not short list."""
+        first = tmp_path / "a.png"
+        second = tmp_path / "b.png"
+        first.write_bytes(b"aaa")
+        second.write_bytes(b"bbbb")
+        mock_client.post_multipart = AsyncMock(
+            return_value={
+                "data": [{"type": "document_attachments", "id": "P/S/D/a.png"}]
+            }
+        )
+
+        with pytest.raises(
+            RuntimeError, match=r"1 ids for 2 submitted.*list_document_attachments"
+        ):
+            await create_document_attachments(
+                mock_ctx,
+                project_id="P",
+                space_id="S",
+                document_name="D",
+                attachments=[
+                    DocumentAttachmentSpec(file_path=str(first)),
+                    DocumentAttachmentSpec(file_path=str(second)),
+                ],
                 dry_run=False,
             )
 

--- a/tests/mcp_server_polarion/tools/test_comments.py
+++ b/tests/mcp_server_polarion/tools/test_comments.py
@@ -997,13 +997,34 @@ class TestCreateDocumentCommentsErrors:
     ) -> None:
         """201 with no IDs must raise, not silently return created=True."""
         mock_client.post.return_value = {}
-        with pytest.raises(RuntimeError, match="no comment IDs"):
+        with pytest.raises(
+            RuntimeError, match=r"0 ids for 1 submitted.*list_document_comments"
+        ):
             await create_document_comments(
                 mock_ctx,
                 project_id="P",
                 space_id="S",
                 document_name="D",
                 comments=[CommentSpec(text="hi")],
+                dry_run=False,
+            )
+
+    async def test_short_id_echo_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """201 echoing fewer ids than submitted must raise, not short list."""
+        mock_client.post.return_value = {
+            "data": [{"type": "document_comments", "id": "P/S/D/1"}]
+        }
+        with pytest.raises(
+            RuntimeError, match=r"1 ids for 2 submitted.*list_document_comments"
+        ):
+            await create_document_comments(
+                mock_ctx,
+                project_id="P",
+                space_id="S",
+                document_name="D",
+                comments=[CommentSpec(text="hi"), CommentSpec(text="ho")],
                 dry_run=False,
             )
 
@@ -1307,12 +1328,35 @@ class TestCreateWorkItemCommentsErrors:
     ) -> None:
         """201 with no IDs must raise, not silently return created=True."""
         mock_client.post.return_value = {}
-        with pytest.raises(RuntimeError, match="no comment IDs"):
+        with pytest.raises(
+            RuntimeError, match=r"0 ids for 1 submitted.*list_work_item_comments"
+        ):
             await create_work_item_comments(
                 mock_ctx,
                 project_id="P",
                 work_item_id="MCPT-1",
                 comments=[WorkItemCommentSpec(text="hi")],
+                dry_run=False,
+            )
+
+    async def test_short_id_echo_raises_runtime_error(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        """201 echoing fewer ids than submitted must raise, not short list."""
+        mock_client.post.return_value = {
+            "data": [{"type": "workitem_comments", "id": "P/MCPT-1/1"}]
+        }
+        with pytest.raises(
+            RuntimeError, match=r"1 ids for 2 submitted.*list_work_item_comments"
+        ):
+            await create_work_item_comments(
+                mock_ctx,
+                project_id="P",
+                work_item_id="MCPT-1",
+                comments=[
+                    WorkItemCommentSpec(text="hi"),
+                    WorkItemCommentSpec(text="ho"),
+                ],
                 dry_run=False,
             )
 

--- a/tests/mcp_server_polarion/tools/test_links.py
+++ b/tests/mcp_server_polarion/tools/test_links.py
@@ -29,7 +29,6 @@ from mcp_server_polarion.tools.links import (
     _build_create_links_payload,
     _build_delete_links_payload,
     _build_update_link_payload,
-    _extract_created_link_ids,
     create_work_item_links,
     delete_work_item_links,
     list_work_item_links,
@@ -518,37 +517,6 @@ class TestBuildCreateLinksPayload:
         ]
 
 
-class TestExtractCreatedLinkIds:
-    """Private ``_extract_created_link_ids`` helper."""
-
-    def test_extracts_in_order(self) -> None:
-        response: dict[str, object] = {
-            "data": [
-                {"type": "linkedworkitems", "id": "P/WI-1/parent/P/WI-2"},
-                {"type": "linkedworkitems", "id": "P/WI-1/verifies/P/WI-3"},
-            ]
-        }
-        assert _extract_created_link_ids(response) == [
-            "P/WI-1/parent/P/WI-2",
-            "P/WI-1/verifies/P/WI-3",
-        ]
-
-    def test_skips_entries_missing_id(self) -> None:
-        response: dict[str, object] = {
-            "data": [
-                {"type": "linkedworkitems", "id": "P/WI-1/parent/P/WI-2"},
-                {"type": "linkedworkitems"},
-            ]
-        }
-        assert _extract_created_link_ids(response) == ["P/WI-1/parent/P/WI-2"]
-
-    def test_returns_empty_on_missing_data(self) -> None:
-        assert _extract_created_link_ids({}) == []
-
-    def test_returns_empty_on_non_list_data(self) -> None:
-        assert _extract_created_link_ids({"data": "oops"}) == []
-
-
 class TestCreateWorkItemLinksDryRun:
     """``create_work_item_links`` with ``dry_run=True``."""
 
@@ -879,7 +847,7 @@ class TestCreateWorkItemLinksResponseParsing:
     ) -> None:
         mock_client.post.return_value = {"data": []}
 
-        with pytest.raises(RuntimeError, match="0 ids for 1 requested links"):
+        with pytest.raises(RuntimeError, match="0 ids for 1 submitted"):
             await create_work_item_links(
                 mock_ctx,
                 project_id="MyProj",
@@ -895,7 +863,7 @@ class TestCreateWorkItemLinksResponseParsing:
     ) -> None:
         mock_client.post.return_value = {"data": [{"type": "linkedworkitems"}]}
 
-        with pytest.raises(RuntimeError, match="0 ids for 1 requested links"):
+        with pytest.raises(RuntimeError, match="0 ids for 1 submitted"):
             await create_work_item_links(
                 mock_ctx,
                 project_id="MyProj",
@@ -919,7 +887,9 @@ class TestCreateWorkItemLinksResponseParsing:
             ]
         }
 
-        with pytest.raises(RuntimeError, match="1 ids for 2 requested links"):
+        with pytest.raises(
+            RuntimeError, match=r"1 ids for 2 submitted.*list_work_item_links"
+        ):
             await create_work_item_links(
                 mock_ctx,
                 project_id="MyProj",


### PR DESCRIPTION
## Summary

Bulk create tools parsed 201 echoes via `extract_created_short_ids` / `extract_created_full_ids`, but `create_document_attachments` and both comment create tools only guarded the empty echo — a 201 body echoing fewer entries than submitted returned a silently-short id list. The submitted-vs-echoed count guard now lives once at the shared level: both extractors take required `expected_count` + `list_tool` keyword params and raise a RuntimeError naming both counts and the matching list tool. All seven batching create call sites (work items, test runs, test records, links, document attachments, document comments, work item comments) route through it; the duplicated per-tool count checks and the private comment/link extractor copies are removed. Closes #208

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Short 201 echo silently returned truncated id list on batch creates
- Shared count guard in created-id extractors; all 7 create sites pass expected count

## Testing

- TDD: shared-seam tests for count mismatch (short echo, empty data, non-list data, malformed-entry shrink) on both extractors
- Call-site tests: new short-echo tests for document attachments and both comment tools; existing mismatch tests for work items / test runs / test records / links updated to the unified message
- `uv run pytest` (2225 passed), `ruff check` + `ruff format` + `mypy src/` clean, diff-cover 100% changed-line coverage

## Notes for Reviewers

Error wording unified across tools ("returned N ids for M submitted entries ... verify with <list_tool> before retrying"), so the previous per-tool "no comment IDs" / "requested links" phrasings changed — these are runtime error strings only; eval-gated tool docstrings are untouched.
