### PR TITLE
chore(lint): adapt ruff config for 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,14 @@ include = [
 target-version = "py313"
 line-length = 88
 # eval fixtures: un-annotated verbose samples (skill input corpus).
-extend-exclude = [".claude/skills/*/evals/files"]
+# references: teaching docs — example code blocks deliberately unformatted
+# (ruff 0.16 formats markdown code blocks by default).
+extend-exclude = [".claude/skills/*/evals/files", ".claude/skills/*/references"]
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN", "PL", "C4", "PTH", "RUF", "S"]
+# PLR0917 stable in ruff 0.16: MCP tool signature = many positional params by design.
+ignore = ["PLR0917"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["ANN", "PLR", "S101", "S105", "S106"]

--- a/src/mcp_server_polarion/models/common.py
+++ b/src/mcp_server_polarion/models/common.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 # `Mapping[str, object]`: recursive self-reference break FastMCP
 # `json_schema_to_type` (unresolved `ForwardRef('Root')`).
 type JsonValue = (
-    str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+    str | int | float | bool | list[JsonValue] | dict[str, JsonValue] | None
 )
 
 # Per-item cap against prompt-injected multi-MB bodies; real bodies ~30 KB.


### PR DESCRIPTION
## Summary

Unblocks #238: ruff 0.16.0 stabilizes PLR0917 and RUF036 and formats markdown code blocks by default, turning the dependabot dev-group bump CI red (27 lint errors + 1 format diff).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- ruff 0.16 stabilizes PLR0917/RUF036 + formats markdown code blocks; dependabot bump PR #238 CI red
- ignore PLR0917 repo-wide, move None last in JsonValue union, exclude skill reference docs from format

## Testing

Verified locally with both ruff versions: `uvx ruff@0.16.0 check .` + `format --check` clean, locked 0.15.22 check/format clean, mypy clean, full pytest 2448 passed, diff-cover gate green (no coverable lines in diff).

## Notes for Reviewers

PLR0917 ignored repo-wide instead of 27 per-function noqas: MCP tool signatures carry many positional params by design (PLR0913 already noqa'd per function). Skill reference docs excluded from formatting — their example code blocks are deliberately shaped teaching material. After merge, `@dependabot rebase` on #238 makes it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)