### PR TITLE
refactor(guard): self-heal enum checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CI: same order + `ruff format --check` + `pytest --cov-fail-under=90`; diff-cove
 ## Architecture
 
 - `core/` — `client.py` (async httpx; serialize + pace + retry per Gotchas), `exceptions.py`, `config.py` (`POLARION_URL`/`POLARION_TOKEN`), `logging.py` (stderr-only).
-- `tools/` — domain module per resource; `_build_*_payload` = unit-test seam; `tools/__init__.py` import registers `@mcp.tool`s. `_shared/`: `parse.py` (JSON:API→models), `pagination.py`, `fields.py`/`custom_fields.py` (sparse-fieldset + custom-field policy), `cache.py` (`TTLCache`), `sql.py`, `guard/` (pre-write validation, submodule per domain axis; new guards compose `_http.py` `guarded_get`/`guarded_pages` + `_custom_keys.py` `check_custom_keys`). `tools/guides/` = on-demand data served by `recipes.py`.
+- `tools/` — domain module per resource; `_build_*_payload` = unit-test seam; `tools/__init__.py` import registers `@mcp.tool`s. `_shared/`: `parse.py` (JSON:API→models), `pagination.py`, `fields.py`/`custom_fields.py` (sparse-fieldset + custom-field policy), `cache.py` (`TTLCache`), `sql.py`, `guard/` (pre-write validation, submodule per domain axis; new guards compose `_http.py` `guarded_get`/`guarded_pages` + `_custom_keys.py` `check_custom_keys` + `_revalidate.py` `resolve_with_refetch` — any guard rejecting against cached set route through it, stale entry never reject alone). `tools/guides/` = on-demand data served by `recipes.py`.
 - `middleware.py` — compact tool-arg `ValidationError` to one-line summary (raw Pydantic dump = token waste).
 - `utils/html.py` — Markdown↔HTML, `stamp_block_ids`, `first_anchorless_block`.
 - `models/` — Pydantic v2, re-exported from `models/__init__.py`; `PaginatedResult[T]` wrap list responses.

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -74,12 +74,21 @@ class DiscoveredDocument(NamedTuple):
     last_updated_by_name: str = ""
 
 
-# 60s cap window where stale entry accept admin-removed option.
-_GUARD_TTL_SECONDS: Final[float] = 60.0
+# Custom-field key schema: sampling scan = priciest guard fetch, and only
+# admin field edit change it. Stale window trade against that scan.
+_SCHEMA_TTL_SECONDS: Final[float] = 900.0
+
+# Enum options: admin-configured too, but guard reject against them, so
+# refetch-once (guard/_revalidate.py) carry the freshness, not TTL.
+_ENUM_TTL_SECONDS: Final[float] = 600.0
+
+# Work item existence: saved fetch = one batched query, and portal user
+# delete work items any time -- keep dangling window narrow.
+_TARGET_TTL_SECONDS: Final[float] = 60.0
 
 # 404 "not an Enumeration field" = stable schema fact; stale worst case
 # just defer to Polarion — safe to outlive positive option sets.
-_FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS: Final[float] = 600.0
+_FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS: Final[float] = 3600.0
 
 # New documents surface within ~1 min (create also invalidate on write).
 _DOCUMENT_LIST_TTL_SECONDS: Final[float] = 60.0
@@ -114,7 +123,7 @@ def invalidate_documents_cache(project_id: str) -> None:
 # beside id so display-name reader (rendering layout `label`) reuse guard's
 # fetch instead of spending second request; unnamed option = "".
 _field_option_cache: TTLCache[tuple[str, Resource, str, str], Mapping[str, str]] = (
-    TTLCache(_GUARD_TTL_SECONDS)
+    TTLCache(_ENUM_TTL_SECONDS)
 )
 
 
@@ -149,9 +158,19 @@ def store_cached_field_options(  # noqa: PLR0913
     )
 
 
+def invalidate_field_options(
+    project_id: str,
+    resource: Resource,
+    field_id: str,
+    type_id: str,
+) -> None:
+    """Drop cached options for field/type (refetch-once before reject)."""
+    _field_option_cache.invalidate((project_id, resource, field_id, type_id))
+
+
 # (project, enum_name) -> project-level enum option ids (no type axis).
 _enum_option_id_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
-    _GUARD_TTL_SECONDS
+    _ENUM_TTL_SECONDS
 )
 
 
@@ -168,14 +187,19 @@ def store_cached_enum_option_ids(
     enum_name: str,
     option_ids: frozenset[str],
 ) -> None:
-    """Cache valid option ids for project enum for ``_GUARD_TTL_SECONDS``."""
+    """Cache valid option ids for project enum for ``_ENUM_TTL_SECONDS``."""
     _enum_option_id_cache.set((project_id, enum_name), option_ids)
+
+
+def invalidate_enum_option_ids(project_id: str, enum_name: str) -> None:
+    """Drop cached option ids for project enum (refetch-once before reject)."""
+    _enum_option_id_cache.invalidate((project_id, enum_name))
 
 
 # (project, work_item_id) -> True once confirmed existing. Positives only --
 # a missing WI may be created later, so absence never cache as a negative.
 _confirmed_work_item_cache: TTLCache[tuple[str, str], bool] = TTLCache(
-    _GUARD_TTL_SECONDS
+    _TARGET_TTL_SECONDS
 )
 
 
@@ -189,7 +213,7 @@ def get_cached_confirmed_work_item(project_id: str, work_item_id: str) -> bool |
 
 def store_cached_confirmed_work_item(project_id: str, work_item_id: str) -> None:
     """Mark ``(project, work_item)`` confirmed existing for
-    ``_GUARD_TTL_SECONDS`` -- partial batches merge naturally since each
+    ``_TARGET_TTL_SECONDS`` -- partial batches merge naturally since each
     id is its own entry.
     """
     _confirmed_work_item_cache.set((project_id, work_item_id), True)
@@ -197,7 +221,7 @@ def store_cached_confirmed_work_item(project_id: str, work_item_id: str) -> None
 
 # (project, work_item_type) -> full custom-field key schema (MIN-per-key sample).
 _work_item_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
-    _GUARD_TTL_SECONDS
+    _SCHEMA_TTL_SECONDS
 )
 
 
@@ -227,7 +251,7 @@ def invalidate_work_item_custom_keys(project_id: str, work_item_type: str) -> No
 
 # (project, document_type) -> custom-field key schema; document-side mirror.
 _document_type_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
-    _GUARD_TTL_SECONDS
+    _SCHEMA_TTL_SECONDS
 )
 
 
@@ -256,7 +280,9 @@ def invalidate_document_type_custom_keys(project_id: str, document_type: str) ->
 
 
 # project -> testrun custom-field key schema (project config, no type axis).
-_test_run_custom_key_cache: TTLCache[str, frozenset[str]] = TTLCache(_GUARD_TTL_SECONDS)
+_test_run_custom_key_cache: TTLCache[str, frozenset[str]] = TTLCache(
+    _SCHEMA_TTL_SECONDS
+)
 
 
 def get_test_run_custom_keys(project_id: str) -> frozenset[str] | None:
