### PR TITLE
test(evals): allow list-then-get attach-content

### DIFF
--- a/evals/cases/triggers.py
+++ b/evals/cases/triggers.py
@@ -212,7 +212,9 @@ CASES: list[Case] = [
         "side sibling and metadata listing do not render it.",
         covers=["get_work_item_attachment_content"],
         expect="get_work_item_attachment_content",
-        reject=["get_document_attachment_content", "list_work_item_attachments"],
+        # list_* not rejected: list-then-get is valid; expect still enforce
+        # content call fire (list-only stop fail expect).
+        reject=["get_document_attachment_content"],
         match={
             "project_id": PROJECT,
             "work_item_id": FLOATING_TASK_ID,
@@ -230,7 +232,9 @@ CASES: list[Case] = [
         "side sibling and metadata listing do not render it.",
         covers=["get_test_record_attachment_content"],
         expect="get_test_record_attachment_content",
-        reject=["get_work_item_attachment_content", "list_test_record_attachments"],
+        # list_* not rejected: list-then-get is valid; expect still enforce
+        # content call fire (list-only stop fail expect).
+        reject=["get_work_item_attachment_content"],
         match={
             "project_id": PROJECT,
             "test_run_id": TEST_RUN_ID,


### PR DESCRIPTION
## Summary

Two attachment-content trigger cases (`TRIG-WI-ATTACHMENT-CONTENT`, `TRIG-TR-ATTACHMENT-CONTENT`) failed the triggers gate 0/3 on main: the model calls `list_*_attachments` to resolve the attachment id before the content call, and `list_*` sat in each case's `reject` list, so the check tripped even though the correct content tool did fire.

Dropping `list_*` from `reject` is correct: `expect` still requires `get_*_attachment_content` to fire successfully, so a model that stops at listing still fails. The cross-sibling reject (wrong-scope content tool) stays.

Verified: on-demand `triggers` eval (runs=1) on this branch — all three attachment-content cases PASS, GATE PASS.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- WI/TR attachment-content triggers reject-tripped on list_* before content call, failing gate 0/3 though content fired
- Drop list_* from reject; expect still enforces content call, blocking list-only stop

## Testing

- Local: ruff + format-check clean, eval tests 241 pass
- On-demand triggers eval (runs=1) on branch: TRIG-DOC/WI/TR-ATTACHMENT-CONTENT all PASS, GATE PASS

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>