### PR TITLE
refactor(guard): split enum naming by endpoint

### DIFF
--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -1,6 +1,9 @@
 """In-process TTL caches for near-static project facts — spare server's
 tight budget (throttle deployment-configured, no concurrency). Own ALL
 cache state; tool logic reach it only via typed get / store wrappers.
+
+Naming mirror :mod:`...tools._shared.guard.enums`: ``field_*`` = per-field
+``getAvailableOptions``, ``enum_*`` = per-project ``/enumerations/``.
 """
 
 from __future__ import annotations
@@ -8,6 +11,7 @@ from __future__ import annotations
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Final, Literal, NamedTuple
 
 
@@ -23,7 +27,12 @@ class _Entry[V]:
 
 
 class TTLCache[K, V]:
-    """Single-threaded TTL cache; lazy expiry — bounded key space stay bounded."""
+    """Single-threaded TTL cache; lazy expiry — bounded key space stay bounded.
+
+    ``get`` hand back stored object itself — wrapper must close that path,
+    by storing immutable value or copying on get. Mutable value reaching
+    caller = one edit poison every later read until TTL expire.
+    """
 
     def __init__(self, ttl_seconds: float) -> None:
         self._ttl = ttl_seconds
@@ -70,7 +79,7 @@ _GUARD_TTL_SECONDS: Final[float] = 60.0
 
 # 404 "not an Enumeration field" = stable schema fact; stale worst case
 # just defer to Polarion — safe to outlive positive option sets.
-_ENUM_NOT_FOUND_TTL_SECONDS: Final[float] = 600.0
+_FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS: Final[float] = 600.0
 
 # New documents surface within ~1 min (create also invalidate on write).
 _DOCUMENT_LIST_TTL_SECONDS: Final[float] = 60.0
@@ -104,22 +113,22 @@ def invalidate_documents_cache(project_id: str) -> None:
 # (project, resource, field, type) -> option id -> display name. Name kept
 # beside id so display-name reader (rendering layout `label`) reuse guard's
 # fetch instead of spending second request; unnamed option = "".
