### PR TITLE
fix(documents): key status guard on doc type

### DIFF
--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -935,7 +935,7 @@ async def _resolve_document_type(
     space_id: str,
     document_name: str,
 ) -> str:
-    """Resolve the ``type`` axis the custom-field guard key on."""
+    """Resolve the ``type`` axis status + custom-field guards key on."""
     attrs = await _fetch_document_attributes(
         client,
         project_id,
@@ -948,7 +948,8 @@ async def _resolve_document_type(
     if not doc_type:
         raise RuntimeError(
             f"Document '{space_id}/{document_name}' in project '{project_id}' has no "
-            f"resolvable type; cannot validate custom_fields. Pass `type` explicitly."
+            f"resolvable type; cannot validate status or custom_fields. "
+            f"Pass `type` explicitly."
         )
     return doc_type
 
@@ -1099,11 +1100,19 @@ async def update_document(  # noqa: PLR0913
     )
 
     client = get_client(ctx)
-    # Type-agnostic enum guard: avoid extra GET, still catch ghost ids.
+    # Status options key on document own type; '~' serve generic workflow
+    # only, so typed doc status false-reject there. Retype PATCH set both
+    # attributes, so new type = axis. Resolved once, custom-field guard
+    # reuse it.
+    effective_type = type or (
+        await _resolve_document_type(client, project_id, space_id, document_name)
+        if status
+        else ""
+    )
     await guard_document_enums(
         client,
         project_id,
-        document_type="~",
+        document_type=effective_type or "~",
         type=type,
         status=status,
     )
@@ -1130,11 +1139,11 @@ async def update_document(  # noqa: PLR0913
         rendering_layouts=rendering_layouts,
         custom_fields=custom_fields,
     )
-    # Type change key custom-field schema on new type, else current.
     if custom_fields:
-        effective_type = type or await _resolve_document_type(
-            client, project_id, space_id, document_name
-        )
+        if not effective_type:
+            effective_type = await _resolve_document_type(
+                client, project_id, space_id, document_name
+            )
         await guard_document_custom_fields(
             client, project_id, effective_type, custom_fields
         )

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -102,6 +102,29 @@ def _enum_get_response(ids: list[str]) -> dict[str, object]:
     }
 
 
+def _doc_type_get_response(document_type: str) -> dict[str, object]:
+    """Sparse ``fields[documents]=type`` reply the status guard key on."""
+    return {"data": {"attributes": {"type": document_type}}}
+
+
+def _enum_probe_types(mock_client: AsyncMock) -> list[str]:
+    """``type`` axis of each ``getAvailableOptions`` GET, call order kept."""
+    return [
+        str(kwargs["params"]["type"])
+        for (_args, kwargs) in mock_client.get.call_args_list
+        if "getAvailableOptions" in _args[0]
+    ]
+
+
+def _type_resolution_get_count(mock_client: AsyncMock) -> int:
+    """GETs spent resolving the document's own type."""
+    return sum(
+        1
+        for (_args, kwargs) in mock_client.get.call_args_list
+        if kwargs.get("params", {}).get("fields[documents]") == "type"
+    )
+
+
 def _enum_get_by_resource(
     document_types: list[str], work_item_types: list[str]
 ) -> Callable[..., dict[str, object]]:
@@ -2382,6 +2405,8 @@ class TestUpdateDocumentValidation:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         # workflow_action paired with at least one attribute = OK.
+        # status guard resolve doc type first; enum probe then defer (no ids).
+        mock_client.get.return_value = _doc_type_get_response("generic")
         result = await update_document(
             mock_ctx,
             project_id="MyProj",
@@ -2627,6 +2652,7 @@ class TestUpdateDocumentHappyPath:
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
         mock_client.patch.return_value = {}
+        mock_client.get.return_value = _doc_type_get_response("generic")
 
         await update_document(
             mock_ctx,
@@ -2852,6 +2878,7 @@ class TestUpdateDocumentHappyPath:
     ) -> None:
         # Action IDs with reserved chars must be URL-encoded.
         mock_client.patch.return_value = {}
+        mock_client.get.return_value = _doc_type_get_response("generic")
 
         await update_document(
             mock_ctx,
@@ -4194,10 +4221,91 @@ class TestEnumGuardUpdateDocument:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        mock_client.get.return_value = _enum_get_response(["draft", "approved"])
+        # GETs: resolve doc type, then that type's status options.
+        mock_client.get.side_effect = [
+            _doc_type_get_response("softwareReqSpecification"),
+            _enum_get_response(["draft", "approved"]),
+        ]
 
-        with pytest.raises(ValueError, match="status='ghost'"):
+        with pytest.raises(ValueError, match="status='ghost'") as exc:
             await _call_update_doc(mock_ctx, status="ghost")
+
+        # Message name resolved type, so model know which type to pass to
+        # list_document_enum_options.
+        assert "softwareReqSpecification" in str(exc.value)
+        mock_client.patch.assert_not_called()
+
+    async def test_status_checked_against_resolved_type_not_generic(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        """Type-specific status pass — '~' options would false-reject it."""
+        mock_client.get.side_effect = [
+            _doc_type_get_response("softwareReqSpecification"),
+            _enum_get_response(["draft", "inreview", "reviewed"]),
+        ]
+
+        result = await _call_update_doc(mock_ctx, status="reviewed", dry_run=True)
+
+        assert result.dry_run is True  # type: ignore[attr-defined]
+        assert _enum_probe_types(mock_client) == ["softwareReqSpecification"]
+
+    async def test_explicit_type_skips_resolution_get(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        """Retype PATCH set both attrs — new type is the status axis."""
+        mock_client.get.side_effect = [
+            _enum_get_response(["generic", "softwareReqSpecification"]),
+            _enum_get_response(["draft", "reviewed"]),
+        ]
+
+        await _call_update_doc(
+            mock_ctx, status="reviewed", type="softwareReqSpecification", dry_run=True
+        )
+
+        # type probe on '~' axis, status probe on supplied type; no
+        # resolution GET between.
+        assert _enum_probe_types(mock_client) == ["~", "softwareReqSpecification"]
+
+    async def test_status_and_custom_fields_resolve_type_once(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        # GETs: resolve doc type, status options, custom-field enum probe
+        # (404 = not enum field, defer). Key schema primed, so no sample GET.
+        mock_client.get.side_effect = [
+            _doc_type_get_response("generic"),
+            _enum_get_response(["draft", "published"]),
+            PolarionNotFoundError("not an Enumeration field", status_code=404),
+        ]
+        _cache_mod.store_document_type_custom_keys(
+            "MyProj", "generic", frozenset({"doc_risk"})
+        )
+
+        await _call_update_doc(
+            mock_ctx, status="draft", custom_fields={"doc_risk": 9}, dry_run=True
+        )
+
+        assert _type_resolution_get_count(mock_client) == 1
+
+    async def test_unresolvable_type_blocks_status_write(
+        self,
+        mock_ctx: MagicMock,
+        mock_client: AsyncMock,
+        reset_enum_guard_caches: None,
+    ) -> None:
+        """Fail closed: no type axis, no silent '~' fallback."""
+        mock_client.get.return_value = {"data": {"attributes": {}}}
+
+        with pytest.raises(RuntimeError, match="status"):
+            await _call_update_doc(mock_ctx, status="reviewed")
         mock_client.patch.assert_not_called()
 
     async def test_unknown_custom_field_key_raises_via_priming_get(


### PR DESCRIPTION
## Summary

`update_document` validated the `status` argument against the type-agnostic (`~`) document status
enum regardless of the target document's real type, so every type-specific status was rejected
client-side before Polarion was ever asked:

```
status='reviewed' is not a valid status option in project '<project>' for documents type '~'.
Valid options: ['draft', 'obsolete', 'published'].
```

Polarion keys `documents/fields/status/actions/getAvailableOptions` on document type — a
requirement-spec type serves `draft, inreview, reviewed, approved, rejected`, while `~` serves only
the generic workflow. A raw `PATCH .../documents/{d}` with `attributes.status = "reviewed"` on that
same document returns 204, so the guard was rejecting a value Polarion accepts. The enum endpoint
returns a type's whole value set, never "allowed next transitions" — transition order is enforced
by `workflowAction`, not by this guard.

Net effect before this PR: a document could be created in a type-specific status (`create_document`
already guards on the real type) but never updated into one. `update_work_items` already resolves
each item's own type for the same reason, so documents were the outlier.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Status was validated on the `~` axis, so every type-specific status was rejected before Polarion saw it
- Resolve the document's own type once and share it with the custom-field guard; explicit type skips that GET

## Testing

- `uv run pytest` — 2538 passed, 11 skipped; `ruff check` / `ruff format --check` / `mypy src/` clean;
  `diff-cover` 100% on changed lines.
- Five new cases in `TestEnumGuardUpdateDocument`: status checked on the resolved type, error names
  that type, explicit `type` skips the resolution GET, `status` + `custom_fields` resolve it exactly
  once, unresolvable type fails closed.
- Live `dry_run=True` check against the testdrive project (no writes): a typed requirement-spec
  document now accepts `reviewed` and rejects a ghost status while listing the five real options; a
  generic document still accepts `published` and still rejects `reviewed` — the `~` axis stays
  correct where it belongs.

## Notes for Reviewers

- Type resolution stays lazy at two call sites rather than one up-front fetch: hoisting it above
  `_build_update_document_payload` would spend a GET before the free `merge_custom_fields` collision
  check on a `custom_fields`-only call. `effective_type` is single-flight, so at most one GET either
  way.
- No LLM-facing docstring change: the error now names the real document type, which is exactly the
  `document_type` the model must pass to `list_document_enum_options`.
- Separate follow-up, not in this PR: a 403 from a document write maps to a fixed "check your
  POLARION_TOKEN permissions" message (55 sites across 9 modules), which hides causes a token change
  cannot fix — e.g. a document whose workflow status locks every REST write, where Polarion's own
  detail is `Cannot move Work Item(s) to a Document due to limited permissions.`
