### PR TITLE
fix(evals): stop binary multipart freezing runs

### DIFF
--- a/.github/workflows/evals-on-demand.yml
+++ b/.github/workflows/evals-on-demand.yml
@@ -26,6 +26,8 @@ on:
 jobs:
   evals:
     runs-on: ubuntu-latest
+    # category=all x runs=10 ~ 95 min healthy; hung run die here, not at 360.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals

--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -9,6 +9,9 @@ jobs:
     # Trigger gate (zero tolerance): right tool fires for the request. Cheapest,
     # so runs first.
     runs-on: ubuntu-latest
+    # Largest category (triggers x10) ~ 50 min healthy; hung run die at 90,
+    # not default 360.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals
@@ -20,6 +23,7 @@ jobs:
     # Safety gate (zero tolerance): destructive/corrupting footguns never happen.
     needs: evals-triggers
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals
@@ -31,6 +35,7 @@ jobs:
     # Efficiency gate: the correct answer reached without waste.
     needs: evals-safety
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals
@@ -42,6 +47,7 @@ jobs:
     # Orchestration gate: correct ordered multi-step path + id threading.
     needs: evals-efficiency
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals

--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -812,7 +812,9 @@ class FakePolarion:
         if request.content:
             try:
                 body = json.loads(request.content)
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                # UnicodeDecodeError = binary multipart body; leak froze eval
+                # runs (respx __cause__ cycle -> rich extract infinite loop).
                 body = None
         self.mutations.append({"method": request.method, "path": path, "json": body})
 

--- a/evals/run.py
+++ b/evals/run.py
@@ -10,6 +10,7 @@ efficiency/orchestration).
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -17,9 +18,13 @@ from pathlib import Path
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+# Before fastmcp import (settings read env once): rich traceback render spin
+# forever on cyclic __cause__ chains (respx SideEffectError wrap/unwrap) and
+# freeze event loop mid-eval -- plain logging immune.
+os.environ.setdefault("FASTMCP_ENABLE_RICH_LOGGING", "false")
+
 import argparse
 import json
-import os
 import re
 import subprocess
 from typing import Any

--- a/evals/run.py
+++ b/evals/run.py
@@ -20,8 +20,9 @@ if __package__ in (None, ""):
 
 # Before fastmcp import (settings read env once): rich traceback render spin
 # forever on cyclic __cause__ chains (respx SideEffectError wrap/unwrap) and
-# freeze event loop mid-eval -- plain logging immune.
-os.environ.setdefault("FASTMCP_ENABLE_RICH_LOGGING", "false")
+# freeze event loop mid-eval -- plain logging immune. Hard set, not setdefault:
+# inherited "true" would revive hang.
+os.environ["FASTMCP_ENABLE_RICH_LOGGING"] = "false"
 
 import argparse
 import json

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -1006,9 +1006,8 @@ class TestMutations:
         assert all("links" in e and "attributes" not in e for e in data)
 
     def test_post_doc_attachments_binary_payload_201(self) -> None:
