### PR TITLE
docs(claude): split API gotchas into domain docs

### DIFF
--- a/.claude/agents/spec-researcher.md
+++ b/.claude/agents/spec-researcher.md
@@ -16,8 +16,10 @@ into a spec; your job is to make sure every fact it uses is real.
    page is too large to fetch whole, `curl` it to the scratchpad and extract
    the relevant section with a script. Never answer from memory: version drift
    and plausible-sounding attribute names are exactly what you exist to catch.
-2. Cross-check against this repo's `CLAUDE.md` "Polarion API Gotchas" — flag
-   where the vendor doc contradicts or extends a recorded gotcha.
+2. Cross-check against this repo's recorded gotchas — `CLAUDE.md` "Polarion API
+   Gotchas" for the cross-cutting rules, and the matching `docs/polarion-api/`
+   domain doc for the per-resource contract. Flag where the vendor doc
+   contradicts or extends a recorded fact.
 3. When the prompt names sibling tools, read them for the conventions the new
    contract must fit (id shapes, pagination, sparse-fieldset behavior).
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,8 +4,9 @@ Thanks for taking the time to contribute. Every bug report, doc fix, and pull re
 
 This guide walks you through the contributor's path: **find something to work on → set up your
 environment → make the change → open a pull request.** For the codebase architecture, tool-design
-conventions, and Polarion API gotchas, see [CLAUDE.md](../CLAUDE.md) — read it before touching
-`tools/` or `core/`.
+conventions, and cross-cutting Polarion API gotchas, see [CLAUDE.md](../CLAUDE.md) — read it before
+touching `tools/` or `core/`. Per-domain API contracts live in
+[docs/polarion-api/](../docs/polarion-api/); read the one for the domain you are changing.
 
 > **The best first step is often an issue.** A clear bug report or a short design proposal lets us
 > agree on the approach before anyone writes code — that saves you from reworking a PR later.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ diff-cover changed lines ≥90% cover `src/` + `evals/` both — incl parser def
 ## Architecture
 
 - `core/client.py` — async httpx; serialize + pace + retry per Gotchas.
+- `core/exceptions.py` — `PolarionError` tree raised by client; map to builtins per Non-Negotiable Rules.
 - `core/config.py` — `POLARION_URL`/`POLARION_TOKEN`/`POLARION_MAX_REQUESTS_PER_SECOND`.
 - `core/logging.py` — stderr-only.
 - `tools/` — domain module per resource; `tools/__init__.py` import registers `@mcp.tool`s.
@@ -35,7 +36,7 @@ diff-cover changed lines ≥90% cover `src/` + `evals/` both — incl parser def
 
 - NEVER `print()` — stdout = MCP JSON-RPC; log to stderr.
 - NEVER `typing.Any` — concrete types or `object`.
-- NEVER ship delete tool for unrecoverable data (attachment, work item, document) even where REST allow it — removal = human via portal.
+- NEVER ship delete tool for unrecoverable data (attachment, work item, document) even where REST allow it (test record attachment DELETE = 204) — removal = human via portal.
   - `dry_run` + `destructiveHint` = advisory, model still call with `dry_run=False`; withhold capability = only hard guarantee.
   - Reversible relationship delete allowed (`delete_work_item_links` — recreate from context, zero data loss).
   - Deliberate posture, not gap — no re-litigate per review round.
@@ -59,7 +60,7 @@ diff-cover changed lines ≥90% cover `src/` + `evals/` both — incl parser def
 - Field descriptions one line, skip when name + type say all.
 - Tool description template (order, skip empty): [1] verb-first what + hard limits; [2] sibling routing ("— use X instead"); [3] call strategy only if behavior-change (REPLACE / "Call X first" / Atomic); [4] round-trip format rules; [5] returns + follow-up; [6] errors as prevention-form ("resolve via list_*_enum_options first").
 - Shipped text = docstring prose + `Field(description=...)` + input spec-model class docstrings (`$defs` ship them).
-- Bans + budgets (read ≤~50, write ≤~150 words) enforced by `test_tool_description_style.py`: no exception class names / raw HTTP codes / RST double-backticks, params single-line, `dry_run` byte-exact. Caps only NEVER/REPLACE/Atomic.
+- Budget advisory: read ≤~50, write ≤~150 words. Bans enforced by `test_tool_description_style.py` (char caps + text rules): no exception class names / raw HTTP codes / RST double-backticks, params single-line, `dry_run` byte-exact. Caps only NEVER/REPLACE/Atomic.
 - Eval-FAIL-restored phrase = lock via docstring contract test.
 - No `WARNING:`/`NOTE:` prefixes, dev-narrative, banner dividers.
 - CLAUDE.md dev-only — MCP-user info live in `@mcp.tool` docstrings. Module docstring = why module exist; constraints inline next to what they constrain.
@@ -90,7 +91,7 @@ Baseline: Polarion REST API v2506 — assume that version behavior. Rules below 
 | test runs, test records, e-signature | [docs/polarion-api/test-runs.md](docs/polarion-api/test-runs.md) |
 | documents, `renderingLayouts`, copy | [docs/polarion-api/documents.md](docs/polarion-api/documents.md) |
 | comments (all three resources) | [docs/polarion-api/comments.md](docs/polarion-api/comments.md) |
-| work items, links | [docs/polarion-api/work-items.md](docs/polarion-api/work-items.md) |
+| work items, links, document-membership moves | [docs/polarion-api/work-items.md](docs/polarion-api/work-items.md) |
 
 - JSON:API v1. HTML stored as `{"type": "text/html", "value": "..."}`.
 - Linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,47 +13,68 @@ uv run pytest --cov=src/mcp_server_polarion --cov=evals --cov-report=xml \
 uv run mcp-server-polarion                               # run server (stdio)
 ```
 
-CI: same order + `ruff format --check` + `pytest --cov-fail-under=90`; diff-cover changed lines ≥90% cover `src/` + `evals/` both — incl parser defensive branches + `evals/harness` request handlers.
+CI: same order + `ruff format --check` + `pytest --cov-fail-under=90`.
+diff-cover changed lines ≥90% cover `src/` + `evals/` both — incl parser defensive branches + `evals/harness` request handlers.
 
 ## Architecture
 
-- `core/` — `client.py` (async httpx; serialize + pace + retry per Gotchas), `exceptions.py`, `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only).
-- `tools/` — domain module per resource; `_build_*_payload` = unit-test seam; `tools/__init__.py` import registers `@mcp.tool`s. `_shared/`: `parse.py` (JSON:API→models), `pagination.py`, `fields.py`/`custom_fields.py` (sparse-fieldset + custom-field policy), `cache.py` (`TTLCache`), `sql.py`, `guard/` (pre-write validation, submodule per domain axis; new guards compose `_http.py` `guarded_get`/`guarded_pages` + `_custom_keys.py` `check_custom_keys`). `tools/guides/` = on-demand data served by `recipes.py`.
+- `core/client.py` — async httpx; serialize + pace + retry per Gotchas.
+- `core/config.py` — `POLARION_URL`/`POLARION_TOKEN`/`POLARION_MAX_REQUESTS_PER_SECOND`.
+- `core/logging.py` — stderr-only.
+- `tools/` — domain module per resource; `tools/__init__.py` import registers `@mcp.tool`s.
+- `_build_*_payload` = unit-test seam.
+- `tools/_shared/` — `parse.py` (JSON:API→models), `pagination.py`, `fields.py`/`custom_fields.py` (sparse-fieldset + custom-field policy), `cache.py` (`TTLCache`), `sql.py`.
+- `tools/_shared/guard/` — pre-write validation, submodule per domain axis; new guards compose `_http.py` `guarded_get`/`guarded_pages` + `_custom_keys.py` `check_custom_keys`.
+- `tools/guides/` — on-demand data served by `recipes.py`.
 - `middleware.py` — compact tool-arg `ValidationError` to one-line summary (raw Pydantic dump = token waste).
 - `utils/html.py` — Markdown↔HTML, `stamp_block_ids`, `first_anchorless_block`.
-- `models/` — Pydantic v2, re-exported from `models/__init__.py`; `PaginatedResult[T]` wrap list responses.
+- `models/` — `PaginatedResult[T]` wrap list responses; re-export from `models/__init__.py`.
 - `server.py` — FastMCP instance; lifespan owns `PolarionClient`.
 
 ## Non-Negotiable Rules
 
 - NEVER `print()` — stdout = MCP JSON-RPC; log to stderr.
 - NEVER `typing.Any` — concrete types or `object`.