@@ -289,6 +315,8 @@ __all__ = [
     "get_work_item_custom_keys",
     "invalidate_document_type_custom_keys",
     "invalidate_documents_cache",
+    "invalidate_enum_option_ids",
+    "invalidate_field_options",
     "invalidate_test_run_custom_keys",
     "invalidate_work_item_custom_keys",
     "store_cached_confirmed_work_item",

--- a/src/mcp_server_polarion/tools/_shared/cache.py
+++ b/src/mcp_server_polarion/tools/_shared/cache.py
@@ -76,6 +76,8 @@ class DiscoveredDocument(NamedTuple):
 
 # Custom-field key schema: sampling scan = priciest guard fetch, and only
 # admin field edit change it. Stale window trade against that scan.
+# Accepted risk both here and below: refetch-once heal missing entry only, so
+# admin-REMOVED key/option stay accepted till expiry -- ghost write unrecoverable.
 _SCHEMA_TTL_SECONDS: Final[float] = 900.0
 
 # Enum options: admin-configured too, but guard reject against them, so
@@ -158,16 +160,6 @@ def store_cached_field_options(  # noqa: PLR0913
     )
 
 
-def invalidate_field_options(
-    project_id: str,
-    resource: Resource,
-    field_id: str,
-    type_id: str,
-) -> None:
-    """Drop cached options for field/type (refetch-once before reject)."""
-    _field_option_cache.invalidate((project_id, resource, field_id, type_id))
-
-
 # (project, enum_name) -> project-level enum option ids (no type axis).
 _enum_option_id_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
     _ENUM_TTL_SECONDS
@@ -189,11 +181,6 @@ def store_cached_enum_option_ids(
 ) -> None:
     """Cache valid option ids for project enum for ``_ENUM_TTL_SECONDS``."""
     _enum_option_id_cache.set((project_id, enum_name), option_ids)
-
-
-def invalidate_enum_option_ids(project_id: str, enum_name: str) -> None:
-    """Drop cached option ids for project enum (refetch-once before reject)."""
-    _enum_option_id_cache.invalidate((project_id, enum_name))
 
 
 # (project, work_item_id) -> True once confirmed existing. Positives only --
@@ -244,11 +231,6 @@ def store_work_item_custom_keys(
     _work_item_custom_key_cache.set((project_id, work_item_type), keys)
 
 
-def invalidate_work_item_custom_keys(project_id: str, work_item_type: str) -> None:
-    """Drop cached schema for ``(project, type)`` (bypass-retry)."""
-    _work_item_custom_key_cache.invalidate((project_id, work_item_type))
-
-
 # (project, document_type) -> custom-field key schema; document-side mirror.
 _document_type_custom_key_cache: TTLCache[tuple[str, str], frozenset[str]] = TTLCache(
     _SCHEMA_TTL_SECONDS
@@ -274,11 +256,6 @@ def store_document_type_custom_keys(
     _document_type_custom_key_cache.set((project_id, document_type), keys)
 
 
-def invalidate_document_type_custom_keys(project_id: str, document_type: str) -> None:
-    """Drop cached schema for ``(project, document_type)`` (bypass-retry)."""
-    _document_type_custom_key_cache.invalidate((project_id, document_type))
-
-
 # project -> testrun custom-field key schema (project config, no type axis).
 _test_run_custom_key_cache: TTLCache[str, frozenset[str]] = TTLCache(
     _SCHEMA_TTL_SECONDS
@@ -297,11 +274,6 @@ def store_test_run_custom_keys(project_id: str, keys: frozenset[str]) -> None:
     _test_run_custom_key_cache.set(project_id, keys)
 
 
-def invalidate_test_run_custom_keys(project_id: str) -> None:
-    """Drop cached testrun schema for *project_id* (bypass-retry)."""
-    _test_run_custom_key_cache.invalidate(project_id)
-
-
 __all__ = [
     "DiscoveredDocument",
     "Resource",
@@ -313,12 +285,7 @@ __all__ = [
     "get_document_type_custom_keys",
     "get_test_run_custom_keys",
     "get_work_item_custom_keys",
-    "invalidate_document_type_custom_keys",
     "invalidate_documents_cache",
-    "invalidate_enum_option_ids",
-    "invalidate_field_options",
-    "invalidate_test_run_custom_keys",
-    "invalidate_work_item_custom_keys",
     "store_cached_confirmed_work_item",
     "store_cached_documents",
     "store_cached_enum_option_ids",

--- a/src/mcp_server_polarion/tools/_shared/guard/_custom_keys.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/_custom_keys.py
@@ -15,7 +15,6 @@ async def check_custom_keys(  # noqa: PLR0913
     custom_fields: dict[str, object],
     *,
     get_cached: Callable[[], frozenset[str] | None],
-    invalidate: Callable[[], None],
     fetch: Callable[[], Awaitable[frozenset[str]]],
     scope: str,
     discovery_tool: str,
@@ -33,7 +32,6 @@ async def check_custom_keys(  # noqa: PLR0913
 
     schema = await resolve_with_refetch(
         get_cached=get_cached,
-        invalidate=invalidate,
         fetch=fetch,
         accepts=known_keys,
     )

--- a/src/mcp_server_polarion/tools/_shared/guard/_custom_keys.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/_custom_keys.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 
+from mcp_server_polarion.tools._shared.guard._revalidate import resolve_with_refetch
 from mcp_server_polarion.tools._shared.helpers import format_option_list
 
 
@@ -26,18 +27,18 @@ async def check_custom_keys(  # noqa: PLR0913
     empty schema fail closed with ``RuntimeError(empty_schema_error)`` (ghost
     write unrecoverable).
     """
-    schema = get_cached()
-    fetched_fresh = schema is None
-    if schema is None:
-        schema = await fetch()
 
-    if all(key in schema for key in custom_fields):
+    def known_keys(schema: frozenset[str]) -> bool:
+        return all(key in schema for key in custom_fields)
+
+    schema = await resolve_with_refetch(
+        get_cached=get_cached,
+        invalidate=invalidate,
+        fetch=fetch,
+        accepts=known_keys,
+    )
+    if known_keys(schema):
         return
-
-    # Unknown key may be admin-added since caching; refetch once before reject.
-    if not fetched_fresh:
-        invalidate()
-        schema = await fetch()
 
     if not schema:
         raise RuntimeError(empty_schema_error)

--- a/src/mcp_server_polarion/tools/_shared/guard/_revalidate.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/_revalidate.py
@@ -1,0 +1,31 @@
+"""Stale-cache revalidation shared by guards that reject against a cached
+option/key set: cached value never reject on its own, one refetch settle it.
+
+Admin-added option or key land in Polarion mid-TTL; without this the guard
+block a legitimate write until expiry, and the error's discovery-tool hint
+cannot free it (that tool bypass the guard cache).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+
+async def resolve_with_refetch[T](
+    *,
+    get_cached: Callable[[], T | None],
+    invalidate: Callable[[], None],
+    fetch: Callable[[], Awaitable[T]],
+    accepts: Callable[[T], bool],
+) -> T:
+    """Value to judge against: cached one when *accepts* pass, else a fresh
+    fetch. Freshly fetched value never refetch — caller reject on it.
+    """
+    value = get_cached()
+    if value is None:
+        return await fetch()
+    if accepts(value):
+        return value
+
+    invalidate()
+    return await fetch()

--- a/src/mcp_server_polarion/tools/_shared/guard/_revalidate.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/_revalidate.py
@@ -14,18 +14,16 @@ from collections.abc import Awaitable, Callable
 async def resolve_with_refetch[T](
     *,
     get_cached: Callable[[], T | None],
-    invalidate: Callable[[], None],
     fetch: Callable[[], Awaitable[T]],
     accepts: Callable[[T], bool],
 ) -> T:
     """Value to judge against: cached one when *accepts* pass, else a fresh
     fetch. Freshly fetched value never refetch — caller reject on it.
+
+    Stale entry left in place: *fetch* overwrite it on success, and a failed
+    one keep it readable for the next caller it still satisfy.
     """
     value = get_cached()
-    if value is None:
-        return await fetch()
-    if accepts(value):
+    if value is not None and accepts(value):
         return value
-
-    invalidate()
     return await fetch()

--- a/src/mcp_server_polarion/tools/_shared/guard/documents.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/documents.py
@@ -8,7 +8,6 @@ from collections.abc import Iterable, Sequence
 from mcp_server_polarion.core.client import PolarionClient
 from mcp_server_polarion.tools._shared.cache import (
     get_document_type_custom_keys,
-    invalidate_document_type_custom_keys,
     store_document_type_custom_keys,
 )
 from mcp_server_polarion.tools._shared.custom_fields import (
@@ -158,9 +157,6 @@ async def _check_document_custom_keys(
     await check_custom_keys(
         custom_fields,
         get_cached=lambda: get_document_type_custom_keys(project_id, document_type),
-        invalidate=lambda: invalidate_document_type_custom_keys(
-            project_id, document_type
-        ),
         fetch=lambda: _fetch_document_type_custom_keys(
             client, project_id, document_type
         ),

--- a/src/mcp_server_polarion/tools/_shared/guard/enums.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/enums.py
@@ -8,7 +8,8 @@ type; ``enum_*`` = ``/projects/{p}/enumerations/``, scoped per enum name.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
+from functools import partial
 
 from mcp_server_polarion.core.client import PolarionClient
 from mcp_server_polarion.core.exceptions import PolarionNotFoundError
@@ -16,6 +17,8 @@ from mcp_server_polarion.tools._shared.cache import (
     Resource,
     get_cached_enum_option_ids,
     get_cached_field_options,
+    invalidate_enum_option_ids,
+    invalidate_field_options,
     store_cached_enum_option_ids,
     store_cached_field_options,
 )
@@ -23,6 +26,7 @@ from mcp_server_polarion.tools._shared.guard._http import (
     GUARD_PAGE_SIZE,
     guarded_get,
 )
+from mcp_server_polarion.tools._shared.guard._revalidate import resolve_with_refetch
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     format_option_list,
@@ -53,7 +57,21 @@ async def fetch_field_options(
     cached = get_cached_field_options(project_id, resource, field_id, type_id)
     if cached is not None:
         return cached
+    return await _fetch_field_options_uncached(
+        client, project_id, resource, field_id, type_id
+    )
 
+
+async def _fetch_field_options_uncached(
+    client: PolarionClient,
+    project_id: str,
+    resource: Resource,
+    field_id: str,
+    type_id: str,
+) -> Mapping[str, str]:
+    """Request + parse + store, bypassing any cached entry — refetch seam for
+    :func:`resolve_with_refetch`.
+    """
     path = (
         f"/projects/{encode_path_segment(project_id)}"
         f"/{resource}/fields/{encode_path_segment(field_id)}"
@@ -100,6 +118,31 @@ async def fetch_field_options(
     return options
 
 
+async def _options_for_check(  # noqa: PLR0913
+    client: PolarionClient,
+    project_id: str,
+    resource: Resource,
+    field_id: str,
+    type_id: str,
+    accepts: Callable[[Mapping[str, str]], bool],
+) -> Mapping[str, str]:
+    """Option set to judge against: stale cache refetch once before it may
+    reject, so admin-added option never block a legitimate write.
+    """
+    return await resolve_with_refetch(
+        get_cached=lambda: get_cached_field_options(
+            project_id, resource, field_id, type_id
+        ),
+        invalidate=lambda: invalidate_field_options(
+            project_id, resource, field_id, type_id
+        ),
+        fetch=lambda: _fetch_field_options_uncached(
+            client, project_id, resource, field_id, type_id
+        ),
+        accepts=accepts,
+    )
+
+
 async def check_field_value(  # noqa: PLR0913
     client: PolarionClient,
     project_id: str,
@@ -108,8 +151,15 @@ async def check_field_value(  # noqa: PLR0913
     type_id: str,
     value: str,
 ) -> None:
-    options = await fetch_field_options(client, project_id, resource, field_id, type_id)
     # Empty mapping = successful no-options fetch; defer rather than false-positive.
+    options = await _options_for_check(
+        client,
+        project_id,
+        resource,
+        field_id,
+        type_id,
+        lambda known: not known or value in known,
+    )
     if not options or value in options:
         return
     raise ValueError(
@@ -134,11 +184,29 @@ async def fetch_enum_option_ids(
     ``data.attributes.options[].id``. Cached for the default guard TTL
     (404 included); fail-closed.
     """
-    cache_key = f"{context}/{enum_name}"
-    cached = get_cached_enum_option_ids(project_id, cache_key)
+    cached = get_cached_enum_option_ids(project_id, _enum_cache_key(context, enum_name))
     if cached is not None:
         return cached
+    return await _fetch_enum_option_ids_uncached(client, project_id, enum_name, context)
 
+
+def _enum_cache_key(context: str, enum_name: str) -> str:
+    """Cache key folding both path segments — same enum name resolve to
+    different option sets per context.
+    """
+    return f"{context}/{enum_name}"
+
+
+async def _fetch_enum_option_ids_uncached(
+    client: PolarionClient,
+    project_id: str,
+    enum_name: str,
+    context: str,
+) -> frozenset[str]:
+    """Request + parse + store, bypassing any cached entry — refetch seam for
+    :func:`resolve_with_refetch`.
+    """
+    cache_key = _enum_cache_key(context, enum_name)
     path = (
         f"/projects/{encode_path_segment(project_id)}"
         f"/enumerations/{encode_path_segment(context)}"
@@ -195,7 +263,15 @@ async def check_enum_values(  # noqa: PLR0913
     if not requested:
         return
 
-    option_ids = await fetch_enum_option_ids(client, project_id, enum_name, context)
+    cache_key = _enum_cache_key(context, enum_name)
+    option_ids = await resolve_with_refetch(
+        get_cached=lambda: get_cached_enum_option_ids(project_id, cache_key),
+        invalidate=lambda: invalidate_enum_option_ids(project_id, cache_key),
+        fetch=lambda: _fetch_enum_option_ids_uncached(
+            client, project_id, enum_name, context
+        ),
+        accepts=lambda known: not known or requested <= known,
+    )
     # Empty set = no options / enum unsupported; defer.
     if not option_ids:
         return
@@ -236,6 +312,19 @@ def _bad_custom_enum_value(  # noqa: PLR0913
     )
 
 
+def _custom_value_known(value: object, options: Mapping[str, str]) -> bool:
+    """Whether *value* already satisfy *options*. Shape error count as known —
+    refetch cannot turn a non-string into a valid option id.
+    """
+    if not options:
+        return True
+    if isinstance(value, str):
+        return value in options
+    if isinstance(value, list):
+        return all(element in options for element in value if isinstance(element, str))
+    return True
+
+
 async def check_custom_field_enum_values(
     client: PolarionClient,
     project_id: str,
@@ -255,8 +344,13 @@ async def check_custom_field_enum_values(
         # Payload builders drop empty values — nothing to validate, skip probe.
         if value is None or value in ("", []):
             continue
-        options = await fetch_field_options(
-            client, project_id, resource, field_id, type_id
+        options = await _options_for_check(
+            client,
+            project_id,
+            resource,
+            field_id,
+            type_id,
+            partial(_custom_value_known, value),
         )
         if not options:
             continue

--- a/src/mcp_server_polarion/tools/_shared/guard/enums.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/enums.py
@@ -17,8 +17,6 @@ from mcp_server_polarion.tools._shared.cache import (
     Resource,
     get_cached_enum_option_ids,
     get_cached_field_options,
-    invalidate_enum_option_ids,
-    invalidate_field_options,
     store_cached_enum_option_ids,
     store_cached_field_options,
 )
@@ -31,6 +29,7 @@ from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     format_option_list,
 )
+from mcp_server_polarion.tools._shared.parse import parse_option_map
 
 logger = logging.getLogger("mcp_server_polarion.tools._shared.guard.enums")
 
@@ -77,6 +76,9 @@ async def _fetch_field_options_uncached(
         f"/{resource}/fields/{encode_path_segment(field_id)}"
         "/actions/getAvailableOptions"
     )
+    # Page 1 only: field with over GUARD_PAGE_SIZE options cache truncated and
+    # reject the rest, refetch cannot heal that. Accepted -- paging every probe
+    # cost one request per page at the client's pace.
     params: dict[str, str | int] = {
         "type": type_id,
         "page[size]": GUARD_PAGE_SIZE,
@@ -103,17 +105,7 @@ async def _fetch_field_options_uncached(
         )
         return {}
 
-    data = response.get("data", [])
-    options: dict[str, str] = {}
-    if isinstance(data, list):
-        for entry in data:
-            if not isinstance(entry, dict):
-                continue
-            opt_id = entry.get("id")
-            if isinstance(opt_id, str) and opt_id:
-                name = entry.get("name")
-                options[opt_id] = name if isinstance(name, str) else ""
-
+    options = parse_option_map(response.get("data", []))
     store_cached_field_options(project_id, resource, field_id, type_id, options)
     return options
 
@@ -133,9 +125,6 @@ async def _options_for_check(  # noqa: PLR0913
         get_cached=lambda: get_cached_field_options(
             project_id, resource, field_id, type_id
         ),
-        invalidate=lambda: invalidate_field_options(
-            project_id, resource, field_id, type_id
-        ),
         fetch=lambda: _fetch_field_options_uncached(
             client, project_id, resource, field_id, type_id
         ),
@@ -151,16 +140,15 @@ async def check_field_value(  # noqa: PLR0913
     type_id: str,
     value: str,
 ) -> None:
-    # Empty mapping = successful no-options fetch; defer rather than false-positive.
+    def accepts(known: Mapping[str, str]) -> bool:
+        # Empty mapping = successful no-options fetch; defer rather than
+        # false-positive.
+        return not known or value in known
+
     options = await _options_for_check(
-        client,
-        project_id,
-        resource,
-        field_id,
-        type_id,
-        lambda known: not known or value in known,
+        client, project_id, resource, field_id, type_id, accepts
     )
-    if not options or value in options:
+    if accepts(options):
         return
     raise ValueError(
         f"{field_id}='{value}' is not a valid {field_id} option in "
@@ -181,7 +169,7 @@ async def fetch_enum_option_ids(
     (link/hyperlink role, testrun type/status). ``context`` = enumeration
     context path segment (``testing`` for testrun enums; ``~`` does NOT
     resolve them). Response ``data`` = dict (not list), options at
-    ``data.attributes.options[].id``. Cached for the default guard TTL
+    ``data.attributes.options[].id``. Cached for ``_ENUM_TTL_SECONDS``
     (404 included); fail-closed.
     """
     cached = get_cached_enum_option_ids(project_id, _enum_cache_key(context, enum_name))
@@ -263,28 +251,29 @@ async def check_enum_values(  # noqa: PLR0913
     if not requested:
         return
 
+    def accepts(known: frozenset[str]) -> bool:
+        # Empty set = no options / enum unsupported; defer.
+        return not known or requested <= known
+
     cache_key = _enum_cache_key(context, enum_name)
     option_ids = await resolve_with_refetch(
         get_cached=lambda: get_cached_enum_option_ids(project_id, cache_key),
-        invalidate=lambda: invalidate_enum_option_ids(project_id, cache_key),
         fetch=lambda: _fetch_enum_option_ids_uncached(
             client, project_id, enum_name, context
         ),
-        accepts=lambda known: not known or requested <= known,
+        accepts=accepts,
     )
-    # Empty set = no options / enum unsupported; defer.
-    if not option_ids:
+    if accepts(option_ids):
         return
 
     unknown = sorted(requested - option_ids)
-    if unknown:
-        raise ValueError(
-            f"{field_label} id(s) {format_option_list(unknown)} are not valid "
-            f"in project '{project_id}'. "
-            f"Valid options: {format_option_list(option_ids)}. "
-            f"An unknown {field_label} ghosts silently (never matches Lucene) "
-            f"-- {discovery_hint}"
-        )
+    raise ValueError(
+        f"{field_label} id(s) {format_option_list(unknown)} are not valid "
+        f"in project '{project_id}'. "
+        f"Valid options: {format_option_list(option_ids)}. "
+        f"An unknown {field_label} ghosts silently (never matches Lucene) "
+        f"-- {discovery_hint}"
+    )
 
 
 def _bad_custom_enum_value(  # noqa: PLR0913

--- a/src/mcp_server_polarion/tools/_shared/guard/test_runs.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/test_runs.py
@@ -10,7 +10,6 @@ from mcp_server_polarion.core.client import PolarionClient
 from mcp_server_polarion.core.exceptions import PolarionNotFoundError
 from mcp_server_polarion.tools._shared.cache import (
     get_test_run_custom_keys,
-    invalidate_test_run_custom_keys,
     store_test_run_custom_keys,
 )
 from mcp_server_polarion.tools._shared.custom_fields import (
@@ -138,7 +137,6 @@ async def _check_test_run_custom_keys(
     await check_custom_keys(
         custom_fields,
         get_cached=lambda: get_test_run_custom_keys(project_id),
-        invalidate=lambda: invalidate_test_run_custom_keys(project_id),
         fetch=lambda: _fetch_test_run_custom_keys(client, project_id),
         scope=f"test runs in project '{project_id}'",
         discovery_tool="sample of existing runs",

--- a/src/mcp_server_polarion/tools/_shared/guard/work_items.py
+++ b/src/mcp_server_polarion/tools/_shared/guard/work_items.py
@@ -10,7 +10,6 @@ from mcp_server_polarion.core.client import PolarionClient
 from mcp_server_polarion.core.exceptions import PolarionNotFoundError
 from mcp_server_polarion.tools._shared.cache import (
     get_work_item_custom_keys,
-    invalidate_work_item_custom_keys,
     store_work_item_custom_keys,
 )
 from mcp_server_polarion.tools._shared.custom_fields import (
@@ -116,7 +115,6 @@ async def _check_work_item_custom_keys(
     await check_custom_keys(
         custom_fields,
         get_cached=lambda: get_work_item_custom_keys(project_id, work_item_type),
-        invalidate=lambda: invalidate_work_item_custom_keys(project_id, work_item_type),
         fetch=lambda: _fetch_work_item_type_custom_keys(
             client, project_id, work_item_type
         ),

--- a/src/mcp_server_polarion/tools/_shared/parse.py
+++ b/src/mcp_server_polarion/tools/_shared/parse.py
@@ -639,6 +639,26 @@ def parse_attachments_page(
     return make_page(attachment_items, response, page_number, page_size)
 
 
+def parse_option_map(data: object) -> dict[str, str]:
+    """``getAvailableOptions`` payload → option id → display name.
+
+    Non-string / empty id skipped: they cannot address an option, and both
+    the write guard and the read tool prime one cache entry from here — a
+    coerced key would accept a value the other writer reject.
+    """
+    options: dict[str, str] = {}
+    if not isinstance(data, list):
+        return options
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        opt_id = entry.get("id")
+        if isinstance(opt_id, str) and opt_id:
+            name = entry.get("name")
+            options[opt_id] = name if isinstance(name, str) else ""
+    return options
+
+
 def parse_enum_option(entry: dict[str, object]) -> EnumOption:
     """JSON:API enumeration entry → ``EnumOption``; non-bool flags coerce to False."""
 
@@ -669,6 +689,7 @@ __all__: list[str] = [
     "parse_hyperlinks",
     "parse_included_user_name_map",
     "parse_included_work_item_map",
+    "parse_option_map",
     "parse_test_record_detail",
     "parse_work_item_detail",
     "parse_work_item_summaries",

--- a/src/mcp_server_polarion/tools/enum.py
+++ b/src/mcp_server_polarion/tools/enum.py
@@ -18,6 +18,7 @@ from mcp_server_polarion.core.exceptions import (
 )
 from mcp_server_polarion.models import EnumOption, PaginatedResult
 from mcp_server_polarion.server import mcp
+from mcp_server_polarion.tools._shared.cache import store_cached_field_options
 from mcp_server_polarion.tools._shared.helpers import (
     encode_path_segment,
     get_client,
@@ -54,6 +55,11 @@ async def _list_enum_options(  # noqa: PLR0913
     try:
         response = await client.get(path, params=params)
     except PolarionNotFoundError as exc:
+        # Same fact write guards cache on own 404 probe -- store so later
+        # writes skip one request.
+        store_cached_field_options(
+            project_id, resource, field_id, type_id, {}, not_found=True
+        )
         raise ValueError(
             f"No enum options for field '{field_id}' on {type_label} type "
             f"'{type_id}' in project '{project_id}' -- field unknown or not "
@@ -76,7 +82,19 @@ async def _list_enum_options(  # noqa: PLR0913
             if isinstance(entry, dict):
                 items.append(parse_enum_option(entry))
 
-    return make_page(items, response, page_number, page_size)
+    page = make_page(items, response, page_number, page_size)
+    # Complete option set only: partial page prime = valid ids rejected until
+    # expiry. Never invalidate here -- discovery typically run right before
+    # write, so dropping entry cost that write one fetch.
+    if page_number == 1 and not page.has_more:
+        store_cached_field_options(
+            project_id,
+            resource,
+            field_id,
+            type_id,
+            {option.id: option.name for option in items},
+        )
+    return page
 
 
 @mcp.tool(

--- a/src/mcp_server_polarion/tools/enum.py
+++ b/src/mcp_server_polarion/tools/enum.py
@@ -27,7 +27,10 @@ from mcp_server_polarion.tools._shared.pagination import (
     DEFAULT_PAGE_SIZE,
     make_page,
 )
-from mcp_server_polarion.tools._shared.parse import parse_enum_option
+from mcp_server_polarion.tools._shared.parse import (
+    parse_enum_option,
+    parse_option_map,
+)
 
 
 async def _list_enum_options(  # noqa: PLR0913
@@ -94,7 +97,7 @@ async def _list_enum_options(  # noqa: PLR0913
             resource,
             field_id,
             type_id,
-            {option.id: option.name for option in items},
+            parse_option_map(data),
         )
     return page
 

--- a/src/mcp_server_polarion/tools/enum.py
+++ b/src/mcp_server_polarion/tools/enum.py
@@ -55,11 +55,13 @@ async def _list_enum_options(  # noqa: PLR0913
     try:
         response = await client.get(path, params=params)
     except PolarionNotFoundError as exc:
-        # Same fact write guards cache on own 404 probe -- store so later
-        # writes skip one request.
-        store_cached_field_options(
-            project_id, resource, field_id, type_id, {}, not_found=True
-        )
+        # Page 1 only: same fact write guards cache on own 404 probe, so store
+        # it and later writes skip one request. Overshoot 404 = different fact
+        # -- storing it would defer enum validation for whole TTL.
+        if page_number == 1:
+            store_cached_field_options(
+                project_id, resource, field_id, type_id, {}, not_found=True
+            )
         raise ValueError(
             f"No enum options for field '{field_id}' on {type_label} type "
             f"'{type_id}' in project '{project_id}' -- field unknown or not "

--- a/tests/mcp_server_polarion/tools/_shared/guard/test__custom_keys.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test__custom_keys.py
@@ -21,13 +21,11 @@ class TestCheckCustomKeys:
         custom_fields: dict[str, object],
         *,
         get_cached: MagicMock,
-        invalidate: MagicMock,
         fetch: AsyncMock,
     ) -> None:
         await check_custom_keys(
             custom_fields,
             get_cached=get_cached,
-            invalidate=invalidate,
             fetch=fetch,
             scope="scope 'S'",
             discovery_tool="a sample",
@@ -36,63 +34,44 @@ class TestCheckCustomKeys:
 
     async def test_cached_schema_passes_without_fetch(self) -> None:
         get_cached = MagicMock(return_value=frozenset({"risk"}))
-        invalidate = MagicMock()
         fetch = AsyncMock()
 
-        await self._run(
-            {"risk": 1}, get_cached=get_cached, invalidate=invalidate, fetch=fetch
-        )
+        await self._run({"risk": 1}, get_cached=get_cached, fetch=fetch)
 
         fetch.assert_not_awaited()
-        invalidate.assert_not_called()
 
     async def test_cache_miss_fetches_once_and_passes(self) -> None:
         get_cached = MagicMock(return_value=None)
-        invalidate = MagicMock()
         fetch = AsyncMock(return_value=frozenset({"risk"}))
 
-        await self._run(
-            {"risk": 1}, get_cached=get_cached, invalidate=invalidate, fetch=fetch
-        )
+        await self._run({"risk": 1}, get_cached=get_cached, fetch=fetch)
 
         fetch.assert_awaited_once()
-        invalidate.assert_not_called()
 
     async def test_unknown_key_against_cached_schema_refetches_once(self) -> None:
         # Key admin-added since caching: stale cache says unknown, fresh says known.
         get_cached = MagicMock(return_value=frozenset({"risk"}))
-        invalidate = MagicMock()
         fetch = AsyncMock(return_value=frozenset({"risk", "newKey"}))
 
-        await self._run(
-            {"newKey": 1}, get_cached=get_cached, invalidate=invalidate, fetch=fetch
-        )
+        await self._run({"newKey": 1}, get_cached=get_cached, fetch=fetch)
 
-        invalidate.assert_called_once()
         fetch.assert_awaited_once()
 
     async def test_unknown_key_against_fresh_fetch_rejects_without_retry(self) -> None:
         get_cached = MagicMock(return_value=None)
-        invalidate = MagicMock()
         fetch = AsyncMock(return_value=frozenset({"risk"}))
 
         with pytest.raises(ValueError, match=r"\['ghost'\]"):
-            await self._run(
-                {"ghost": 1}, get_cached=get_cached, invalidate=invalidate, fetch=fetch
-            )
+            await self._run({"ghost": 1}, get_cached=get_cached, fetch=fetch)
 
         fetch.assert_awaited_once()
-        invalidate.assert_not_called()
 
     async def test_empty_schema_fails_closed_with_supplied_error(self) -> None:
         get_cached = MagicMock(return_value=None)
-        invalidate = MagicMock()
         fetch = AsyncMock(return_value=frozenset())
 
         with pytest.raises(RuntimeError, match="empty schema for S"):
-            await self._run(
-                {"ghost": 1}, get_cached=get_cached, invalidate=invalidate, fetch=fetch
-            )
+            await self._run({"ghost": 1}, get_cached=get_cached, fetch=fetch)
 
 
 class TestRejectUnknownCustomKeys:

--- a/tests/mcp_server_polarion/tools/_shared/guard/test__revalidate.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test__revalidate.py
@@ -1,0 +1,108 @@
+"""Stale-cache revalidation engine: one refetch before a cached value is
+allowed to reject.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import AsyncMock, MagicMock
+
+from mcp_server_polarion.tools._shared.guard._revalidate import resolve_with_refetch
+
+
+class TestResolveWithRefetch:
+    async def _run(
+        self,
+        *,
+        get_cached: MagicMock,
+        invalidate: MagicMock,
+        fetch: AsyncMock,
+        accepts: Callable[[frozenset[str]], bool],
+    ) -> frozenset[str]:
+        return await resolve_with_refetch(
+            get_cached=get_cached,
+            invalidate=invalidate,
+            fetch=fetch,
+            accepts=accepts,
+        )
+
+    async def test_accepted_cached_value_skips_fetch(self) -> None:
+        get_cached = MagicMock(return_value=frozenset({"open"}))
+        invalidate = MagicMock()
+        fetch = AsyncMock()
+
+        result = await self._run(
+            get_cached=get_cached,
+            invalidate=invalidate,
+            fetch=fetch,
+            accepts=lambda options: "open" in options,
+        )
+
+        assert result == frozenset({"open"})
+        fetch.assert_not_awaited()
+        invalidate.assert_not_called()
+
+    async def test_cache_miss_fetches_once(self) -> None:
+        get_cached = MagicMock(return_value=None)
+        invalidate = MagicMock()
+        fetch = AsyncMock(return_value=frozenset({"open"}))
+
+        result = await self._run(
+            get_cached=get_cached,
+            invalidate=invalidate,
+            fetch=fetch,
+            accepts=lambda options: "open" in options,
+        )
+
+        assert result == frozenset({"open"})
+        fetch.assert_awaited_once()
+        invalidate.assert_not_called()
+
+    async def test_rejected_cached_value_invalidates_and_refetches(self) -> None:
+        # Option admin-added since caching: stale set reject, fresh set accept.
+        get_cached = MagicMock(return_value=frozenset({"open"}))
+        invalidate = MagicMock()
+        fetch = AsyncMock(return_value=frozenset({"open", "blocked"}))
+
+        result = await self._run(
+            get_cached=get_cached,
+            invalidate=invalidate,
+            fetch=fetch,
+            accepts=lambda options: "blocked" in options,
+        )
+
+        assert result == frozenset({"open", "blocked"})
+        invalidate.assert_called_once()
+        fetch.assert_awaited_once()
+
+    async def test_fresh_fetch_never_refetched(self) -> None:
+        get_cached = MagicMock(return_value=None)
+        invalidate = MagicMock()
+        fetch = AsyncMock(return_value=frozenset({"open"}))
+
+        result = await self._run(
+            get_cached=get_cached,
+            invalidate=invalidate,
+            fetch=fetch,
+            accepts=lambda options: "blocked" in options,
+        )
+
+        assert result == frozenset({"open"})
+        fetch.assert_awaited_once()
+        invalidate.assert_not_called()
+
+    async def test_refetched_value_returned_even_when_still_rejected(self) -> None:
+        get_cached = MagicMock(return_value=frozenset({"stale"}))
+        invalidate = MagicMock()
+        fetch = AsyncMock(return_value=frozenset({"open"}))
+
+        result = await self._run(
+            get_cached=get_cached,
+            invalidate=invalidate,
+            fetch=fetch,
+            accepts=lambda options: "blocked" in options,
+        )
+
+        # Caller render rejection from fresh set, never stale one.
+        assert result == frozenset({"open"})
+        fetch.assert_awaited_once()

--- a/tests/mcp_server_polarion/tools/_shared/guard/test__revalidate.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test__revalidate.py
@@ -15,90 +15,74 @@ class TestResolveWithRefetch:
         self,
         *,
         get_cached: MagicMock,
-        invalidate: MagicMock,
         fetch: AsyncMock,
         accepts: Callable[[frozenset[str]], bool],
     ) -> frozenset[str]:
         return await resolve_with_refetch(
             get_cached=get_cached,
-            invalidate=invalidate,
             fetch=fetch,
             accepts=accepts,
         )
 
     async def test_accepted_cached_value_skips_fetch(self) -> None:
         get_cached = MagicMock(return_value=frozenset({"open"}))
-        invalidate = MagicMock()
         fetch = AsyncMock()
 
         result = await self._run(
             get_cached=get_cached,
-            invalidate=invalidate,
             fetch=fetch,
             accepts=lambda options: "open" in options,
         )
 
         assert result == frozenset({"open"})
         fetch.assert_not_awaited()
-        invalidate.assert_not_called()
 
     async def test_cache_miss_fetches_once(self) -> None:
         get_cached = MagicMock(return_value=None)
-        invalidate = MagicMock()
         fetch = AsyncMock(return_value=frozenset({"open"}))
 
         result = await self._run(
             get_cached=get_cached,
-            invalidate=invalidate,
             fetch=fetch,
             accepts=lambda options: "open" in options,
         )
 
         assert result == frozenset({"open"})
         fetch.assert_awaited_once()
-        invalidate.assert_not_called()
 
-    async def test_rejected_cached_value_invalidates_and_refetches(self) -> None:
+    async def test_rejected_cached_value_refetches(self) -> None:
         # Option admin-added since caching: stale set reject, fresh set accept.
         get_cached = MagicMock(return_value=frozenset({"open"}))
-        invalidate = MagicMock()
         fetch = AsyncMock(return_value=frozenset({"open", "blocked"}))
 
         result = await self._run(
             get_cached=get_cached,
-            invalidate=invalidate,
             fetch=fetch,
             accepts=lambda options: "blocked" in options,
         )
 
         assert result == frozenset({"open", "blocked"})
-        invalidate.assert_called_once()
         fetch.assert_awaited_once()
 
     async def test_fresh_fetch_never_refetched(self) -> None:
         get_cached = MagicMock(return_value=None)
-        invalidate = MagicMock()
         fetch = AsyncMock(return_value=frozenset({"open"}))
 
         result = await self._run(
             get_cached=get_cached,
-            invalidate=invalidate,
             fetch=fetch,
             accepts=lambda options: "blocked" in options,
         )
 
         assert result == frozenset({"open"})
         fetch.assert_awaited_once()
-        invalidate.assert_not_called()
 
     async def test_refetched_value_returned_even_when_still_rejected(self) -> None:
         get_cached = MagicMock(return_value=frozenset({"stale"}))
-        invalidate = MagicMock()
         fetch = AsyncMock(return_value=frozenset({"open"}))
 
         result = await self._run(
             get_cached=get_cached,
-            invalidate=invalidate,
             fetch=fetch,
             accepts=lambda options: "blocked" in options,
         )

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
@@ -412,3 +412,24 @@ class TestStaleCacheRefetch:
 
         assert "stale" not in str(exc_info.value)
         assert mock_client.get.await_count == 1
+
+    async def test_refetch_error_blocks_write(self, mock_client: AsyncMock) -> None:
+        # Fail-closed hold through refetch: stale set never serve as fallback.
+        store_cached_field_options("P", "workitems", "status", "task", {"stale": ""})
+        mock_client.get.side_effect = PolarionError("backend down")
+
+        with pytest.raises(RuntimeError, match="Refusing the write"):
+            await check_field_value(
+                mock_client, "P", "workitems", "status", "task", "ghost"
+            )
+
+    async def test_refetch_not_found_defers_instead_of_rejecting(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Refetch 404 = field no longer enum-typed; defer, not reject on stale.
+        store_cached_field_options("P", "workitems", "status", "task", {"stale": ""})
+        mock_client.get.side_effect = PolarionNotFoundError("nope", status_code=404)
+
+        await check_field_value(
+            mock_client, "P", "workitems", "status", "task", "ghost"
+        )

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
@@ -15,6 +15,7 @@ from mcp_server_polarion.core.exceptions import (
 )
 from mcp_server_polarion.tools._shared import cache as cache_mod
 from mcp_server_polarion.tools._shared.cache import (
+    get_cached_field_options,
     store_cached_enum_option_ids,
     store_cached_field_options,
 )
@@ -433,3 +434,19 @@ class TestStaleCacheRefetch:
         await check_field_value(
             mock_client, "P", "workitems", "status", "task", "ghost"
         )
+
+    async def test_failed_refetch_keeps_cached_options(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Entry still usable by next caller -- dropping it buys a cold fetch.
+        store_cached_field_options("P", "workitems", "status", "task", {"open": "Open"})
+        mock_client.get.side_effect = PolarionError("backend down")
+
+        with pytest.raises(RuntimeError, match="Refusing the write"):
+            await check_field_value(
+                mock_client, "P", "workitems", "status", "task", "ghost"
+            )
+
+        assert get_cached_field_options("P", "workitems", "status", "task") == {
+            "open": "Open"
+        }

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_enums.py
@@ -14,8 +14,15 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.tools._shared import cache as cache_mod
+from mcp_server_polarion.tools._shared.cache import (
+    store_cached_enum_option_ids,
+    store_cached_field_options,
+)
 from mcp_server_polarion.tools._shared.guard import guard_work_item_enums
 from mcp_server_polarion.tools._shared.guard.enums import (
+    check_custom_field_enum_values,
+    check_enum_values,
+    check_field_value,
     fetch_enum_option_ids,
     fetch_field_options,
 )
@@ -78,7 +85,7 @@ class TestFetchFieldOptions:
         monkeypatch.setattr(cache_mod, "_now", lambda: clock[0])
 
         await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
-        clock[0] += 61.0  # past the 60s TTL
+        clock[0] += cache_mod._ENUM_TTL_SECONDS + 1.0
         await fetch_field_options(mock_client, "P", "workitems", "severity", "task")
 
         assert mock_client.get.await_count == 2
@@ -216,7 +223,7 @@ class TestFetchEnumOptionIds:
         monkeypatch.setattr(cache_mod, "_now", lambda: clock[0])
 
         await fetch_enum_option_ids(mock_client, "P", "hyperlink-role")
-        clock[0] += cache_mod._GUARD_TTL_SECONDS + 1
+        clock[0] += cache_mod._ENUM_TTL_SECONDS + 1
         await fetch_enum_option_ids(mock_client, "P", "hyperlink-role")
 
         assert mock_client.get.await_count == 2
@@ -264,3 +271,144 @@ class TestFetchEnumOptionIds:
         result = await fetch_enum_option_ids(mock_client, "P", "workitem-link-role")
 
         assert result == frozenset({"ok"})
+
+
+class TestStaleCacheRefetch:
+    """Cached option set never reject alone -- one refetch settle it."""
+
+    async def test_stale_field_options_refetched_then_value_accepted(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Admin added `blocked` after cache entry stored.
+        store_cached_field_options("P", "workitems", "status", "task", {"open": "Open"})
+        mock_client.get.return_value = enum_response(["open", "blocked"])
+
+        await check_field_value(
+            mock_client, "P", "workitems", "status", "task", "blocked"
+        )
+
+        assert mock_client.get.await_count == 1
+
+    async def test_cached_value_hit_skips_refetch(self, mock_client: AsyncMock) -> None:
+        store_cached_field_options("P", "workitems", "status", "task", {"open": "Open"})
+
+        await check_field_value(mock_client, "P", "workitems", "status", "task", "open")
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_empty_cached_options_defer_without_refetch(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # 404 entry: nothing to validate against, so no refetch, no rejection.
+        store_cached_field_options(
+            "P", "workitems", "freeText", "task", {}, not_found=True
+        )
+
+        await check_field_value(
+            mock_client, "P", "workitems", "freeText", "task", "anything"
+        )
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_refetch_still_missing_rejects_with_fresh_options(
+        self, mock_client: AsyncMock
+    ) -> None:
+        store_cached_field_options("P", "workitems", "status", "task", {"stale": ""})
+        mock_client.get.return_value = enum_response(["open"])
+
+        with pytest.raises(ValueError, match="open") as exc_info:
+            await check_field_value(
+                mock_client, "P", "workitems", "status", "task", "ghost"
+            )
+
+        assert "stale" not in str(exc_info.value)
+        assert mock_client.get.await_count == 1
+
+    async def test_fresh_fetch_rejects_without_second_request(
+        self, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = enum_response(["open"])
+
+        with pytest.raises(ValueError, match="ghost"):
+            await check_field_value(
+                mock_client, "P", "workitems", "status", "task", "ghost"
+            )
+
+        assert mock_client.get.await_count == 1
+
+    async def test_stale_custom_field_options_refetched(
+        self, mock_client: AsyncMock
+    ) -> None:
+        store_cached_field_options("P", "workitems", "asil", "task", {"a": "A"})
+        mock_client.get.return_value = enum_response(["a", "b"])
+
+        await check_custom_field_enum_values(
+            mock_client, "P", "workitems", "task", {"asil": "b"}
+        )
+
+        assert mock_client.get.await_count == 1
+
+    async def test_stale_custom_field_list_value_refetched(
+        self, mock_client: AsyncMock
+    ) -> None:
+        store_cached_field_options("P", "workitems", "platform", "task", {"a": "A"})
+        mock_client.get.return_value = enum_response(["a", "b"])
+
+        await check_custom_field_enum_values(
+            mock_client, "P", "workitems", "task", {"platform": ["a", "b"]}
+        )
+
+        assert mock_client.get.await_count == 1
+
+    async def test_wrong_shaped_custom_value_rejects_without_refetch(
+        self, mock_client: AsyncMock
+    ) -> None:
+        # Refetch cannot turn int into option id -- spend no request.
+        store_cached_field_options("P", "workitems", "asil", "task", {"a": "A"})
+
+        with pytest.raises(ValueError, match="enumeration field but got int"):
+            await check_custom_field_enum_values(
+                mock_client, "P", "workitems", "task", {"asil": 5}
+            )
+
+        mock_client.get.assert_not_awaited()
+
+    async def test_stale_enum_option_ids_refetched_then_role_accepted(
+        self, mock_client: AsyncMock
+    ) -> None:
+        store_cached_enum_option_ids("P", "~/workitem-link-role", frozenset({"parent"}))
+        mock_client.get.return_value = project_enum_response(
+            "workitem-link-role", ["parent", "verifies"]
+        )
+
+        await check_enum_values(
+            mock_client,
+            "P",
+            "workitem-link-role",
+            ["verifies"],
+            field_label="role",
+            discovery_hint="read an existing link.",
+        )
+
+        assert mock_client.get.await_count == 1
+
+    async def test_stale_enum_option_ids_reject_after_refetch(
+        self, mock_client: AsyncMock
+    ) -> None:
+        store_cached_enum_option_ids("P", "~/workitem-link-role", frozenset({"stale"}))
+        mock_client.get.return_value = project_enum_response(
+            "workitem-link-role", ["parent"]
+        )
+
+        with pytest.raises(ValueError, match="parent") as exc_info:
+            await check_enum_values(
+                mock_client,
+                "P",
+                "workitem-link-role",
+                ["ghost"],
+                field_label="role",
+                discovery_hint="read an existing link.",
+            )
+
+        assert "stale" not in str(exc_info.value)
+        assert mock_client.get.await_count == 1

--- a/tests/mcp_server_polarion/tools/_shared/guard/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/_shared/guard/test_work_items.py
@@ -410,7 +410,7 @@ class TestGuardWorkItemCustomFieldEnums:
     async def test_not_found_outlives_guard_ttl(
         self, mock_client: AsyncMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # 404 entries get the long not_found TTL; positive sets keep 60s.
+        # 404 entries get long not_found TTL; positive sets keep enum TTL.
         mock_client.get.side_effect = PolarionNotFoundError("not enum", status_code=404)
         clock = [1000.0]
         monkeypatch.setattr(cache_mod, "_now", lambda: clock[0])
@@ -420,13 +420,12 @@ class TestGuardWorkItemCustomFieldEnums:
         store_work_item_custom_keys("P", "task", frozenset({"f"}))
 
         await guard_work_item_custom_fields(mock_client, "P", "task", {"f": "x"})
-        clock[0] += 61.0  # past _GUARD_TTL_SECONDS, within not_found TTL
-        # Key schema share 60s TTL; re-prime so only enum cache expiry measured.
+        clock[0] += cache_mod._ENUM_TTL_SECONDS + 1.0  # within not_found TTL
         store_work_item_custom_keys("P", "task", frozenset({"f"}))
         await guard_work_item_custom_fields(mock_client, "P", "task", {"f": "x"})
         assert mock_client.get.await_count == 1
 
-        clock[0] += 600.0  # past _FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS
+        clock[0] += cache_mod._FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS
         store_work_item_custom_keys("P", "task", frozenset({"f"}))
         await guard_work_item_custom_fields(mock_client, "P", "task", {"f": "x"})
         assert mock_client.get.await_count == 2

--- a/tests/mcp_server_polarion/tools/_shared/test_cache.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_cache.py
@@ -17,6 +17,8 @@ from mcp_server_polarion.tools._shared.cache import (
     get_work_item_custom_keys,
     invalidate_document_type_custom_keys,
     invalidate_documents_cache,
+    invalidate_enum_option_ids,
+    invalidate_field_options,
     invalidate_work_item_custom_keys,
     store_cached_documents,
     store_cached_enum_option_ids,
@@ -196,10 +198,21 @@ class TestFieldOptionCache:
         assert get_cached_field_options("P", "documents", "severity", "task") is None
         assert get_cached_field_options("P", "workitems", "status", "task") is None
 
-    def test_expiry_uses_guard_ttl(self, clock: list[float]) -> None:
+    def test_invalidate_drops_only_its_axis(self) -> None:
+        store_cached_field_options("P", "workitems", "severity", "task", {"high": ""})
+        store_cached_field_options("P", "workitems", "severity", "bug", {"high": ""})
+
+        invalidate_field_options("P", "workitems", "severity", "task")
+
+        assert get_cached_field_options("P", "workitems", "severity", "task") is None
+        assert get_cached_field_options("P", "workitems", "severity", "bug") == (
+            {"high": ""}
+        )
+
+    def test_expiry_uses_enum_ttl(self, clock: list[float]) -> None:
         store_cached_field_options("P", "workitems", "severity", "task", {"high": ""})
 
-        clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
+        clock[0] += cache_mod._ENUM_TTL_SECONDS + 1.0
         assert get_cached_field_options("P", "workitems", "severity", "task") is None
 
     def test_not_found_entries_use_long_ttl(self, clock: list[float]) -> None:
@@ -207,7 +220,7 @@ class TestFieldOptionCache:
             "P", "workitems", "freeText", "task", {}, not_found=True
         )
 
-        clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
+        clock[0] += cache_mod._ENUM_TTL_SECONDS + 1.0
         assert get_cached_field_options("P", "workitems", "freeText", "task") == {}
 
         clock[0] += cache_mod._FIELD_OPTIONS_NOT_FOUND_TTL_SECONDS
@@ -232,10 +245,21 @@ class TestEnumOptionIdCache:
         assert get_cached_enum_option_ids("P", "hyperlink-role") is None
         assert get_cached_enum_option_ids("Q", "workitem-link-role") is None
 
-    def test_expiry_uses_guard_ttl(self, clock: list[float]) -> None:
+    def test_invalidate_drops_only_its_enum(self) -> None:
+        store_cached_enum_option_ids("P", "workitem-link-role", frozenset({"parent"}))
         store_cached_enum_option_ids("P", "hyperlink-role", frozenset({"ref_ext"}))
 
-        clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
+        invalidate_enum_option_ids("P", "workitem-link-role")
+
+        assert get_cached_enum_option_ids("P", "workitem-link-role") is None
+        assert get_cached_enum_option_ids("P", "hyperlink-role") == frozenset(
+            {"ref_ext"}
+        )
+
+    def test_expiry_uses_enum_ttl(self, clock: list[float]) -> None:
+        store_cached_enum_option_ids("P", "hyperlink-role", frozenset({"ref_ext"}))
+
+        clock[0] += cache_mod._ENUM_TTL_SECONDS + 1.0
         assert get_cached_enum_option_ids("P", "hyperlink-role") is None
 
 
@@ -271,7 +295,7 @@ class TestWorkItemCustomKeys:
     def test_expiry(self, clock: list[float]) -> None:
         store_work_item_custom_keys("P", "task", frozenset({"a"}))
 
-        clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
+        clock[0] += cache_mod._SCHEMA_TTL_SECONDS + 1.0
         assert get_work_item_custom_keys("P", "task") is None
 
 
@@ -308,5 +332,5 @@ class TestDocumentTypeCustomKeys:
     def test_expiry(self, clock: list[float]) -> None:
         store_document_type_custom_keys("P", "generic", frozenset({"a"}))
 
-        clock[0] += cache_mod._GUARD_TTL_SECONDS + 1.0
+        clock[0] += cache_mod._SCHEMA_TTL_SECONDS + 1.0
         assert get_document_type_custom_keys("P", "generic") is None

--- a/tests/mcp_server_polarion/tools/_shared/test_cache.py
+++ b/tests/mcp_server_polarion/tools/_shared/test_cache.py
@@ -15,11 +15,7 @@ from mcp_server_polarion.tools._shared.cache import (
     get_cached_field_options,
     get_document_type_custom_keys,
     get_work_item_custom_keys,
-    invalidate_document_type_custom_keys,
     invalidate_documents_cache,
-    invalidate_enum_option_ids,
-    invalidate_field_options,
-    invalidate_work_item_custom_keys,
     store_cached_documents,
     store_cached_enum_option_ids,
     store_cached_field_options,
@@ -198,17 +194,6 @@ class TestFieldOptionCache:
         assert get_cached_field_options("P", "documents", "severity", "task") is None
         assert get_cached_field_options("P", "workitems", "status", "task") is None
 
-    def test_invalidate_drops_only_its_axis(self) -> None:
-        store_cached_field_options("P", "workitems", "severity", "task", {"high": ""})
-        store_cached_field_options("P", "workitems", "severity", "bug", {"high": ""})
-
-        invalidate_field_options("P", "workitems", "severity", "task")
-
-        assert get_cached_field_options("P", "workitems", "severity", "task") is None
-        assert get_cached_field_options("P", "workitems", "severity", "bug") == (
-            {"high": ""}
-        )
-
     def test_expiry_uses_enum_ttl(self, clock: list[float]) -> None:
         store_cached_field_options("P", "workitems", "severity", "task", {"high": ""})
 
@@ -245,17 +230,6 @@ class TestEnumOptionIdCache:
         assert get_cached_enum_option_ids("P", "hyperlink-role") is None
         assert get_cached_enum_option_ids("Q", "workitem-link-role") is None
 
-    def test_invalidate_drops_only_its_enum(self) -> None:
-        store_cached_enum_option_ids("P", "workitem-link-role", frozenset({"parent"}))
-        store_cached_enum_option_ids("P", "hyperlink-role", frozenset({"ref_ext"}))
-
-        invalidate_enum_option_ids("P", "workitem-link-role")
-
-        assert get_cached_enum_option_ids("P", "workitem-link-role") is None
-        assert get_cached_enum_option_ids("P", "hyperlink-role") == frozenset(
-            {"ref_ext"}
-        )
-
     def test_expiry_uses_enum_ttl(self, clock: list[float]) -> None:
         store_cached_enum_option_ids("P", "hyperlink-role", frozenset({"ref_ext"}))
 
@@ -264,7 +238,7 @@ class TestEnumOptionIdCache:
 
 
 class TestWorkItemCustomKeys:
-    """``store/get/invalidate_work_item_custom_keys`` — type key schema."""
+    """``store/get_work_item_custom_keys`` — type key schema."""
 
     def test_store_then_get(self) -> None:
         store_work_item_custom_keys("P", "task", frozenset({"a", "b"}))
@@ -286,12 +260,6 @@ class TestWorkItemCustomKeys:
     def test_miss_returns_none(self) -> None:
         assert get_work_item_custom_keys("P", "never_sampled") is None
 
-    def test_invalidate(self) -> None:
-        store_work_item_custom_keys("P", "task", frozenset({"a"}))
-        invalidate_work_item_custom_keys("P", "task")
-
-        assert get_work_item_custom_keys("P", "task") is None
-
     def test_expiry(self, clock: list[float]) -> None:
         store_work_item_custom_keys("P", "task", frozenset({"a"}))
 
@@ -300,7 +268,7 @@ class TestWorkItemCustomKeys:
 
 
 class TestDocumentTypeCustomKeys:
-    """``store/get/invalidate_document_type_custom_keys`` keyed by (project, type)."""
+    """``store/get_document_type_custom_keys`` keyed by (project, type)."""
 
     def test_store_then_get(self) -> None:
         store_document_type_custom_keys(
@@ -322,12 +290,6 @@ class TestDocumentTypeCustomKeys:
 
         assert get_document_type_custom_keys("P", "systemReqSpecification") is None
         assert get_document_type_custom_keys("Q", "generic") is None
-
-    def test_invalidate(self) -> None:
-        store_document_type_custom_keys("P", "generic", frozenset({"a"}))
-        invalidate_document_type_custom_keys("P", "generic")
-
-        assert get_document_type_custom_keys("P", "generic") is None
 
     def test_expiry(self, clock: list[float]) -> None:
         store_document_type_custom_keys("P", "generic", frozenset({"a"}))

--- a/tests/mcp_server_polarion/tools/test_enum.py
+++ b/tests/mcp_server_polarion/tools/test_enum.py
@@ -626,3 +626,27 @@ class TestGuardCacheWriteThrough:
             )
             == {}
         )
+
+    async def test_later_page_not_found_leaves_cache_untouched(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Overshoot 404 != guard's page-1 probe fact; storing deferral here
+        # would disable enum validation for whole TTL.
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="No enum options"):
+            await list_work_item_enum_options(
+                mock_ctx,
+                project_id="MCP_Test_Project",
+                field_id="status",
+                work_item_type="task",
+                page_size=100,
+                page_number=7,
+            )
+
+        assert (
+            get_cached_field_options("MCP_Test_Project", "workitems", "status", "task")
+            is None
+        )

--- a/tests/mcp_server_polarion/tools/test_enum.py
+++ b/tests/mcp_server_polarion/tools/test_enum.py
@@ -650,3 +650,26 @@ class TestGuardCacheWriteThrough:
             get_cached_field_options("MCP_Test_Project", "workitems", "status", "task")
             is None
         )
+
+    async def test_prime_skips_ids_the_guard_parser_drops(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Guard populate same entry from raw ids -- coerced key would accept a
+        # value the guard's own fetch reject.
+        mock_client.get.return_value = {
+            "data": [{"id": 5, "name": "Five"}, {"id": "open", "name": "Open"}],
+            "meta": {"totalCount": 2},
+        }
+
+        await list_work_item_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            work_item_type="task",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert get_cached_field_options(
+            "MCP_Test_Project", "workitems", "status", "task"
+        ) == {"open": "Open"}

--- a/tests/mcp_server_polarion/tools/test_enum.py
+++ b/tests/mcp_server_polarion/tools/test_enum.py
@@ -15,6 +15,7 @@ from mcp_server_polarion.core.exceptions import (
     PolarionNotFoundError,
 )
 from mcp_server_polarion.models import EnumOption, PaginatedResult
+from mcp_server_polarion.tools._shared.cache import get_cached_field_options
 from mcp_server_polarion.tools.enum import (
     list_document_enum_options,
     list_work_item_enum_options,
@@ -516,3 +517,112 @@ class TestListDocumentEnumOptionsFieldValidation:
     def test_page_number_rejects_zero(self) -> None:
         with pytest.raises(ValidationError):
             self._adapter_for("page_number").validate_python(0)
+
+
+class TestGuardCacheWriteThrough:
+    """Complete first page prime the write guards' option cache."""
+
+    async def test_single_page_primes_guard_cache(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": _STATUS_DATA, "meta": {"totalCount": 3}}
+
+        await list_work_item_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            work_item_type="task",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert get_cached_field_options(
+            "MCP_Test_Project", "workitems", "status", "task"
+        ) == {"draft": "Draft", "inreview": "In Review", "approved": "Approved"}
+
+    async def test_document_options_prime_document_axis(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": _STATUS_DATA, "meta": {"totalCount": 3}}
+
+        await list_document_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            document_type="generic",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert (
+            get_cached_field_options(
+                "MCP_Test_Project", "documents", "status", "generic"
+            )
+            is not None
+        )
+
+    async def test_partial_page_leaves_cache_untouched(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        # Storing part of option set would reject valid ids for whole TTL.
+        mock_client.get.return_value = {
+            "data": _STATUS_DATA * 34,
+            "meta": {"totalCount": 150},
+        }
+
+        await list_work_item_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            work_item_type="task",
+            page_size=100,
+            page_number=1,
+        )
+
+        assert (
+            get_cached_field_options("MCP_Test_Project", "workitems", "status", "task")
+            is None
+        )
+
+    async def test_later_page_leaves_cache_untouched(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.return_value = {"data": _STATUS_DATA, "meta": {"totalCount": 3}}
+
+        await list_work_item_enum_options(
+            mock_ctx,
+            project_id="MCP_Test_Project",
+            field_id="status",
+            work_item_type="task",
+            page_size=100,
+            page_number=2,
+        )
+
+        assert (
+            get_cached_field_options("MCP_Test_Project", "workitems", "status", "task")
+            is None
+        )
+
+    async def test_not_found_caches_deferral(
+        self, mock_ctx: MagicMock, mock_client: AsyncMock
+    ) -> None:
+        mock_client.get.side_effect = PolarionNotFoundError(
+            "Not found", status_code=404
+        )
+
+        with pytest.raises(ValueError, match="No enum options"):
+            await list_work_item_enum_options(
+                mock_ctx,
+                project_id="MCP_Test_Project",
+                field_id="freeText",
+                work_item_type="task",
+                page_size=100,
+                page_number=1,
+            )
+
+        assert (
+            get_cached_field_options(
+                "MCP_Test_Project", "workitems", "freeText", "task"
+            )
+            == {}
+        )

--- a/tests/mcp_server_polarion/tools/test_work_items.py
+++ b/tests/mcp_server_polarion/tools/test_work_items.py
@@ -952,10 +952,11 @@ class TestUpdateWorkItemsHyperlinkRoleGuard:
     async def test_bad_role_names_offending_item_via_cache(
         self, mock_ctx: MagicMock, mock_client: AsyncMock
     ) -> None:
-        # Item 0 role pass; item 1 reuse cached options (no second enum
-        # GET), rejected with batch position and id.
+        # Item 0 role pass off cached options; item 1 miss them, so guard
+        # refetch once before naming batch position + id.
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task"), ("MCPT-2", "task")),
+            _project_enum_get_response("hyperlink-role", ["ref_int", "ref_ext"]),
             _project_enum_get_response("hyperlink-role", ["ref_int", "ref_ext"]),
         ]
 
@@ -972,7 +973,8 @@ class TestUpdateWorkItemsHyperlinkRoleGuard:
                 dry_run=True,
             )
 
-        assert mock_client.get.await_count == 2
+        # Existence query + first enum fetch + one stale-cache refetch.
+        assert mock_client.get.await_count == 3
         mock_client.patch.assert_not_called()
 
 
@@ -1453,10 +1455,11 @@ class TestEnumGuardUpdateWorkItems:
         mock_client: AsyncMock,
         reset_enum_guard_caches: None,
     ) -> None:
-        # Item 1 pass; item 2 reuse cached options — rejected with batch
-        # position and id.
+        # Item 1 pass off cached options; item 2 miss them, so guard refetch
+        # once (option may be admin-added) before naming batch position + id.
         mock_client.get.side_effect = [
             _existence_response(("MCPT-1", "task"), ("MCPT-2", "task")),
+            _enum_get_response(["50.0"]),
             _enum_get_response(["50.0"]),
         ]
 


### PR DESCRIPTION
## Summary

Guard caches held enum option sets for 60s, and a cached set could reject a legitimate write for that whole window whenever an admin had just added an option. The recovery the error message suggests — calling `list_*_enum_options` — reads Polarion directly and never touched the guard cache, so following that advice returned the new option yet the write kept failing until the entry expired.

`check_custom_keys` already solved this for custom-field keys by refetching once before rejecting. This PR extracts that control flow into `guard/_revalidate.py` and routes the enum checks through it, primes the guard cache from complete discovery pages, and then splits the single 60s guard TTL by data character.

TTLs after this change:

| Cache | Before | After |
|---|---|---|
| custom-field key schema (work item / document / test run) | 60s | 900s |
| field options + project enum option ids | 60s | 600s |
| confirmed work item existence | 60s | 60s (unchanged) |
| field options 404 deferral | 600s | 3600s |
| document discovery list | 60s | 60s (unchanged) |

**What the self-heal fixes.** A cache *smaller* than reality — an admin added an option or key mid-TTL — can no longer reject a valid write: the guard refetches once and judges against the fresh set. That removes the false-*rejection* cost of a longer TTL entirely, which is what makes the widening reviewable at all.

**What the widening costs.** A cache *larger* than reality — an admin removed an option or key — cannot self-heal in any of these caches, because an accepted value never triggers a refetch. So the false-*acceptance* window grows with the TTL: 600s for enum options, 900s for the custom-field key schema. A false acceptance writes an unknown key or enum id that persists as a silent ghost, and there is deliberately no delete tool for that data. The trade is accepted because mid-session admin removals are rare and the caches are per-process, but it is a real cost rather than one the self-heal covers; it is now stated in a comment beside the TTL constants so the next reader does not have to re-derive it.

Work item existence stays at 60s deliberately: it saves roughly one batched query per write call, while the work items it caches can be deleted from the portal at any time, so widening that window buys little and lengthens the dangling-link exposure. Document discovery stays at 60s because it is the one cache a user reads directly, and a measurement on a live testdrive project showed the scan is a single GET taking 5.8-5.9s (a plain GET on the same instance is 0.85s) — expensive enough that dropping or shortening the cache would cost a multi-second wait on every page of `list_documents`, which slices the scan client-side.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes, code quality improvement)
- [ ] Test update (adds or corrects tests / eval cases, no production behavior change)
- [ ] Documentation update
- [ ] CI / tooling / dependency update

## Changes

- Stale enum caches rejected valid writes for a full TTL, and the error's suggested recovery bypassed that cache.
- Refetch once before any cached set rejects, prime it from complete discovery pages, and tier the guard TTLs.

## Review Round 1 Follow-up

A code review of the first two commits raised eight findings; all are addressed here.

- **404 deferral was stored from any page number.** `list_*_enum_options` accepts an arbitrary `page_number`, and a 404 from a page overshoot is not the same fact as the guard's own page-1 probe. Storing it installed a 3600s empty option set, which the guard reads as "defer to Polarion" — enum validation silently off for that field for an hour, from a read-only call. The store is now gated on `page_number == 1`, matching the success path. This was the only fail-open path the PR had introduced.
- **`invalidate` was a no-op in every call site.** None of the five fetch closures read the cache; they all fetch and store. So invalidating before the refetch only cost something: a failed refetch dropped a still-usable entry, and a concurrent caller whose value was in the stale set had to fetch instead of hitting cache. The parameter is gone from `resolve_with_refetch` and `check_custom_keys`, along with the five cache helpers that existed only to feed it.
- **The read tool primed the guard cache through a different parser.** `parse_enum_option` coerces via `safe_str`, so `{"id": 5}` primed a `"5"` key that the guard's own parser would have dropped. Both writers now share `parse_option_map`.
- **The acceptance predicate was written twice per check.** `check_field_value` and `check_enum_values` now name it once and use it for both the refetch decision and the final rejection, mirroring `check_custom_keys`.
- **The guard's own option fetch reads page 1 only.** A field with more than 100 options caches a truncated set and rejects the rest, and the refetch cannot heal that. Left as is — paging every guard probe would cost one request per page at the client's pace — but now stated in a comment so it is not mistaken for a complete set.
- **Fail-closed was not pinned through the refetch path.** Two tests were added: a refetch that raises blocks the write, and a refetch that 404s defers instead of rejecting against the stale set. Both were checked against a deliberate mutation that makes `resolve_with_refetch` swallow the error and fall back to the stale value; both fail under it.
- **A stale docstring** named "the default guard TTL" after the tiering removed it.
- Not changed: a persistently invalid value still costs one extra GET per attempt. That is inherent to refetching before rejecting, and suppressing it would narrow the self-heal window it exists for.

## Testing

- `uv run pytest` — 2565 passed, 11 skipped.
- `ruff check` / `ruff format --check` / `mypy src/` clean.
- `diff-cover` against `origin/main`: 72 changed lines, 100% covered.
- Live smoke against a testdrive project, GET and `dry_run=True` only (guards run before the dry-run return, so the real path is exercised without writing):
  1. `list_work_item_enum_options` for `type` returned a single page and primed the guard cache.
  2. A following `create_work_items(dry_run=True)` with a valid type issued **0** requests — the discovery page covered it.
  3. An unknown type was rejected after **1** request (the self-heal refetch), with the fresh option list in the message.
  4. With a deliberately stale project-enum entry, a real link role was accepted after one refetch; the only rejection came from target existence.
  5. With a deliberately stale type-option entry, a real type passed after one refetch instead of being rejected — the exact failure this PR removes.

Five existing tests were updated: rejection paths now spend one extra request by design, so their mocked responses and request counts moved with the behavior, and the `invalidate` argument left their call sites.

`main` was merged in to resolve a conflict with #263, which restructured the CLAUDE.md architecture section; this branch's `_revalidate.py` line was re-applied onto the new bullet.

## Notes for Reviewers

- Refetch-on-reject only fixes a cache that is *smaller* than reality. See "What the widening costs" above for the direction it cannot fix.
- `list_*_enum_options` never invalidates the guard cache, only fills it, and only from a complete first page. A partial page would reject valid ids until expiry, and invalidating would defeat the common discovery-then-write sequence.
- Whether Polarion actually 404s on a page overshoot for `getAvailableOptions` is unverified — the gate is defensive. Its cost is one cached entry not taken in a rare case, which the guard re-derives on its own page-1 probe.
- `TTLCache` still expires lazily with no size bound. Only the work item existence cache is keyed by something that grows with write volume, and its TTL is unchanged here, so residency is the same as before. A `max_entries` bound is worth revisiting if memory growth is ever observed.