-_enum_option_cache: TTLCache[tuple[str, Resource, str, str], Mapping[str, str]] = (
+_field_option_cache: TTLCache[tuple[str, Resource, str, str], Mapping[str, str]] = (
     TTLCache(_GUARD_TTL_SECONDS)
 )
 
 
-def get_cached_enum_options(
+def get_cached_field_options(
     project_id: str,
     resource: Resource,
     field_id: str,
     type_id: str,
 ) -> Mapping[str, str] | None:
     """Cached option id → display name for field/type, or ``None`` on miss."""
-    return _enum_option_cache.get((project_id, resource, field_id, type_id))
+    return _field_option_cache.get((project_id, resource, field_id, type_id))
 
 
-def store_cached_enum_options(  # noqa: PLR0913
+def store_cached_field_options(  # noqa: PLR0913
     project_id: str,
     resource: Resource,
     field_id: str,
@@ -129,36 +138,38 @@ def store_cached_enum_options(  # noqa: PLR0913
     not_found: bool = False,
 ) -> None:
     """Cache option id → name for field/type; ``not_found=True`` (404 result)
-    use longer ``_ENUM_NOT_FOUND_TTL_SECONDS``.
+    use longer ``_FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS``.
     """
-    _enum_option_cache.set(
+    # Store read-only view: ``TTLCache.get`` hand back stored object itself,
+    # so plain dict would let one caller's mutation poison every later guard.
+    _field_option_cache.set(
         (project_id, resource, field_id, type_id),
-        dict(options),
-        ttl_seconds=_ENUM_NOT_FOUND_TTL_SECONDS if not_found else None,
+        MappingProxyType(dict(options)),
+        ttl_seconds=_FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS if not_found else None,
     )
 
 
 # (project, enum_name) -> project-level enum option ids (no type axis).
-_project_enum_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
+_enum_option_id_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
     _GUARD_TTL_SECONDS
 )
 
 
-def get_cached_project_enum(
+def get_cached_enum_option_ids(
     project_id: str,
     enum_name: str,
 ) -> frozenset[str] | None:
     """Cached valid option ids for project enum, or ``None`` on miss."""
-    return _project_enum_cache.get((project_id, enum_name))
+    return _enum_option_id_cache.get((project_id, enum_name))
 
 
-def store_cached_project_enum(
+def store_cached_enum_option_ids(
     project_id: str,
     enum_name: str,
     option_ids: frozenset[str],
 ) -> None:
     """Cache valid option ids for project enum for ``_GUARD_TTL_SECONDS``."""
-    _project_enum_cache.set((project_id, enum_name), option_ids)
+    _enum_option_id_cache.set((project_id, enum_name), option_ids)
 
 
 # (project, work_item_id) -> True once confirmed existing. Positives only --
@@ -271,8 +282,8 @@ __all__ = [
     "TTLCache",
     "get_cached_confirmed_work_item",
     "get_cached_documents",
-    "get_cached_enum_options",
-    "get_cached_project_enum",
+    "get_cached_enum_option_ids",
+    "get_cached_field_options",
     "get_document_type_custom_keys",
     "get_test_run_custom_keys",
     "get_work_item_custom_keys",
@@ -282,8 +293,8 @@ __all__ = [
     "invalidate_work_item_custom_keys",
     "store_cached_confirmed_work_item",
     "store_cached_documents",
-    "store_cached_enum_options",
-    "store_cached_project_enum",
+    "store_cached_enum_option_ids",
+    "store_cached_field_options",
     "store_document_type_custom_keys",
     "store_test_run_custom_keys",
     "store_work_item_custom_keys",

--- a/src/mcp_server_polarion/tools/_shared/guard/__init__.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/__init__.py
@@ -21,7 +21,7 @@ from mcp_server_polarion.tools._shared.guard.documents import (
     guard_document_enums,
     guard_document_rendering_layout_types,
 )
-from mcp_server_polarion.tools._shared.guard.enums import fetch_enum_options
+from mcp_server_polarion.tools._shared.guard.enums import fetch_field_options
 from mcp_server_polarion.tools._shared.guard.links import (
     guard_hyperlink_roles,
     guard_work_item_link_roles,
@@ -46,7 +46,7 @@ from mcp_server_polarion.tools._shared.guard.work_items import (
 )
 
 __all__ = [
-    "fetch_enum_options",
+    "fetch_field_options",
     "guard_document_attachment_refs",
     "guard_document_comment_attachment_refs",
     "guard_document_custom_fields",

--- a/src/mcp_server_polarion/tools/_shared/guard/__init__.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/__init__.py
@@ -6,7 +6,9 @@ option set and 404 defer to Polarion. Caching in :mod:`...tools._shared.cache`.
 
 Naming: ``guard_*`` = pure validators (return ``None``, raise on invalid);
 ``resolve_*``/``partition_*`` = fail-closed helpers whose validation result
-caller also need as data.
+caller also need as data; ``fetch_*`` = raw option fetch behind them, split by
+endpoint (``field_*`` = ``getAvailableOptions``, ``enum_*`` =
+``/projects/{p}/enumerations/``).
 """
 
 from __future__ import annotations

--- a/src/mcp_server_polarion/tools/_shared/guard/documents.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/documents.py
@@ -23,8 +23,8 @@ from mcp_server_polarion.tools._shared.guard._custom_keys import check_custom_ke
 from mcp_server_polarion.tools._shared.guard._http import guarded_pages
 from mcp_server_polarion.tools._shared.guard.enums import (
     check_custom_field_enum_values,
-    check_enum,
-    fetch_enum_option_ids,
+    check_field_value,
+    fetch_field_options,
 )
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
@@ -43,9 +43,9 @@ async def guard_document_enums(
 ) -> None:
     """Validate every supplied document enum arg against ``getAvailableOptions``."""
     if type is not None and type != "":
-        await check_enum(client, project_id, "documents", "type", "~", type)
+        await check_field_value(client, project_id, "documents", "type", "~", type)
     if status is not None and status != "":
-        await check_enum(
+        await check_field_value(
             client, project_id, "documents", "status", document_type, status
         )
 
@@ -63,7 +63,7 @@ async def guard_document_rendering_layout_types(
     UI precedence undefined, so refuse instead of dedupe silently.
 
     Message name ``rendering_layout_types``, never bare ``type`` — both write
-    tools carry own ``type`` parameter, so ``check_enum`` wording send model
+    tools carry own ``type`` parameter, so ``check_field_value`` wording send model
     to wrong argument. Batched fetch report every bad id at once; per-id loop
     cost one failed write each.
     """
@@ -85,18 +85,16 @@ async def guard_document_rendering_layout_types(
             f"Each work item type may appear once -- Polarion accepts duplicate "
             f"entries but which one wins in the UI is undefined."
         )
-    option_ids = await fetch_enum_option_ids(
-        client, project_id, "workitems", "type", "~"
-    )
-    # Empty set = successful no-options fetch; defer rather than false-positive.
-    if not option_ids:
+    options = await fetch_field_options(client, project_id, "workitems", "type", "~")
+    # Empty mapping = successful no-options fetch; defer rather than false-positive.
+    if not options:
         return
-    unknown = sorted(set(types) - option_ids)
+    unknown = sorted(set(types) - options.keys())
     if unknown:
         raise ValueError(
             f"rendering_layout_types has unknown work item type ID(s) "
             f"{format_option_list(unknown)} in project '{project_id}'. "
-            f"Valid options: {format_option_list(option_ids)}. "
+            f"Valid options: {format_option_list(options.keys())}. "
             f"Unknown ids ghost silently (their fields never render) -- call "
             f"list_work_item_enum_options first."
         )

--- a/src/mcp_server_polarion/tools/_shared/guard/enums.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/enums.py
@@ -14,10 +14,10 @@ from mcp_server_polarion.core.client import PolarionClient
 from mcp_server_polarion.core.exceptions import PolarionNotFoundError
 from mcp_server_polarion.tools._shared.cache import (
     Resource,
-    get_cached_enum_options,
-    get_cached_project_enum,
-    store_cached_enum_options,
-    store_cached_project_enum,
+    get_cached_enum_option_ids,
+    get_cached_field_options,
+    store_cached_enum_option_ids,
+    store_cached_field_options,
 )
 from mcp_server_polarion.tools._shared.guard._http import (
     GUARD_PAGE_SIZE,
@@ -31,7 +31,7 @@ from mcp_server_polarion.tools._shared.helpers import (
 logger = logging.getLogger("mcp_server_polarion.tools._shared.guard.enums")
 
 
-_ENUM_DISCOVERY_TOOL: dict[Resource, str] = {
+_FIELD_DISCOVERY_TOOL: dict[Resource, str] = {
     "workitems": "list_work_item_enum_options",
     "documents": "list_document_enum_options",
 }
@@ -50,7 +50,7 @@ async def fetch_field_options(
     Name = what the portal show for the option (work item type ``testcase``
     → ``Test Case``). Option served without one map to ``""``.
     """
-    cached = get_cached_enum_options(project_id, resource, field_id, type_id)
+    cached = get_cached_field_options(project_id, resource, field_id, type_id)
     if cached is not None:
         return cached
 
@@ -80,7 +80,7 @@ async def fetch_field_options(
             resource,
             project_id,
         )
-        store_cached_enum_options(
+        store_cached_field_options(
             project_id, resource, field_id, type_id, {}, not_found=True
         )
         return {}
@@ -96,7 +96,7 @@ async def fetch_field_options(
                 name = entry.get("name")
                 options[opt_id] = name if isinstance(name, str) else ""
 
-    store_cached_enum_options(project_id, resource, field_id, type_id, options)
+    store_cached_field_options(project_id, resource, field_id, type_id, options)
     return options
 
 
@@ -117,7 +117,7 @@ async def check_field_value(  # noqa: PLR0913
         f"project '{project_id}' for {resource} type '{type_id}'. "
         f"Valid options: {format_option_list(options.keys())}. "
         f"Unknown ids ghost silently (never match Lucene) -- call "
-        f"{_ENUM_DISCOVERY_TOOL[resource]} first."
+        f"{_FIELD_DISCOVERY_TOOL[resource]} first."
     )
 
 
@@ -131,11 +131,11 @@ async def fetch_enum_option_ids(
     (link/hyperlink role, testrun type/status). ``context`` = enumeration
     context path segment (``testing`` for testrun enums; ``~`` does NOT
     resolve them). Response ``data`` = dict (not list), options at
-    ``data.attributes.options[].id``. Cached; fail-closed like
-    :func:`fetch_field_options`.
+    ``data.attributes.options[].id``. Cached for the default guard TTL
+    (404 included); fail-closed.
     """
     cache_key = f"{context}/{enum_name}"
-    cached = get_cached_project_enum(project_id, cache_key)
+    cached = get_cached_enum_option_ids(project_id, cache_key)
     if cached is not None:
         return cached
 
@@ -154,13 +154,13 @@ async def fetch_enum_option_ids(
         )
     except PolarionNotFoundError:
         logger.warning(
-            "enumeration '%s' returned 404 for project=%s; skipping role "
-            "validation -- the enumeration is unsupported here, so there is "
-            "nothing to validate against.",
+            "enumeration '%s' returned 404 for project=%s; skipping "
+            "validation against it -- the enumeration is unsupported here, so "
+            "there is nothing to validate against.",
             enum_name,
             project_id,
         )
-        store_cached_project_enum(project_id, cache_key, frozenset())
+        store_cached_enum_option_ids(project_id, cache_key, frozenset())
         return frozenset()
 
     ids: set[str] = set()
@@ -177,7 +177,7 @@ async def fetch_enum_option_ids(
                     ids.add(opt_id)
 
     option_ids = frozenset(ids)
-    store_cached_project_enum(project_id, cache_key, option_ids)
+    store_cached_enum_option_ids(project_id, cache_key, option_ids)
     return option_ids
 
 
@@ -203,8 +203,9 @@ async def check_enum_values(  # noqa: PLR0913
     unknown = sorted(requested - option_ids)
     if unknown:
         raise ValueError(
-            f"{field_label} id(s) {unknown} are not valid in project "
-            f"'{project_id}'. Valid options: {format_option_list(option_ids)}. "
+            f"{field_label} id(s) {format_option_list(unknown)} are not valid "
+            f"in project '{project_id}'. "
+            f"Valid options: {format_option_list(option_ids)}. "
             f"An unknown {field_label} ghosts silently (never matches Lucene) "
             f"-- {discovery_hint}"
         )
@@ -231,7 +232,7 @@ def _bad_custom_enum_value(  # noqa: PLR0913
         f"{problem} in project '{project_id}' for {resource} type '{type_id}'. "
         f"Valid options: {format_option_list(options.keys())}. "
         f"Unknown enum values ghost silently (invisible to UI/Lucene) -- call "
-        f"{_ENUM_DISCOVERY_TOOL[resource]} first."
+        f"{_FIELD_DISCOVERY_TOOL[resource]} first."
     )
 
 

--- a/src/mcp_server_polarion/tools/_shared/guard/enums.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/enums.py
@@ -1,5 +1,8 @@
 """Enum option fetch + validation: ``getAvailableOptions`` (work items /
 documents) and project-level enumerations (roles, testrun enums).
+
+Naming: ``field_*`` = ``getAvailableOptions``, scoped per field + work item
+type; ``enum_*`` = ``/projects/{p}/enumerations/``, scoped per enum name.
 """
 
 from __future__ import annotations
@@ -34,22 +37,7 @@ _ENUM_DISCOVERY_TOOL: dict[Resource, str] = {
 }
 
 
-async def fetch_enum_option_ids(
-    client: PolarionClient,
-    project_id: str,
-    resource: Resource,
-    field_id: str,
-    type_id: str,
-) -> frozenset[str]:
-    """Valid option ids for ``(project, resource, field, type)``; cached,
-    fail-closed, 404 defer (empty set).
-    """
-    return frozenset(
-        await fetch_enum_options(client, project_id, resource, field_id, type_id)
-    )
-
-
-async def fetch_enum_options(
+async def fetch_field_options(
     client: PolarionClient,
     project_id: str,
     resource: Resource,
@@ -112,7 +100,7 @@ async def fetch_enum_options(
     return options
 
 
-async def check_enum(  # noqa: PLR0913
+async def check_field_value(  # noqa: PLR0913
     client: PolarionClient,
     project_id: str,
     resource: Resource,
@@ -120,22 +108,20 @@ async def check_enum(  # noqa: PLR0913
     type_id: str,
     value: str,
 ) -> None:
-    option_ids = await fetch_enum_option_ids(
-        client, project_id, resource, field_id, type_id
-    )
-    # Empty set = successful no-options fetch; defer rather than false-positive.
-    if not option_ids or value in option_ids:
+    options = await fetch_field_options(client, project_id, resource, field_id, type_id)
+    # Empty mapping = successful no-options fetch; defer rather than false-positive.
+    if not options or value in options:
         return
     raise ValueError(
         f"{field_id}='{value}' is not a valid {field_id} option in "
         f"project '{project_id}' for {resource} type '{type_id}'. "
-        f"Valid options: {format_option_list(option_ids)}. "
+        f"Valid options: {format_option_list(options.keys())}. "
         f"Unknown ids ghost silently (never match Lucene) -- call "
         f"{_ENUM_DISCOVERY_TOOL[resource]} first."
     )
 
 
-async def fetch_project_enum_option_ids(
+async def fetch_enum_option_ids(
     client: PolarionClient,
     project_id: str,
     enum_name: str,
@@ -146,7 +132,7 @@ async def fetch_project_enum_option_ids(
     context path segment (``testing`` for testrun enums; ``~`` does NOT
     resolve them). Response ``data`` = dict (not list), options at
     ``data.attributes.options[].id``. Cached; fail-closed like
-    :func:`fetch_enum_option_ids`.
+    :func:`fetch_field_options`.
     """
     cache_key = f"{context}/{enum_name}"
     cached = get_cached_project_enum(project_id, cache_key)
@@ -195,23 +181,21 @@ async def fetch_project_enum_option_ids(
     return option_ids
 
 
-async def check_project_enum_roles(  # noqa: PLR0913
+async def check_enum_values(  # noqa: PLR0913
     client: PolarionClient,
     project_id: str,
     enum_name: str,
-    roles: Iterable[str],
+    values: Iterable[str],
     *,
     field_label: str,
     discovery_hint: str,
     context: str = "~",
 ) -> None:
-    requested = {role for role in roles if role}
+    requested = {value for value in values if value}
     if not requested:
         return
 
-    option_ids = await fetch_project_enum_option_ids(
-        client, project_id, enum_name, context
-    )
+    option_ids = await fetch_enum_option_ids(client, project_id, enum_name, context)
     # Empty set = no options / enum unsupported; defer.
     if not option_ids:
         return
@@ -229,7 +213,7 @@ async def check_project_enum_roles(  # noqa: PLR0913
 def _bad_custom_enum_value(  # noqa: PLR0913
     field_id: str,
     value: object,
-    option_ids: frozenset[str],
+    options: Mapping[str, str],
     project_id: str,
     resource: Resource,
     type_id: str,
@@ -245,7 +229,7 @@ def _bad_custom_enum_value(  # noqa: PLR0913
     )
     return ValueError(
         f"{problem} in project '{project_id}' for {resource} type '{type_id}'. "
-        f"Valid options: {format_option_list(option_ids)}. "
+        f"Valid options: {format_option_list(options.keys())}. "
         f"Unknown enum values ghost silently (invisible to UI/Lucene) -- call "
         f"{_ENUM_DISCOVERY_TOOL[resource]} first."
     )
@@ -270,15 +254,15 @@ async def check_custom_field_enum_values(
         # Payload builders drop empty values — nothing to validate, skip probe.
         if value is None or value in ("", []):
             continue
-        option_ids = await fetch_enum_option_ids(
+        options = await fetch_field_options(
             client, project_id, resource, field_id, type_id
         )
-        if not option_ids:
+        if not options:
             continue
         if isinstance(value, str):
-            if value not in option_ids:
+            if value not in options:
                 raise _bad_custom_enum_value(
-                    field_id, value, option_ids, project_id, resource, type_id
+                    field_id, value, options, project_id, resource, type_id
                 )
         elif isinstance(value, list):
             for element in value:
@@ -286,17 +270,17 @@ async def check_custom_field_enum_values(
                     raise _bad_custom_enum_value(
                         field_id,
                         element,
-                        option_ids,
+                        options,
                         project_id,
                         resource,
                         type_id,
                         shape=True,
                     )
-                if element not in option_ids:
+                if element not in options:
                     raise _bad_custom_enum_value(
-                        field_id, element, option_ids, project_id, resource, type_id
+                        field_id, element, options, project_id, resource, type_id
                     )
         elif value is not None:
             raise _bad_custom_enum_value(
-                field_id, value, option_ids, project_id, resource, type_id, shape=True
+                field_id, value, options, project_id, resource, type_id, shape=True
             )

--- a/src/mcp_server_polarion/tools/_shared/guard/links.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/links.py
@@ -14,7 +14,7 @@ from mcp_server_polarion.core.exceptions import (
 from mcp_server_polarion.models import WorkItemLinkSpec
 from mcp_server_polarion.tools._shared.guard._http import paged_responses
 from mcp_server_polarion.tools._shared.guard._targets import missing_work_item_targets
-from mcp_server_polarion.tools._shared.guard.enums import check_project_enum_roles
+from mcp_server_polarion.tools._shared.guard.enums import check_enum_values
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     format_option_list,
@@ -31,7 +31,7 @@ async def guard_work_item_link_roles(
     """Reject link roles not in ``workitem-link-role`` — unknown role store
     verbatim (HTTP 201) as ghost link.
     """
-    await check_project_enum_roles(
+    await check_enum_values(
         client,
         project_id,
         "workitem-link-role",
@@ -52,7 +52,7 @@ async def guard_hyperlink_roles(
     """Reject hyperlink roles not in project ``hyperlink-role`` enum
     (typically ``ref_int``/``ref_ext``) — unknown roles ghost silently.
     """
-    await check_project_enum_roles(
+    await check_enum_values(
         client,
         project_id,
         "hyperlink-role",

--- a/src/mcp_server_polarion/tools/_shared/guard/test_records.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/test_records.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable
 
 from mcp_server_polarion.core.client import PolarionClient
 from mcp_server_polarion.tools._shared.guard._targets import missing_work_item_targets
-from mcp_server_polarion.tools._shared.guard.enums import check_project_enum_roles
+from mcp_server_polarion.tools._shared.guard.enums import check_enum_values
 from mcp_server_polarion.tools._shared.helpers import format_option_list
 
 
@@ -22,7 +22,7 @@ async def guard_test_record_results(
     enum -- unknown value stores verbatim (HTTP 201), ghosting silently
     against Lucene/UI result filters.
     """
-    await check_project_enum_roles(
+    await check_enum_values(
         client,
         project_id,
         "test-result",

--- a/src/mcp_server_polarion/tools/_shared/guard/test_runs.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/test_runs.py
@@ -24,7 +24,7 @@ from mcp_server_polarion.tools._shared.guard._http import (
     guarded_get,
     guarded_pages,
 )
-from mcp_server_polarion.tools._shared.guard.enums import check_project_enum_roles
+from mcp_server_polarion.tools._shared.guard.enums import check_enum_values
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     format_option_list,
@@ -42,7 +42,7 @@ async def guard_test_run_enums(
     project enumerations — testruns have no ``getAvailableOptions`` endpoint,
     and ``~`` wildcard context not resolve these enums.
     """
-    await check_project_enum_roles(
+    await check_enum_values(
         client,
         project_id,
         "testrun-type",
@@ -51,7 +51,7 @@ async def guard_test_run_enums(
         discovery_hint="use list_test_runs to see values in use.",
         context="testing",
     )
-    await check_project_enum_roles(
+    await check_enum_values(
         client,
         project_id,
         "testrun-status",

--- a/src/mcp_server_polarion/tools/_shared/guard/work_items.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/work_items.py
@@ -32,7 +32,7 @@ from mcp_server_polarion.tools._shared.guard._http import (
 )
 from mcp_server_polarion.tools._shared.guard.enums import (
     check_custom_field_enum_values,
-    check_enum,
+    check_field_value,
 )
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
@@ -61,21 +61,21 @@ async def guard_work_item_enums(  # noqa: PLR0913
     reuse as scoping axis.
     """
     if type is not None and type != "":
-        await check_enum(client, project_id, "workitems", "type", "~", type)
+        await check_field_value(client, project_id, "workitems", "type", "~", type)
     if status is not None and status != "":
-        await check_enum(
+        await check_field_value(
             client, project_id, "workitems", "status", work_item_type, status
         )
     if severity is not None and severity != "":
-        await check_enum(
+        await check_field_value(
             client, project_id, "workitems", "severity", work_item_type, severity
         )
     if priority is not None and priority != "":
-        await check_enum(
+        await check_field_value(
             client, project_id, "workitems", "priority", work_item_type, priority
         )
     if resolution is not None and resolution != "":
-        await check_enum(
+        await check_field_value(
             client, project_id, "workitems", "resolution", work_item_type, resolution
         )
 

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -47,7 +47,7 @@ from mcp_server_polarion.tools._shared.fields import (
     WORK_ITEM_PART_FIELDS,
 )
 from mcp_server_polarion.tools._shared.guard import (
-    fetch_enum_options,
+    fetch_field_options,
     guard_document_attachment_refs,
     guard_document_custom_fields,
     guard_document_enums,
@@ -515,7 +515,7 @@ async def _fetch_work_item_type_labels(
     failure. Endpoint absent (404) or option served nameless = empty mapping,
     which drop `label` rather than block write.
     """
-    return await fetch_enum_options(client, project_id, "workitems", "type", "~")
+    return await fetch_field_options(client, project_id, "workitems", "type", "~")
 
 
 def _parse_rendering_layout_types(attributes: dict[str, object]) -> list[str]:

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
@@ -48,6 +48,20 @@ class TestFetchFieldOptions:
         assert kwargs["params"]["type"] == "task"
         assert kwargs["params"]["page[size]"] == 100
 
+    async def test_display_name_kept_when_it_differs_from_id(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Rendering-layout `label` read the name, so id -> name must not
+        # collapse; shared builder always set name == id, hide the mapping.
+        mock_client.get.return_value = {
+            "data": [{"id": "testcase", "name": "Test Case"}],
+            "meta": {"totalCount": 1},
+        }
+
+        options = await fetch_field_options(mock_client, "P", "workitems", "type", "~")
+
+        assert options == {"testcase": "Test Case"}
+
     async def test_second_call_uses_cache(self, mock_client: AsyncMock) -> None:
         mock_client.get.return_value = enum_response(["a", "b"])
 

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
@@ -17,7 +17,7 @@ from mcp_server_polarion.tools._shared import cache as cache_mod
 from mcp_server_polarion.tools._shared.guard import guard_work_item_enums
 from mcp_server_polarion.tools._shared.guard.enums import (
     fetch_enum_option_ids,
-    fetch_project_enum_option_ids,
+    fetch_field_options,
 )
 from tests.mcp_server_polarion.tools._shared.guard._builders import (
     enum_response,
@@ -25,19 +25,19 @@ from tests.mcp_server_polarion.tools._shared.guard._builders import (
 )
 
 
-class TestFetchEnumOptionIds:
+class TestFetchFieldOptions:
     """Direct ``getAvailableOptions`` parsing + caching."""
 
-    async def test_first_call_hits_polarion_and_parses_ids(
+    async def test_first_call_hits_polarion_and_parses_options(
         self, mock_client: AsyncMock
     ) -> None:
         mock_client.get.return_value = enum_response(["must_have", "should_have"])
 
-        ids = await fetch_enum_option_ids(
+        options = await fetch_field_options(
             mock_client, "P", "workitems", "severity", "task"
         )
 
-        assert ids == frozenset({"must_have", "should_have"})
+        assert options == {"must_have": "must_have", "should_have": "should_have"}
         mock_client.get.assert_awaited_once()
         path, kwargs = (
             mock_client.get.call_args.args[0],
@@ -51,8 +51,8 @@ class TestFetchEnumOptionIds:
     async def test_second_call_uses_cache(self, mock_client: AsyncMock) -> None:
         mock_client.get.return_value = enum_response(["a", "b"])
 
-        await fetch_enum_option_ids(mock_client, "P", "workitems", "severity", "task")
-        await fetch_enum_option_ids(mock_client, "P", "workitems", "severity", "task")
+        await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
+        await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
 
         assert mock_client.get.await_count == 1
 
@@ -63,9 +63,9 @@ class TestFetchEnumOptionIds:
         clock = [1000.0]
         monkeypatch.setattr(cache_mod, "_now", lambda: clock[0])
 
-        await fetch_enum_option_ids(mock_client, "P", "workitems", "severity", "task")
+        await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
         clock[0] += 61.0  # past the 60s TTL
-        await fetch_enum_option_ids(mock_client, "P", "workitems", "severity", "task")
+        await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
 
         assert mock_client.get.await_count == 2
 
@@ -84,9 +84,7 @@ class TestFetchEnumOptionIds:
         mock_client.get.side_effect = PolarionError("backend down")
 
         with pytest.raises(RuntimeError, match="Refusing the write"):
-            await fetch_enum_option_ids(
-                mock_client, "P", "workitems", "severity", "task"
-            )
+            await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
 
         assert any("blocking write" in r.message for r in caplog.records)
 
@@ -96,9 +94,7 @@ class TestFetchEnumOptionIds:
         mock_client.get.side_effect = PolarionAuthError("forbidden", status_code=403)
 
         with pytest.raises(PermissionError, match="lacks permission"):
-            await fetch_enum_option_ids(
-                mock_client, "P", "workitems", "severity", "task"
-            )
+            await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
 
     async def test_not_found_defers_instead_of_blocking(
         self,
@@ -115,19 +111,19 @@ class TestFetchEnumOptionIds:
             "no such endpoint", status_code=404
         )
 
-        ids = await fetch_enum_option_ids(
+        options = await fetch_field_options(
             mock_client, "P", "workitems", "severity", "task"
         )
 
-        assert ids == frozenset()
+        assert options == {}
         assert any("404" in r.message for r in caplog.records)
 
     async def test_not_found_result_is_cached(self, mock_client: AsyncMock) -> None:
         # Deferred result cached; missing endpoint not re-probed within TTL.
         mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
 
-        await fetch_enum_option_ids(mock_client, "P", "workitems", "severity", "task")
-        await fetch_enum_option_ids(mock_client, "P", "workitems", "severity", "task")
+        await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
+        await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
 
         assert mock_client.get.await_count == 1
 
@@ -141,16 +137,16 @@ class TestFetchEnumOptionIds:
             mock_client, "P", "task", severity="anything"
         )  # must not raise
 
-    async def test_unknown_resource_field_returns_empty_set(
+    async def test_unknown_resource_field_returns_empty_mapping(
         self, mock_client: AsyncMock
     ) -> None:
         mock_client.get.return_value = {"data": [], "meta": {"totalCount": 0}}
 
-        ids = await fetch_enum_option_ids(
+        options = await fetch_field_options(
             mock_client, "P", "workitems", "weirdField", "task"
         )
 
-        assert ids == frozenset()
+        assert options == {}
 
     async def test_malformed_data_entries_are_skipped(
         self, mock_client: AsyncMock
@@ -160,14 +156,14 @@ class TestFetchEnumOptionIds:
             "meta": {},
         }
 
-        ids = await fetch_enum_option_ids(
+        options = await fetch_field_options(
             mock_client, "P", "workitems", "severity", "task"
         )
 
-        assert ids == frozenset({"ok"})
+        assert options == {"ok": ""}
 
 
-class TestFetchProjectEnumOptionIds:
+class TestFetchEnumOptionIds:
     """Single-enumeration GET parsing (dict ``data``) + caching + fail-closed."""
 
     async def test_first_call_hits_polarion_and_parses_dict_options(
@@ -177,9 +173,7 @@ class TestFetchProjectEnumOptionIds:
             "workitem-link-role", ["parent", "relates_to"]
         )
 
-        result = await fetch_project_enum_option_ids(
-            mock_client, "P", "workitem-link-role"
-        )
+        result = await fetch_enum_option_ids(mock_client, "P", "workitem-link-role")
 
         assert result == frozenset({"parent", "relates_to"})
         mock_client.get.assert_awaited_once()
@@ -195,8 +189,8 @@ class TestFetchProjectEnumOptionIds:
             "hyperlink-role", ["ref_int", "ref_ext"]
         )
 
-        await fetch_project_enum_option_ids(mock_client, "P", "hyperlink-role")
-        await fetch_project_enum_option_ids(mock_client, "P", "hyperlink-role")
+        await fetch_enum_option_ids(mock_client, "P", "hyperlink-role")
+        await fetch_enum_option_ids(mock_client, "P", "hyperlink-role")
 
         assert mock_client.get.await_count == 1
 
@@ -207,9 +201,9 @@ class TestFetchProjectEnumOptionIds:
         clock = [1000.0]
         monkeypatch.setattr(cache_mod, "_now", lambda: clock[0])
 
-        await fetch_project_enum_option_ids(mock_client, "P", "hyperlink-role")
+        await fetch_enum_option_ids(mock_client, "P", "hyperlink-role")
         clock[0] += cache_mod._GUARD_TTL_SECONDS + 1
-        await fetch_project_enum_option_ids(mock_client, "P", "hyperlink-role")
+        await fetch_enum_option_ids(mock_client, "P", "hyperlink-role")
 
         assert mock_client.get.await_count == 2
 
@@ -217,7 +211,7 @@ class TestFetchProjectEnumOptionIds:
         mock_client.get.side_effect = PolarionError("backend down")
 
         with pytest.raises(RuntimeError, match="Refusing the write"):
-            await fetch_project_enum_option_ids(mock_client, "P", "workitem-link-role")
+            await fetch_enum_option_ids(mock_client, "P", "workitem-link-role")
 
     async def test_auth_error_raises_permission_error(
         self, mock_client: AsyncMock
@@ -225,24 +219,22 @@ class TestFetchProjectEnumOptionIds:
         mock_client.get.side_effect = PolarionAuthError("forbidden", status_code=403)
 
         with pytest.raises(PermissionError, match="lacks permission"):
-            await fetch_project_enum_option_ids(mock_client, "P", "workitem-link-role")
+            await fetch_enum_option_ids(mock_client, "P", "workitem-link-role")
 
     async def test_not_found_defers_with_empty_set(
         self, mock_client: AsyncMock
     ) -> None:
         mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
 
-        result = await fetch_project_enum_option_ids(
-            mock_client, "P", "workitem-link-role"
-        )
+        result = await fetch_enum_option_ids(mock_client, "P", "workitem-link-role")
 
         assert result == frozenset()
 
     async def test_not_found_result_is_cached(self, mock_client: AsyncMock) -> None:
         mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
 
-        await fetch_project_enum_option_ids(mock_client, "P", "workitem-link-role")
-        await fetch_project_enum_option_ids(mock_client, "P", "workitem-link-role")
+        await fetch_enum_option_ids(mock_client, "P", "workitem-link-role")
+        await fetch_enum_option_ids(mock_client, "P", "workitem-link-role")
 
         assert mock_client.get.await_count == 1
 
@@ -255,8 +247,6 @@ class TestFetchProjectEnumOptionIds:
             }
         }
 
-        result = await fetch_project_enum_option_ids(
-            mock_client, "P", "workitem-link-role"
-        )
+        result = await fetch_enum_option_ids(mock_client, "P", "workitem-link-role")
 
         assert result == frozenset({"ok"})

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_test_runs.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_test_runs.py
@@ -22,7 +22,7 @@ from mcp_server_polarion.tools._shared.guard import (
 )
 from mcp_server_polarion.tools._shared.guard._http import GUARD_PAGE_SIZE
 from mcp_server_polarion.tools._shared.guard.enums import (
-    fetch_project_enum_option_ids,
+    fetch_enum_option_ids,
 )
 from tests.mcp_server_polarion.tools._shared.guard._builders import (
     project_enum_response,
@@ -89,7 +89,7 @@ class TestGuardTestRunEnums:
             project_enum_response("testrun-type", ["stale"]),
             project_enum_response("testrun-type", ["manual"]),
         ]
-        await fetch_project_enum_option_ids(mock_client, "P", "testrun-type")
+        await fetch_enum_option_ids(mock_client, "P", "testrun-type")
 
         await guard_test_run_enums(mock_client, "P", type="manual")
 

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_work_items.py
@@ -426,7 +426,7 @@ class TestGuardWorkItemCustomFieldEnums:
         await guard_work_item_custom_fields(mock_client, "P", "task", {"f": "x"})
         assert mock_client.get.await_count == 1
 
-        clock[0] += 600.0  # past _ENUM_NOT_FOUND_TTL_SECONDS
+        clock[0] += 600.0  # past _FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS
         store_work_item_custom_keys("P", "task", frozenset({"f"}))
         await guard_work_item_custom_fields(mock_client, "P", "task", {"f": "x"})
         assert mock_client.get.await_count == 2

--- a/tests/mcp_server_polarion/tools/_shared/test_cache.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_cache.py
@@ -11,16 +11,16 @@ from mcp_server_polarion.tools._shared.cache import (
     DiscoveredDocument,
     TTLCache,
     get_cached_documents,
-    get_cached_enum_options,
-    get_cached_project_enum,
+    get_cached_enum_option_ids,
+    get_cached_field_options,
     get_document_type_custom_keys,
     get_work_item_custom_keys,
     invalidate_document_type_custom_keys,
     invalidate_documents_cache,
     invalidate_work_item_custom_keys,
     store_cached_documents,
-    store_cached_enum_options,
-    store_cached_project_enum,
+    store_cached_enum_option_ids,
+    store_cached_field_options,
     store_document_type_custom_keys,
     store_work_item_custom_keys,
 )
@@ -30,8 +30,8 @@ from mcp_server_polarion.tools._shared.cache import (
 def _reset_caches() -> None:
     """Start each test with every module-level cache cold."""
     cache_mod._document_list_cache.clear()
-    cache_mod._enum_option_cache.clear()
-    cache_mod._project_enum_cache.clear()
+    cache_mod._field_option_cache.clear()
+    cache_mod._enum_option_id_cache.clear()
     cache_mod._work_item_custom_key_cache.clear()
     cache_mod._document_type_custom_key_cache.clear()
 
@@ -157,76 +157,86 @@ class TestDocumentListCache:
         assert get_cached_documents("P") is None
 
 
-class TestEnumOptionCache:
-    """Enum-option wrappers keyed by (project, resource, field, type)."""
+class TestFieldOptionCache:
+    """Field-option wrappers keyed by (project, resource, field, type)."""
 
     def test_store_then_get_hits(self) -> None:
-        store_cached_enum_options(
+        store_cached_field_options(
             "P", "workitems", "severity", "task", {"high": "High", "low": "Low"}
         )
 
-        assert get_cached_enum_options("P", "workitems", "severity", "task") == (
+        assert get_cached_field_options("P", "workitems", "severity", "task") == (
             {"high": "High", "low": "Low"}
         )
 
     def test_stored_mapping_copied(self) -> None:
         # Caller mutating own dict after store must not rewrite cached entry.
         options = {"high": "High"}
-        store_cached_enum_options("P", "workitems", "severity", "task", options)
+        store_cached_field_options("P", "workitems", "severity", "task", options)
         options["low"] = "Low"
 
-        assert get_cached_enum_options("P", "workitems", "severity", "task") == (
+        assert get_cached_field_options("P", "workitems", "severity", "task") == (
             {"high": "High"}
         )
 
-    def test_keys_are_distinct_per_axis(self) -> None:
-        store_cached_enum_options("P", "workitems", "severity", "task", {"high": ""})
+    def test_returned_mapping_is_read_only(self) -> None:
+        # ``TTLCache.get`` hand back stored object -- writable mapping would
+        # let one caller poison every later guard within the TTL.
+        store_cached_field_options("P", "workitems", "severity", "task", {"high": ""})
+        cached = get_cached_field_options("P", "workitems", "severity", "task")
 
-        assert get_cached_enum_options("P", "workitems", "severity", "bug") is None
-        assert get_cached_enum_options("P", "documents", "severity", "task") is None
-        assert get_cached_enum_options("P", "workitems", "status", "task") is None
+        assert cached is not None
+        with pytest.raises(TypeError):
+            cached["low"] = "Low"  # type: ignore[index]
+
+    def test_keys_are_distinct_per_axis(self) -> None:
+        store_cached_field_options("P", "workitems", "severity", "task", {"high": ""})
+
+        assert get_cached_field_options("P", "workitems", "severity", "bug") is None
+        assert get_cached_field_options("P", "documents", "severity", "task") is None
+        assert get_cached_field_options("P", "workitems", "status", "task") is None
 
     def test_expiry_uses_guard_ttl(self, clock: list[float]) -> None:
-        store_cached_enum_options("P", "workitems", "severity", "task", {"high": ""})
+        store_cached_field_options("P", "workitems", "severity", "task", {"high": ""})
 
         clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
-        assert get_cached_enum_options("P", "workitems", "severity", "task") is None
+        assert get_cached_field_options("P", "workitems", "severity", "task") is None
 
     def test_not_found_entries_use_long_ttl(self, clock: list[float]) -> None:
-        store_cached_enum_options(
+        store_cached_field_options(
             "P", "workitems", "freeText", "task", {}, not_found=True
         )
 
         clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
-        assert get_cached_enum_options("P", "workitems", "freeText", "task") == {}
+        assert get_cached_field_options("P", "workitems", "freeText", "task") == {}
 
-        clock[0] += cache_mod._ENUM_NOT_FOUND_TTL_SECONDS
-        assert get_cached_enum_options("P", "workitems", "freeText", "task") is None
+        clock[0] += cache_mod._FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS
+        assert get_cached_field_options("P", "workitems", "freeText", "task") is None
 
 
-class TestProjectEnumCache:
+class TestEnumOptionIdCache:
     """Project-level enum wrappers keyed by (project, enum_name)."""
 
     def test_store_then_get_hits(self) -> None:
-        store_cached_project_enum(
+        store_cached_enum_option_ids(
             "P", "workitem-link-role", frozenset({"parent", "relates_to"})
         )
 
-        assert get_cached_project_enum("P", "workitem-link-role") == frozenset(
+        assert get_cached_enum_option_ids("P", "workitem-link-role") == frozenset(
             {"parent", "relates_to"}
         )
 
     def test_keys_are_distinct_per_enum_and_project(self) -> None:
-        store_cached_project_enum("P", "workitem-link-role", frozenset({"parent"}))
+        store_cached_enum_option_ids("P", "workitem-link-role", frozenset({"parent"}))
 
-        assert get_cached_project_enum("P", "hyperlink-role") is None
-        assert get_cached_project_enum("Q", "workitem-link-role") is None
+        assert get_cached_enum_option_ids("P", "hyperlink-role") is None
+        assert get_cached_enum_option_ids("Q", "workitem-link-role") is None
 
     def test_expiry_uses_guard_ttl(self, clock: list[float]) -> None:
-        store_cached_project_enum("P", "hyperlink-role", frozenset({"ref_ext"}))
+        store_cached_enum_option_ids("P", "hyperlink-role", frozenset({"ref_ext"}))
 
         clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
-        assert get_cached_project_enum("P", "hyperlink-role") is None
+        assert get_cached_enum_option_ids("P", "hyperlink-role") is None
 
 
 class TestWorkItemCustomKeys:

--- a/tests/mcp_server_polarion/tools/conftest.py
+++ b/tests/mcp_server_polarion/tools/conftest.py
@@ -14,8 +14,8 @@ from mcp_server_polarion.tools._shared import cache as _cache_mod
 
 def _clear_guard_caches() -> None:
     """Drop enum / custom-field guard caches owned by ``_shared/cache.py``."""
-    _cache_mod._enum_option_cache.clear()
-    _cache_mod._project_enum_cache.clear()
+    _cache_mod._field_option_cache.clear()
+    _cache_mod._enum_option_id_cache.clear()
     _cache_mod._work_item_custom_key_cache.clear()
     _cache_mod._document_type_custom_key_cache.clear()
     _cache_mod._test_run_custom_key_cache.clear()

--- a/tests/mcp_server_polarion/tools/test_documents.py
+++ b/tests/mcp_server_polarion/tools/test_documents.py
@@ -202,8 +202,8 @@ def _project_enum_get_response(enum_name: str, ids: list[str]) -> dict[str, obje
 @pytest.fixture
 def reset_enum_guard_caches() -> None:
     """Drop guard caches between tests — each scenario start cold."""
-    _cache_mod._enum_option_cache.clear()
-    _cache_mod._project_enum_cache.clear()
+    _cache_mod._field_option_cache.clear()
+    _cache_mod._enum_option_id_cache.clear()
     _cache_mod._work_item_custom_key_cache.clear()
     _cache_mod._document_type_custom_key_cache.clear()
 

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -135,8 +135,8 @@ async def _call_create_wi(mock_ctx: MagicMock, **overrides: object) -> object:
 @pytest.fixture
 def reset_enum_guard_caches() -> None:
     """Drop guard caches between tests — each scenario start cold."""
-    _cache_mod._enum_option_cache.clear()
-    _cache_mod._project_enum_cache.clear()
+    _cache_mod._field_option_cache.clear()
+    _cache_mod._enum_option_id_cache.clear()
     _cache_mod._work_item_custom_key_cache.clear()
     _cache_mod._document_type_custom_key_cache.clear()
 


### PR DESCRIPTION
## Summary

`guard/enums.py` covers two unrelated Polarion endpoints, but every helper name shared the same `enum_option` token, so no name told you which API it hit:

| family | endpoint | scope |
|---|---|---|
| field options | `/projects/{p}/{resource}/fields/{f}/actions/getAvailableOptions` | resource + field + work item type |
| project enumerations | `/projects/{p}/enumerations/{context}/{enum}/~` | project + enum name + context |

The only discriminator was the `project_` prefix, which is misleading — both take `project_id`; the real difference is the endpoint.

Two follow-on problems came with it:

1. `fetch_enum_option_ids` was migration residue, not a designed split. #257 widened the cache from `frozenset` to `Mapping[str, str]` for layout labels and kept a 3-line shim so call sites did not have to change. `Mapping.keys()` is a set-like view, so the set algebra works directly, and the `Mapping` return annotation already blocks mutation under mypy strict — the shim no longer earns its place.
2. `check_project_enum_roles` was wrong for 3 of its 5 call sites (`test-result`, `testrun-type`, `testrun-status` are not roles), and so was its `roles` parameter.

Result: 6 helpers down to 5, with the two API families no longer sharing name tokens.

**getAvailableOptions family — `field_*` vocabulary**

| before | after |
|---|---|
| `fetch_enum_options` | `fetch_field_options` (`Mapping[str, str]`) |
| `fetch_enum_option_ids` | deleted |
| `check_enum` | `check_field_value` |
| `check_custom_field_enum_values` | unchanged — "enum-typed custom field values only" is the accurate scope |

**/enumerations/ family — `enum_*` vocabulary**

| before | after |
|---|---|
| `fetch_project_enum_option_ids` | `fetch_enum_option_ids` (`frozenset[str]`) |
| `check_project_enum_roles` | `check_enum_values` (param `roles` → `values`) |

## Review round: the split stopped one layer too early

The first commit renamed `guard/enums.py` but left the cache wrappers it calls and one log line still mixing the two vocabularies, so the rule the new module docstring states was violated immediately below it. The second commit carries the split down.

**`tools/_shared/cache.py`**

| before | after | family |
|---|---|---|
| `_enum_option_cache` | `_field_option_cache` | getAvailableOptions |
| `get`/`store_cached_enum_options` | `get`/`store_cached_field_options` | getAvailableOptions |
| `_ENUM_NOT_FOUND_TTL_SECONDS` | `_FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS` | getAvailableOptions |
| `_project_enum_cache` | `_enum_option_id_cache` | /enumerations/ |
| `get`/`store_cached_project_enum` | `get`/`store_cached_enum_option_ids` | /enumerations/ |

No old name is reused for a new target, so a missed reference fails with `ImportError`/`AttributeError` rather than silently clearing the wrong cache in the autouse test fixture.

Also in this round:

- `_ENUM_DISCOVERY_TOOL` → `_FIELD_DISCOVERY_TOOL` — it maps to the field-family discovery tools.
- The `/enumerations/` 404 warning said "skipping role validation"; 3 of the 5 call sites are not roles. Now "skipping validation against it".
- `fetch_enum_option_ids` no longer claims TTL parity with `fetch_field_options` in its docstring — the two cache 404s for different durations (60s vs 600s). Behavior unchanged; see follow-up below.
- The guard package docstring's naming paragraph now covers `fetch_*` and the endpoint split, so `fetch_field_options` is placeable without opening `enums.py`.

## Behavior deltas

Two, both narrow:

1. **Field options are handed out as a read-only view.** `store_cached_field_options` now stores `MappingProxyType(dict(options))`. `TTLCache.get` returns the stored object itself, so before this every guard call site received the live cached dict; one caller's `.pop()` would poison every later guard read for the TTL. The `Mapping` annotation only stops that under mypy — the proxy stops it at runtime. `TTLCache`'s own docstring now states the invariant so the next cache added has the rule in front of it.
2. **`check_enum_values` truncates the rejected-value list.** `{unknown}` → `{format_option_list(unknown)}`, matching `_bad_custom_enum_value` and `guard_document_rendering_layout_types`. `unknown` is already sorted and `format_option_list` sorts and `repr`s, so the rendered string is byte-identical at or below `OPTION_LIST_LIMIT` (50); past it the message truncates instead of inlining every value.

Nothing else changes at runtime. The earlier "no error message text changed" claim held for the first commit only.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

Still a refactor in intent; the two deltas above are the exceptions and are internal to the guard layer.

## Changes

- One enum_option token named two different APIs; check_project_enum_roles was wrong for 3 of its 5 call sites.
- getAvailableOptions helpers take field_* names, /enumerations/ keeps enum_*; split carried into the cache wrappers, field options served read-only.

## Testing

All gates green locally:

- `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/` — clean
- `uv run pytest` — 2542 passed, 11 skipped
- `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` — 51 changed lines, 100%

Behavior is pinned by the existing suite: guard rejection paths (including `ValueError` message text), 404 deferral, cache hit counts, and the `guard_work_item_enums` integration cases all pass unchanged.

Two tests added:

- `TestFieldOptionCache::test_returned_mapping_is_read_only` — pins the proxy.
- `TestFetchFieldOptions::test_display_name_kept_when_it_differs_from_id` — the shared `enum_response` builder always sets `name == id`, which hides the id → name mapping #257 introduced. This asserts it directly with `{"id": "testcase", "name": "Test Case"}`; it was previously only covered end-to-end through the document label tests.

No `@mcp.tool` docstring or `Field(description=...)` was touched, so no eval rerun is needed.

## Notes for Reviewers

- **Name reuse is deliberate.** The new `fetch_enum_option_ids` is the `/enumerations/` fetch, not the deleted field-family shim. The new signature is `(client, project_id, enum_name, context="~")` — 4 parameters, where the old field-family calls passed 5 arguments. A stale call site fails loudly with `TypeError`; there is no path where it silently means the other thing.
- `check_enum_values` call sites pass values positionally, so the `roles` → `values` parameter rename touched no caller.
- `_fetch_work_item_type_labels` in `documents.py` stays despite being a one-line pass-through. Unlike the deleted shim, it carries domain reasoning its two call sites should not repeat: the label is free because the layout guard already fetched those options, and an empty mapping means "drop `label`", not "block the write".
- Three caches now use three different immutability techniques — `frozenset` for option ids, `MappingProxyType` for the id → name mapping, `tuple` on store plus `list()` on get for the ordered document listing. That is the value shape dictating the type, not drift: the document listing is index-sliced for pagination and must keep `sorted` order, and the option-id caches are consumed by set difference and membership.
- **Merge order matters.** #258 touches the `guard/links.py` import block and both `test_enums.py` and `test_test_runs.py`; #256 touches `documents.py`. This branch now also touches `cache.py`, `tests/.../tools/conftest.py`, `test_documents.py` and `test_work_items.py`, so the conflict surface grew. Whichever merges second should rebase first — a bad resolution here resurrects undefined names and surfaces only as `ruff` F821 or an import error, not as a test failure.

## Follow-up

Not fixed here, to keep the diff behavior-neutral: the `/enumerations/` 404 result is cached for `_GUARD_TTL_SECONDS` (60s) while the `getAvailableOptions` 404 uses `_FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS` (600s). "This enumeration does not exist" is the same kind of stable schema fact, so the short TTL means an instance without the enumeration re-probes every 60s, and with the default 1 request/second cap that probe delays real writes. Worth aligning in its own PR.
