### PR TITLE
docs(claude): record no-delete-tool posture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ CI: same order + `ruff format --check` + `pytest --cov-fail-under=90`; diff-cove
 - Every list tool: `page_size` (max 100) + `page_number` → `PaginatedResult[T]` with `has_more`.
 - Timestamps (where Polarion serve both): `list_*` summary = `updated` only; metadata-bearing `get_*`/`read_*` detail add `created` (read_document body-only synthesis — exempt). Domain without `get_*` tool: list expose what API serve (comments `created`-only). API without timestamps: omit.
 - Every write tool: `dry_run: bool = False` — return payload, no hit Polarion.
+- NEVER ship delete tool for unrecoverable data (attachment, work item, document) even where REST allow it (test record attachment DELETE = 204) — removal = human via portal. `dry_run` + `destructiveHint` = advisory, model still call with `dry_run=False`; withhold capability = only hard guarantee. Reversible relationship delete allowed (`delete_work_item_links` — recreate from context, zero data loss). Deliberate posture, not gap (#224 closed) — no re-litigate per review round.
 - Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`; user-fixable status allowed narrower map (attachment 409 dup fileName→`ValueError`).
 - Guards fail closed: validation GET error block write; only successful empty option set defer to Polarion.
 - Docstrings = LLM manual, Google-style; only prose above `Args:` ship — keep tight; return-field bullets sync with model. Field descriptions one line, skip when name + type say all.


### PR DESCRIPTION
## Summary

Records the server's deliberate no-delete-tool posture as a Non-Negotiable Rule in `CLAUDE.md`.

The posture was never written down anywhere — `CLAUDE.md`, `.github/CONTRIBUTING.md`, and `README.md` had no mention of it. That is why #224 re-argued the case for an attachment delete tool from scratch, and why any future review round would have done the same.

The rule draws the line on recoverability, not on destructiveness in the abstract: deleting a link destroys a relationship that can be recreated from calling context (zero data loss), while deleting an attachment destroys bytes with no undelete in the REST API. `dry_run` and `destructiveHint` are advisory — a model can call with `dry_run=False` — so withholding the capability is the only hard guarantee.

Closes #224.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Posture lived only in maintainer's head, so #224 re-argued it from scratch; no repo doc recorded it.
- Add Non-Negotiable Rule by dry_run: no delete tools for unrecoverable data, reversible link deletes excepted.

## Testing

Documentation only — no Python source changed, so the lint/type/test gates have nothing to exercise beyond what CI runs automatically.

## Notes for Reviewers

The rule text names the test record attachment `DELETE` 204 explicitly, since that live-verified behavior is what makes the omission look like a gap rather than a choice. #242 remains the only open follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