+- NEVER ship delete tool for unrecoverable data (attachment, work item, document) even where REST allow it — removal = human via portal.
+  - `dry_run` + `destructiveHint` = advisory, model still call with `dry_run=False`; withhold capability = only hard guarantee.
+  - Reversible relationship delete allowed (`delete_work_item_links` — recreate from context, zero data loss).
+  - Deliberate posture, not gap — no re-litigate per review round.
 - All functions: full annotations + `from __future__ import annotations`. Tool functions: `async def` return Pydantic model.
 - Body fields asymmetric by tool purpose:
   - Round-trip: `get_*(include_*_html=True)` return raw Polarion HTML; `update_*(*_html=...)` accept verbatim — no sanitize/convert.
   - Greenfield create (Markdown): `markdown_to_html` + `sanitize_html`. Post-create edits = raw-HTML round-trip; formats never mix.
   - Synthesis (READ-ONLY): `read_*` convert HTML→Markdown; feed output back to writes lose Polarion markup.
-- Write payloads skip `None`/empty (Polarion read empty as "clear default"). Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
+- Write payloads skip `None`/empty (Polarion read empty as "clear default").
+- Resource POSTs wrap in `{"data": [...]}`; action endpoints (`.../actions/<name>`) take flat object.
 - Every list tool: `page_size` (max 100) + `page_number` → `PaginatedResult[T]` with `has_more`.
-- Timestamps (where Polarion serve both): `list_*` summary = `updated` only; metadata-bearing `get_*`/`read_*` detail add `created` (read_document body-only synthesis — exempt). Domain without `get_*` tool: list expose what API serve (comments `created`-only). API without timestamps: omit.
 - Every write tool: `dry_run: bool = False` — return payload, no hit Polarion.
