### PR TITLE
fix(evals): filter title query in fake list route

### DIFF
--- a/evals/harness/fake_polarion.py
+++ b/evals/harness/fake_polarion.py
@@ -48,6 +48,18 @@ def _error_response(status: int, detail: str) -> httpx.Response:
     )
 
 
+def _title_query_terms(query: str) -> list[str]:
+    """Lowercased title phrases from a ``title:`` Lucene clause, ``OR``-split.
+
+    Handles ``title:"phrase"`` and ``title:(a OR b OR c)``. Return ``[]`` when
+    nothing extractable, so the caller keep its return-all fallback.
+    """
+    _, _, tail = query.partition("title:")
+    tail = tail.strip().strip('()"')
+    terms = (term.strip('"').strip().lower() for term in re.split(r"\s+OR\s+", tail))
+    return [t for t in terms if t]
+
+
 def _parse_attachment_multipart(
     request: httpx.Request,
 ) -> tuple[list[dict[str, Any]], int] | httpx.Response:
@@ -563,6 +575,15 @@ class FakePolarion:
                     w
                     for w in self.seeds.work_items.values()
                     if any(t == target for _, t in self.seeds.links.get(w.short_id, []))
+                ]
+            elif "title:" in query and (terms := _title_query_terms(query)):
+                # Live server filter title -- unseeded title (dedup/bulk probe)
+                # return empty, so agent cannot mine anchor id nor mistake seed
+                # for pre-existing item.
+                items = [
+                    w
+                    for w in self.seeds.work_items.values()
+                    if any(t in w.title.lower() for t in terms)
                 ]
             else:
                 items = list(self.seeds.work_items.values())

--- a/tests/evals/harness/test_fake_polarion.py
+++ b/tests/evals/harness/test_fake_polarion.py
@@ -147,6 +147,54 @@ class TestReadRouting:
         assert all(i["attributes"]["type"] == "heading" for i in items)
         assert len(items) == 2
 
+    def test_work_item_list_title_query_no_match_is_empty(self) -> None:
+        # Dedup search for title no seed carries -- real Polarion return
+        # empty, so agent cannot mine anchor id from result.
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/workitems",
+            query='title:"Cache eviction policy"',
+        )
+        assert _json(response)["meta"]["totalCount"] == 0
+        assert _json(response)["data"] == []
+
+    def test_work_item_list_title_query_matches_seed(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/workitems",
+            query='title:"Section A"',
+        )
+        items = _json(response)["data"]
+        assert [i["id"] for i in items] == [f"{PROJECT}/{DOC_HEADING_ID}"]
+
+    def test_work_item_list_title_or_query_no_match_is_empty(self) -> None:
+        # Bulk-create dedup: OR of three unseeded titles -> empty, so agent
+        # must create, not mistake seeds for pre-existing items.
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/workitems",
+            query="title:(Throughput target OR Error budget OR Retry policy)",
+        )
+        assert _json(response)["meta"]["totalCount"] == 0
+
+    def test_work_item_list_non_title_query_returns_all(self) -> None:
+        # Unparsed query (SQL scope) keep return-all fallback -- efficiency
+        # cases lean on it.
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/workitems",
+            query="SQL:(module.id = 'x')",
+        )
+        assert _json(response)["meta"]["totalCount"] == len(SEEDS.work_items)
+
+    def test_work_item_list_empty_title_query_returns_all(self) -> None:
+        response = _get(
+            FakePolarion(),
+            f"/projects/{PROJECT}/workitems",
+            query="title:()",
+        )
+        assert _json(response)["meta"]["totalCount"] == len(SEEDS.work_items)
+
     def test_linked_work_items_empty_when_unlinked(self) -> None:
         response = _get(
             FakePolarion(),


### PR DESCRIPTION
## Summary

The publish gate (real-LLM evals, runs only at deploy) failed two orchestration cases that normal CI never exercises:

- `ORCH-DEDUP-BEFORE-CREATE` — **0/10** (needs ≥80%)
- `ORCH-BULK-SPEC-INTO-DOC` — **5/10**

Root cause: `FakePolarion`'s `/workitems` list route ignored every query except `type:heading` / `linkedWorkItems:`, returning **all** seeded work items. Once `list_work_items` gained `document_name`/`space_id` in its summary, a `title:` dedup search leaked the seeded "Section A" heading (with its document location), so the agent:

- **DEDUP**: mined `previous_part_id` straight from that leaked heading and skipped `read_document_parts` (the required anchor step) → fails every run.
- **BULK**: saw seeds come back for its `title:(A OR B OR C)` existence check, assumed the three requirements already existed, and linked/moved them instead of calling `create_work_items`.

Real Polarion returns **empty** for a search on a title no item carries, forcing the anchor read and the create. The fake was unfaithful; the cases were correct.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [x] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Fake returned every seed for a title: search, so agent mined an anchor (DEDUP 0/10) or reused seeds (BULK 5/10)
- Parse title: clause, match seeds by title; unseeded title now empty like real Polarion; heading/link/SQL kept

## Testing

- 5 new `test_fake_polarion.py` cases (TDD red → green): unseeded `title:"..."` → empty, matching title → that seed only, `title:(a OR b OR c)` no-match → empty, non-title/SQL query → all (fallback preserved), empty `title:()` → all.
- Local serial re-run of the full `orchestration` category, 10 runs/case: **all 11 cases 10/10, GATE PASS** — DEDUP 0→10, BULK 5→10, zero regression on the other nine.
- `ruff check` + `ruff format --check` clean; `mypy src/` clean; `pytest` 2522 passed; `diff-cover` **100%** on changed lines.

## Notes for Reviewers

- Production code (`src/`) untouched — this restores eval-harness fidelity only.
- Only the `title:` Lucene clause is parsed; unrecognized queries (SQL scoping used by efficiency cases) keep the return-all fallback, so no efficiency-case regression.
- Deploy was aborted and unwound (tag + version bump reverted); this PR is the prerequisite before re-attempting the release.
