### PR TITLE
chore(evals): gate on gpt-5.6-luna reasoning

### DIFF
--- a/.claude/skills/shrink-mcp-tool-docs/SKILL.md
+++ b/.claude/skills/shrink-mcp-tool-docs/SKILL.md
@@ -59,7 +59,7 @@ Per param, confirm schema description text matches what you intend to edit. Para
 
 **Global prep**
 1. Work on branch off `main` (e.g. `chore/shrink-mcp-tool-docs`) — never run loop on `main`. Each adopted GREEN committed, so per-cut rollback just `git restore <file>` (or `git checkout -- <file>`) back to that commit — no stash juggling; working tree only ever holds in-flight cut. Whole session lands as one squashed commit/PR.
-2. **Match publish gate's model, or don't run.** Failure boundary model-specific, so optimize against *exact* model publish gate uses — `EVAL_MODEL`'s default `openai/gpt-4o-mini` (CI doesn't override). Needs `OPENAI_API_KEY`; if unset, **STOP and report** — never substitute local/ollama model, boundary found on different model REDs real gate. Then assume branch starts GREEN (released tip), run **one Fast gate** to confirm harness runs and green — not full Confirm; re-proving already-green tip with 10 runs wasted cost. Fast RED at entry = pre-existing breakage → STOP (not yours to fix here). That first GREEN your baseline; checkpoint it.
+2. **Match publish gate's model AND effort, or don't run.** Failure boundary model-specific, so optimize against *exact* model publish gate uses — `EVAL_MODEL`'s default `openai/gpt-5.6-luna` at `EVAL_REASONING_EFFORT`'s default `medium` (CI doesn't override). Needs `OPENAI_API_KEY`; if unset, **STOP and report** — never substitute another model or effort, boundary found elsewhere REDs real gate. Then assume branch starts GREEN (released tip), run **one Fast gate** to confirm harness runs and green — not full Confirm; re-proving already-green tip with 10 runs wasted cost. Fast RED at entry = pre-existing breakage → STOP (not yours to fix here). That first GREEN your baseline; checkpoint it.
 3. Step-0 dump + baseline chars.
 4. Sort tools by LLM-facing chars **descending**.
 
@@ -92,7 +92,7 @@ Per param, confirm schema description text matches what you intend to edit. Para
 
 ## Gates
 
-**Preconditions** (once): `uv sync --group evals` — `strands_evals` not in default env. Eval agent's model from `EVAL_MODEL` (default `openai/gpt-4o-mini`), publish gate uses that default — so **leave at default, provide `OPENAI_API_KEY`**. Optimizing against different model (e.g. local ollama) unsound vs gate (see Global prep 2). Run eval/pytest from CWD outside repo when repo `.env` carries `OPENAI_API_KEY` (shadows `PolarionConfig`); `cd /tmp && uv run --project <repo> ...` avoids it.
+**Preconditions** (once): `uv sync --group evals` — `strands_evals` not in default env. Eval agent's model from `EVAL_MODEL` (default `openai/gpt-5.6-luna`) + `EVAL_REASONING_EFFORT` (default `medium`), publish gate uses those defaults — so **leave both at default, provide `OPENAI_API_KEY`**. Optimizing against different model or effort unsound vs gate (see Global prep 2). Run eval/pytest from CWD outside repo when repo `.env` carries `OPENAI_API_KEY` (shadows `PolarionConfig`); `cd /tmp && uv run --project <repo> ...` avoids it.
 
 **Fast gate** (cheap triage after each cut):
 ```bash

--- a/.github/actions/run-evals/action.yml
+++ b/.github/actions/run-evals/action.yml
@@ -13,7 +13,11 @@ inputs:
   model:
     description: LiteLLM model id (sets EVAL_MODEL).
     required: false
-    default: openai/gpt-4o-mini
+    default: openai/gpt-5.6-luna
+  reasoning-effort:
+    description: Reasoning depth for the agent under test (sets EVAL_REASONING_EFFORT).
+    required: false
+    default: medium
   runs:
     description: Runs per case (sets EVAL_RUNS).
     required: false
@@ -41,6 +45,7 @@ runs:
       env:
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         EVAL_MODEL: ${{ inputs.model }}
+        EVAL_REASONING_EFFORT: ${{ inputs.reasoning-effort }}
         EVAL_RUNS: ${{ inputs.runs }}
       run: uv run python -m evals.run --category "${{ inputs.category }}"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,6 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
-    ignore:
-      # 1.89.x regresses gpt-4o-mini tool-calling and breaks the orchestration
-      # eval gate; held at <1.89 in pyproject. Drop this once upstream is fixed.
-      - dependency-name: "litellm"
-        versions: [">=1.89"]
     groups:
       production:
         dependency-type: "production"

--- a/.github/workflows/evals-on-demand.yml
+++ b/.github/workflows/evals-on-demand.yml
@@ -16,8 +16,18 @@ on:
           - orchestration
       model:
         description: "LiteLLM model id (EVAL_MODEL)"
-        default: "openai/gpt-4o-mini"
+        default: "openai/gpt-5.6-luna"
         type: string
+      reasoning_effort:
+        description: "Reasoning depth (EVAL_REASONING_EFFORT)"
+        default: "medium"
+        type: choice
+        options:
+          - none
+          - low
+          - medium
+          - high
+          - xhigh
       runs:
         description: "Runs per case (EVAL_RUNS)"
         default: "10"
@@ -26,13 +36,15 @@ on:
 jobs:
   evals:
     runs-on: ubuntu-latest
-    # category=all x runs=10 ~ 95 min healthy; hung run die here, not at 360.
-    timeout-minutes: 180
+    # 95 min figure was gpt-4o-mini; reasoning runs longer and no measured
+    # baseline yet, so sit just under the 360 default until one full run land.
+    timeout-minutes: 350
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals
         with:
           category: ${{ inputs.category }}
           model: ${{ inputs.model }}
+          reasoning-effort: ${{ inputs.reasoning_effort }}
           runs: ${{ inputs.runs }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -9,9 +9,10 @@ jobs:
     # Trigger gate (zero tolerance): right tool fires for the request. Cheapest,
     # so runs first.
     runs-on: ubuntu-latest
-    # Largest category (triggers x10) ~ 50 min healthy; hung run die at 90,
-    # not default 360.
-    timeout-minutes: 90
+    # Largest category (triggers x10) was ~50 min on gpt-4o-mini; reasoning
+    # medium run longer, so cap 180 until a full run measure it. Hung run die
+    # here, not at default 360.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals
@@ -23,7 +24,7 @@ jobs:
     # Safety gate (zero tolerance): destructive/corrupting footguns never happen.
     needs: evals-triggers
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals
@@ -35,7 +36,7 @@ jobs:
     # Efficiency gate: the correct answer reached without waste.
     needs: evals-safety
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals
@@ -47,7 +48,7 @@ jobs:
     # Orchestration gate: correct ordered multi-step path + id threading.
     needs: evals-efficiency
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/run-evals

--- a/evals/README.md
+++ b/evals/README.md
@@ -57,31 +57,44 @@ report is written to `evals/reports/gate-<sha>-<model>.json` (gitignored).
 
 ## Model
 
-Switch with `EVAL_MODEL` (one LiteLLM adapter serves cloud and local):
+The gate runs `openai/gpt-5.6-luna` at reasoning effort `medium`; both are
+switchable through the LiteLLM adapter, and both need `OPENAI_API_KEY`.
 
 ```bash
-EVAL_MODEL=openai/gpt-4o-mini uv run python -m evals.run         # cloud (CI default), needs OPENAI_API_KEY
-EVAL_MODEL=ollama_chat/qwen3.5:9b-mlx uv run python -m evals.run # local, free; set EVAL_MODEL_BASE_URL if not localhost:11434
+uv run python -m evals.run                                     # defaults above
+EVAL_MODEL=openai/gpt-5.6-terra uv run python -m evals.run     # other model
+EVAL_REASONING_EFFORT=high uv run python -m evals.run          # other effort
 ```
 
-`temperature` is pinned to 0 and `parallel_tool_calls` off (gpt-4o-mini can emit
-the same call twice in one parallel block) to keep the gate stable.
+Use the `-luna` id, not the bare `openai/gpt-5.6` alias — that alias routes to
+the Sol tier.
+
+`reasoning_effort` is always sent explicitly, for two reasons: GPT-5.6 rejects
+function tools on `/v1/chat/completions`, and LiteLLM only bridges the call to
+the Responses API when the parameter is present. `temperature` is not sent at
+all (the gpt-5 family accepts `1` only), so gate stability rests on the fixed
+effort plus `parallel_tool_calls` off — a model can otherwise emit the same call
+twice in one parallel block. `drop_params` is deliberately not set: a silently
+dropped `reasoning_effort` would run the whole gate unreasoned and still report
+a pass.
 
 ## Limits
 
-Local models can loop; cloud providers return 429 when TPM/RPM is exhausted.
+An agent can loop; cloud providers return 429 when TPM/RPM is exhausted.
 Each case is bounded fail-closed (via `<agent-error: ...>`).
 
 | Env var | Default | Cap |
 | --- | --- | --- |
 | `EVAL_MAX_CYCLES` | `10` | Model calls per case. |
-| `EVAL_CASE_TIMEOUT` | `120` | Wall-clock seconds per case. |
+| `EVAL_CASE_TIMEOUT` | `600` | Wall-clock seconds per case. |
 | `EVAL_NUM_RETRIES` | `10` | LiteLLM retries; OpenAI SDK sleeps `min(0.5·2ⁿ, 8)s` ±25 % jitter, or honours `Retry-After`. |
-| `EVAL_LLM_TIMEOUT` | `60` | Wall-clock seconds per model call. |
+| `EVAL_LLM_TIMEOUT` | `180` | Wall-clock seconds per model call. |
+| `EVAL_REASONING_EFFORT` | `medium` | Reasoning depth; higher raises latency and output-token cost. |
 
-`EVAL_LLM_TIMEOUT` is per attempt, so worst-case per model call is
+The timeout defaults assume reasoning at `medium` — a raised effort needs them
+raised too. `EVAL_LLM_TIMEOUT` is per attempt, so worst-case per model call is
 `EVAL_NUM_RETRIES × EVAL_LLM_TIMEOUT`. Raise `EVAL_CASE_TIMEOUT` in lockstep when
-bumping either (and for slow CPU inference), or the case fail-closes first.
+bumping either, or the case fail-closes first.
 
 ## Release pipeline
 
@@ -89,7 +102,8 @@ bumping either (and for slow CPU inference), or the case fail-closes first.
   calls [`publish-gate.yml`](../.github/workflows/publish-gate.yml) on tag push;
   every later publish job depends on it.
 - **On-demand** — [`evals-on-demand.yml`](../.github/workflows/evals-on-demand.yml)
-  is `workflow_dispatch`: pick a `model` and `runs` from the Actions tab before tagging.
+  is `workflow_dispatch`: pick a `model`, `reasoning_effort` and `runs` from the
+  Actions tab before tagging.
 
 Both read the **`OPENAI_API_KEY` repository secret**; if it is missing the job
 fails and the release is blocked (fail-closed).

--- a/evals/harness/model.py
+++ b/evals/harness/model.py
@@ -1,6 +1,8 @@
-"""Eval-agent model factory: one LiteLLM adapter, backend switched via
-``EVAL_MODEL`` (e.g. ``openai/gpt-4o-mini``, ``ollama/...`` + base URL).
-``temperature=0`` / ``parallel_tool_calls=False`` keep gate stable;
+"""Eval-agent model factory: one LiteLLM adapter, model switched via
+``EVAL_MODEL``, reasoning depth via ``EVAL_REASONING_EFFORT``.
+``reasoning_effort`` ship explicit always: gpt-5.6 reject function tools on
+``/v1/chat/completions``, and litellm bridge to the Responses API only when the
+param is present. ``parallel_tool_calls=False`` keep gate stable;
 ``EVAL_NUM_RETRIES``/``EVAL_LLM_TIMEOUT`` absorb transient 429s.
 """
 
@@ -10,7 +12,9 @@ import os
 
 from strands.models.litellm import LiteLLMModel
 
-DEFAULT_MODEL = "openai/gpt-4o-mini"
+# Luna = cheapest gpt-5.6 tier. Bare `gpt-5.6` alias route to Sol instead.
+DEFAULT_MODEL = "openai/gpt-5.6-luna"
+DEFAULT_REASONING_EFFORT = "medium"
 
 
 def resolve_model_id() -> str:
@@ -22,27 +26,28 @@ def resolve_model_id() -> str:
     return os.environ.get("EVAL_MODEL", DEFAULT_MODEL)
 
 
+def resolve_reasoning_effort() -> str:
+    """Agent reasoning effort -- single source of truth, same as model id.
+
+    Same model at different effort = different gate verdict, so report record
+    it next to the model.
+    """
+    effort = os.environ.get("EVAL_REASONING_EFFORT", "").strip()
+    return effort or DEFAULT_REASONING_EFFORT
+
+
 def build_model() -> LiteLLMModel:
     """Construct agent-under-test model from environment configuration."""
-    model_id = resolve_model_id()
-    base_url = os.environ.get("EVAL_MODEL_BASE_URL")
-
-    client_args: dict[str, object] = {}
-    if base_url:
-        # litellm route both OpenAI-compatible + Ollama traffic via api_base.
-        client_args["api_base"] = base_url
-
     return LiteLLMModel(
-        client_args=client_args or None,
-        model_id=model_id,
+        model_id=resolve_model_id(),
         params={
-            "temperature": 0.0,
             # Some providers double-emit tool call in one parallel block --
-            # nondeterminism no docstring can steer, pin off like temperature.
-            # drop_params let flag-less backends (e.g. Ollama) ignore it.
+            # nondeterminism no docstring can steer, pin off.
             "parallel_tool_calls": False,
-            "drop_params": True,
+            "reasoning_effort": resolve_reasoning_effort(),
             "num_retries": max(0, int(os.environ.get("EVAL_NUM_RETRIES", "10"))),
-            "timeout": max(1.0, float(os.environ.get("EVAL_LLM_TIMEOUT", "60"))),
+            "timeout": max(1.0, float(os.environ.get("EVAL_LLM_TIMEOUT", "180"))),
         },
+        # No drop_params: silently dropped reasoning_effort would run whole gate
+        # unreasoned and still report pass.
     )

--- a/evals/harness/runner.py
+++ b/evals/harness/runner.py
@@ -31,7 +31,7 @@ from .model import build_model
 # _CASE_TIMEOUT_SECONDS = wall-clock ceiling on invoke_async.
 _MAX_CYCLES: int = max(1, int(os.environ.get("EVAL_MAX_CYCLES", "10")))
 _CASE_TIMEOUT_SECONDS: float = max(
-    1.0, float(os.environ.get("EVAL_CASE_TIMEOUT", "120"))
+    1.0, float(os.environ.get("EVAL_CASE_TIMEOUT", "600"))
 )
 
 # Deliberately generic: must NOT teach case rules, else eval test prompt

--- a/evals/run.py
+++ b/evals/run.py
@@ -38,7 +38,7 @@ from evals.cases.orchestration import CASES as ORCHESTRATION_CASES
 from evals.cases.safety import CASES as SAFETY_CASES
 from evals.cases.triggers import CASES as TRIGGER_CASES
 from evals.evaluators.dispatch import CheckDispatchEvaluator
-from evals.harness.model import resolve_model_id
+from evals.harness.model import resolve_model_id, resolve_reasoning_effort
 from evals.harness.runner import AGENT_ERROR_PREFIX, run_case
 
 _REPORT_DIR = Path(__file__).parent / "reports"
@@ -169,9 +169,10 @@ def main() -> int:
 
     evaluator = CheckDispatchEvaluator()
     model = resolve_model_id()
+    reasoning_effort = resolve_reasoning_effort()
     print(
         f"Eval gate · category={args.category} · model={model} · "
-        f"runs={args.runs} · cases={len(cases)}\n"
+        f"effort={reasoning_effort} · runs={args.runs} · cases={len(cases)}\n"
     )
 
     results = [_run_case_n_times(c, args.runs, evaluator) for c in cases]
@@ -185,13 +186,15 @@ def main() -> int:
     report = {
         "git_sha": _git_sha(),
         "model": model,
+        "reasoning_effort": reasoning_effort,
         "runs": args.runs,
         "gate_passed": gate_passed,
         "cases": results,
     }
     _REPORT_DIR.mkdir(exist_ok=True)
-    model_slug = re.sub(r"[^A-Za-z0-9]+", "-", model).strip("-")
-    report_path = _REPORT_DIR / f"gate-{report['git_sha']}-{model_slug}.json"
+    # Effort in filename: same sha + model at another effort = other verdict.
+    run_slug = re.sub(r"[^A-Za-z0-9]+", "-", f"{model}-{reasoning_effort}").strip("-")
+    report_path = _REPORT_DIR / f"gate-{report['git_sha']}-{run_slug}.json"
     report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
 
     print("\n=== Gate summary ===")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,10 @@ dev = [
 evals = [
     "strands-agents[litellm]",
     "strands-agents-evals",
-    # 1.89.x regresses gpt-4o-mini tool-calling: the agent skips
-    # read_document_parts and loops past the cycle cap, breaking orchestration
-    # cases (ORCH-DEDUP-BEFORE-CREATE, ORCH-BULK-SPEC-INTO-DOC).
-    "litellm>=1.83.10,<1.89",
+    # Upper pin dropped with the gpt-4o-mini gate: that 1.89.x regression was
+    # 4o-mini tool-calling only. gpt-5.6 need the Responses-API bridge, which
+    # keeps moving upstream -- test_model.py alarm catch a routing regression.
+    "litellm>=1.83.10",
 ]
 
 [build-system]

--- a/tests/evals/harness/test_model.py
+++ b/tests/evals/harness/test_model.py
@@ -6,11 +6,16 @@ import pytest
 
 # ``model`` import ``strands.models.litellm`` at load; skip on bare install.
 pytest.importorskip("strands")
+pytest.importorskip("litellm")
+
+from litellm.main import responses_api_bridge_check
 
 from evals.harness.model import (
     DEFAULT_MODEL,
+    DEFAULT_REASONING_EFFORT,
     build_model,
     resolve_model_id,
+    resolve_reasoning_effort,
 )
 
 
@@ -19,26 +24,49 @@ class TestResolveModelId:
         monkeypatch.delenv("EVAL_MODEL", raising=False)
         assert resolve_model_id() == DEFAULT_MODEL
 
+    def test_default_is_luna_tier(self) -> None:
+        # Bare `openai/gpt-5.6` route to Sol -- gate price/behaviour differ.
+        assert DEFAULT_MODEL == "openai/gpt-5.6-luna"
+
     def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("EVAL_MODEL", "ollama/qwen2.5-coder:7b")
-        assert resolve_model_id() == "ollama/qwen2.5-coder:7b"
+        monkeypatch.setenv("EVAL_MODEL", "openai/gpt-5.6-terra")
+        assert resolve_model_id() == "openai/gpt-5.6-terra"
+
+
+class TestResolveReasoningEffort:
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EVAL_REASONING_EFFORT", raising=False)
+        assert resolve_reasoning_effort() == DEFAULT_REASONING_EFFORT == "medium"
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("EVAL_REASONING_EFFORT", "high")
+        assert resolve_reasoning_effort() == "high"
+
+    def test_blank_env_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EVAL_REASONING_EFFORT", "  ")
+        assert resolve_reasoning_effort() == DEFAULT_REASONING_EFFORT
 
 
 class TestBuildModel:
-    def test_temperature_is_pinned_to_zero(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("EVAL_MODEL_BASE_URL", raising=False)
-        model = build_model()
-        assert model.get_config()["params"]["temperature"] == 0.0
+    def test_parallel_tool_calls_pinned_off(self) -> None:
+        assert build_model().get_config()["params"]["parallel_tool_calls"] is False
 
-    def test_parallel_tool_calls_pinned_off(
+    def test_reasoning_effort_always_sent(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv("EVAL_MODEL_BASE_URL", raising=False)
+        # Explicit effort = litellm Responses-API bridge trigger; absent param
+        # send tools over chat-completions, which gpt-5.6 reject.
+        monkeypatch.setenv("EVAL_REASONING_EFFORT", "low")
+        assert build_model().get_config()["params"]["reasoning_effort"] == "low"
+
+    def test_no_temperature_and_no_drop_params(self) -> None:
         params = build_model().get_config()["params"]
-        assert params["parallel_tool_calls"] is False
-        assert params["drop_params"] is True
+        # gpt-5 family accept temperature=1 only; drop_params would mask a
+        # silently discarded reasoning_effort.
+        assert "temperature" not in params
+        assert "drop_params" not in params
 
     def test_retries_and_timeout_from_env(
         self, monkeypatch: pytest.MonkeyPatch
@@ -49,11 +77,36 @@ class TestBuildModel:
         assert params["num_retries"] == 3
         assert params["timeout"] == 42.0
 
-    def test_base_url_absent_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("EVAL_MODEL_BASE_URL", raising=False)
-        # No base url -> no api_base routing (LiteLLM normalise None to {}).
-        assert "api_base" not in (build_model().client_args or {})
+    def test_timeout_default_covers_reasoning_latency(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("EVAL_LLM_TIMEOUT", raising=False)
+        assert build_model().get_config()["params"]["timeout"] == 180.0
 
-    def test_base_url_routed_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("EVAL_MODEL_BASE_URL", "http://localhost:11434")
-        assert build_model().client_args == {"api_base": "http://localhost:11434"}
+
+class TestResponsesApiBridge:
+    """Upstream-regression alarm: litellm unpinned, so routing can shift.
+
+    gpt-5.6 + function tools 400 on ``/v1/chat/completions``; litellm dodge it
+    by bridging to the Responses API, but only when ``reasoning_effort`` ride
+    along. Chat routing here = whole gate 400s at run time.
+    """
+
+    @staticmethod
+    def _bridge_mode(reasoning_effort: str | None) -> str | None:
+        provider, _, model = DEFAULT_MODEL.partition("/")
+        model_info, _ = responses_api_bridge_check(
+            model=model,
+            custom_llm_provider=provider,
+            tools=[{"type": "function", "function": {"name": "list_projects"}}],
+            reasoning_effort=reasoning_effort,
+        )
+        mode = model_info.get("mode")
+        return str(mode) if mode is not None else None
+
+    def test_default_model_with_effort_routes_to_responses(self) -> None:
+        assert self._bridge_mode(DEFAULT_REASONING_EFFORT) == "responses"
+
+    def test_effortless_call_stays_on_chat(self) -> None:
+        # Pin why build_model never omit param.
+        assert self._bridge_mode(None) == "chat"

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -4,6 +4,7 @@ fail-closed crashed runs, git-sha resolution, unknown-case exit code.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -146,6 +147,40 @@ class TestMain:
 
         assert run.main() == 0
         assert seen == [c.name for c in EFFICIENCY_CASES]
+
+    def test_report_records_model_and_effort(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        monkeypatch.setattr(
+            run,
+            "_run_case_n_times",
+            lambda case, runs, evaluator: {
+                "name": case.name,
+                "runs": runs,
+                "pass_count": runs,
+                "pass_rate": 1.0,
+                "min_pass_rate": 1.0,
+                "passed": True,
+                "failures": [],
+            },
+        )
+        monkeypatch.setattr(run, "resolve_model_id", lambda: "openai/gpt-5.6-luna")
+        monkeypatch.setattr(run, "resolve_reasoning_effort", lambda: "high")
+        monkeypatch.setattr(run, "_git_sha", lambda: "abc123")
+        monkeypatch.setattr(run, "_REPORT_DIR", tmp_path)
+        monkeypatch.setattr(
+            "sys.argv", ["run", "--case", "SAFE-READONLY", "--runs", "1"]
+        )
+
+        assert run.main() == 0
+        # Effort in filename: same sha + model at other effort must not clobber.
+        report = json.loads(
+            (tmp_path / "gate-abc123-openai-gpt-5-6-luna-high.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert report["model"] == "openai/gpt-5.6-luna"
+        assert report["reasoning_effort"] == "high"
 
     def test_list_flag_prints_catalog_without_running(
         self, monkeypatch: pytest.MonkeyPatch

--- a/uv.lock
+++ b/uv.lock
@@ -1230,7 +1230,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.88.6"
+version = "1.89.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1246,9 +1246,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/a6/d2312da4d65390f0d899a669731500983c8a10bd89009657680949c5766d/litellm-1.88.6.tar.gz", hash = "sha256:07d947dfe92f137d5296c40285dbcf97cb405b4300d73c0feda48d76468d6eb4", size = 13889078, upload-time = "2026-08-09T00:06:33.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/f1/f7cfead063f2ab1877c8fb465d0d7fe300b75f081bcb73525f6d550aeb1c/litellm-1.89.3.tar.gz", hash = "sha256:8fcdb2b7a0ef3381d41adf164443842e31ef9f0cd5bcda6fc3c0bd8bc2959510", size = 14080611, upload-time = "2026-06-20T22:42:26.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/0b/2e42b95ccca2e2a8a524808e9c414f70a0352165dac589efa01192afb8ba/litellm-1.88.6-py3-none-any.whl", hash = "sha256:8c01f7e9aebded5b3509128be648518a2ec4f1feb8dfb87a539895091651898b", size = 15271205, upload-time = "2026-08-09T00:06:30.607Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f1/34d174ff1d84e459b30f971606ac9cb7078ad24cd7661e9786b25adf7def/litellm-1.89.3-py3-none-any.whl", hash = "sha256:414ef5aee504b2b3eb1b219d39f1c11902db399cbdbc06e5fb550c15d731abeb", size = 15495226, upload-time = "2026-06-20T22:42:23.156Z" },
 ]
 
 [[package]]
@@ -1405,7 +1405,7 @@ dev = [
     { name = "ruff", specifier = ">=0.15" },
 ]
 evals = [
-    { name = "litellm", specifier = ">=1.83.10,<1.89" },
+    { name = "litellm", specifier = ">=1.83.10" },
     { name = "strands-agents", extras = ["litellm"] },
     { name = "strands-agents-evals" },
 ]
@@ -2393,8 +2393,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Retires `openai/gpt-4o-mini` as the eval-gate agent and drives the gate with `openai/gpt-5.6-luna` at reasoning effort `medium`.

The effort is always sent explicitly, and that is load-bearing: GPT-5.6 rejects function tools on `/v1/chat/completions`, and LiteLLM only bridges the call to the Responses API when `reasoning_effort` is present. Omitting it (relying on the server-side default) 400s every case.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [x] CI / tooling / dependency update

## Changes

- Gate was calibrated on gpt-4o-mini; a reasoning model needs explicit effort, longer timeouts, no temperature pin.
- Default to `gpt-5.6-luna` at effort `medium`; drop temperature, `drop_params`, local routing; unpin litellm.

## Testing

- `uv run pytest` (2618 passed), `ruff check`, `ruff format --check`, `mypy src/` — all green.
- `diff-cover` on changed lines: 100%.
- Live smoke against the real provider (Polarion mocked as usual): `SAFE-READONLY` 1/1 PASS, `ORCH-DEDUP-BEFORE-CREATE` 1/1 PASS, `ORCH-BULK-SPEC-INTO-DOC` 3/3 PASS at the default cycle cap. Confirms no chat-completions 400, so the Responses bridge engages.
- litellm upgraded 1.88.6 -> 1.89.3 in the lockfile; the two orchestration cases that motivated the old `<1.89` pin pass on the new model.

## Notes for Reviewers

- Full baseline is deliberately out of scope: run `evals-on-demand.yml` per category at `runs=10` before tagging, and use the resulting pass rates to revisit `min_pass_rate`, `EVAL_MAX_CYCLES`, and the CI `timeout-minutes` guesses (180 per publish-gate job, 350 on-demand).
- One early `ORCH-BULK-SPEC-INTO-DOC` run tripped `CycleGuard: exceeded 10 model cycles`; three consecutive reruns then passed with an identical 5-call trajectory, so it reads as run-to-run variance rather than a cap problem. The 10-run baseline should confirm.
- `EVAL_MODEL_BASE_URL` / local-backend support was removed as currently unused; re-add when a local run is actually needed.
- New `TestResponsesApiBridge` test is an upstream alarm: with litellm unpinned, a routing change back to chat-completions would otherwise only surface as a full-gate 400.
- Docstring failure boundaries were tuned to gpt-4o-mini, so `/shrink-mcp-tool-docs` results predate this model. Re-run it after the new baseline.