-- NEVER ship delete tool for unrecoverable data (attachment, work item, document) even where REST allow it (test record attachment DELETE = 204) — removal = human via portal. `dry_run` + `destructiveHint` = advisory, model still call with `dry_run=False`; withhold capability = only hard guarantee. Reversible relationship delete allowed (`delete_work_item_links` — recreate from context, zero data loss). Deliberate posture, not gap (#224 closed) — no re-litigate per review round.
+- Timestamps (where Polarion serve both): `list_*` summary = `updated` only; metadata-bearing `get_*`/`read_*` detail add `created`.
+  - `read_document` body-only synthesis exempt. Domain without `get_*` tool: list expose what API serve (comments `created`-only). API without timestamps: omit.
 - Error mapping: `PolarionNotFoundError`→`ValueError`, `PolarionAuthError`→`PermissionError`, `PolarionError`→`RuntimeError`; user-fixable status allowed narrower map (attachment 409 dup fileName→`ValueError`).
 - Guards fail closed: validation GET error block write; only successful empty option set defer to Polarion.
-- Docstrings = LLM manual, Google-style; only prose above `Args:` ship — keep tight; return-field bullets sync with model. Field descriptions one line, skip when name + type say all.
-- Tool description template (order, skip empty):
-  - [1] verb-first what + hard limits; [2] sibling routing ("— use X instead"); [3] call strategy only if behavior-change (REPLACE / "Call X first" / Atomic).
-  - [4] round-trip format rules; [5] returns + follow-up; [6] errors as prevention-form ("resolve via list_*_enum_options first").
-  - Shipped text = docstring prose + `Field(description=...)` + input spec-model class docstrings (`$defs` ship them) — NEVER exception class names / raw HTTP codes / RST double-backticks; caps only NEVER/REPLACE/Atomic; `dry_run` = approved byte-exact variants.
-  - Budget: read ≤~50, write ≤~150 words. Gate `test_tool_description_style.py`; eval-FAIL-restored phrase = lock via docstring contract test.
-- No `WARNING:`/`NOTE:` prefixes, dev-narrative, banner dividers. CLAUDE.md dev-only — MCP-user info live in `@mcp.tool` docstrings. Module docstring = why module exist; constraints inline next to what they constrain.
-- Comments + dev docstrings caveman-style: drop articles/filler — `# Custom key match standard attr = silent shadow.` Why not what; never restate self-evident code; one distinct fact per line. Technical terms/ids/API names/numbers exact; no invented abbreviations. Exempt (LLM-facing, eval-gated): `@mcp.tool` docstrings + `Field(description=...)` — normal prose per Docstrings rule. `TODO` = `# TODO(#issue): concrete action`. No dead code; comments sync when code change.
+
+### Docstrings
+
+- Docstrings = LLM manual, Google-style; only prose above `Args:` ship — keep tight; return-field bullets sync with model.
+- Field descriptions one line, skip when name + type say all.
+- Tool description template (order, skip empty): [1] verb-first what + hard limits; [2] sibling routing ("— use X instead"); [3] call strategy only if behavior-change (REPLACE / "Call X first" / Atomic); [4] round-trip format rules; [5] returns + follow-up; [6] errors as prevention-form ("resolve via list_*_enum_options first").
+- Shipped text = docstring prose + `Field(description=...)` + input spec-model class docstrings (`$defs` ship them).
+- Bans + budgets (read ≤~50, write ≤~150 words) enforced by `test_tool_description_style.py`: no exception class names / raw HTTP codes / RST double-backticks, params single-line, `dry_run` byte-exact. Caps only NEVER/REPLACE/Atomic.
+- Eval-FAIL-restored phrase = lock via docstring contract test.
+- No `WARNING:`/`NOTE:` prefixes, dev-narrative, banner dividers.
+- CLAUDE.md dev-only — MCP-user info live in `@mcp.tool` docstrings. Module docstring = why module exist; constraints inline next to what they constrain.
+- Comments + dev docstrings caveman-style: drop articles/filler — `# Custom key match standard attr = silent shadow.`
+  - Why not what; never restate self-evident code; one distinct fact per line. Technical terms/ids/API names/numbers exact; no invented abbreviations.
+  - Exempt (LLM-facing, eval-gated): `@mcp.tool` docstrings + `Field(description=...)` — normal prose per Docstrings rule.
+  - `TODO` = `# TODO(#issue): concrete action`. No dead code; comments sync when code change.
 
 ## Naming Rules (LLM surface: params + model fields)
 
-- Cross-resource ref = full-noun `<resource>_id` (`project_id`, `work_item_id`, `test_run_id`, `test_case_id`, `comment_id`, `field_id`, `defect_id`, `template_id`). Documents own no id — address = `space_id` + `document_name` pair; `module_*` never on LLM surface (API `moduleName` map inside payload builder only).
+- Cross-resource ref = full-noun `<resource>_id` (`project_id`, `work_item_id`, `test_run_id`, `test_case_id`, `comment_id`, `field_id`, `defect_id`, `template_id`).
+- Documents own no id — address = `space_id` + `document_name` pair; `module_*` never on LLM surface (API `moduleName` map inside payload builder only).
 - Other location = `target_*` prefix (`target_project_id`, `target_space_id`, `target_document_name`, `target_work_item_id`).
-- Own id in own Summary/Detail model = bare `id`. Composite resource (work_item_**link**, test_**record**) drop parent prefix in own echo/selector fields (`link_id(s)`, `record_id(s)`); tool names + cross-domain refs stay full.
+- Own id in own Summary/Detail model = bare `id`.
+- Composite resource (work_item_**link**, test_**record**) drop parent prefix in own echo/selector fields (`link_id(s)`, `record_id(s)`); tool names + cross-domain refs stay full.
 - Create spec mirror resource attributes (client-supplied id = bare `id`, e.g. `TestRunCreateSpec.id`); update spec = target selector (`work_item_id`/`test_run_id`/`record_id`) + changed attributes.
 - Polarion camelCase → snake_case split at case boundary exact (`homePageContent` → `home_page_content`, `finishedOn` → `finished_on`); ad-hoc compounds banned (never "homepage").
 - Person fields = `<role>_id`/`<role>_name` parallel scalar pairs (author, assignee(s), last_updated_by, executed_by); list/summary = name only, detail add id.
@@ -61,40 +82,34 @@ CI: same order + `ruff format --check` + `pytest --cov-fail-under=90`; diff-cove
 
 ## Polarion API Gotchas
 
-- Baseline: Polarion REST API v2506 — assume that version behavior.
+Baseline: Polarion REST API v2506 — assume that version behavior. Rules below hold everywhere; per-domain contracts live in `docs/polarion-api/` and MUST be read before touching that domain. New domain doc = copy `docs/polarion-api/_TEMPLATE.md`, keep its section order.
+
+| Domain | Read before editing |
+|---|---|
+| attachments (document / work item / test record) | [docs/polarion-api/attachments.md](docs/polarion-api/attachments.md) |
+| test runs, test records, e-signature | [docs/polarion-api/test-runs.md](docs/polarion-api/test-runs.md) |
+| documents, `renderingLayouts`, copy | [docs/polarion-api/documents.md](docs/polarion-api/documents.md) |
+| comments (all three resources) | [docs/polarion-api/comments.md](docs/polarion-api/comments.md) |
+| work items, links | [docs/polarion-api/work-items.md](docs/polarion-api/work-items.md) |
+
 - JSON:API v1. HTML stored as `{"type": "text/html", "value": "..."}`.
-- Linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse. Module ids = 3 segments, doc names may contain `/` — use `split_module_id`.
+- Linked-work-item ids = 5 segments — derive targets via `relationships.workItem.data.id`, never parse.
+- Module ids = 3 segments, doc names may contain `/` — use `split_module_id`.
 - Lucene: trailing wildcards OK, leading 400. `module`/`description` not indexed — use `query="SQL:(...)"`; recipes via `get_sql_query_recipes`.
-- Server limits: throttle deployment-configured (vary per instance), no concurrency. No `Retry-After`/rate-limit headers served — client pacing = only defense. Client serialize via lock + pace per `POLARION_MAX_REQUESTS_PER_SECOND` (default 1 = conservative floor, raise per instance; `0` = no cap; blank env value = default, non-finite + rate under 1/60 rejected at startup; start-based min-interval, so slow request add no extra wait); writes add 1.5s post-delay not covered by cap; retries 429/5xx exponential backoff, each attempt re-paced.
-- Sparse fieldset drop `relationships` block — list relationship names explicit. To-many need `include=`; nested dot-path drop intermediate resource (`module,module.author`, not `module.author` alone). Resource with every requested attr unset ship no `attributes` block at all — parsers default it.
-- `/backlinkedworkitems` unsupported — back direction via `query=linkedWorkItems:{wi}`, so back results have `role=None`.
-- Polarion validate neither custom-field ids (unknown keys persist; wrong-type 400), nor enum values, nor link targets/roles — `guard/` validate pre-write. `getAvailableOptions` = only key→enum-options API (non-enum/unknown → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (`data` = dict, not list).
-- Custom fields inline under `attributes` (no `customFields` container; `@all` tokens dropped). `GET /projects/{p}/documents` absent on some builds.
-- Testruns:
-  - POST require explicit `id` (400 without; UI-only autofill).
-  - Enums resolve only under `testing` context (`~` 404); no `getAvailableOptions` → custom-field enum values unguardable (keys only).
-  - `isTemplate` settable at POST (`attributes.isTemplate`), served only on templates.
-  - `homePageContent` settable at POST/PATCH, served on explicit request — under `useReportFromTemplate` GET serve linked template content.
-  - Default GET (no `fields`) ship only `id`/`title`/`status`.
-- Testrecords:
-  - PATCH batch atomic — one bad id 400 whole batch ("was not found" = 400, not 404). Partial PATCH safe (omitted attrs preserved).
-  - Server validate neither `result` nor `defect` target (204 ghost) — guard pre-write via `testing/test-result` enum + workitem existence.
-  - REST auto-fill nothing — server never populate `executed`/`duration`/`testCaseRevision`; all three settable explicit via PATCH (204, preserved).
-  - `text/plain` comment stored as `text/html`.
-  - `defect` relationship absent from default GET (default = attrs `result`/`iteration` + `testCase` relationship) — serialize only when named in `fields[testrecords]` or via `include=defect` `included`.
-  - Run type may require e-signature → record write 403 portal-only remedy, REST cannot supply — surface Polarion detail in error, token hint alone mislead. E-signature NOT enforced on record attachment POST (manual-type run 201, verified 2026-07-21).
-  - Record attachments (`testrecords/{tcProj}/{tcId}/{iter}/attachments`, verified 2026-07-21): POST multipart contract same as doc attachments (plain form field `resource`, `files` order-matched), but server rewrite id AND served `fileName` to `{testCaseId}_{fileName}` — 201 echo ids ≠ input fileName. Dup fileName 409 whole batch atomic, in-batch AND vs existing (doc-style, no WI counter). Nonexistent record coordinate 404 (no ghost). Attachment DELETE = 204 (doc 405). First record iteration = 0.
-- Document `renderingLayouts` (verified 2026-08-07 + 2026-08-12): entry need `layouter` — `type` alone 400 "Required member 'uri' was not found." (pointer index misleading). Valid layouter includes `paragraph`/`section`/`title`/`default`/`titleTestSteps` (set not enumerable via API; live docs use all five), server-validated (bad value 400); `type` unvalidated (ghost) — guard pre-write; `label`/`properties` optional, property keys unvalidated. Multi-entry OK order-preserved, duplicate `type` accepted (UI precedence undefined). PATCH REPLACE whole array, `[]` clear. Absent from default GET (default attrs = `moduleFolder`/`status`/`title`), served under `@all`. No value normalization (`default` served back verbatim). Fresh UI-made document get `layouter: paragraph` + `label` + `fieldsAtStart=id`/`fieldsAtEnd=status` for every work item type (SRS + test spec both); `section`/`titleTestSteps` come from template-seeded docs, template not API-readable (`/projects/{p}/spaces` 404, no template space). Tools write that same shape — `label` = work item type enum `name` (`getAvailableOptions` serve `name` beside `id`, guard already fetch it = no extra request). `properties` order not round-tripped: server serve own order, content preserved (verified 2026-08-13). Missing layout = work item property panel broken in UI.
-- `documents/.../actions/copy`: flat body, 201 `data` = single dict (not list); `linkOriginalItemsWithRole` unvalidated → ghost link per copied item, guard vs **target** project `workitem-link-role`; documents not REST-deletable (405).
-- Document attachments (`documents/{d}/attachments`): body `<img src="attachment:{id}">` refs unvalidated — nonexistent id persist verbatim (204) and render same as real in `read_document`; work item attachments = separate resource, `workitemimg:` scheme. Attributes `id`/`fileName`/`title`/`updated`/`length` only — no `created`, no mime (`content` serve `application/octet-stream`); `@basic` = `id,fileName,title` no relationships. `sort` rejected (400) — order server-defined. POST multipart (verified 2026-07-20): `resource` = plain form field JSON string (part with explicit `application/json` content-type = 500 — old "always 500" report was this artifact); file parts named `files` order-matched to `data[]` (`lid` only work as part *name*); `attributes.fileName` override multipart filename + become id; dup fileName 409 whole batch atomic; 201 `data` = list in input order, entries `type`/`id`/`links` only. DELETE 405 — uploads REST-irreversible. Doc attachments + document comments: `meta.totalCount` absent on normal page (empty collection too) — appear only when page overshoot non-empty collection; unseeded doc/wrong space 404 (verified 2026-07-18).
-- Testrecord attachments (`testruns/{r}/testrecords/{tcProj}/{tc}/{iter}/attachments`, verified 2026-07-21): hybrid of doc + WI rules. Default GET ship `type`/`id`/`links` ONLY — zero `attributes` block, explicit `fields[testrecord_attachments]` mandatory. `@basic` = `id,fileName,title` (doc rule); `meta.totalCount` = WI rule (every page multi-page + overshoot non-empty; absent single-page/empty); `sort` 400; zero-attachment record = 200 empty, bad run/testcase/iteration = 404 "Test Record ... was not found". POST prepend `{testCaseId}_` to fileName — served `attributes.id` = fileName = prefixed token (≠ upload name); dup fileName 409 (doc rule); DELETE 204 (WI rule). Single-attachment GET exists (`data` = dict, default attrs = `@basic`); content serve `application/octet-stream` byte-exact; `revision` query param address record revision, not attachment. Manual-run e-signature block record PATCH only — attachment POST/DELETE unaffected.
-- Comments (document + work item, verified 2026-07-21; testrecord same rule): `text/plain` POST = server HTML-escape content + store/serve `text/html` — markup in plain text never render, `text/plain` never served back. Comment bodies accept ghost `attachment:`/`workitemimg:` refs verbatim (201); `workitemimg:` resolve in WI comment portal render (ghost = visible broken image) — create-comment tools guard pre-write. REST-created top-level doc comments not surface in portal doc sidebar (2506). Comment PATCH = `resolved` only, text not editable.
-- Work item attachments (`workitems/{wi}/attachments`): attribute set/no-mime/`sort` 400 same as doc attachments, but `@basic` = `id,fileName` only (no `title`), and `meta.totalCount` serve every page of multi-page collection (absent single-page) — diverge doc overshoot-only rule. Nonexistent work item/attachment 404. POST multipart contract same as doc attachments (verified 2026-07-21) EXCEPT: dup fileName never 409 — server prepend monotonic per-WI counter, id = `{counter}-{fileName}` (`3-a.txt`), so id ≠ fileName + `workitemimg:{id}` token unpredictable pre-upload (read from 201 echo); counter not reset by delete; `title` settable at POST + served on explicit fields; attachment DELETE = 204 (doc 405). Ghost `workitemimg:` refs in description persist verbatim (204, now guarded pre-write); body token URL-encoded vs raw `attributes.id`; non-image attachments embeddable via `img`; zero-attachment resource = 200 empty (404 = resource missing). Work item resource single DELETE 405; collection-body form (`DELETE /projects/{p}/workitems` + `{"data":[...]}`) = 204 — document resource stay 405.
+- Sparse fieldset drop `relationships` block — list relationship names explicit.
+- To-many need `include=`; nested dot-path drop intermediate resource (`module,module.author`, not `module.author` alone).
+- Resource with every requested attr unset ship no `attributes` block at all — parsers default it.
+- Custom fields inline under `attributes` (no `customFields` container; `@all` tokens dropped).
+- Polarion validate neither custom-field ids (unknown keys persist; wrong-type 400), nor enum values, nor link targets/roles — `guard/` validate pre-write.
+- `getAvailableOptions` = only key→enum-options API (non-enum/unknown → 404). Link/hyperlink roles not there — use `GET /projects/{p}/enumerations/~/{enumName}/~` (`data` = dict, not list).
+- Server throttle deployment-configured (vary per instance), no concurrency, no `Retry-After`/rate-limit headers served — client pacing = only defense (`core/client.py` serialize + pace + write post-delay + 429/5xx backoff).
 
 ## Testing
 
-- `tests/mcp_server_polarion/` mirror `src` package one-to-one (`tests/` also hold `claude_hooks/`, `github_scripts/`, `evals/`); shared fixtures `tests/conftest.py`; `mock_client`/`mock_ctx` + autouse guard-cache reset in `tools/conftest.py`.
-- `pytest-asyncio` `mode=auto`. Tool tests call functions directly (`@mcp.tool` return original); client tests use `respx`. Pydantic `Field` constraints bypass JSON Schema on direct call — verify via `TypeAdapter` reconstruction.
+- `tests/mcp_server_polarion/` mirror `src` package one-to-one (`tests/` also hold `claude_hooks/`, `github_scripts/`, `evals/`).
+- Shared fixtures `tests/conftest.py`; `mock_client`/`mock_ctx` + autouse guard-cache reset in `tools/conftest.py`.
+- `pytest-asyncio` `mode=auto`. Tool tests call functions directly (`@mcp.tool` return original); client tests use `respx`.
+- Pydantic `Field` constraints bypass JSON Schema on direct call — verify via `TypeAdapter` reconstruction.
 - New `@mcp.tool` needs update `EXPECTED_TOOL_NAMES` in `test_mcp_transport.py` + README tool-table row (marker-anchored sync test, same file).
 - `tests/evals/` open with `pytest.importorskip` (`evals` group; CI sync `--group evals`).
 
@@ -104,9 +119,10 @@ CI: same order + `ruff format --check` + `pytest --cov-fail-under=90`; diff-cove
 
 ## Repo Conventions
 
-Full rules in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md); enforced by `.githooks/commit-msg` + `.claude/hooks/`.
+Full rules in [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md); enforced by `.githooks/commit-msg` + `.claude/hooks/`. Agent-specific deltas:
 
-- Branches off `main`: `<type>/<short-kebab-summary>`; type = feat|fix|refactor|test|docs|chore|ci (pre-push enforce; `feature/` reject). Commits: `type(scope): summary` ≤50 chars + 2-bullet body (motivation, change).
+- Branches off `main`: `<type>/<short-kebab-summary>`; type = feat|fix|refactor|test|docs|chore|ci (pre-push enforce; `feature/` reject).
+- Commits: `type(scope): summary` ≤50 chars + 2-bullet body (motivation, change).
 - PR checklist: flip `[ ]`→`[x]`; don't delete unchecked options.
-- Squash merge only; NEVER `--subject` to `gh pr merge`. Force-push feature branches only with explicit authorization; never `main`.
-- Outward text (PR/issue/commit/release/gist/repo-description, branch names at push) NEVER carry private deployment names (real Polarion project/space/document ids) — generic wording ("live testdrive project"). `block_sensitive_text.py` hook scan vs untracked `.claude/sensitive-patterns.local` (regex per line; copy from `.claude/sensitive-patterns.example`; absent = skip; worktree sessions auto-link via `link_sensitive_patterns.py` SessionStart hook).
+- NEVER `--subject` to `gh pr merge`. Force-push feature branches only with explicit authorization; never `main`.
+- Outward text (PR/issue/commit/release/gist/repo-description, branch names at push) NEVER carry private deployment names (real Polarion project/space/document ids) — generic wording ("live testdrive project"). `block_sensitive_text.py` hook scan vs untracked `.claude/sensitive-patterns.local`.

--- a/docs/polarion-api/_TEMPLATE.md
+++ b/docs/polarion-api/_TEMPLATE.md
@@ -1,0 +1,45 @@
+# <Domain>
+
+> Copy this file to `<domain>.md` and delete this quote block.
+>
+> **Section order is fixed. Drop a section only when it has no facts — never reorder, never invent a new heading.**
+>
+> Writing rules:
+> - One fact per line. A line carrying two facts gets split.
+> - Identifiers, paths, params, and enum values in backticks, spelled exactly as the API spells them.
+> - HTTP status codes as bare numbers (`400`, not `HTTP 400`). Quote the server's own message verbatim when the text is the diagnostic.
+> - Say what the server does, not what our code does. Code behavior belongs in the module it lives in.
+> - No PR or issue numbers, no narrative of how the fact was found, no private deployment names.
+> - Every entry under *Server does not validate* names the guard that covers it, or says `unguarded`.
+> - One fact, one owner. A ghost body ref belongs to the resource whose body holds it, not to the resource being referenced. Anything a sibling doc already states gets a *Cross-domain* link, never a restatement.
+> - Dates live only in *Verified* — never inline in a fact line.
+
+<One line: what this file covers.> Read before touching <tool names>. Baseline Polarion REST API v2506.
+
+## Endpoints
+
+| Method | Path | Notes |
+|---|---|---|
+| | | |
+
+## Read contract
+
+<Default GET shape, `@basic`, mandatory `fields[]`, `include`, `sort`, `meta.totalCount`, empty-vs-404.>
+
+## Write contract
+
+<Body shape, batch atomicity, server-side rewrites, status codes, reversibility.>
+
+## Server does not validate
+
+<Every surface that accepts bad input and persists it — the ghost list. Each line names its guard.>
+
+## Cross-domain
+
+<Links to sibling docs for rules that live there.>
+
+## Verified
+
+| Date | Scope |
+|---|---|
+| | |

--- a/docs/polarion-api/attachments.md
+++ b/docs/polarion-api/attachments.md
@@ -1,0 +1,76 @@
+# Attachments
+
+Document, work item, and test record attachments — three resources with three rule sets. Read before touching `list_*_attachments`, `create_*_attachments`, or `get_*_attachment_content`. Baseline Polarion REST API v2506.
+
+## Endpoints
+
+| Method | Path | Notes |
+|---|---|---|
+| GET, POST | `documents/{d}/attachments` | DELETE 405 — uploads REST-irreversible |
+| GET, POST | `workitems/{wi}/attachments` | DELETE 204 |
+| GET, POST | `testruns/{r}/testrecords/{tcProj}/{tc}/{iter}/attachments` | DELETE 204; single-attachment GET returns `data` as a dict, default attrs `@basic` |
+
+## Read contract
+
+| Aspect | Document | Work item | Test record |
+|---|---|---|---|
+| Default GET attrs | full attribute set | full attribute set | none — `type`/`id`/`links` only |
+| `@basic` | `id,fileName,title` | `id,fileName` | `id,fileName,title` |
+| `meta.totalCount` | only when a page overshoots a non-empty collection | every page of a multi-page collection; absent single-page | every page of a multi-page collection **and** on overshoot; absent single-page or empty |
+| Body ref scheme | `attachment:{id}` | `workitemimg:{id}` | n/a |
+
+- Attributes are `id`, `fileName`, `title`, `updated`, `length` — no `created`, no mime anywhere.
+- `content` is served as `application/octet-stream`; test record content is byte-exact.
+- `sort` is rejected with 400 on all three — order is server-defined.
+- A zero-attachment resource returns 200 empty; 404 means the parent resource is missing.
+- Test record attachments require an explicit `fields[testrecord_attachments]` — the default GET ships no `attributes` block at all.
+- Document `@basic` ships no relationships.
+- Work item `title` is settable at POST and served on explicit fields.
+- An unseeded document or the wrong space returns 404.
+- A bad run, test case, or iteration returns 404 `"Test Record ... was not found"`.
+- The test record `revision` query param addresses the record revision, not the attachment.
+
+## Write contract
+
+POST is multipart on all three, with one shared shape:
+
+- `resource` is a plain form field holding a JSON string — a part with an explicit `application/json` content-type returns 500.
+- File parts are all named `files`, order-matched to `data[]`. `lid` works only as a part *name*, not as a field.
+- `attributes.fileName` overrides the multipart filename.
+- 201 `data` is a list in input order; entries carry `type`/`id`/`links` only.
+
+Server-side id rewriting differs per resource:
+
+| Aspect | Document | Work item | Test record |
+|---|---|---|---|
+| Duplicate `fileName` | 409, whole batch atomic | never 409 | 409, whole batch atomic — in-batch **and** against existing |
+| Stored id | `attributes.fileName` verbatim | `{counter}-{fileName}` (`3-a.txt`) | `{testCaseId}_{fileName}` |
+| Served `fileName` | as uploaded | as uploaded | rewritten to the prefixed token |
+| DELETE | 405 | 204 | 204 |
+
+- The work item counter is monotonic per work item and is not reset by delete, so `workitemimg:{id}` is unpredictable before upload — read it from the 201 echo.
+- Test record 201 echo ids never match the uploaded names.
+- A nonexistent test record coordinate returns 404 and creates no ghost.
+- Record attachment POST and DELETE are not blocked by the manual-run e-signature — see [test-runs.md](test-runs.md) for its scope.
+
+## Server does not validate
+
+Body refs are validated by the resource that owns the body, not by this one — see the *Cross-domain* links below. This resource contributes only the id facts that make a ref easy to get wrong:
+
+- In a body the ref token is URL-encoded against the raw `attributes.id`.
+- Non-image attachments are embeddable via `img` and render as broken, not as an error.
+
+## Cross-domain
+
+- Ghost `attachment:` refs in a document body: [documents.md](documents.md).
+- Ghost `workitemimg:` refs in a work item description: [work-items.md](work-items.md).
+- Ghost refs in comment bodies, and the document-comment `meta.totalCount` rule: [comments.md](comments.md).
+- E-signature scope and record iteration numbering: [test-runs.md](test-runs.md).
+
+## Verified
+
+| Date | Scope |
+|---|---|
+| 2026-07-18 | Document attachment + document comment `meta.totalCount`, unseeded-document 404 |
+| 2026-07-20 | Document attachment POST multipart contract |
+| 2026-07-21 | Work item and test record attachment POST, e-signature scope |

--- a/docs/polarion-api/attachments.md
+++ b/docs/polarion-api/attachments.md
@@ -6,17 +6,20 @@ Document, work item, and test record attachments — three resources with three 
 
 | Method | Path | Notes |
 |---|---|---|
-| GET, POST | `documents/{d}/attachments` | DELETE 405 — uploads REST-irreversible |
-| GET, POST | `workitems/{wi}/attachments` | DELETE 204 |
-| GET, POST | `testruns/{r}/testrecords/{tcProj}/{tc}/{iter}/attachments` | DELETE 204; single-attachment GET returns `data` as a dict, default attrs `@basic` |
+| GET, POST | `projects/{p}/spaces/{s}/documents/{d}/attachments` | DELETE 405 — uploads REST-irreversible |
+| GET | `projects/{p}/spaces/{s}/documents/{d}/attachments/{id}/content` | |
+| GET, POST | `projects/{p}/workitems/{wi}/attachments` | DELETE 204 |
+| GET | `projects/{p}/workitems/{wi}/attachments/{id}/content` | |
+| GET, POST | `projects/{p}/testruns/{r}/testrecords/{tcProj}/{tcId}/{iter}/attachments` | DELETE 204 |
+| GET | `projects/{p}/testruns/{r}/testrecords/{tcProj}/{tcId}/{iter}/attachments/{id}` | `data` is a dict, default attrs `@basic`; `/content` serves the bytes |
 
 ## Read contract
 
 | Aspect | Document | Work item | Test record |
 |---|---|---|---|
-| Default GET attrs | full attribute set | full attribute set | none — `type`/`id`/`links` only |
+| Default GET attrs | not probed — the tools always send `fields[]` | not probed — the tools always send `fields[]` | none — `type`/`id`/`links` only |
 | `@basic` | `id,fileName,title` | `id,fileName` | `id,fileName,title` |
-| `meta.totalCount` | only when a page overshoots a non-empty collection | every page of a multi-page collection; absent single-page | every page of a multi-page collection **and** on overshoot; absent single-page or empty |
+| `meta.totalCount` | only when a page overshoots a non-empty collection; absent on an empty one | every page of a multi-page collection; absent single-page, empty collection not probed | every page of a multi-page collection **and** on overshoot; absent single-page or empty |
 | Body ref scheme | `attachment:{id}` | `workitemimg:{id}` | n/a |
 
 - Attributes are `id`, `fileName`, `title`, `updated`, `length` — no `created`, no mime anywhere.
@@ -29,6 +32,8 @@ Document, work item, and test record attachments — three resources with three 
 - An unseeded document or the wrong space returns 404.
 - A bad run, test case, or iteration returns 404 `"Test Record ... was not found"`.
 - The test record `revision` query param addresses the record revision, not the attachment.
+- In a body the ref token is URL-encoded against the raw `attributes.id`.
+- Non-image attachments are embeddable via `img`.
 
 ## Write contract
 
@@ -48,6 +53,7 @@ Server-side id rewriting differs per resource:
 | Served `fileName` | as uploaded | as uploaded | rewritten to the prefixed token |
 | DELETE | 405 | 204 | 204 |
 
+- The two 204 DELETEs are API capability only: the repo ships no attachment delete tool by policy.
 - The work item counter is monotonic per work item and is not reset by delete, so `workitemimg:{id}` is unpredictable before upload — read it from the 201 echo.
 - Test record 201 echo ids never match the uploaded names.
 - A nonexistent test record coordinate returns 404 and creates no ghost.
@@ -55,10 +61,7 @@ Server-side id rewriting differs per resource:
 
 ## Server does not validate
 
-Body refs are validated by the resource that owns the body, not by this one — see the *Cross-domain* links below. This resource contributes only the id facts that make a ref easy to get wrong:
-
-- In a body the ref token is URL-encoded against the raw `attributes.id`.
-- Non-image attachments are embeddable via `img` and render as broken, not as an error.
+This resource has no unvalidated surface of its own: a body ref is validated by the resource whose body holds it, and each guard is named in the doc linked below.
 
 ## Cross-domain
 

--- a/docs/polarion-api/comments.md
+++ b/docs/polarion-api/comments.md
@@ -1,14 +1,15 @@
 # Comments
 
-Document, work item, and test record comments — one rule set across all three. Read before touching `list_*_comments`, `create_*_comments`, or `update_*_comment`. Baseline Polarion REST API v2506.
+Document and work item comments — one rule set for both. Read before touching `list_document_comments`, `list_work_item_comments`, `create_document_comments`, `create_work_item_comments`, `update_document_comment`, or `update_work_item_comment`. Baseline Polarion REST API v2506.
 
 ## Endpoints
 
 | Method | Path | Notes |
 |---|---|---|
-| GET, POST, PATCH | `documents/{d}/comments` | REST-created top-level comments do not surface in the portal document sidebar |
-| GET, POST, PATCH | `workitems/{wi}/comments` | |
-| GET, POST, PATCH | `testruns/{r}/testrecords/{tcProj}/{tc}/{iter}/comments` | |
+| GET, POST | `projects/{p}/spaces/{s}/documents/{d}/comments` | REST-created top-level comments do not surface in the portal document sidebar |
+| PATCH | `projects/{p}/spaces/{s}/documents/{d}/comments/{comment_id}` | |
+| GET, POST | `projects/{p}/workitems/{wi}/comments` | |
+| PATCH | `projects/{p}/workitems/{wi}/comments/{comment_id}` | |
 
 ## Read contract
 
@@ -22,13 +23,12 @@ Document, work item, and test record comments — one rule set across all three.
 
 ## Server does not validate
 
-- `attachment:` and `workitemimg:` refs in a comment body — accepted verbatim (201) and persisted. Guard: `guard/_attachment_refs.py`, wired into the create-comment tools via `guard_document_comment_attachment_refs` and its work item twin.
-- A ghost `workitemimg:` ref does resolve in the work item comment portal render, so it shows as a visible broken image rather than being ignored.
+- `attachment:` and `workitemimg:` refs in a comment body — accepted verbatim (201) and persisted; a ghost `workitemimg:` ref resolves in the work item comment portal render, so it shows as a visible broken image rather than being ignored. Guard: `guard/_attachment_refs.py`, wired into the create-comment tools via `guard_document_comment_attachment_refs` and its work item twin.
 
 ## Cross-domain
 
 - The id formats that make those refs easy to get wrong: [attachments.md](attachments.md).
-- Test record comment storage is the same rule, listed with the record contract: [test-runs.md](test-runs.md).
+- A test record carries its comment as an attribute of the record, not as a comment resource: [test-runs.md](test-runs.md).
 
 ## Verified
 

--- a/docs/polarion-api/comments.md
+++ b/docs/polarion-api/comments.md
@@ -1,0 +1,37 @@
+# Comments
+
+Document, work item, and test record comments — one rule set across all three. Read before touching `list_*_comments`, `create_*_comments`, or `update_*_comment`. Baseline Polarion REST API v2506.
+
+## Endpoints
+
+| Method | Path | Notes |
+|---|---|---|
+| GET, POST, PATCH | `documents/{d}/comments` | REST-created top-level comments do not surface in the portal document sidebar |
+| GET, POST, PATCH | `workitems/{wi}/comments` | |
+| GET, POST, PATCH | `testruns/{r}/testrecords/{tcProj}/{tc}/{iter}/comments` | |
+
+## Read contract
+
+- `text/plain` is never served back — every comment reads as `text/html`.
+- Document comments follow the document-attachment `meta.totalCount` rule — see [attachments.md](attachments.md).
+
+## Write contract
+
+- A `text/plain` POST is HTML-escaped by the server, then stored and served as `text/html`. Markup written as plain text never renders.
+- PATCH covers `resolved` only — the text is not editable.
+
+## Server does not validate
+
+- `attachment:` and `workitemimg:` refs in a comment body — accepted verbatim (201) and persisted. Guard: `guard/_attachment_refs.py`, wired into the create-comment tools via `guard_document_comment_attachment_refs` and its work item twin.
+- A ghost `workitemimg:` ref does resolve in the work item comment portal render, so it shows as a visible broken image rather than being ignored.
+
+## Cross-domain
+
+- The id formats that make those refs easy to get wrong: [attachments.md](attachments.md).
+- Test record comment storage is the same rule, listed with the record contract: [test-runs.md](test-runs.md).
+
+## Verified
+
+| Date | Scope |
+|---|---|
+| 2026-07-21 | Plain-text storage, ghost ref rendering, portal sidebar gap |

--- a/docs/polarion-api/documents.md
+++ b/docs/polarion-api/documents.md
@@ -1,0 +1,59 @@
+# Documents
+
+Document contracts, `renderingLayouts`, and the copy action. Read before touching `list_documents`, `get_document`, `read_document`, `create_document`, `update_document`, or `copy_document`. Baseline Polarion REST API v2506.
+
+## Endpoints
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `projects/{p}/documents` | absent on some builds |
+| GET, POST, PATCH | `projects/{p}/spaces/{s}/documents` | DELETE 405 — documents are not REST-deletable |
+| POST | `documents/.../actions/copy` | flat body, not `{"data": [...]}` |
+| GET | `projects/{p}/spaces` | 404 — there is no template space, so templates are not API-readable |
+
+## Read contract
+
+- Default GET attrs are `moduleFolder`, `status`, `title`.
+- `renderingLayouts` is absent from that default and served under `@all`.
+- No value normalization on `renderingLayouts` — `default` is served back verbatim.
+- `properties` order is not round-tripped: the server serves its own order, content preserved.
+- The copy action's 201 `data` is a single dict, not a list.
+
+## Write contract
+
+- Every `renderingLayouts` entry needs `layouter`. `type` alone returns 400 `"Required member 'uri' was not found."` — the pointer index in that error is misleading.
+- Known-valid layouters: `paragraph`, `section`, `title`, `default`, `titleTestSteps`. The set is not enumerable via the API; live documents use all five.
+- `layouter` is server-validated — a bad value is 400.
+- `label` and `properties` are optional.
+- Multi-entry is accepted and order-preserved. Duplicate `type` is accepted, with undefined UI precedence.
+- PATCH REPLACES the whole `renderingLayouts` array; `[]` clears it.
+- A missing layout breaks the work item property panel in the UI.
+- The copy action takes a flat body.
+
+### Layout shape the tools write
+
+A freshly UI-made document carries, for every work item type: `layouter: paragraph`, a `label`, `fieldsAtStart=id`, `fieldsAtEnd=status` — confirmed on both an SRS and a test spec document. The tools write that same shape.
+
+`label` is the work item type enum `name`. `getAvailableOptions` serves `name` beside `id` and the guard already fetches it, so this costs no extra request.
+
+`section` and `titleTestSteps` come from template-seeded documents, which the API cannot read back.
+
+## Server does not validate
+
+- Body `<img src="attachment:{id}">` refs — a nonexistent id persists verbatim (204) and renders identically to a real one in `read_document`. Guard: `guard/documents.py` `guard_document_attachment_refs`.
+- `renderingLayouts[].type` — accepted unvalidated and ghosts. Guard: `guard/documents.py` `guard_document_rendering_layout_types`.
+- `renderingLayouts[].properties` keys — accepted unvalidated, `unguarded`.
+- Copy `linkOriginalItemsWithRole` — a bad role creates a ghost link per copied item. Guard: `guard/links.py` `guard_work_item_link_roles`, called against the **target** project's `workitem-link-role` enum.
+
+## Cross-domain
+
+- Document attachments and `attachment:` body refs: [attachments.md](attachments.md).
+- Document comments and the portal sidebar gap: [comments.md](comments.md).
+
+## Verified
+
+| Date | Scope |
+|---|---|
+| 2026-08-07 | `renderingLayouts` required members, layouter validation |
+| 2026-08-12 | Layout shape of UI-made documents, template readability |
+| 2026-08-13 | `properties` order round-trip |

--- a/docs/polarion-api/documents.md
+++ b/docs/polarion-api/documents.md
@@ -1,6 +1,6 @@
 # Documents
 
-Document contracts, `renderingLayouts`, and the copy action. Read before touching `list_documents`, `get_document`, `read_document`, `create_document`, `update_document`, or `copy_document`. Baseline Polarion REST API v2506.
+Document contracts, `renderingLayouts`, and the copy action. Read before touching `list_documents`, `get_document`, `read_document`, `read_document_parts`, `create_document`, `update_document`, or `copy_document`. Baseline Polarion REST API v2506.
 
 ## Endpoints
 
@@ -8,7 +8,7 @@ Document contracts, `renderingLayouts`, and the copy action. Read before touchin
 |---|---|---|
 | GET | `projects/{p}/documents` | absent on some builds |
 | GET, POST, PATCH | `projects/{p}/spaces/{s}/documents` | DELETE 405 — documents are not REST-deletable |
-| POST | `documents/.../actions/copy` | flat body, not `{"data": [...]}` |
+| POST | `projects/{p}/spaces/{s}/documents/{d}/actions/copy` | flat body, not `{"data": [...]}` |
 | GET | `projects/{p}/spaces` | 404 — there is no template space, so templates are not API-readable |
 
 ## Read contract
@@ -17,7 +17,6 @@ Document contracts, `renderingLayouts`, and the copy action. Read before touchin
 - `renderingLayouts` is absent from that default and served under `@all`.
 - No value normalization on `renderingLayouts` — `default` is served back verbatim.
 - `properties` order is not round-tripped: the server serves its own order, content preserved.
-- The copy action's 201 `data` is a single dict, not a list.
 
 ## Write contract
 
@@ -28,15 +27,13 @@ Document contracts, `renderingLayouts`, and the copy action. Read before touchin
 - Multi-entry is accepted and order-preserved. Duplicate `type` is accepted, with undefined UI precedence.
 - PATCH REPLACES the whole `renderingLayouts` array; `[]` clears it.
 - A missing layout breaks the work item property panel in the UI.
-- The copy action takes a flat body.
+- The copy action takes a flat body, not the `{"data": [...]}` wrapper, and its 201 `data` is a single dict.
 
-### Layout shape the tools write
+Layout shape of a UI-made document:
 
-A freshly UI-made document carries, for every work item type: `layouter: paragraph`, a `label`, `fieldsAtStart=id`, `fieldsAtEnd=status` — confirmed on both an SRS and a test spec document. The tools write that same shape.
-
-`label` is the work item type enum `name`. `getAvailableOptions` serves `name` beside `id` and the guard already fetches it, so this costs no extra request.
-
-`section` and `titleTestSteps` come from template-seeded documents, which the API cannot read back.
+- A freshly UI-made document carries, for every work item type: `layouter: paragraph`, a `label`, `fieldsAtStart=id`, `fieldsAtEnd=status` — confirmed on both an SRS and a test spec document.
+- `label` is the work item type enum `name`, which `getAvailableOptions` serves beside `id`.
+- `section` and `titleTestSteps` come from template-seeded documents, which the API cannot read back.
 
 ## Server does not validate
 

--- a/docs/polarion-api/test-runs.md
+++ b/docs/polarion-api/test-runs.md
@@ -1,0 +1,50 @@
+# Test runs and test records
+
+Test run and test record contracts, including the e-signature block. Read before touching `list_test_runs`, `get_test_run`, `create_test_runs`, `update_test_runs`, `list_test_records`, `get_test_record`, `create_test_records`, or `update_test_records`. Baseline Polarion REST API v2506.
+
+## Endpoints
+
+| Method | Path | Notes |
+|---|---|---|
+| GET, POST, PATCH | `projects/{p}/testruns` | POST requires an explicit `id` |
+| GET, PATCH | `testruns/{r}/testrecords` | PATCH batches are atomic |
+| GET | `projects/{p}/enumerations/testing/{enumName}/~` | the `~` context returns 404 for test run enums |
+
+## Read contract
+
+- Test run default GET (no `fields`) ships only `id`, `title`, `status`.
+- Test run enums resolve only under the `testing` context — the `~` context returns 404.
+- There is no `getAvailableOptions` for test runs.
+- `isTemplate` is served only on templates.
+- `homePageContent` is served only on explicit request. Under `useReportFromTemplate` the GET serves the linked template's content instead of the run's own.
+- Test record default GET ships attrs `result` and `iteration` plus the `testCase` relationship.
+- The `defect` relationship is absent from that default — serialize it only when named in `fields[testrecords]` or pulled via `include=defect` into `included`.
+- The first record iteration is `0`.
+
+## Write contract
+
+- Test run POST requires an explicit `id`; without one the server returns 400. The UI autofill is UI-only.
+- `isTemplate` is settable at POST via `attributes.isTemplate`.
+- `homePageContent` is settable at POST and PATCH.
+- Test record PATCH batches are atomic — one bad id fails the whole batch with 400, and `"was not found"` arrives as 400, not 404.
+- Partial PATCH is safe: omitted attributes are preserved.
+- REST auto-fills nothing. The server never populates `executed`, `duration`, or `testCaseRevision`; all three are settable explicitly via PATCH (204, preserved).
+- A run's type may require an e-signature. Record PATCH then fails 403 and the remedy is portal-only — REST cannot supply the signature. Surface the Polarion detail in the error; a token hint alone misleads the caller.
+- The e-signature block covers record PATCH only.
+
+## Server does not validate
+
+- Test record `result` — a bad value returns 204 and ghosts. Guard: `guard/test_records.py` `guard_test_record_results` against the `testing/test-result` enum.
+- Test record `defect` target — a nonexistent work item returns 204 and ghosts. Guard: `guard/test_records.py` `guard_test_record_defect_targets`; the target work item *type* stays unchecked.
+- Test run custom-field enum *values* — there is no `getAvailableOptions` for test runs, so values are `unguarded`; keys are guarded.
+
+## Cross-domain
+
+- Record attachments, including why the e-signature block does not reach them: [attachments.md](attachments.md).
+- A `text/plain` record comment is stored as `text/html`: [comments.md](comments.md).
+
+## Verified
+
+| Date | Scope |
+|---|---|
+| 2026-07-21 | E-signature scope on manual-type runs |

--- a/docs/polarion-api/test-runs.md
+++ b/docs/polarion-api/test-runs.md
@@ -7,7 +7,8 @@ Test run and test record contracts, including the e-signature block. Read before
 | Method | Path | Notes |
 |---|---|---|
 | GET, POST, PATCH | `projects/{p}/testruns` | POST requires an explicit `id` |
-| GET, PATCH | `testruns/{r}/testrecords` | PATCH batches are atomic |
+| GET, POST, PATCH | `projects/{p}/testruns/{r}/testrecords` | PATCH batches are atomic |
+| GET | `projects/{p}/testruns/{r}/testrecords/{tcProj}/{tcId}/{iter}` | the single-record coordinate — `{tcProj}/{tcId}` is the full test case id split in two |
 | GET | `projects/{p}/enumerations/testing/{enumName}/~` | the `~` context returns 404 for test run enums |
 
 ## Read contract
@@ -29,6 +30,7 @@ Test run and test record contracts, including the e-signature block. Read before
 - Test record PATCH batches are atomic — one bad id fails the whole batch with 400, and `"was not found"` arrives as 400, not 404.
 - Partial PATCH is safe: omitted attributes are preserved.
 - REST auto-fills nothing. The server never populates `executed`, `duration`, or `testCaseRevision`; all three are settable explicitly via PATCH (204, preserved).
+- A record comment is `attributes.comment` on the record itself, not a comment sub-resource. A `text/plain` value is stored and served as `text/html`, and the text stays editable by PATCH.
 - A run's type may require an e-signature. Record PATCH then fails 403 and the remedy is portal-only — REST cannot supply the signature. Surface the Polarion detail in the error; a token hint alone misleads the caller.
 - The e-signature block covers record PATCH only.
 
@@ -41,7 +43,7 @@ Test run and test record contracts, including the e-signature block. Read before
 ## Cross-domain
 
 - Record attachments, including why the e-signature block does not reach them: [attachments.md](attachments.md).
-- A `text/plain` record comment is stored as `text/html`: [comments.md](comments.md).
+- The same plain-text-to-HTML storage rule on document and work item comment resources: [comments.md](comments.md).
 
 ## Verified
 

--- a/docs/polarion-api/work-items.md
+++ b/docs/polarion-api/work-items.md
@@ -1,0 +1,36 @@
+# Work items and links
+
+Work item query, delete, and link contracts. Read before touching `list_work_items`, `get_work_item`, `read_work_item`, `create_work_items`, `update_work_items`, or any `*_work_item_links` tool. Baseline Polarion REST API v2506.
+
+## Endpoints
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `projects/{p}/workitems` | `query=linkedWorkItems:{wi}` is the only back-link direction |
+| DELETE | `projects/{p}/workitems` | 204 with a `{"data": [...]}` body |
+| DELETE | `workitems/{wi}` | 405 — the single-resource form does not exist |
+| GET | `workitems/{wi}/backlinkedworkitems` | unsupported |
+
+## Read contract
+
+- Back-links come from `query=linkedWorkItems:{wi}`, and those results carry `role=None` — the role is not recoverable in that direction.
+
+## Write contract
+
+- The collection-body DELETE returns 204. This is API capability only: the repo ships no work item delete tool by policy, and documents stay 405 either way.
+
+## Server does not validate
+
+- `workitemimg:` refs in a description — accepted verbatim (204) and persisted. Guard: `guard/work_items.py` `guard_work_item_attachment_refs`, built on `guard/_attachment_refs.py`.
+- Link targets and roles — accepted unvalidated. Guard: `guard/links.py` against the project's `workitem-link-role` enum, `guard/_targets.py` for target existence.
+
+## Cross-domain
+
+- Work item attachment ids, which make `workitemimg:` tokens unpredictable before upload: [attachments.md](attachments.md).
+- Ghost refs in comment bodies: [comments.md](comments.md).
+
+## Verified
+
+| Date | Scope |
+|---|---|
+| — | No dated probe; observed across v2506 development |

--- a/docs/polarion-api/work-items.md
+++ b/docs/polarion-api/work-items.md
@@ -1,6 +1,6 @@
 # Work items and links
 
-Work item query, delete, and link contracts. Read before touching `list_work_items`, `get_work_item`, `read_work_item`, `create_work_items`, `update_work_items`, or any `*_work_item_links` tool. Baseline Polarion REST API v2506.
+Work item query, delete, document-membership, and link contracts. Read before touching `list_work_items`, `get_work_item`, `read_work_item`, `create_work_items`, `update_work_items`, `move_work_item_to_document`, `move_work_item_from_document`, or any `*_work_item_links` tool. Baseline Polarion REST API v2506.
 
 ## Endpoints
 
@@ -8,8 +8,12 @@ Work item query, delete, and link contracts. Read before touching `list_work_ite
 |---|---|---|
 | GET | `projects/{p}/workitems` | `query=linkedWorkItems:{wi}` is the only back-link direction |
 | DELETE | `projects/{p}/workitems` | 204 with a `{"data": [...]}` body |
-| DELETE | `workitems/{wi}` | 405 — the single-resource form does not exist |
-| GET | `workitems/{wi}/backlinkedworkitems` | unsupported |
+| DELETE | `projects/{p}/workitems/{wi}` | 405 — the single-resource form does not exist |
+| GET | `projects/{p}/workitems/{wi}/backlinkedworkitems` | unsupported |
+| POST | `projects/{p}/workitems/{wi}/actions/moveToDocument` | flat body, not `{"data": [...]}` |
+| POST | `projects/{p}/workitems/{wi}/actions/moveFromDocument` | takes no body |
+| GET, POST, DELETE | `projects/{p}/workitems/{wi}/linkedworkitems` | DELETE takes a `{"data": [...]}` body |
+| PATCH | `projects/{p}/workitems/{wi}/linkedworkitems/{role}/{targetProject}/{targetId}` | the link coordinate — the same 5 segments as the link `id` |
 
 ## Read contract
 

--- a/src/mcp_server_polarion/tools/attachments.py
+++ b/src/mcp_server_polarion/tools/attachments.py
@@ -1,5 +1,7 @@
 """Attachment tools — list attachments of a document or work item; fetch one
 attachment's content for viewing; upload document or work item attachments.
+
+API contract quirks: docs/polarion-api/attachments.md
 """
 
 from __future__ import annotations

--- a/src/mcp_server_polarion/tools/attachments.py
+++ b/src/mcp_server_polarion/tools/attachments.py
@@ -1,5 +1,6 @@
-"""Attachment tools — list attachments of a document or work item; fetch one
-attachment's content for viewing; upload document or work item attachments.
+"""Attachment tools — list attachments of a document, work item, or test
+record; fetch one attachment's content for viewing; upload attachments to any
+of the three.
 
 API contract quirks: docs/polarion-api/attachments.md
 """

--- a/src/mcp_server_polarion/tools/comments.py
+++ b/src/mcp_server_polarion/tools/comments.py
@@ -1,4 +1,7 @@
-"""Comment tools — list comments, create + resolve them."""
+"""Comment tools — list comments, create + resolve them.
+
+API contract quirks: docs/polarion-api/comments.md
+"""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/tools/documents.py
+++ b/src/mcp_server_polarion/tools/documents.py
@@ -1,4 +1,7 @@
-"""Document tools — query, read, create, update, and copy."""
+"""Document tools — query, read, create, update, and copy.
+
+API contract quirks: docs/polarion-api/documents.md
+"""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/tools/links.py
+++ b/src/mcp_server_polarion/tools/links.py
@@ -1,4 +1,7 @@
-"""Work item link tools — list, create, delete, and update links."""
+"""Work item link tools — list, create, delete, and update links.
+
+API contract quirks: docs/polarion-api/work-items.md
+"""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/tools/moves.py
+++ b/src/mcp_server_polarion/tools/moves.py
@@ -1,4 +1,7 @@
-"""Work item document-membership tools — move into / out of documents."""
+"""Work item document-membership tools — move into / out of documents.
+
+API contract quirks: docs/polarion-api/work-items.md
+"""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/tools/test_records.py
+++ b/src/mcp_server_polarion/tools/test_records.py
@@ -1,4 +1,7 @@
-"""Test record tools — list, get, create, and update execution records of a test run."""
+"""Test record tools — list, get, create, and update execution records of a test run.
+
+API contract quirks: docs/polarion-api/test-runs.md
+"""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/tools/test_runs.py
+++ b/src/mcp_server_polarion/tools/test_runs.py
@@ -1,4 +1,7 @@
-"""Test run tools — list, search, get, create, and update test runs in a project."""
+"""Test run tools — list, search, get, create, and update test runs in a project.
+
+API contract quirks: docs/polarion-api/test-runs.md
+"""
 
 from __future__ import annotations
 

--- a/src/mcp_server_polarion/tools/work_items.py
+++ b/src/mcp_server_polarion/tools/work_items.py
@@ -1,4 +1,7 @@
-"""Work item tools — query, create, and update."""
+"""Work item tools — query, create, and update.
+
+API contract quirks: docs/polarion-api/work-items.md
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` had grown to 18.6KB / 4735 tokens, half of it per-domain Polarion REST contracts that only matter while editing that one domain. This splits those contracts into `docs/polarion-api/`, unified behind a fixed template, and slims what stays resident.

Audit criteria applied, in priority order:

1. **Restorability** — a fact recoverable by reading our own code gets deleted; a fact about server behavior never does.
2. **Obsolete gotcha** — deletable only if no tool uses the endpoint, the fact predates v2506, or our code never takes that path.
3. **Need-by-time** — always needed stays in `CLAUDE.md`, domain-specific moves out.
4. **Gate overlap** — rules a test already enforces shrink to a pointer at that test.
5. **Doc overlap** — anything `CONTRIBUTING.md` already states shrinks to a pointer.
6. **Provenance** — keep the fact, drop the PR number and the story of how it was found.
7. **Line shape** — one fact per line.
8. **Failure cost** — rules that break the runtime sort above rules that are stylistic.

Criterion 2 matched nothing: no gotcha was dropped, only relocated.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [x] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- `CLAUDE.md` carried 9.3KB of Polarion contracts every session, most of it needed only when editing one domain.
- Move them to `docs/polarion-api/` behind a fixed template, cutting the always-resident file 37% with no fact dropped.

## Testing

- `ruff check`, `ruff format --check`, `mypy src/` clean; `pytest` 2540 passed, 11 skipped.
- diff-cover reports no lines with coverage information — the only source edits are module docstrings.
- No-loss check: every backticked identifier in the old `CLAUDE.md` was diffed against the new corpus. All 15 absences are either the deletions listed under criteria 1 and 5, or a path that moved into an Endpoints table row. Prose facts were spot-checked the same way.
- Duplicate check: bullets normalized and compared across all six files — zero exact duplicates, three near-matches, all of them intentional cross-domain links.
- Guard names cited in the new docs were verified against the code rather than trusted, which caught three wrong attributions (copy link-role, test record defect target, work item ref guard).

## Notes for Reviewers

- The corpus total grew 45% (4735 to 6896 tokens). That is the cost of one-fact-per-line plus cross-links. The number that matters is the resident file: 4735 to 2966. Opening the largest domain doc on top of it still totals 4061, under the old always-on cost.
- `docs/polarion-api/_TEMPLATE.md` fixes the section order — Endpoints, Read contract, Write contract, Server does not validate, Cross-domain, Verified. Sections may be dropped when empty, never reordered. Two rules in it are load-bearing: every unvalidated surface names its guard or says `unguarded`, and each fact has exactly one owning file, with a ghost body ref owned by the resource whose body holds it.
- Verification dates moved out of the prose into a per-file Verified table.
- Tool modules that have a matching doc got an `API contract quirks:` docstring pointer, so the doc is reachable from the file as well as from `CLAUDE.md`.
- Not done here: the docstring rules block in `CLAUDE.md` (~2.3KB) could also move out, but it applies to nearly every tool edit, so it fails criterion 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)