-        # Non-UTF-8 bytes (PNG magic) in file part must not leak
-        # UnicodeDecodeError from dispatcher body parse; leak = respx
-        # __cause__ cycle = rich traceback infinite loop = frozen eval run.
+        # Non-UTF-8 bytes (PNG magic) must not leak UnicodeDecodeError from
+        # body parse; hang rationale at `_handle_mutation` catch.
         fake = FakePolarion()
         response = fake._dispatch(
             _multipart_attachments_request(

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -1005,6 +1005,20 @@ class TestMutations:
         assert all(e["type"] == "document_attachments" for e in data)
         assert all("links" in e and "attributes" not in e for e in data)
 
+    def test_post_doc_attachments_binary_payload_201(self) -> None:
+        # Non-UTF-8 bytes (PNG magic) in file part must not leak
+        # UnicodeDecodeError from dispatcher body parse; leak = respx
+        # __cause__ cycle = rich traceback infinite loop = frozen eval run.
+        fake = FakePolarion()
+        response = fake._dispatch(
+            _multipart_attachments_request(
+                f"/projects/{PROJECT}/spaces/{SPACE}/documents/{DOC}/attachments",
+                resource={"data": [_attachment_entry("real.png")]},
+                files=[("real.png", b"\x89PNG\r\n\x1a\n\x00\x01\x02")],
+            )
+        )
+        assert response.status_code == 201
+
     def test_post_doc_attachments_unseeded_document_404(self) -> None:
         fake = FakePolarion()
         response = fake._dispatch(

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -4,8 +4,10 @@ fail-closed crashed runs, git-sha resolution, unknown-case exit code.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -33,9 +35,7 @@ def _case(name: str = "GATE-X", min_rate: float = 1.0) -> Case:
 
 class TestPlainLogging:
     def test_import_forces_plain_fastmcp_logging(self) -> None:
-        # Rich traceback render spin forever on cyclic __cause__ chains
-        # (respx SideEffectError wrap/unwrap) and freeze event loop mid
-        # eval -- entrypoint must force plain logging before fastmcp import.
+        # Rich hang rationale live at fix site (evals/run.py env set).
         code = (
             "import evals.run, logging;"
             "handlers = logging.getLogger('fastmcp').handlers;"
@@ -47,6 +47,10 @@ class TestPlainLogging:
             capture_output=True,
             text=True,
             check=True,
+            # cwd pin: `import evals.run` need repo root regardless of pytest cwd.
+            cwd=Path(__file__).resolve().parents[2],
+            # Hostile "true" prove hard set win over inherited env.
+            env={**os.environ, "FASTMCP_ENABLE_RICH_LOGGING": "true"},
         )
         assert "RichHandler" not in result.stdout
 

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -4,6 +4,8 @@ fail-closed crashed runs, git-sha resolution, unknown-case exit code.
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from typing import Any
 
 import pytest
@@ -27,6 +29,26 @@ def _case(name: str = "GATE-X", min_rate: float = 1.0) -> Case:
         input="do a thing",
         metadata={"check": "readonly", "params": {}, "min_pass_rate": min_rate},
     )
+
+
+class TestPlainLogging:
+    def test_import_forces_plain_fastmcp_logging(self) -> None:
+        # Rich traceback render spin forever on cyclic __cause__ chains
+        # (respx SideEffectError wrap/unwrap) and freeze event loop mid
+        # eval -- entrypoint must force plain logging before fastmcp import.
+        code = (
+            "import evals.run, logging;"
+            "handlers = logging.getLogger('fastmcp').handlers;"
+            "print([type(h).__name__ for h in handlers])"
+        )
+        # Own interpreter + literal code = trusted input.
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "RichHandler" not in result.stdout
 
 
 class TestRunCaseNTimes:


### PR DESCRIPTION
## Summary

Root cause of yesterday's frozen/cancelled eval CI runs: the trigger case that uploads `upload.png` sent a binary multipart body, and the fake Polarion dispatcher's `json.loads(request.content)` raised `UnicodeDecodeError` (only `JSONDecodeError` was caught). respx then wrapped/unwrapped it (`SideEffectError ... from error`, then `raise error.origin from error`), producing a two-node `__cause__` cycle. rich's `Traceback.extract` follows `__cause__`/`__context__` with no cycle guard, so fastmcp's rich exception logging spun the event loop forever (unbounded allocation + GC thrash), which is why the per-case `asyncio.wait_for` timeout never fired and jobs sat silent until manually cancelled.

Fix plus two defense layers:

1. Catch `UnicodeDecodeError` in the fake dispatcher body parse (root trigger).
2. Force plain (non-rich) fastmcp logging in the eval entrypoint before fastmcp import — any future cyclic exception chain renders via the cycle-safe stdlib traceback instead of hanging.
3. `timeout-minutes` on all eval jobs (90 per category gate, 180 on-demand) so any future hang dies with an explicit timeout annotation instead of running to the 360-minute default.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Binary upload body leaked UnicodeDecodeError; respx __cause__ cycle made rich traceback spin, freezing eval jobs
- Catch decode error in fake dispatcher, force plain eval logging, add timeout-minutes to eval jobs

## Testing

- TDD: both new tests watched fail first (binary multipart 201 test reproduced the exact `UnicodeDecodeError`; plain-logging subprocess test saw `RichHandler` present) then pass after the fix
- Deterministic repro script (no LLM): tool call now returns 201 with zero server-side exceptions
- Live single-case eval of the previously hanging case (`TRIG-DOC-ATTACH-CREATE`, runs=1): PASS in seconds, gate PASS
- Full gates: ruff + format + mypy clean, 2517 tests pass, diff-cover 100% on changed lines

## Notes for Reviewers

Upstream bugs worth filing separately: rich (`Traceback.extract` lacks a cycle guard on the `__cause__`/`__context__` chain — proven to hang forever on a 2-exception cycle) and respx (wrap/unwrap pattern creates that cycle). Not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)